### PR TITLE
feat(comparison): add metadata diff view with word-level highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Metadata Comparison Diff View**: Enhanced comparison modal with intelligent difference highlighting for iterating through generation variations:
+  - **Toggle between Standard and Diff views**: New view mode button in comparison metadata panel
+  - **Word-level diff for prompts**: Only changed words are highlighted (e.g., "brick" vs "wooden" or "yellow" vs "red")
+  - **Smart field comparison**: Automatically detects differences in models, LoRAs, seeds, CFG, clip skip, steps, sampler, and other generation parameters
+  - **Neutral visual design**: Subtle blue highlighting for differences, no intrusive badges
+  - **Clip Skip field added**: Now displays clip_skip values in comparison view (previously missing)
+  - **Array comparison**: Deep comparison for LoRAs arrays with weights
 - **LoRA Weight Display**: ImageModal and ImagePreviewSidebar now display LoRA weights when available (e.g., `style_lora_v1.safetensors (0.8)`), providing better visibility of LoRA strength used in generation.
 - **Shared LoRA Extraction Helper**: Added `extractLoRAsWithWeights()` utility function in `promptCleaner.ts` to standardize LoRA extraction with weight parsing across all parsers.
 - **MetaHub Save Node Integration**: Full support for images saved with [MetaHub Save Node](https://github.com/LuqP2/ImageMetaHub-ComfyUI-Save) across all formats:

--- a/components/ComparisonMetadataPanel.tsx
+++ b/components/ComparisonMetadataPanel.tsx
@@ -1,6 +1,7 @@
-import React, { FC } from 'react';
-import { ChevronDown, ChevronRight, Copy } from 'lucide-react';
-import { ComparisonMetadataPanelProps } from '../types';
+import React, { FC, useMemo } from 'react';
+import { ChevronDown, ChevronRight, Copy, AlertTriangle } from 'lucide-react';
+import { ComparisonMetadataPanelProps, BaseMetadata } from '../types';
+import { compareField, formatFieldValue, diffText, DiffToken } from '../utils/metadataComparison';
 
 // Helper component for individual metadata fields
 const MetadataField: FC<{
@@ -8,11 +9,81 @@ const MetadataField: FC<{
   value: any;
   onCopy?: () => void;
   multiline?: boolean;
-}> = ({ label, value, onCopy, multiline }) => {
-  if (!value && value !== 0) return null;
+  otherValue?: any;
+  isDiffMode?: boolean;
+  field?: string;
+}> = ({ label, value, onCopy, multiline, otherValue, isDiffMode, field }) => {
+  // Check if value exists
+  const hasValue = value !== undefined && value !== null && value !== '';
+  const hasOtherValue = otherValue !== undefined && otherValue !== null && otherValue !== '';
+
+  if (!hasValue) {
+    // In diff mode, show missing fields if the other image has them
+    if (isDiffMode && hasOtherValue) {
+      return (
+        <div className="bg-gray-800/40 p-2 rounded border border-gray-600/50">
+          <div className="flex justify-between items-start">
+            <div className="flex items-center gap-1">
+              <p className="text-gray-400 text-xs uppercase tracking-wider">{label}</p>
+              <AlertTriangle className="w-3 h-3 text-gray-500" />
+            </div>
+          </div>
+          <p className="text-gray-400 text-sm mt-1 italic">Missing</p>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  // Check if this field is different from the other image
+  const isDifferent = isDiffMode &&
+    hasOtherValue &&
+    !compareField(field || label.toLowerCase(), value, otherValue);
+
+  // For text prompts, use word-level diff
+  const isPromptField = field === 'prompt' || field === 'negativePrompt';
+  const shouldShowWordDiff = isDiffMode && isDifferent && isPromptField && typeof value === 'string' && typeof otherValue === 'string';
+
+  // Apply highlighting based on difference
+  const highlightClass = isDifferent
+    ? 'bg-blue-900/20 border-blue-700/40'
+    : 'bg-gray-900/50 border-gray-700/50';
+
+  // Format the value for display
+  const displayValue = field ? formatFieldValue(field, value) : String(value);
+
+  // Render word-level diff for prompts
+  const renderContent = () => {
+    if (shouldShowWordDiff) {
+      const stringValue = String(value);
+      const stringOtherValue = String(otherValue);
+      const diff = diffText(stringValue, stringOtherValue);
+
+      return (
+        <div className="text-gray-200 text-sm mt-1 whitespace-pre-wrap break-words">
+          {diff.tokensA.map((token, idx) => {
+            if (token.status === 'removed') {
+              return (
+                <span key={idx} className="bg-blue-500/30 px-0.5 rounded">
+                  {token.text}
+                </span>
+              );
+            }
+            return <span key={idx}>{token.text}</span>;
+          })}
+        </div>
+      );
+    }
+
+    return (
+      <p className={`text-gray-200 text-sm mt-1 ${multiline ? 'whitespace-pre-wrap break-words' : ''}`}>
+        {displayValue}
+      </p>
+    );
+  };
 
   return (
-    <div className="bg-gray-900/50 p-2 rounded border border-gray-700/50">
+    <div className={`p-2 rounded border ${highlightClass}`}>
       <div className="flex justify-between items-start">
         <p className="text-gray-400 text-xs uppercase tracking-wider">{label}</p>
         {onCopy && (
@@ -25,9 +96,7 @@ const MetadataField: FC<{
           </button>
         )}
       </div>
-      <p className={`text-gray-200 text-sm mt-1 ${multiline ? 'whitespace-pre-wrap break-words' : ''}`}>
-        {String(value)}
-      </p>
+      {renderContent()}
     </div>
   );
 };
@@ -35,9 +104,12 @@ const MetadataField: FC<{
 const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
   image,
   isExpanded,
-  onToggleExpanded
+  onToggleExpanded,
+  viewMode = 'standard',
+  otherImageMetadata
 }) => {
   const metadata = image.metadata?.normalizedMetadata;
+  const isDiffMode = viewMode === 'diff';
 
   const copyToClipboard = (value: string, label: string) => {
     if (navigator.clipboard && window.isSecureContext) {
@@ -114,91 +186,132 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
       {isExpanded && (
         <div className="p-3 space-y-3 max-h-[300px] overflow-y-auto border-t border-gray-700/50">
           {/* Prompt */}
-          {metadata.prompt && (
+          {(metadata.prompt || (isDiffMode && otherImageMetadata?.prompt)) && (
             <MetadataField
               label="Prompt"
+              field="prompt"
               value={metadata.prompt}
-              onCopy={() => copyToClipboard(metadata.prompt, 'Prompt')}
+              otherValue={otherImageMetadata?.prompt}
+              isDiffMode={isDiffMode}
+              onCopy={metadata.prompt ? () => copyToClipboard(metadata.prompt, 'Prompt') : undefined}
               multiline
             />
           )}
 
           {/* Negative Prompt */}
-          {metadata.negativePrompt && (
+          {(metadata.negativePrompt || (isDiffMode && otherImageMetadata?.negativePrompt)) && (
             <MetadataField
               label="Negative Prompt"
+              field="negativePrompt"
               value={metadata.negativePrompt}
-              onCopy={() => copyToClipboard(metadata.negativePrompt, 'Negative Prompt')}
+              otherValue={otherImageMetadata?.negativePrompt}
+              isDiffMode={isDiffMode}
+              onCopy={metadata.negativePrompt ? () => copyToClipboard(metadata.negativePrompt, 'Negative Prompt') : undefined}
               multiline
             />
           )}
 
           {/* Grid of smaller fields */}
           <div className="grid grid-cols-2 gap-2">
-            {metadata.model && (
+            {(metadata.model || (isDiffMode && otherImageMetadata?.model)) && (
               <MetadataField
                 label="Model"
+                field="model"
                 value={metadata.model}
-                onCopy={() => copyToClipboard(metadata.model, 'Model')}
+                otherValue={otherImageMetadata?.model}
+                isDiffMode={isDiffMode}
+                onCopy={metadata.model ? () => copyToClipboard(metadata.model, 'Model') : undefined}
               />
             )}
 
-            {(metadata.seed !== undefined && metadata.seed !== null) && (
+            {((metadata.seed !== undefined && metadata.seed !== null) || (isDiffMode && otherImageMetadata?.seed !== undefined)) && (
               <MetadataField
                 label="Seed"
+                field="seed"
                 value={metadata.seed}
-                onCopy={() => copyToClipboard(String(metadata.seed), 'Seed')}
+                otherValue={otherImageMetadata?.seed}
+                isDiffMode={isDiffMode}
+                onCopy={metadata.seed !== undefined ? () => copyToClipboard(String(metadata.seed), 'Seed') : undefined}
               />
             )}
 
-            {metadata.steps && (
+            {(metadata.steps || (isDiffMode && otherImageMetadata?.steps)) && (
               <MetadataField
                 label="Steps"
+                field="steps"
                 value={metadata.steps}
-                onCopy={() => copyToClipboard(String(metadata.steps), 'Steps')}
+                otherValue={otherImageMetadata?.steps}
+                isDiffMode={isDiffMode}
+                onCopy={metadata.steps ? () => copyToClipboard(String(metadata.steps), 'Steps') : undefined}
               />
             )}
 
-            {metadata.cfg_scale && (
+            {(metadata.cfg_scale || (isDiffMode && otherImageMetadata?.cfg_scale)) && (
               <MetadataField
                 label="CFG Scale"
+                field="cfg_scale"
                 value={metadata.cfg_scale}
-                onCopy={() => copyToClipboard(String(metadata.cfg_scale), 'CFG Scale')}
+                otherValue={otherImageMetadata?.cfg_scale}
+                isDiffMode={isDiffMode}
+                onCopy={metadata.cfg_scale ? () => copyToClipboard(String(metadata.cfg_scale), 'CFG Scale') : undefined}
               />
             )}
 
-            {(metadata.sampler || metadata.scheduler) && (
+            {(metadata.clip_skip || (isDiffMode && otherImageMetadata?.clip_skip)) && (
+              <MetadataField
+                label="Clip Skip"
+                field="clip_skip"
+                value={metadata.clip_skip}
+                otherValue={otherImageMetadata?.clip_skip}
+                isDiffMode={isDiffMode}
+                onCopy={metadata.clip_skip ? () => copyToClipboard(String(metadata.clip_skip), 'Clip Skip') : undefined}
+              />
+            )}
+
+            {((metadata.sampler || metadata.scheduler) || (isDiffMode && (otherImageMetadata?.sampler || otherImageMetadata?.scheduler))) && (
               <MetadataField
                 label="Sampler"
+                field="sampler"
                 value={metadata.sampler || metadata.scheduler}
-                onCopy={() => copyToClipboard(metadata.sampler || metadata.scheduler, 'Sampler')}
+                otherValue={otherImageMetadata?.sampler || otherImageMetadata?.scheduler}
+                isDiffMode={isDiffMode}
+                onCopy={(metadata.sampler || metadata.scheduler) ? () => copyToClipboard(metadata.sampler || metadata.scheduler, 'Sampler') : undefined}
               />
             )}
 
-            {metadata.width && metadata.height && (
+            {((metadata.width && metadata.height) || (isDiffMode && otherImageMetadata?.width && otherImageMetadata?.height)) && (
               <MetadataField
                 label="Dimensions"
-                value={`${metadata.width}x${metadata.height}`}
-                onCopy={() => copyToClipboard(`${metadata.width}x${metadata.height}`, 'Dimensions')}
+                field="dimensions"
+                value={metadata.width && metadata.height ? `${metadata.width}x${metadata.height}` : undefined}
+                otherValue={otherImageMetadata?.width && otherImageMetadata?.height ? `${otherImageMetadata.width}x${otherImageMetadata.height}` : undefined}
+                isDiffMode={isDiffMode}
+                onCopy={(metadata.width && metadata.height) ? () => copyToClipboard(`${metadata.width}x${metadata.height}`, 'Dimensions') : undefined}
               />
             )}
           </div>
 
           {/* LoRAs if present */}
-          {metadata.loras && metadata.loras.length > 0 && (
+          {((metadata.loras && metadata.loras.length > 0) || (isDiffMode && otherImageMetadata?.loras && otherImageMetadata.loras.length > 0)) && (
             <MetadataField
               label="LoRAs"
-              value={metadata.loras.join(', ')}
-              onCopy={() => copyToClipboard(metadata.loras.join(', '), 'LoRAs')}
+              field="loras"
+              value={metadata.loras}
+              otherValue={otherImageMetadata?.loras}
+              isDiffMode={isDiffMode}
+              onCopy={metadata.loras && metadata.loras.length > 0 ? () => copyToClipboard(formatFieldValue('loras', metadata.loras), 'LoRAs') : undefined}
               multiline
             />
           )}
 
           {/* Generator if present */}
-          {metadata.generator && (
+          {(metadata.generator || (isDiffMode && otherImageMetadata?.generator)) && (
             <MetadataField
               label="Generator"
+              field="generator"
               value={metadata.generator}
+              otherValue={otherImageMetadata?.generator}
+              isDiffMode={isDiffMode}
             />
           )}
         </div>

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -18,6 +18,7 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   const [sharedZoom, setSharedZoom] = useState<ZoomState>({ zoom: 1, x: 0, y: 0 });
   const [metadataExpanded, setMetadataExpanded] = useState(false);
   const [viewMode, setViewMode] = useState<ComparisonViewMode>('side-by-side');
+  const [metadataViewMode, setMetadataViewMode] = useState<'standard' | 'diff'>('standard');
 
   // Handlers
   const updateSharedZoom = (zoom: number, x: number, y: number) => {
@@ -204,17 +205,50 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
 
       {/* Metadata Panels */}
       <div className="bg-gray-900/50 border-t border-gray-700 p-4 overflow-y-auto max-h-[40vh]">
+        {/* Metadata View Mode Toggle */}
+        <div className="flex justify-between items-center mb-4 max-w-7xl mx-auto">
+          <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">Metadata</h3>
+          <div className="inline-flex bg-gray-900/60 border border-gray-700/70 rounded-lg overflow-hidden">
+            <button
+              onClick={() => setMetadataViewMode('standard')}
+              className={`px-3 py-1.5 text-sm font-medium transition-colors border-r border-gray-700/40
+                         ${metadataViewMode === 'standard'
+                           ? 'bg-blue-600 text-white border-blue-500/60'
+                           : 'text-gray-300 hover:text-white hover:bg-gray-700/60'
+                         }`}
+              title="Show all metadata in standard format"
+            >
+              Standard View
+            </button>
+            <button
+              onClick={() => setMetadataViewMode('diff')}
+              className={`px-3 py-1.5 text-sm font-medium transition-colors
+                         ${metadataViewMode === 'diff'
+                           ? 'bg-blue-600 text-white border-blue-500/60'
+                           : 'text-gray-300 hover:text-white hover:bg-gray-700/60'
+                         }`}
+              title="Highlight differences between metadata"
+            >
+              Diff View
+            </button>
+          </div>
+        </div>
+
         <div className="flex flex-col md:flex-row gap-4 max-w-7xl mx-auto">
           <ComparisonMetadataPanel
             image={comparisonImages[0]}
             isExpanded={metadataExpanded}
             onToggleExpanded={() => setMetadataExpanded(!metadataExpanded)}
+            viewMode={metadataViewMode}
+            otherImageMetadata={comparisonImages[1]?.metadata?.normalizedMetadata}
           />
 
           <ComparisonMetadataPanel
             image={comparisonImages[1]}
             isExpanded={metadataExpanded}
             onToggleExpanded={() => setMetadataExpanded(!metadataExpanded)}
+            viewMode={metadataViewMode}
+            otherImageMetadata={comparisonImages[0]?.metadata?.normalizedMetadata}
           />
         </div>
       </div>

--- a/components/ProOnlyModal.tsx
+++ b/components/ProOnlyModal.tsx
@@ -27,6 +27,17 @@ const featureInfo = {
       'Batch generation support',
     ],
   },
+  comfyui: {
+    name: 'ComfyUI Integration',
+    icon: Sparkles,
+    description: 'Generate variations or copy workflows to ComfyUI',
+    benefits: [
+      'Quick generation from metadata',
+      'Real-time WebSocket progress tracking',
+      'Workflow copy for manual editing',
+      'Automatic metadata-rich saves',
+    ],
+  },
   comparison: {
     name: 'Image Comparison',
     icon: GitCompare,
@@ -64,7 +75,12 @@ const ProOnlyModal: React.FC<ProOnlyModalProps> = ({
 }) => {
   if (!isOpen) return null;
 
-  const info = featureInfo[feature];
+  const info = featureInfo[feature] ?? {
+    name: 'Pro Feature',
+    icon: Sparkles,
+    description: 'Unlock additional features with Pro access',
+    benefits: ['Pro-only functionality'],
+  };
   const Icon = info.icon;
 
   const trialCopy = (() => {

--- a/packages/metadata-engine/src/core/types.ts
+++ b/packages/metadata-engine/src/core/types.ts
@@ -610,4 +610,6 @@ export interface ComparisonMetadataPanelProps {
   image: IndexedImage;
   isExpanded: boolean;
   onToggleExpanded: () => void;
+  viewMode?: 'standard' | 'diff';
+  otherImageMetadata?: BaseMetadata | null;
 }

--- a/types.ts
+++ b/types.ts
@@ -637,4 +637,6 @@ export interface ComparisonMetadataPanelProps {
   image: IndexedImage;
   isExpanded: boolean;
   onToggleExpanded: () => void;
+  viewMode?: 'standard' | 'diff';
+  otherImageMetadata?: BaseMetadata | null;
 }

--- a/utils/metadataComparison.ts
+++ b/utils/metadataComparison.ts
@@ -1,0 +1,325 @@
+import { BaseMetadata } from '../types';
+
+/**
+ * Comparison utility for metadata fields
+ * Handles different types: strings, numbers, arrays, objects
+ */
+
+/**
+ * Compare two values for equality
+ * Handles strings (case-insensitive), numbers, arrays, and objects
+ */
+export function compareField(field: string, valueA: any, valueB: any): boolean {
+  // Handle null/undefined cases
+  if (valueA === null || valueA === undefined) {
+    return valueB === null || valueB === undefined;
+  }
+  if (valueB === null || valueB === undefined) {
+    return false;
+  }
+
+  // String comparison (case-insensitive for most fields)
+  if (typeof valueA === 'string' && typeof valueB === 'string') {
+    // For prompts and notes, do case-sensitive comparison
+    const caseSensitiveFields = ['prompt', 'negativePrompt', 'notes'];
+    if (caseSensitiveFields.includes(field)) {
+      return valueA === valueB;
+    }
+    return valueA.toLowerCase() === valueB.toLowerCase();
+  }
+
+  // Number comparison (exact match)
+  if (typeof valueA === 'number' && typeof valueB === 'number') {
+    return valueA === valueB;
+  }
+
+  // Array comparison (for LoRAs, etc.)
+  if (Array.isArray(valueA) && Array.isArray(valueB)) {
+    if (valueA.length !== valueB.length) return false;
+
+    // Deep comparison for arrays
+    return valueA.every((item, index) => {
+      const itemB = valueB[index];
+
+      // If array items are objects (like LoRA info)
+      if (typeof item === 'object' && typeof itemB === 'object') {
+        return JSON.stringify(item) === JSON.stringify(itemB);
+      }
+
+      // Simple comparison for primitive values
+      return item === itemB;
+    });
+  }
+
+  // Object comparison (deep equality via JSON)
+  if (typeof valueA === 'object' && typeof valueB === 'object') {
+    return JSON.stringify(valueA) === JSON.stringify(valueB);
+  }
+
+  // Default: convert to string and compare
+  return String(valueA) === String(valueB);
+}
+
+/**
+ * Get a set of field names that differ between two metadata objects
+ * Returns a Set of field names that have different values
+ */
+export function getMetadataDifferences(
+  metadataA: BaseMetadata | null | undefined,
+  metadataB: BaseMetadata | null | undefined
+): Set<string> {
+  const differences = new Set<string>();
+
+  if (!metadataA && !metadataB) return differences;
+  if (!metadataA || !metadataB) {
+    // If one is missing, all fields are different
+    const existingMetadata = metadataA || metadataB;
+    if (existingMetadata) {
+      Object.keys(existingMetadata).forEach(key => differences.add(key));
+    }
+    return differences;
+  }
+
+  // Get all unique keys from both objects
+  const allKeys = new Set([
+    ...Object.keys(metadataA),
+    ...Object.keys(metadataB)
+  ]);
+
+  // Compare each field
+  allKeys.forEach(field => {
+    const valueA = (metadataA as any)[field];
+    const valueB = (metadataB as any)[field];
+
+    if (!compareField(field, valueA, valueB)) {
+      differences.add(field);
+    }
+  });
+
+  return differences;
+}
+
+/**
+ * Field categories for organized display
+ */
+export const METADATA_FIELD_CATEGORIES = {
+  prompts: ['prompt', 'negativePrompt'],
+  models: ['model', 'models', 'loras', 'vae'],
+  parameters: ['cfg_scale', 'clip_skip', 'seed', 'steps', 'sampler', 'scheduler'],
+  dimensions: ['width', 'height'],
+  other: ['generator', 'version', 'module', 'notes', 'tags']
+};
+
+/**
+ * Priority order for field display
+ * Fields listed first will be displayed first
+ */
+export const FIELD_DISPLAY_ORDER = [
+  // Prompts (most important)
+  'prompt',
+  'negativePrompt',
+
+  // Models
+  'model',
+  'models',
+  'loras',
+  'vae',
+
+  // Key parameters
+  'cfg_scale',
+  'clip_skip',
+  'seed',
+  'steps',
+  'sampler',
+  'scheduler',
+
+  // Dimensions
+  'width',
+  'height',
+
+  // Other
+  'generator',
+  'version',
+  'notes',
+  'tags'
+];
+
+/**
+ * Format a field value for display
+ * Handles special formatting for arrays, numbers, etc.
+ */
+export function formatFieldValue(field: string, value: any): string {
+  if (value === null || value === undefined) {
+    return 'N/A';
+  }
+
+  // Array formatting (for LoRAs)
+  if (Array.isArray(value)) {
+    if (value.length === 0) return 'None';
+
+    // Format LoRA info objects
+    return value.map(item => {
+      if (typeof item === 'object' && item !== null) {
+        // LoRAInfo object: { name, weight, ... }
+        const name = item.name || item.model_name || 'Unknown';
+        const weight = item.weight !== undefined ? item.weight : item.model_weight;
+        if (weight !== undefined) {
+          return `${name} (${weight})`;
+        }
+        return name;
+      }
+      return String(item);
+    }).join(', ');
+  }
+
+  // Dimensions formatting
+  if (field === 'width' || field === 'height') {
+    return String(value);
+  }
+
+  // Number formatting
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  // Default: convert to string
+  return String(value);
+}
+
+/**
+ * Get a human-readable label for a field name
+ */
+export function getFieldLabel(field: string): string {
+  const labels: Record<string, string> = {
+    prompt: 'Prompt',
+    negativePrompt: 'Negative Prompt',
+    model: 'Model',
+    models: 'Models',
+    loras: 'LoRAs',
+    vae: 'VAE',
+    cfg_scale: 'CFG Scale',
+    clip_skip: 'Clip Skip',
+    seed: 'Seed',
+    steps: 'Steps',
+    sampler: 'Sampler',
+    scheduler: 'Scheduler',
+    width: 'Width',
+    height: 'Height',
+    generator: 'Generator',
+    version: 'Version',
+    module: 'Module',
+    notes: 'Notes',
+    tags: 'Tags'
+  };
+
+  return labels[field] || field.charAt(0).toUpperCase() + field.slice(1);
+}
+
+/**
+ * Simple diff algorithm for text comparison
+ * Returns array of tokens with their diff status
+ */
+export interface DiffToken {
+  text: string;
+  status: 'added' | 'removed' | 'unchanged';
+}
+
+export function diffText(textA: string, textB: string): { tokensA: DiffToken[]; tokensB: DiffToken[] } {
+  if (!textA && !textB) {
+    return { tokensA: [], tokensB: [] };
+  }
+  if (!textA) {
+    return {
+      tokensA: [],
+      tokensB: textB.split(/(\s+)/).map(token => ({ text: token, status: 'added' as const }))
+    };
+  }
+  if (!textB) {
+    return {
+      tokensA: textA.split(/(\s+)/).map(token => ({ text: token, status: 'removed' as const })),
+      tokensB: []
+    };
+  }
+
+  // Split by words and whitespace (preserve whitespace)
+  const wordsA = textA.split(/(\s+)/);
+  const wordsB = textB.split(/(\s+)/);
+
+  // Simple LCS-based diff algorithm
+  const lcs = longestCommonSubsequence(wordsA, wordsB);
+  const lcsSet = new Set(lcs);
+
+  const tokensA: DiffToken[] = [];
+  const tokensB: DiffToken[] = [];
+
+  let lcsIndexA = 0;
+  let lcsIndexB = 0;
+
+  // Process tokens A
+  for (let i = 0; i < wordsA.length; i++) {
+    const word = wordsA[i];
+    const isInLCS = lcsIndexA < lcs.length && word === lcs[lcsIndexA];
+
+    if (isInLCS) {
+      tokensA.push({ text: word, status: 'unchanged' });
+      lcsIndexA++;
+    } else {
+      tokensA.push({ text: word, status: 'removed' });
+    }
+  }
+
+  // Process tokens B
+  for (let i = 0; i < wordsB.length; i++) {
+    const word = wordsB[i];
+    const isInLCS = lcsIndexB < lcs.length && word === lcs[lcsIndexB];
+
+    if (isInLCS) {
+      tokensB.push({ text: word, status: 'unchanged' });
+      lcsIndexB++;
+    } else {
+      tokensB.push({ text: word, status: 'added' });
+    }
+  }
+
+  return { tokensA, tokensB };
+}
+
+/**
+ * Longest Common Subsequence algorithm
+ * Used for text diffing
+ */
+function longestCommonSubsequence(arr1: string[], arr2: string[]): string[] {
+  const m = arr1.length;
+  const n = arr2.length;
+  const dp: number[][] = Array(m + 1).fill(null).map(() => Array(n + 1).fill(0));
+
+  // Build DP table
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (arr1[i - 1] === arr2[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  // Backtrack to find LCS
+  const lcs: string[] = [];
+  let i = m;
+  let j = n;
+
+  while (i > 0 && j > 0) {
+    if (arr1[i - 1] === arr2[j - 1]) {
+      lcs.unshift(arr1[i - 1]);
+      i--;
+      j--;
+    } else if (dp[i - 1][j] > dp[i][j - 1]) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+
+  return lcs;
+}


### PR DESCRIPTION
Implement intelligent metadata comparison feature for iterating through generation variations:

- Add toggle button to switch between Standard and Diff view modes
- Implement word-level diff algorithm (LCS-based) for prompts that highlights only changed words
- Apply neutral blue highlighting for different fields instead of intrusive badges
- Add missing clip_skip field to metadata display
- Support deep comparison for arrays (LoRAs with weights)
- Handle missing fields gracefully with subtle gray styling

Technical changes:
- Created utils/metadataComparison.ts with comparison utilities and LCS diff algorithm
- Enhanced ComparisonMetadataPanel with viewMode prop and diff rendering
- Updated ComparisonModal with metadata view mode toggle
- Extended ComparisonMetadataPanelProps interface with viewMode and otherImageMetadata

This makes it significantly easier to spot differences when comparing similar images, particularly useful for iterating on prompts and generation parameters.