### PR TITLE
Improve zoom controls for all platforms

### DIFF
--- a/KEYBOARD_SHORTCUTS.md
+++ b/KEYBOARD_SHORTCUTS.md
@@ -17,6 +17,9 @@ These shortcuts work anywhere in the application:
 | `Ctrl/Cmd+F` | Focus Search | Jump to search input |
 | `/` | Quick Search | Alternative search activation |
 | `Ctrl/Cmd+Shift+F` | Toggle Advanced Filters | Show/hide advanced filtering |
+| `Ctrl/Cmd+=` or `Ctrl/Cmd++` | Zoom In | Increase interface zoom (also works with numpad `+`) |
+| `Ctrl/Cmd+-` | Zoom Out | Decrease interface zoom (also works with numpad `-`) |
+| `Ctrl/Cmd+0` | Reset Zoom | Restore default zoom level |
 | `Ctrl/Cmd+A` | Select All | Select all visible images |
 | `Delete` | Delete Selected | Move selected images to trash |
 | `Space` | Toggle Quick Preview | Show/hide preview pane |


### PR DESCRIPTION
## Summary
- add explicit zoom management helpers with clamped zoom factor and keyboard handling for Ctrl/Cmd + plus/minus/0
- replace zoom menu roles with labeled items in View and Window menus for consistent Windows/Linux/macOS support
- document zoom keyboard shortcuts including numpad variants

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692333d5fa288327814862c8542bf7fb)