### PR TITLE
Fix issue #45: Separate LoRAs from Models filter and add case-insensi…

### DIFF
--- a/services/parsers/invokeAIParser.ts
+++ b/services/parsers/invokeAIParser.ts
@@ -76,7 +76,11 @@ export function extractModelsFromInvokeAI(metadata: InvokeAIMetadata): string[] 
     if (modelName) models.add(modelName);
   }
 
-  const metadataStr = JSON.stringify(metadata).toLowerCase();
+  // FIX: Create a copy of metadata WITHOUT loras field to avoid picking up LoRA .safetensors files
+  const metadataWithoutLoras = { ...metadata };
+  delete metadataWithoutLoras.loras;
+
+  const metadataStr = JSON.stringify(metadataWithoutLoras).toLowerCase();
   const modelMatches = metadataStr.match(/['"]\s*([^'"]*\.(safetensors|ckpt|pt))\s*['"]/g);
   if (modelMatches) {
     modelMatches.forEach(match => {

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -245,10 +245,15 @@ export const useImageStore = create<ImageState>((set, get) => {
             if (image.dimensions && image.dimensions !== '0x0') dimensions.add(image.dimensions);
         }
 
+        // Case-insensitive alphabetical comparator
+        const caseInsensitiveSort = (a: string, b: string) => {
+            return a.toLowerCase().localeCompare(b.toLowerCase());
+        };
+
         return {
-            availableModels: Array.from(models).sort(),
-            availableLoras: Array.from(loras).sort(),
-            availableSchedulers: Array.from(schedulers).sort(),
+            availableModels: Array.from(models).sort(caseInsensitiveSort),
+            availableLoras: Array.from(loras).sort(caseInsensitiveSort),
+            availableSchedulers: Array.from(schedulers).sort(caseInsensitiveSort),
             availableDimensions: Array.from(dimensions).sort((a, b) => {
                 // Sort dimensions by total pixels (width * height)
                 const [aWidth, aHeight] = a.split('x').map(Number);


### PR DESCRIPTION

PROBLEM:
- LoRAs were incorrectly appearing in the Models filter list instead of being separated into their own LoRAs filter category
- Filter lists were using case-sensitive sorting, causing inconsistent alphabetical order

FIXES:
1. InvokeAI Parser (services/parsers/invokeAIParser.ts):
   - Fixed extractModelsFromInvokeAI() to exclude the loras field before regex matching for model filenames
   - This prevents LoRA .safetensors files from being incorrectly added to the models array

2. Filter Sorting (store/useImageStore.ts):
   - Implemented case-insensitive alphabetical sorting for all filter lists (models, loras, schedulers)
   - Uses localeCompare() with toLowerCase() for proper alphabetical ordering
   - Dimensions continue to be sorted by pixel count as before

RESULT:
- LoRAs now appear only in the LoRAs filter dropdown
- Models appear only in the Models filter dropdown
- All filter lists are sorted alphabetically ignoring case (e.g., "alfa" < "Bravo" < "charlie")