### PR TITLE
Add display option to show filenames in grid

### DIFF
--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -22,6 +22,7 @@ const ImageCard: React.FC<ImageCardProps> = ({ image, onImageClick, isSelected, 
   const [aspectRatio, setAspectRatio] = useState<number>(1);
   const setPreviewImage = useImageStore((state) => state.setPreviewImage);
   const thumbnailsDisabled = useSettingsStore((state) => state.disableThumbnails);
+  const showFilenames = useSettingsStore((state) => state.showFilenames);
 
   useThumbnail(image);
 
@@ -74,44 +75,53 @@ const ImageCard: React.FC<ImageCardProps> = ({ image, onImageClick, isSelected, 
   };
 
   return (
-    <div
-      className={`bg-gray-800 rounded-lg overflow-hidden shadow-md cursor-pointer transition-all duration-300 hover:shadow-xl hover:shadow-blue-500/30 group relative flex items-center justify-center ${
-        isSelected ? 'ring-4 ring-blue-500 ring-opacity-75' : ''
-      } ${
-        isFocused ? 'ring-2 ring-yellow-400 ring-opacity-75' : ''
-      }`}
-      style={{ width: `${baseWidth}px`, height: `${baseWidth * 1.2}px`, flexShrink: 0 }}
-      onClick={(e) => onImageClick(image, e)}
-      onContextMenu={(e) => onContextMenu && onContextMenu(image, e)}
-    >
-      {isSelected && (
-        <div className="absolute top-2 right-2 z-10">
-          <div className="w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center">
-            <Check className="w-4 h-4 text-white" />
+    <div className="flex flex-col items-center" style={{ width: `${baseWidth}px` }}>
+      <div
+        className={`bg-gray-800 rounded-lg overflow-hidden shadow-md cursor-pointer transition-all duration-300 hover:shadow-xl hover:shadow-blue-500/30 group relative flex items-center justify-center ${
+          isSelected ? 'ring-4 ring-blue-500 ring-opacity-75' : ''
+        } ${
+          isFocused ? 'ring-2 ring-yellow-400 ring-opacity-75' : ''
+        }`}
+        style={{ width: '100%', height: `${baseWidth * 1.2}px`, flexShrink: 0 }}
+        onClick={(e) => onImageClick(image, e)}
+        onContextMenu={(e) => onContextMenu && onContextMenu(image, e)}
+      >
+        {isSelected && (
+          <div className="absolute top-2 right-2 z-10">
+            <div className="w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center">
+              <Check className="w-4 h-4 text-white" />
+            </div>
           </div>
+        )}
+        <button
+          onClick={handlePreviewClick}
+          className="absolute top-2 left-2 z-10 p-1.5 bg-black/50 rounded-full text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-blue-500"
+          title="Show details"
+        >
+          <Info className="h-4 w-4" />
+        </button>
+
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={image.name}
+            className="max-w-full max-h-full object-contain"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full animate-pulse bg-gray-700"></div>
+        )}
+        {!showFilenames && (
+          <div className="absolute bottom-0 left-0 right-0 p-2 bg-gradient-to-t from-black/80 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+            <p className="text-white text-xs truncate">{image.name}</p>
+          </div>
+        )}
+      </div>
+      {showFilenames && (
+        <div className="mt-2 w-full px-1">
+          <p className="text-[11px] text-gray-400 text-center truncate">{image.name}</p>
         </div>
       )}
-      <button
-        onClick={handlePreviewClick}
-        className="absolute top-2 left-2 z-10 p-1.5 bg-black/50 rounded-full text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-blue-500"
-        title="Show details"
-      >
-        <Info className="h-4 w-4" />
-      </button>
-
-      {imageUrl ? (
-        <img
-          src={imageUrl}
-          alt={image.name}
-          className="max-w-full max-h-full object-contain"
-          loading="lazy"
-        />
-      ) : (
-        <div className="w-full h-full animate-pulse bg-gray-700"></div>
-      )}
-      <div className="absolute bottom-0 left-0 right-0 p-2 bg-gradient-to-t from-black/80 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-        <p className="text-white text-xs truncate">{image.name}</p>
-      </div>
     </div>
   );
 };

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -20,6 +20,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, initialT
   const toggleAutoUpdate = useSettingsStore((state) => state.toggleAutoUpdate);
   const indexingConcurrency = useSettingsStore((state) => state.indexingConcurrency);
   const setIndexingConcurrency = useSettingsStore((state) => state.setIndexingConcurrency);
+  const showFilenames = useSettingsStore((state) => state.showFilenames);
+  const setShowFilenames = useSettingsStore((state) => state.setShowFilenames);
 
   const [currentCachePath, setCurrentCachePath] = useState('');
   const [defaultCachePath, setDefaultCachePath] = useState('');
@@ -166,6 +168,28 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, initialT
                   type="checkbox"
                   checked={autoUpdate}
                   onChange={toggleAutoUpdate}
+                  className="sr-only peer"
+                />
+                <div className="w-11 h-6 bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-800 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+              </label>
+            </div>
+          </div>
+
+          {/* Display */}
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Display</h3>
+            <div className="flex items-center justify-between bg-gray-900 p-3 rounded-md">
+              <div>
+                <p className="text-sm">Show filenames under thumbnails</p>
+                <p className="text-xs text-gray-400">
+                  Always display file names below each thumbnail in the grid.
+                </p>
+              </div>
+              <label className="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={showFilenames}
+                  onChange={(event) => setShowFilenames(event.target.checked)}
                   className="sr-only peer"
                 />
                 <div className="w-11 h-6 bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-800 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -53,6 +53,7 @@ interface SettingsState {
   lastViewedVersion: string | null;
   indexingConcurrency: number;
   disableThumbnails: boolean;
+  showFilenames: boolean;
 
   // Actions
   setSortOrder: (order: 'asc' | 'desc') => void;
@@ -68,6 +69,7 @@ interface SettingsState {
   setLastViewedVersion: (version: string) => void;
   setIndexingConcurrency: (value: number) => void;
   setDisableThumbnails: (value: boolean) => void;
+  setShowFilenames: (value: boolean) => void;
   resetState: () => void;
 }
 
@@ -92,6 +94,7 @@ export const useSettingsStore = create<SettingsState>()(
       lastViewedVersion: null,
       indexingConcurrency: defaultIndexingConcurrency,
       disableThumbnails: false,
+      showFilenames: false,
 
       // Actions
       setSortOrder: (order) => set({ sortOrder: order }),
@@ -114,6 +117,7 @@ export const useSettingsStore = create<SettingsState>()(
             : 1,
         }),
       setDisableThumbnails: (value) => set({ disableThumbnails: !!value }),
+      setShowFilenames: (value) => set({ showFilenames: !!value }),
       updateKeybinding: (scope, action, keybinding) =>
         set((state) => ({
           keymap: {
@@ -138,6 +142,7 @@ export const useSettingsStore = create<SettingsState>()(
         lastViewedVersion: null,
         indexingConcurrency: defaultIndexingConcurrency,
         disableThumbnails: false,
+        showFilenames: false,
       }),
     }),
     {
@@ -147,6 +152,10 @@ export const useSettingsStore = create<SettingsState>()(
         // Migration: Fix invalid itemsPerPage values from older versions
         if (state && (typeof state.itemsPerPage !== 'number' || state.itemsPerPage <= 0 || state.itemsPerPage > 100)) {
           state.itemsPerPage = 100;
+        }
+
+        if (state && typeof state.showFilenames !== 'boolean') {
+          state.showFilenames = false;
         }
       },
     }


### PR DESCRIPTION
## Summary
- add a display setting to toggle showing filenames under thumbnails
- persist the new filename display preference with a safe default
- render filenames below thumbnails when enabled and hide the hover overlay label

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692337ba0e988327b69ea65254b4490a)