### PR TITLE
fix(cache): guard IPC cache writes against oversized ComfyUI metadata

### DIFF
--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -310,7 +310,7 @@ class IncrementalCacheWriter {
           });
           if (retry && !retry.success) {
             console.error('[Cache] Failed to write cache chunk after sanitization:', retry.error);
-            return;
+            throw new Error(retry.error || 'Failed to write cache chunk');
           }
           return;
         }
@@ -350,7 +350,7 @@ class IncrementalCacheWriter {
           });
           if (retry && !retry.success) {
             console.error('[Cache] Failed to rewrite cache chunk after sanitization:', retry.error);
-            return;
+            throw new Error(retry.error || 'Failed to rewrite cache chunk');
           }
           return;
         }


### PR DESCRIPTION
sanitize cache payloads before IPC writes to avoid V8 serializer crashes on huge metadata add size caps/truncation for metadata strings and fields, plus buffer limits detect heavy metadata objects (imagemetahub_data/workflow/prompt/prompt_api) and clone safely skip/replace oversized metadata in cache with a stub that preserves normalizedMetadata add logging for sanitization/skip cases and retry with sanitized payloads on clone errors broaden clone error detection to include serializer-related failures