### PR TITLE
Optimize indexing batches and remove live count toggle

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -541,6 +541,7 @@ export default function App() {
                 filteredCount={filteredImages.length}
                 totalCount={images.length}
                 directoryCount={directories.length}
+                showCounts={indexingState !== 'indexing'}
               />
 
               <div className="flex-1 min-h-0">

--- a/components/ActionToolbar.tsx
+++ b/components/ActionToolbar.tsx
@@ -13,6 +13,7 @@ interface ActionToolbarProps {
   filteredCount?: number;
   totalCount?: number;
   directoryCount?: number;
+  showCounts?: boolean;
 }
 
 const ActionToolbar: React.FC<ActionToolbarProps> = ({
@@ -25,10 +26,11 @@ const ActionToolbar: React.FC<ActionToolbarProps> = ({
   onViewModeChange,
   filteredCount,
   totalCount,
-  directoryCount
+  directoryCount,
+  showCounts = true
 }) => {
   const folderText = directoryCount === 1 ? 'folder' : 'folders';
-  
+
   return (
     <div className="flex justify-between items-center mb-4 px-4 py-2 bg-gray-800/60 rounded-lg border border-gray-700">
       <div className="flex items-center gap-4">
@@ -44,8 +46,8 @@ const ActionToolbar: React.FC<ActionToolbarProps> = ({
           <option value="asc">A-Z</option>
           <option value="desc">Z-A</option>
         </select>
-        
-        {filteredCount !== undefined && totalCount !== undefined && directoryCount !== undefined && (
+
+        {showCounts && filteredCount !== undefined && totalCount !== undefined && directoryCount !== undefined && (
           <>
             <div className="border-l border-gray-600 h-6 mx-2"></div>
             <span className="text-gray-400 text-sm">

--- a/components/StatusBar.tsx
+++ b/components/StatusBar.tsx
@@ -12,9 +12,9 @@ interface StatusBarProps {
   onCancelIndexing: () => void;
 }
 
-const StatusBar: React.FC<StatusBarProps> = ({ 
-  filteredCount, 
-  totalCount, 
+const StatusBar: React.FC<StatusBarProps> = ({
+  filteredCount,
+  totalCount,
   directoryCount,
   indexingState = 'idle',
   progress,
@@ -23,7 +23,7 @@ const StatusBar: React.FC<StatusBarProps> = ({
   onCancelIndexing
 }) => {
   const folderText = directoryCount === 1 ? 'folder' : 'folders';
-  
+
   return (
     <div className="mb-4 px-4 py-2 bg-gray-800/50 rounded-lg border border-gray-700 text-gray-300 flex justify-between items-center">
       <span>


### PR DESCRIPTION
## Summary
- stage indexed image batches per directory and commit them after scanning completes to avoid recalculating counts while indexing
- update the loader to queue batches, clear staged data on cancel, and only refresh metadata once when finalizing
- remove the live image count setting, hiding toolbar counts during indexing while keeping progress updates visible
