### PR TITLE
Fix folder selection persistence and tri-state behavior

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -57,18 +57,18 @@ export default function App() {
     selectedLoras,
     selectedSchedulers,
     advancedFilters,
-    visibleSubfolders,
-    visibleRoots,
+    folderSelection,
+    isFolderSelectionLoaded,
     setSearchQuery,
     setSelectedFilters,
     setAdvancedFilters,
     setSelectedImage,
     removeImage,
-    removeDirectory,
     updateImage,
     toggleDirectoryVisibility,
-    toggleSubfolderVisibility,
-    toggleRootVisibility,
+    setFolderSelectionState,
+    getFolderSelectionState,
+    initializeFolderSelection,
     resetState,
     setIndexingState,
     setLoading,
@@ -122,6 +122,12 @@ export default function App() {
     setIsHotkeyHelpOpen(false);
     handleOpenSettings('hotkeys');
   };
+
+  useEffect(() => {
+    if (!isFolderSelectionLoaded) {
+      initializeFolderSelection();
+    }
+  }, [initializeFolderSelection, isFolderSelectionLoaded]);
 
   // --- Indexing Control Functions ---
   const handlePauseIndexing = useCallback(() => {
@@ -397,10 +403,9 @@ export default function App() {
             onRemoveDirectory={handleRemoveDirectory}
             onUpdateDirectory={handleUpdateFolder}
             onToggleVisibility={toggleDirectoryVisibility}
-            onToggleSubfolderVisibility={toggleSubfolderVisibility}
-            onToggleRootVisibility={toggleRootVisibility}
-            visibleSubfolders={visibleSubfolders}
-            visibleRoots={visibleRoots}
+            onUpdateSelection={setFolderSelectionState}
+            getSelectionState={getFolderSelectionState}
+            folderSelection={folderSelection}
             isIndexing={indexingState === 'indexing' || indexingState === 'paused' || indexingState === 'completed'}
             scanSubfolders={scanSubfolders}
           />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Resolved folder selection inconsistencies that hid images when expanding directories by introducing tri-state hierarchy rules and persistent IndexedDB-backed folder selection state.
+
 ## [0.9.4] - 2025-10-20
 
 ### Fixed

--- a/services/folderSelectionStorage.ts
+++ b/services/folderSelectionStorage.ts
@@ -1,0 +1,115 @@
+/// <reference lib="dom" />
+
+export type StoredSelectionState = 'checked' | 'unchecked';
+
+const DB_NAME = 'image-metahub-preferences';
+const DB_VERSION = 1;
+const STORE_NAME = 'folderSelection';
+const RECORD_KEY = 'selection';
+
+const getIndexedDB = () => {
+  if (typeof indexedDB === 'undefined') {
+    console.warn('IndexedDB is not available in this environment. Folder selection persistence is disabled.');
+    return null;
+  }
+  return indexedDB;
+};
+
+async function openDatabase(): Promise<IDBDatabase | null> {
+  const idb = getIndexedDB();
+  if (!idb) {
+    return null;
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = idb.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    request.onerror = () => {
+      console.error('Failed to open folder selection storage', request.error);
+      reject(request.error);
+    };
+  }).catch((error) => {
+    console.error('IndexedDB open error for folder selection storage:', error);
+    return null;
+  });
+}
+
+export async function loadFolderSelection(): Promise<Record<string, StoredSelectionState>> {
+  const db = await openDatabase();
+  if (!db) {
+    return {};
+  }
+
+  return new Promise((resolve) => {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(RECORD_KEY);
+
+    request.onsuccess = () => {
+      const result = request.result;
+      if (result && result.data) {
+        resolve(result.data as Record<string, StoredSelectionState>);
+      } else {
+        resolve({});
+      }
+    };
+
+    request.onerror = () => {
+      console.error('Failed to load folder selection state', request.error);
+      resolve({});
+    };
+  });
+}
+
+export async function saveFolderSelection(selection: Record<string, StoredSelectionState>): Promise<void> {
+  const db = await openDatabase();
+  if (!db) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put({ id: RECORD_KEY, data: selection });
+
+    request.onsuccess = () => resolve();
+    request.onerror = () => {
+      console.error('Failed to save folder selection state', request.error);
+      reject(request.error);
+    };
+  }).catch((error) => {
+    console.error('IndexedDB save error for folder selection state:', error);
+  });
+}
+
+export async function clearFolderSelection(): Promise<void> {
+  const db = await openDatabase();
+  if (!db) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.delete(RECORD_KEY);
+
+    request.onsuccess = () => resolve();
+    request.onerror = () => {
+      console.error('Failed to clear folder selection state', request.error);
+      reject(request.error);
+    };
+  }).catch((error) => {
+    console.error('IndexedDB delete error for folder selection state:', error);
+  });
+}


### PR DESCRIPTION
## Summary
- replace the folder visibility sets with a tri-state-aware selection map that drives filtering
- persist folder selection state in IndexedDB and restore it on startup
- update the directory list UI to reflect tri-state selection without unexpected toggles and document the change

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ff88c4a5e083278f4643292948feed