### PR TITLE
feat: Enhance image generation provider integration and filtering options

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -90,6 +90,10 @@ export default function App() {
   const selectedLoras = useImageStore((state) => state.selectedLoras);
   const selectedSchedulers = useImageStore((state) => state.selectedSchedulers);
   const advancedFilters = useImageStore((state) => state.advancedFilters);
+  const setSelectedTags = useImageStore((state) => state.setSelectedTags);
+  const setExcludedTags = useImageStore((state) => state.setExcludedTags);
+  const setSelectedAutoTags = useImageStore((state) => state.setSelectedAutoTags);
+  const setFavoriteFilterMode = useImageStore((state) => state.setFavoriteFilterMode);
 
   // Folder selection selectors
   const selectedFolders = useImageStore((state) => state.selectedFolders);
@@ -768,6 +772,10 @@ export default function App() {
           onSchedulerChange={(schedulers) => setSelectedFilters({ schedulers })}
           onClearAllFilters={() => {
             setSelectedFilters({ models: [], loras: [], schedulers: [] });
+            setSelectedTags([]);
+            setExcludedTags([]);
+            setSelectedAutoTags([]);
+            setFavoriteFilterMode('neutral');
             setAdvancedFilters({});
           }}
           advancedFilters={advancedFilters}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Indexed Folder Transfers**: Added desktop support for copying or moving images between indexed folders, including a destination picker modal, concurrent transfer handling, and preservation of tags, favorites, and shadow metadata.
 - **Editable Field Context Menu**: Added a native right-click context menu with `Cut`, `Copy`, and `Paste` for editable text fields such as the search bar.
 - **Metadata Selection Context Menu**: Added right-click actions for selected text in `ImageModal` and `ImagePreviewSidebar`, including `Copy` and `Search Selection` for faster filtering from prompts and metadata.
+- **Viewer Annotation Hotkeys**: Added customizable image-viewer shortcuts for toggling favorites, focusing the add-tag field, and deleting the current image without leaving keyboard navigation.
 
 ### Improved
 
@@ -20,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Directory Load Feedback**: Added a "Loading Library" progress bar with per-folder progress directly in the directory list, including a scanning state while totals are still being determined.
 - **Directory Discovery Speed**: Greatly reduced the delay before indexing starts on large folders by parallelizing Electron-side file stat collection during directory scanning.
 - **Viewer Responsiveness**: Improved Image Modal loading behavior so the full-resolution image is prioritized over background thumbnail warmup, reducing the delay after the thumbnail preview appears.
+- **Viewer Generate Actions**: Added per-provider viewer toggles in Settings so Automatic1111 and ComfyUI actions can be hidden independently in Image Modal and Image Preview Sidebar, with single-provider labels simplified to `Generate`.
+- **Favorites & Tags Filters**: Favorites and manual tags in the sidebar now cycle through include, exclude, and off states, making it possible to quickly hide favorites or exclude specific tags without leaving the current view.
 - **ComfyUI Metadata Compatibility**: Improved parsing for prompt-only ComfyUI graph payloads, added support for `smZ CLIPTextEncode`, and normalized prompt whitespace for cleaner imported prompts.
 
 ### Fixed

--- a/KEYBOARD_SHORTCUTS.md
+++ b/KEYBOARD_SHORTCUTS.md
@@ -47,6 +47,9 @@ These shortcuts work when viewing an image in the modal:
 | Shortcut | Action | Description |
 |----------|--------|-------------|
 | `←/→` | Previous/Next Image | Navigate through images |
+| `F` | Toggle Favorite | Add or remove the current image from favorites |
+| `T` | Focus Add Tag | Jump to the add-tag field and start typing |
+| `Delete` | Delete Image | Move the current image to trash |
 | `Enter` | Close Modal | Close modal and return to grid |
 | `Alt+Enter` | Toggle Image Viewer | Switch between modal view and fullscreen image viewer |
 | `Esc` | Exit or Close | Exit fullscreen viewer or close modal |

--- a/__tests__/hotkey-utils.test.ts
+++ b/__tests__/hotkey-utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { eventMatchesKeybinding, isTypingElement } from '../utils/hotkeyUtils';
+
+const keyboardEvent = (overrides: Partial<KeyboardEvent> = {}): Pick<KeyboardEvent, 'key' | 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey'> => ({
+  key: '',
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  shiftKey: false,
+  ...overrides,
+});
+
+describe('eventMatchesKeybinding', () => {
+  it('matches plain and function keys', () => {
+    expect(eventMatchesKeybinding(keyboardEvent({ key: 'f' }), 'f')).toBe(true);
+    expect(eventMatchesKeybinding(keyboardEvent({ key: 'F5' }), 'f5')).toBe(true);
+  });
+
+  it('matches aliases and modifier combinations', () => {
+    expect(eventMatchesKeybinding(keyboardEvent({ key: 'ArrowLeft' }), 'left')).toBe(true);
+    expect(eventMatchesKeybinding(keyboardEvent({ key: 'x', ctrlKey: true }), 'delete, ctrl+x')).toBe(true);
+    expect(eventMatchesKeybinding(keyboardEvent({ key: 'k', metaKey: true }), 'ctrl+k, cmd+k')).toBe(true);
+  });
+
+  it('rejects mismatched shortcuts', () => {
+    expect(eventMatchesKeybinding(keyboardEvent({ key: 'f', shiftKey: true }), 'f')).toBe(false);
+    expect(eventMatchesKeybinding(keyboardEvent({ key: 'Delete' }), 'ctrl+x')).toBe(false);
+  });
+});
+
+describe('isTypingElement', () => {
+  it('detects editable targets', () => {
+    const input = document.createElement('input');
+    const textarea = document.createElement('textarea');
+    const editable = document.createElement('div');
+    editable.contentEditable = 'true';
+
+    expect(isTypingElement(input)).toBe(true);
+    expect(isTypingElement(textarea)).toBe(true);
+    expect(isTypingElement(editable)).toBe(true);
+  });
+
+  it('ignores non-editable targets', () => {
+    const button = document.createElement('button');
+    expect(isTypingElement(button)).toBe(false);
+    expect(isTypingElement(null)).toBe(false);
+  });
+});

--- a/__tests__/useImageStore.filters.test.ts
+++ b/__tests__/useImageStore.filters.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Directory, IndexedImage } from '../types';
+import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+
+const directory: Directory = {
+  id: 'dir-1',
+  name: 'Library',
+  path: 'D:/library',
+  handle: {} as FileSystemDirectoryHandle,
+  visible: true,
+};
+
+const createImage = (
+  id: string,
+  name: string,
+  options: {
+    isFavorite?: boolean;
+    tags?: string[];
+  } = {}
+): IndexedImage => ({
+  id,
+  name,
+  handle: {} as FileSystemFileHandle,
+  metadata: {} as IndexedImage['metadata'],
+  metadataString: '',
+  lastModified: 1,
+  models: [],
+  loras: [],
+  scheduler: '',
+  directoryId: directory.id,
+  directoryName: directory.name,
+  isFavorite: options.isFavorite,
+  tags: options.tags,
+});
+
+const images: IndexedImage[] = [
+  createImage('dir-1::favorite-portrait.png', 'favorite-portrait.png', {
+    isFavorite: true,
+    tags: ['portrait', 'warm'],
+  }),
+  createImage('dir-1::portrait.png', 'portrait.png', {
+    tags: ['portrait'],
+  }),
+  createImage('dir-1::landscape.png', 'landscape.png', {
+    isFavorite: true,
+    tags: ['landscape'],
+  }),
+  createImage('dir-1::untagged.png', 'untagged.png'),
+];
+
+describe('useImageStore filter toggles', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({
+      enableSafeMode: false,
+      blurSensitiveImages: true,
+      sensitiveTags: ['nsfw', 'private', 'hidden'],
+    });
+
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      directories: [directory],
+      images,
+      filteredImages: images,
+      isAnnotationsLoaded: true,
+    });
+    useImageStore.getState().filterAndSortImages();
+  });
+
+  it('includes and excludes favorites with the tri-state filter', () => {
+    useImageStore.getState().setFavoriteFilterMode('include');
+    expect(useImageStore.getState().filteredImages.map((image) => image.id)).toEqual([
+      'dir-1::landscape.png',
+      'dir-1::favorite-portrait.png',
+    ]);
+
+    useImageStore.getState().setFavoriteFilterMode('exclude');
+    expect(useImageStore.getState().filteredImages.map((image) => image.id)).toEqual([
+      'dir-1::untagged.png',
+      'dir-1::portrait.png',
+    ]);
+
+    useImageStore.getState().setFavoriteFilterMode('neutral');
+    expect(useImageStore.getState().filteredImages).toHaveLength(4);
+  });
+
+  it('combines included and excluded tag filters', () => {
+    useImageStore.getState().setSelectedTags(['portrait']);
+    expect(useImageStore.getState().filteredImages.map((image) => image.id)).toEqual([
+      'dir-1::portrait.png',
+      'dir-1::favorite-portrait.png',
+    ]);
+
+    useImageStore.getState().setExcludedTags(['warm']);
+    expect(useImageStore.getState().filteredImages.map((image) => image.id)).toEqual([
+      'dir-1::portrait.png',
+    ]);
+
+    useImageStore.getState().setSelectedTags([]);
+    useImageStore.getState().setExcludedTags(['portrait']);
+    expect(useImageStore.getState().filteredImages.map((image) => image.id)).toEqual([
+      'dir-1::untagged.png',
+      'dir-1::landscape.png',
+    ]);
+  });
+});

--- a/components/ActiveFilters.tsx
+++ b/components/ActiveFilters.tsx
@@ -7,14 +7,16 @@ const ActiveFilters: React.FC = () => {
     const selectedLoras = useImageStore((state) => state.selectedLoras);
     const selectedSchedulers = useImageStore((state) => state.selectedSchedulers);
     const selectedTags = useImageStore((state) => state.selectedTags);
+    const excludedTags = useImageStore((state) => state.excludedTags);
     const searchQuery = useImageStore((state) => state.searchQuery);
-    const showFavoritesOnly = useImageStore((state) => state.showFavoritesOnly);
+    const favoriteFilterMode = useImageStore((state) => state.favoriteFilterMode);
     const advancedFilters = useImageStore((state) => state.advancedFilters);
 
     const setSelectedFilters = useImageStore((state) => state.setSelectedFilters);
     const setSelectedTags = useImageStore((state) => state.setSelectedTags);
+    const setExcludedTags = useImageStore((state) => state.setExcludedTags);
     const setSearchQuery = useImageStore((state) => state.setSearchQuery);
-    const setShowFavoritesOnly = useImageStore((state) => state.setShowFavoritesOnly);
+    const setFavoriteFilterMode = useImageStore((state) => state.setFavoriteFilterMode);
     const setAdvancedFilters = useImageStore((state) => state.setAdvancedFilters);
 
     const hasActiveFilters = 
@@ -22,8 +24,9 @@ const ActiveFilters: React.FC = () => {
         selectedLoras.length > 0 ||
         selectedSchedulers.length > 0 ||
         selectedTags.length > 0 ||
+        excludedTags.length > 0 ||
         !!searchQuery ||
-        showFavoritesOnly ||
+        favoriteFilterMode !== 'neutral' ||
         (advancedFilters && Object.keys(advancedFilters).length > 0);
 
     if (!hasActiveFilters) {
@@ -52,12 +55,16 @@ const ActiveFilters: React.FC = () => {
         setSelectedTags(selectedTags.filter((t) => t !== tag));
     };
 
+    const removeExcludedTag = (tag: string) => {
+        setExcludedTags(excludedTags.filter((t) => t !== tag));
+    };
+
     const clearSearch = () => {
         setSearchQuery('');
     };
 
     const clearFavorites = () => {
-        setShowFavoritesOnly(false);
+        setFavoriteFilterMode('neutral');
     };
 
     const removeAdvancedFilter = (key: string) => {
@@ -83,12 +90,24 @@ const ActiveFilters: React.FC = () => {
             )}
 
             {/* Favorites Tag */}
-            {showFavoritesOnly && (
+            {favoriteFilterMode === 'include' && (
                 <div className="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-yellow-900/40 text-yellow-200 border border-yellow-700/50 flex-shrink-0 animate-fade-in">
-                     <span>★ Favorites</span>
+                    <span>★ Favorites</span>
                     <button
                         onClick={clearFavorites}
                         className="ml-1 hover:text-yellow-100 rounded-full hover:bg-yellow-800/50 p-0.5 transition-colors"
+                    >
+                        <X size={12} />
+                    </button>
+                </div>
+            )}
+
+            {favoriteFilterMode === 'exclude' && (
+                <div className="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-red-900/40 text-red-200 border border-red-700/50 flex-shrink-0 animate-fade-in">
+                    <span>★ Not Favorites</span>
+                    <button
+                        onClick={clearFavorites}
+                        className="ml-1 hover:text-red-100 rounded-full hover:bg-red-800/50 p-0.5 transition-colors"
                     >
                         <X size={12} />
                     </button>
@@ -229,6 +248,22 @@ const ActiveFilters: React.FC = () => {
                     <button
                         onClick={() => removeTag(tag)}
                         className="ml-1 hover:text-white rounded-full hover:bg-gray-600 p-0.5 transition-colors"
+                    >
+                        <X size={12} />
+                    </button>
+                </div>
+            ))}
+
+            {excludedTags.map((tag) => (
+                <div
+                    key={`excluded-tag-${tag}`}
+                    className="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-red-900/40 text-red-200 border border-red-700/50 flex-shrink-0 animate-fade-in"
+                >
+                    <span className="opacity-80">not #</span>
+                    <span className="truncate max-w-[150px]">{tag}</span>
+                    <button
+                        onClick={() => removeExcludedTag(tag)}
+                        className="ml-1 hover:text-red-100 rounded-full hover:bg-red-800/50 p-0.5 transition-colors"
                     >
                         <X size={12} />
                     </button>

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -184,8 +184,9 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   const selectedLoras = useImageStore((state) => state.selectedLoras);
   const selectedSchedulers = useImageStore((state) => state.selectedSchedulers);
   const selectedTags = useImageStore((state) => state.selectedTags);
+  const excludedTags = useImageStore((state) => state.excludedTags);
   const searchQuery = useImageStore((state) => state.searchQuery);
-  const showFavoritesOnly = useImageStore((state) => state.showFavoritesOnly);
+  const favoriteFilterMode = useImageStore((state) => state.favoriteFilterMode);
 
   const advancedFilters = useImageStore((state) => state.advancedFilters);
 
@@ -194,17 +195,10 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedLoras.length > 0 ||
       selectedSchedulers.length > 0 ||
       selectedTags.length > 0 ||
+      excludedTags.length > 0 ||
       !!searchQuery ||
-      showFavoritesOnly ||
-      (advancedFilters && (
-        !!advancedFilters.dateRange?.from || 
-        !!advancedFilters.dateRange?.to || 
-        (advancedFilters.steps && (advancedFilters.steps.min !== 0 || advancedFilters.steps.max !== 150)) || 
-        (advancedFilters.cfgScale && (advancedFilters.cfgScale.min !== 0 || advancedFilters.cfgScale.max !== 30)) || 
-        (advancedFilters.width && (advancedFilters.width.min !== 64 || advancedFilters.width.max !== 2048)) || 
-        (advancedFilters.height && (advancedFilters.height.min !== 64 || advancedFilters.height.max !== 2048)) ||
-        advancedFilters.isVerifiedOnly
-      ));
+      favoriteFilterMode !== 'neutral' ||
+      (advancedFilters && Object.keys(advancedFilters).length > 0);
 
   if (selectedCount === 0 && !hasActiveFilters) {
     return null;

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, FC, useCallback } from 'react';
+import React, { useEffect, useState, FC, useCallback, useRef } from 'react';
 import { type IndexedImage, type BaseMetadata, type LoRAInfo } from '../types';
 import { FileOperations } from '../services/fileOperations';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
@@ -9,15 +9,18 @@ import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
 import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
 import { useImageComparison } from '../hooks/useImageComparison';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
+import { useGenerationProviderAvailability } from '../hooks/useGenerationProviderAvailability';
 import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } from './A1111GenerateModal';
 import { ComfyUIGenerateModal, type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGenerateModal';
 import ProBadge from './ProBadge';
 import hotkeyManager from '../services/hotkeyManager';
 import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
 import { mediaSourceCache } from '../services/mediaSourceCache';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
+import { eventMatchesKeybinding, isTypingElement } from '../utils/hotkeyUtils';
 import { useShadowMetadata } from '../hooks/useShadowMetadata';
 import { MetadataEditorModal } from './MetadataEditorModal';
 
@@ -420,6 +423,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   // Feature access (license/trial gating)
   const { canUseA1111, canUseComfyUI, canUseComparison, showProModal, initialized } = useFeatureAccess();
+  const { a1111Enabled, comfyUIEnabled, visibleProviders, singleVisibleProvider } = useGenerationProviderAvailability();
 
   // Annotations hooks
   const toggleFavorite = useImageStore((state) => state.toggleFavorite);
@@ -442,6 +446,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
   );
   const thumbnail = useResolvedThumbnail(imageFromStore ?? image);
   const isVideo = isVideoFileName(image.name, image.fileType);
+  const showA1111Actions = !isVideo && a1111Enabled;
+  const showComfyUIActions = !isVideo && comfyUIEnabled;
+  const showComfyUIHeading = showA1111Actions && visibleProviders.length > 1;
+  const a1111GenerateLabel = singleVisibleProvider?.id === 'a1111' ? 'Generate' : 'Generate with A1111';
+  const comfyGenerateLabel = singleVisibleProvider?.id === 'comfyui' ? 'Generate' : 'Generate with ComfyUI';
   const currentTags = imageFromStore?.tags || image.tags || [];
   const currentAutoTags = imageFromStore?.autoTags || image.autoTags || [];
   const currentIsFavorite = imageFromStore?.isFavorite ?? image.isFavorite ?? false;
@@ -451,6 +460,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
   // State for tag input
   const [tagInput, setTagInput] = useState('');
   const [showTagAutocomplete, setShowTagAutocomplete] = useState(false);
+  const tagInputRef = useRef<HTMLInputElement>(null);
+  const previewKeymap = useSettingsStore((state) => state.keymap.preview as Record<string, string> | undefined);
 
   // Full screen toggle - calls Electron API for actual fullscreen
   const toggleFullscreen = useCallback(async () => {
@@ -865,52 +876,25 @@ const ImageModal: React.FC<ImageModalProps> = ({
     };
   }, [image.id, image.handle, image.thumbnailHandle, image.name, directoryPath, preferredThumbnailUrl, isVideo]);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      // Don't handle navigation keys if hotkeys are paused (e.g., GenerateModal is open)
-      if (hotkeyManager.areHotkeysPaused()) {
-        return;
-      }
+  const handleToggleFavorite = useCallback(() => {
+    toggleFavorite(image.id);
+  }, [image.id, toggleFavorite]);
 
-      if (isRenaming) return;
-
-      // Alt+Enter = Toggle fullscreen (works in both grid and modal)
-      if (event.key === 'Enter' && event.altKey) {
-        event.preventDefault();
-        event.stopPropagation();
-        toggleFullscreen(); // Toggle fullscreen ON/OFF
-        return;
-      }
-
-      // Escape = Exit fullscreen first, then close modal
-      if (event.key === 'Escape') {
-        event.stopPropagation(); // Prevent global hotkeys (closing sidebar)
-        if (isFullscreen) {
-          // Call toggleFullscreen to actually exit Electron fullscreen
-          toggleFullscreen();
-        } else {
-          onClose();
-        }
-        return;
-      }
-
-      if (event.key === 'ArrowLeft') onNavigatePrevious?.();
-      if (event.key === 'ArrowRight') onNavigateNext?.();
-      if (event.key === 'Delete') handleDelete();
+  const focusTagInput = useCallback(async () => {
+    const focusInput = () => {
+      tagInputRef.current?.focus();
+      tagInputRef.current?.select();
+      setShowTagAutocomplete((tagInputRef.current?.value ?? '').trim().length > 0);
     };
 
-    const handleClickOutside = () => {
-      hideContextMenu();
-    };
+    if (isFullscreen) {
+      await toggleFullscreen();
+      window.setTimeout(focusInput, 50);
+      return;
+    }
 
-    window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('click', handleClickOutside);
-
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('click', handleClickOutside);
-    };
-  }, [hideContextMenu, isFullscreen, isRenaming, onClose, onNavigateNext, onNavigatePrevious, toggleFullscreen]);
+    focusInput();
+  }, [isFullscreen, toggleFullscreen]);
 
   // Separate effect for wheel event listener to avoid image reloading on zoom changes
   useEffect(() => {
@@ -926,7 +910,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
     };
   }, [handleWheel]);
 
-  const handleDelete = async () => {
+  const handleDelete = useCallback(async () => {
+    if (isIndexing) {
+      return;
+    }
+
     if (window.confirm('Are you sure you want to delete this image? This action cannot be undone.')) {
       const idToDelete = image.id;
       const imageToDelete = image; // Capture reference
@@ -956,7 +944,102 @@ const ImageModal: React.FC<ImageModalProps> = ({
         alert(`Failed to delete file: ${result.error}`);
       }
     }
-  };
+  }, [currentIndex, image, isIndexing, onClose, onImageDeleted, onNavigateNext, onNavigatePrevious, totalImages]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Don't handle navigation keys if hotkeys are paused (e.g., GenerateModal is open)
+      if (hotkeyManager.areHotkeysPaused()) {
+        return;
+      }
+
+      if (isRenaming) return;
+      const isTypingContext = isTypingElement(event.target);
+
+      // Let focused text fields handle their own Escape behavior.
+      if (event.key === 'Escape') {
+        if (isTypingContext) {
+          return;
+        }
+
+        event.stopPropagation(); // Prevent global hotkeys (closing sidebar)
+        if (isFullscreen) {
+          // Call toggleFullscreen to actually exit Electron fullscreen
+          toggleFullscreen();
+        } else {
+          onClose();
+        }
+        return;
+      }
+
+      if (isTypingContext) {
+        return;
+      }
+
+      // Alt+Enter = Toggle fullscreen (works in both grid and modal)
+      if (event.key === 'Enter' && event.altKey) {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleFullscreen(); // Toggle fullscreen ON/OFF
+        return;
+      }
+
+      if (eventMatchesKeybinding(event, previewKeymap?.toggleFavoriteInViewer)) {
+        event.preventDefault();
+        handleToggleFavorite();
+        return;
+      }
+
+      if (eventMatchesKeybinding(event, previewKeymap?.focusAddTagInViewer)) {
+        event.preventDefault();
+        focusTagInput().catch((error) => {
+          console.error('Failed to focus tag input:', error);
+        });
+        return;
+      }
+
+      if (eventMatchesKeybinding(event, previewKeymap?.deleteImageInViewer)) {
+        event.preventDefault();
+        handleDelete().catch((error) => {
+          console.error('Failed to delete image from shortcut:', error);
+        });
+        return;
+      }
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        onNavigatePrevious?.();
+      }
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        onNavigateNext?.();
+      }
+    };
+
+    const handleClickOutside = () => {
+      hideContextMenu();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('click', handleClickOutside);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('click', handleClickOutside);
+    };
+  }, [
+    focusTagInput,
+    handleDelete,
+    handleToggleFavorite,
+    hideContextMenu,
+    isFullscreen,
+    isRenaming,
+    onClose,
+    onNavigateNext,
+    onNavigatePrevious,
+    previewKeymap,
+    toggleFullscreen,
+  ]);
 
   const confirmRename = async () => {
     if (!newName.trim() || !FileOperations.validateFilename(newName).valid) {
@@ -992,10 +1075,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
     // Add as manual tag and remove from auto-tags
     await addTagToImage(image.id, tag);
     removeAutoTagFromImage(image.id, tag);
-  };
-
-  const handleToggleFavorite = () => {
-    toggleFavorite(image.id);
   };
 
   // Filter autocomplete tags
@@ -1202,6 +1281,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 {/* Add Tag Input */}
                 <div className="relative">
                   <input
+                    ref={tagInputRef}
                     type="text"
                     placeholder="Add tag..."
                     value={tagInput}
@@ -1503,7 +1583,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
           </div>
 
           {/* A1111 Integration - Separate Buttons with Visual Hierarchy */}
-          {nMeta && !isVideo && (
+          {nMeta && showA1111Actions && (
             <div className="mt-3 space-y-2">
               {/* Hero Button: Generate Variation */}
               <button
@@ -1528,7 +1608,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 ) : (
                   <>
                     <Sparkles className="w-4 h-4" />
-                    <span>Generate with A1111</span>
+                    <span>{a1111GenerateLabel}</span>
                     {!canUseA1111 && initialized && <ProBadge size="sm" />}
                   </>
                 )}
@@ -1575,7 +1655,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
               )}
 
               {/* Generate Variation Modal */}
-              {isGenerateModalOpen && nMeta && (
+              {showA1111Actions && isGenerateModalOpen && nMeta && (
                 <A1111GenerateModal
                   isOpen={isGenerateModalOpen}
                   onClose={() => setIsGenerateModalOpen(false)}
@@ -1602,9 +1682,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
           )}
 
           {/* ComfyUI Integration */}
-          {nMeta && !isVideo && (
-            <div className="mt-3 pt-3 border-t border-gray-700">
-              <h4 className="text-xs text-gray-400 uppercase tracking-wider mb-2">ComfyUI</h4>
+          {nMeta && showComfyUIActions && (
+            <div className={`mt-3 ${showComfyUIHeading ? 'pt-3 border-t border-gray-700' : ''}`}>
+              {showComfyUIHeading && (
+                <h4 className="text-xs text-gray-400 uppercase tracking-wider mb-2">ComfyUI</h4>
+              )}
 
               {/* Generate Button */}
               <button
@@ -1629,7 +1711,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 ) : (
                   <>
                     <Sparkles className="w-4 h-4" />
-                    <span>Generate with ComfyUI</span>
+                    <span>{comfyGenerateLabel}</span>
                     {!canUseComfyUI && initialized && <ProBadge size="sm" />}
                   </>
                 )}
@@ -1676,7 +1758,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
               )}
 
               {/* ComfyUI Generate Modal */}
-              {isComfyUIGenerateModalOpen && nMeta && (
+              {showComfyUIActions && isComfyUIGenerateModalOpen && nMeta && (
                 <ComfyUIGenerateModal
                   isOpen={isComfyUIGenerateModalOpen}
                   onClose={() => setIsComfyUIGenerateModalOpen(false)}

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -7,6 +7,7 @@ import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
 import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
+import { useGenerationProviderAvailability } from '../hooks/useGenerationProviderAvailability';
 import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } from './A1111GenerateModal';
 import { ComfyUIGenerateModal, type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGenerateModal';
 import ProBadge from './ProBadge';
@@ -190,10 +191,16 @@ const ImagePreviewSidebar: React.FC = () => {
 
   // Feature access (license/trial gating)
   const { canUseA1111, canUseComfyUI, showProModal, initialized } = useFeatureAccess();
+  const { a1111Enabled, comfyUIEnabled, visibleProviders, singleVisibleProvider } = useGenerationProviderAvailability();
 
   const activeImage = previewImageFromStore || previewImage;
   const thumbnail = useResolvedThumbnail(activeImage);
   const isVideo = !!activeImage && isVideoFileName(activeImage.name, activeImage.fileType);
+  const showA1111Actions = !isVideo && a1111Enabled;
+  const showComfyUIActions = !isVideo && comfyUIEnabled;
+  const showComfyUIHeading = showA1111Actions && visibleProviders.length > 1;
+  const a1111GenerateLabel = singleVisibleProvider?.id === 'a1111' ? 'Generate' : 'Generate with A1111';
+  const comfyGenerateLabel = singleVisibleProvider?.id === 'comfyui' ? 'Generate' : 'Generate with ComfyUI';
   const preferredThumbnailUrl = thumbnail?.thumbnailUrl ?? null;
   const tagSuggestions = buildTagSuggestions(recentTags, availableTags, activeImage?.tags ?? []);
 
@@ -665,7 +672,7 @@ const ImagePreviewSidebar: React.FC = () => {
             )}
 
             {/* A1111 Actions - Separate Buttons with Visual Hierarchy */}
-            {!isVideo && (
+            {showA1111Actions && (
               <div className="mt-4 space-y-2">
               {/* Hero Button: Generate Variation */}
               <button
@@ -690,7 +697,7 @@ const ImagePreviewSidebar: React.FC = () => {
                 ) : (
                   <>
                     <Sparkles className="w-4 h-4" />
-                    <span>Generate with A1111</span>
+                    <span>{a1111GenerateLabel}</span>
                     {!canUseA1111 && initialized && <ProBadge size="sm" />}
                   </>
                 )}
@@ -737,7 +744,7 @@ const ImagePreviewSidebar: React.FC = () => {
               )}
 
               {/* Generate Variation Modal */}
-              {isGenerateModalOpen && nMeta && (
+              {showA1111Actions && isGenerateModalOpen && nMeta && (
                 <A1111GenerateModal
                   isOpen={isGenerateModalOpen}
                   onClose={() => setIsGenerateModalOpen(false)}
@@ -764,8 +771,11 @@ const ImagePreviewSidebar: React.FC = () => {
             )}
 
             {/* ComfyUI Actions */}
-            <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
-              <h4 className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">ComfyUI</h4>
+            {showComfyUIActions && (
+            <div className={`mt-3 ${showComfyUIHeading ? 'pt-3 border-t border-gray-200 dark:border-gray-700' : ''}`}>
+              {showComfyUIHeading && (
+                <h4 className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">ComfyUI</h4>
+              )}
 
               {/* Generate Button */}
               <button
@@ -790,7 +800,7 @@ const ImagePreviewSidebar: React.FC = () => {
                 ) : (
                   <>
                     <Sparkles className="w-4 h-4" />
-                    <span>Generate with ComfyUI</span>
+                    <span>{comfyGenerateLabel}</span>
                     {!canUseComfyUI && initialized && <ProBadge size="sm" />}
                   </>
                 )}
@@ -837,7 +847,7 @@ const ImagePreviewSidebar: React.FC = () => {
               )}
 
               {/* ComfyUI Generate Modal */}
-              {isComfyUIGenerateModalOpen && nMeta && (
+              {showComfyUIActions && isComfyUIGenerateModalOpen && nMeta && (
                 <ComfyUIGenerateModal
                   isOpen={isComfyUIGenerateModalOpen}
                   onClose={() => setIsComfyUIGenerateModalOpen(false)}
@@ -868,6 +878,7 @@ const ImagePreviewSidebar: React.FC = () => {
                 />
               )}
             </div>
+            )}
 
           </>
         ) : (

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -47,16 +47,20 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, initialT
   const setBlurSensitiveImages = useSettingsStore((state) => state.setBlurSensitiveImages);
 
   // A1111 Integration settings
+  const a1111Enabled = useSettingsStore((state) => state.a1111Enabled);
   const a1111ServerUrl = useSettingsStore((state) => state.a1111ServerUrl);
   const a1111AutoStart = useSettingsStore((state) => state.a1111AutoStart);
   const a1111LastConnectionStatus = useSettingsStore((state) => state.a1111LastConnectionStatus);
+  const setA1111Enabled = useSettingsStore((state) => state.setA1111Enabled);
   const setA1111ServerUrl = useSettingsStore((state) => state.setA1111ServerUrl);
   const toggleA1111AutoStart = useSettingsStore((state) => state.toggleA1111AutoStart);
   const setA1111ConnectionStatus = useSettingsStore((state) => state.setA1111ConnectionStatus);
 
   // ComfyUI Integration settings
+  const comfyUIEnabled = useSettingsStore((state) => state.comfyUIEnabled);
   const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
   const comfyUILastConnectionStatus = useSettingsStore((state) => state.comfyUILastConnectionStatus);
+  const setComfyUIEnabled = useSettingsStore((state) => state.setComfyUIEnabled);
   const setComfyUIServerUrl = useSettingsStore((state) => state.setComfyUIServerUrl);
   const setComfyUIConnectionStatus = useSettingsStore((state) => state.setComfyUIConnectionStatus);
 
@@ -462,6 +466,24 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, initialT
               Configure connection to your local Automatic1111 instance. Make sure A1111 is running with the --api flag.
             </p>
 
+            <div className="flex items-center justify-between bg-gray-900 p-3 rounded-md mb-3">
+              <div>
+                <p className="text-sm">Show in viewer</p>
+                <p className="text-xs text-gray-400">
+                  Show A1111 actions in Image Modal and Image Preview Sidebar.
+                </p>
+              </div>
+              <label className="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={a1111Enabled}
+                  onChange={(event) => setA1111Enabled(event.target.checked)}
+                  className="sr-only peer"
+                />
+                <div className="w-11 h-6 bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-800 peer-checked:after:translate-x-full peer-checked:after:border-gray-50 after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-gray-50 after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+              </label>
+            </div>
+
             {/* Server URL Input */}
             <div className="space-y-2 mb-3">
               <label className="text-sm text-gray-300">Server URL</label>
@@ -521,6 +543,24 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, initialT
                 Requires MetaHub Save Node installed in ComfyUI.
               </span>
             </p>
+
+            <div className="flex items-center justify-between bg-gray-900 p-3 rounded-md mb-3">
+              <div>
+                <p className="text-sm">Show in viewer</p>
+                <p className="text-xs text-gray-400">
+                  Show ComfyUI actions in Image Modal and Image Preview Sidebar.
+                </p>
+              </div>
+              <label className="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={comfyUIEnabled}
+                  onChange={(event) => setComfyUIEnabled(event.target.checked)}
+                  className="sr-only peer"
+                />
+                <div className="w-11 h-6 bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-800 peer-checked:after:translate-x-full peer-checked:after:border-gray-50 after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-gray-50 after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+              </label>
+            </div>
 
             {/* Server URL Input */}
             <div className="space-y-2 mb-3">

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import AdvancedFilters from './AdvancedFilters';
 import TagsAndFavorites from './TagsAndFavorites';
 import { ChevronLeft, X, ChevronDown, Plus, RefreshCw } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useImageStore } from '../store/useImageStore';
 
 interface SidebarProps {
   searchQuery: string;
@@ -67,6 +68,10 @@ const Sidebar: React.FC<SidebarProps> = ({
   onSortOrderChange,
   onReshuffle
 }) => {
+  const selectedTags = useImageStore((state) => state.selectedTags);
+  const excludedTags = useImageStore((state) => state.excludedTags);
+  const selectedAutoTags = useImageStore((state) => state.selectedAutoTags);
+  const favoriteFilterMode = useImageStore((state) => state.favoriteFilterMode);
 
   const [expandedSections, setExpandedSections] = useState({
     models: true,
@@ -477,7 +482,14 @@ const Sidebar: React.FC<SidebarProps> = ({
       </div>
 
       {/* Clear All Filters */}
-      {(selectedModels.length > 0 || selectedLoras.length > 0 || selectedSchedulers.length > 0 || Object.keys(advancedFilters || {}).length > 0) && (
+      {(selectedModels.length > 0 ||
+        selectedLoras.length > 0 ||
+        selectedSchedulers.length > 0 ||
+        selectedTags.length > 0 ||
+        excludedTags.length > 0 ||
+        selectedAutoTags.length > 0 ||
+        favoriteFilterMode !== 'neutral' ||
+        Object.keys(advancedFilters || {}).length > 0) && (
         <div className="p-4 border-t border-gray-700">
           <button
             onClick={onClearAllFilters}

--- a/components/TagsAndFavorites.tsx
+++ b/components/TagsAndFavorites.tsx
@@ -1,17 +1,54 @@
 import React, { useState } from 'react';
-import { ChevronDown, X, Star, Tag } from 'lucide-react';
+import { Check, ChevronDown, Star, Tag, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useImageStore } from '../store/useImageStore';
+import { InclusionFilterMode } from '../types';
+
+const getNextFilterMode = (mode: InclusionFilterMode): InclusionFilterMode => {
+  if (mode === 'neutral') return 'include';
+  if (mode === 'include') return 'exclude';
+  return 'neutral';
+};
+
+const getFilterModeLabel = (mode: InclusionFilterMode): string => {
+  if (mode === 'include') return 'Include';
+  if (mode === 'exclude') return 'Exclude';
+  return 'Off';
+};
+
+const CycleToggle: React.FC<{
+  mode: InclusionFilterMode;
+  onClick: () => void;
+  title: string;
+}> = ({ mode, onClick, title }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    title={title}
+    aria-label={title}
+    className={`flex h-4 w-4 items-center justify-center rounded border transition-colors ${
+      mode === 'include'
+        ? 'border-blue-500 bg-blue-500/20 text-blue-300'
+        : mode === 'exclude'
+          ? 'border-red-500 bg-red-500/20 text-red-300'
+          : 'border-gray-600 bg-gray-700 text-transparent hover:border-gray-500 hover:bg-gray-700/80'
+    }`}
+  >
+    {mode === 'include' ? <Check className="h-3 w-3" /> : mode === 'exclude' ? <X className="h-3 w-3" /> : <span className="h-3 w-3" />}
+  </button>
+);
 
 const TagsAndFavorites: React.FC = () => {
   const {
-    showFavoritesOnly,
-    setShowFavoritesOnly,
+    favoriteFilterMode,
+    setFavoriteFilterMode,
     availableTags,
     availableAutoTags,
     selectedTags,
+    excludedTags,
     selectedAutoTags,
     setSelectedTags,
+    setExcludedTags,
     setSelectedAutoTags,
     refreshAvailableAutoTags,
     filteredImages,
@@ -32,6 +69,7 @@ const TagsAndFavorites: React.FC = () => {
 
   // Count favorites in filtered set (for display)
   const favoriteCount = filteredImages.filter(img => img.isFavorite).length;
+  const favoriteBadgeCount = favoriteFilterMode === 'include' ? favoriteCount : totalFavoriteCount;
 
   // Get tags only from current images (not all from IndexedDB)
   const currentImagesTags = React.useMemo(() => {
@@ -62,12 +100,30 @@ const TagsAndFavorites: React.FC = () => {
       )
     : availableAutoTags;
 
-  const handleTagToggle = (tagName: string, checked: boolean) => {
-    if (checked) {
-      setSelectedTags([...selectedTags, tagName]);
-    } else {
-      setSelectedTags(selectedTags.filter(t => t !== tagName));
+  const getTagFilterMode = (tagName: string): InclusionFilterMode => {
+    if (selectedTags.includes(tagName)) return 'include';
+    if (excludedTags.includes(tagName)) return 'exclude';
+    return 'neutral';
+  };
+
+  const handleTagCycle = (tagName: string) => {
+    const currentMode = getTagFilterMode(tagName);
+    const nextMode = getNextFilterMode(currentMode);
+
+    if (nextMode === 'include') {
+      setSelectedTags([...selectedTags.filter(t => t !== tagName), tagName]);
+      setExcludedTags(excludedTags.filter(t => t !== tagName));
+      return;
     }
+
+    if (nextMode === 'exclude') {
+      setSelectedTags(selectedTags.filter(t => t !== tagName));
+      setExcludedTags([...excludedTags.filter(t => t !== tagName), tagName]);
+      return;
+    }
+
+    setSelectedTags(selectedTags.filter(t => t !== tagName));
+    setExcludedTags(excludedTags.filter(t => t !== tagName));
   };
 
   const handleAutoTagToggle = (tagName: string, checked: boolean) => {
@@ -80,6 +136,7 @@ const TagsAndFavorites: React.FC = () => {
 
   const clearSelectedTags = () => {
     setSelectedTags([]);
+    setExcludedTags([]);
   };
 
   const clearSelectedAutoTags = () => {
@@ -99,7 +156,7 @@ const TagsAndFavorites: React.FC = () => {
       >
         <div className="flex items-center space-x-2">
           <span className="text-gray-300 font-medium">Favorites & Tags</span>
-          {(showFavoritesOnly || selectedTags.length > 0) && (
+          {(favoriteFilterMode !== 'neutral' || selectedTags.length > 0 || excludedTags.length > 0 || selectedAutoTags.length > 0) && (
             <span className="text-xs bg-blue-900/40 text-blue-300 px-2 py-0.5 rounded border border-blue-700/50">
               active
             </span>
@@ -121,23 +178,32 @@ const TagsAndFavorites: React.FC = () => {
             <div className="px-4 pb-4 space-y-3">
               {/* Favorites Toggle */}
               {totalFavoriteCount > 0 && (
-                <label className="flex items-center space-x-2 cursor-pointer group">
-                  <input
-                    type="checkbox"
-                    checked={showFavoritesOnly}
-                    onChange={(e) => setShowFavoritesOnly(e.target.checked)}
-                    className="w-4 h-4 rounded border-gray-600 bg-gray-700 text-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-offset-0 cursor-pointer"
+                <div className="flex items-center space-x-2 group py-1 px-2 rounded hover:bg-gray-700/50">
+                  <CycleToggle
+                    mode={favoriteFilterMode}
+                    onClick={() => setFavoriteFilterMode(getNextFilterMode(favoriteFilterMode))}
+                    title={`Favorites filter: ${getFilterModeLabel(favoriteFilterMode)}. Click to cycle.`}
                   />
                   <Star
-                    className={`w-4 h-4 ${showFavoritesOnly ? 'text-yellow-400 fill-yellow-400' : 'text-gray-400 group-hover:text-yellow-400'}`}
+                    className={`w-4 h-4 ${
+                      favoriteFilterMode === 'include'
+                        ? 'text-yellow-400 fill-yellow-400'
+                        : favoriteFilterMode === 'exclude'
+                          ? 'text-red-300'
+                          : 'text-gray-400 group-hover:text-yellow-400'
+                    }`}
                   />
-                  <span className="text-sm text-gray-300 group-hover:text-gray-50">
-                    Show Favorites Only
+                  <span className="text-sm text-gray-300 group-hover:text-gray-50 flex-1">
+                    {favoriteFilterMode === 'include'
+                      ? 'Show Favorites Only'
+                      : favoriteFilterMode === 'exclude'
+                        ? 'Exclude Favorites'
+                        : 'Favorites'}
                   </span>
                   <span className="text-xs bg-gray-700 text-gray-400 px-2 py-0.5 rounded border border-gray-600">
-                    {favoriteCount}
+                    {favoriteBadgeCount}
                   </span>
-                </label>
+                </div>
               )}
 
               {/* Tags Section */}
@@ -149,12 +215,18 @@ const TagsAndFavorites: React.FC = () => {
                       <span className="text-sm text-gray-400 font-medium">Tags</span>
                       {selectedTags.length > 0 && (
                         <span className="text-xs bg-blue-900/40 text-blue-300 px-2 py-0.5 rounded border border-blue-700/50">
-                          {selectedTags.length} selected
+                          {selectedTags.length} include
+                        </span>
+                      )}
+                      {excludedTags.length > 0 && (
+                        <span className="text-xs bg-red-900/40 text-red-300 px-2 py-0.5 rounded border border-red-700/50">
+                          {excludedTags.length} exclude
                         </span>
                       )}
                     </div>
-                    {selectedTags.length > 0 && (
+                    {(selectedTags.length > 0 || excludedTags.length > 0) && (
                       <button
+                        type="button"
                         onClick={clearSelectedTags}
                         className="text-xs text-gray-400 hover:text-red-400 cursor-pointer"
                         title="Clear tag filters"
@@ -175,6 +247,10 @@ const TagsAndFavorites: React.FC = () => {
                     />
                   )}
 
+                  <p className="text-[11px] text-gray-500">
+                    Click a tag to cycle include, exclude, and off.
+                  </p>
+
                   {/* Tags List */}
                   <div className="max-h-48 overflow-y-auto scrollbar-thin space-y-1">
                     {filteredTags.length === 0 ? (
@@ -183,15 +259,14 @@ const TagsAndFavorites: React.FC = () => {
                       </div>
                     ) : (
                       filteredTags.map((tag) => (
-                        <label
+                        <div
                           key={tag.name}
                           className="flex items-center space-x-2 cursor-pointer group py-1 px-2 rounded hover:bg-gray-700/50"
                         >
-                          <input
-                            type="checkbox"
-                            checked={selectedTags.includes(tag.name)}
-                            onChange={(e) => handleTagToggle(tag.name, e.target.checked)}
-                            className="w-3.5 h-3.5 rounded border-gray-600 bg-gray-700 text-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-offset-0 cursor-pointer"
+                          <CycleToggle
+                            mode={getTagFilterMode(tag.name)}
+                            onClick={() => handleTagCycle(tag.name)}
+                            title={`Tag "${tag.name}": ${getFilterModeLabel(getTagFilterMode(tag.name))}. Click to cycle.`}
                           />
                           <span className="text-sm text-gray-300 group-hover:text-gray-50 flex-1">
                             {tag.name}
@@ -199,7 +274,7 @@ const TagsAndFavorites: React.FC = () => {
                           <span className="text-xs text-gray-500 group-hover:text-gray-400">
                             {tag.count}
                           </span>
-                        </label>
+                        </div>
                       ))
                     )}
                   </div>

--- a/hooks/useGenerationProviderAvailability.ts
+++ b/hooks/useGenerationProviderAvailability.ts
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+import { useFeatureAccess } from './useFeatureAccess';
+import { useSettingsStore } from '../store/useSettingsStore';
+
+export type GenerationProviderId = 'a1111' | 'comfyui';
+
+export interface VisibleGenerationProvider {
+  id: GenerationProviderId;
+  shortLabel: 'A1111' | 'ComfyUI';
+  generateLabel: string;
+  menuLabel: string;
+  canUse: boolean;
+}
+
+export const useGenerationProviderAvailability = () => {
+  const { canUseA1111, canUseComfyUI } = useFeatureAccess();
+  const a1111Enabled = useSettingsStore((state) => state.a1111Enabled);
+  const comfyUIEnabled = useSettingsStore((state) => state.comfyUIEnabled);
+
+  const visibleProviders = useMemo<VisibleGenerationProvider[]>(() => {
+    const providers: VisibleGenerationProvider[] = [];
+
+    if (a1111Enabled) {
+      providers.push({
+        id: 'a1111',
+        shortLabel: 'A1111',
+        generateLabel: 'Generate (A1111)',
+        menuLabel: 'with A1111 WebUI',
+        canUse: canUseA1111,
+      });
+    }
+
+    if (comfyUIEnabled) {
+      providers.push({
+        id: 'comfyui',
+        shortLabel: 'ComfyUI',
+        generateLabel: 'Generate (ComfyUI)',
+        menuLabel: 'with ComfyUI',
+        canUse: canUseComfyUI,
+      });
+    }
+
+    return providers;
+  }, [a1111Enabled, canUseA1111, canUseComfyUI, comfyUIEnabled]);
+
+  const singleVisibleProvider = visibleProviders.length === 1 ? visibleProviders[0] : null;
+
+  return {
+    a1111Enabled,
+    comfyUIEnabled,
+    visibleProviders,
+    singleVisibleProvider,
+    hasVisibleProviders: visibleProviders.length > 0,
+    hasMultipleVisibleProviders: visibleProviders.length > 1,
+    headerButtonLabel: singleVisibleProvider?.generateLabel ?? 'Generate',
+  };
+};

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,11 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.2] - 2026-03-17
+## [0.13.2] - 2026-03-23
+
+### Added
+
+- **Indexed Folder Transfers**: Added desktop support for copying or moving images between indexed folders, including a destination picker modal, concurrent transfer handling, and preservation of tags, favorites, and shadow metadata.
+- **Editable Field Context Menu**: Added a native right-click context menu with `Cut`, `Copy`, and `Paste` for editable text fields such as the search bar.
+- **Metadata Selection Context Menu**: Added right-click actions for selected text in `ImageModal` and `ImagePreviewSidebar`, including `Copy` and `Search Selection` for faster filtering from prompts and metadata.
+- **Viewer Annotation Hotkeys**: Added customizable image-viewer shortcuts for toggling favorites, focusing the add-tag field, and deleting the current image without leaving keyboard navigation.
+
+### Improved
+
+- **Large Library Browsing Performance**: Significantly improved browsing responsiveness for large libraries by separating thumbnail state from the main image collections, reducing unnecessary full-list updates as thumbnails arrive.
+- **Thumbnail Loading Pipeline**: Reworked thumbnail scheduling so visible items are prioritized, background warmup is throttled, and the first visible images fill in faster during startup, folder changes, and infinite scrolling.
+- **Directory Load Feedback**: Added a "Loading Library" progress bar with per-folder progress directly in the directory list, including a scanning state while totals are still being determined.
+- **Directory Discovery Speed**: Greatly reduced the delay before indexing starts on large folders by parallelizing Electron-side file stat collection during directory scanning.
+- **Viewer Responsiveness**: Improved Image Modal loading behavior so the full-resolution image is prioritized over background thumbnail warmup, reducing the delay after the thumbnail preview appears.
+- **Favorites & Tags Filters**: Favorites and manual tags in the sidebar now cycle through include, exclude, and off states, making it possible to quickly hide favorites or exclude specific tags without leaving the current view.
+- **ComfyUI Metadata Compatibility**: Improved parsing for prompt-only ComfyUI graph payloads, added support for `smZ CLIPTextEncode`, and normalized prompt whitespace for cleaner imported prompts.
 
 ### Fixed
 
 - **Search Filter**: Fixed a bug where pressing the ESC key to close the image modal would also inadvertently clear the active search filter text.
+- **Settings**: Fixed a critical bug where `settings.json` could become corrupted on exit, causing user preferences (like disabling auto-updates) to reset to defaults on the next launch. Implemented atomic file saves to guarantee settings integrity.
+- **Auto-Updater**: Fixed an issue where background update checks would display an intrusive error dialog if the internet was disconnected or blocked by a firewall. Also prevented cached update dialogs from appearing when the auto-update setting is disabled.
+- **Draw Things**: Fixed missing LoRA weights and parsing issues for recent Draw Things metadata formats.
+- **Metadata Display**: Fixed inconsistent CFG scale display for some parsed images by normalizing both `cfgScale` and `cfg_scale` metadata field variants.
+- **Library Grid**: Fixed filename labels being overlapped by thumbnails below them when "Show filenames under thumbnails" was enabled.
+- **Display Settings**: Fixed "Show full file path" so it now displays the actual full image path in both grid and list views, with safer truncation for long paths in the grid.
+- **Thumbnail Generation During Indexing**: Fixed a regression where thumbnail generation could be blocked while a directory was still indexing, causing empty-looking grids and delayed thumbnail appearance exactly when loading a folder.
+- **Folder Load Empty State**: Fixed cases where newly added or cached folders could briefly show "No images found" even though discovery or cache hydration was still in progress.
+- **Electron Fallback Image Paths**: Fixed Electron image loading fallbacks for files inside subfolders so modal/sidebar/comparison views resolve the correct relative path and avoid unnecessary load failures or delays.
+- **Image Source Refresh**: Fixed thumbnail/full-image refresh behavior for files that change content while keeping the same image id, reducing stale visual state after updates.
 
 ## [0.13.1] - 2026-03-16
 

--- a/services/hotkeyConfig.ts
+++ b/services/hotkeyConfig.ts
@@ -30,6 +30,9 @@ export const hotkeyConfig: HotkeyDefinition[] = [
   // Preview Scope
   { id: 'navigatePrevious', name: 'Previous Image', scope: 'preview', defaultKey: 'left' },
   { id: 'navigateNext', name: 'Next Image', scope: 'preview', defaultKey: 'right' },
+  { id: 'toggleFavoriteInViewer', name: 'Toggle Favorite in Viewer', scope: 'preview', defaultKey: 'f' },
+  { id: 'focusAddTagInViewer', name: 'Focus Add Tag in Viewer', scope: 'preview', defaultKey: 't' },
+  { id: 'deleteImageInViewer', name: 'Delete Image in Viewer', scope: 'preview', defaultKey: 'delete' },
 ];
 
 export const getDefaultKeymap = (): Keymap => {

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, AutoTag, IndexedImageTransferProgress } from '../types';
+import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, AutoTag, IndexedImageTransferProgress, InclusionFilterMode } from '../types';
 import { loadSelectedFolders, saveSelectedFolders, loadExcludedFolders, saveExcludedFolders } from '../services/folderSelectionStorage';
 import {
   loadAllAnnotations,
@@ -221,8 +221,9 @@ interface ImageState {
   availableAutoTags: TagInfo[]; // Top auto-tags by frequency
   recentTags: string[];
   selectedTags: string[];
+  excludedTags: string[];
   selectedAutoTags: string[]; // Filter by auto-tags
-  showFavoritesOnly: boolean;
+  favoriteFilterMode: InclusionFilterMode;
   isAnnotationsLoaded: boolean;
   activeWatchers: Set<string>; // IDs das pastas sendo monitoradas
   refreshingDirectories: Set<string>;
@@ -342,8 +343,9 @@ interface ImageState {
   bulkAddTag: (imageIds: string[], tag: string) => Promise<void>;
   bulkRemoveTag: (imageIds: string[], tag: string) => Promise<void>;
   setSelectedTags: (tags: string[]) => void;
+  setExcludedTags: (tags: string[]) => void;
   setSelectedAutoTags: (tags: string[]) => void;
-  setShowFavoritesOnly: (show: boolean) => void;
+  setFavoriteFilterMode: (mode: InclusionFilterMode) => void;
   getImageAnnotations: (imageId: string) => ImageAnnotations | null;
   refreshAvailableTags: () => Promise<void>;
   refreshAvailableAutoTags: () => void;
@@ -557,8 +559,9 @@ export const useImageStore = create<ImageState>((set, get) => {
 
     const isFilteringActive = (state: ImageState) => {
         if (state.searchQuery) return true;
-        if (state.showFavoritesOnly) return true;
+        if (state.favoriteFilterMode !== 'neutral') return true;
         if (state.selectedTags?.length) return true;
+        if (state.excludedTags?.length) return true;
         if (state.selectedAutoTags?.length) return true;
         if (state.selectedModels?.length || state.selectedLoras?.length || state.selectedSchedulers?.length) return true;
         if (state.advancedFilters && Object.keys(state.advancedFilters).length > 0) return true;
@@ -745,8 +748,10 @@ export const useImageStore = create<ImageState>((set, get) => {
         let results = selectionFiltered;
 
         // Step 2: Favorites filter
-        if (state.showFavoritesOnly) {
+        if (state.favoriteFilterMode === 'include') {
             results = results.filter(img => img.isFavorite === true);
+        } else if (state.favoriteFilterMode === 'exclude') {
+            results = results.filter(img => img.isFavorite !== true);
         }
 
         // Step 3: Sensitive tags filter (safe mode)
@@ -769,6 +774,13 @@ export const useImageStore = create<ImageState>((set, get) => {
                 if (!img.tags || img.tags.length === 0) return false;
                 // Match ANY selected tag (OR logic)
                 return state.selectedTags.some(tag => img.tags!.includes(tag));
+            });
+        }
+
+        if (state.excludedTags && state.excludedTags.length > 0) {
+            results = results.filter(img => {
+                if (!img.tags || img.tags.length === 0) return true;
+                return !state.excludedTags.some(tag => img.tags!.includes(tag));
             });
         }
 
@@ -1012,8 +1024,9 @@ export const useImageStore = create<ImageState>((set, get) => {
         availableAutoTags: [],
         recentTags: loadRecentTags(),
         selectedTags: [],
+        excludedTags: [],
         selectedAutoTags: [],
-        showFavoritesOnly: false,
+        favoriteFilterMode: 'neutral',
         isAnnotationsLoaded: false,
         activeWatchers: new Set(),
         refreshingDirectories: new Set(),
@@ -2124,8 +2137,13 @@ export const useImageStore = create<ImageState>((set, get) => {
             return { ...newState, ...filterAndSort(newState) };
         }),
 
-        setShowFavoritesOnly: (show) => set(state => {
-            const newState = { ...state, showFavoritesOnly: show };
+        setExcludedTags: (tags) => set(state => {
+            const newState = { ...state, excludedTags: tags };
+            return { ...newState, ...filterAndSort(newState) };
+        }),
+
+        setFavoriteFilterMode: (mode) => set(state => {
+            const newState = { ...state, favoriteFilterMode: mode };
             return { ...newState, ...filterAndSort(newState) };
         }),
 
@@ -2340,8 +2358,9 @@ export const useImageStore = create<ImageState>((set, get) => {
             availableAutoTags: [],
             recentTags: loadRecentTags(),
             selectedTags: [],
+            excludedTags: [],
             selectedAutoTags: [],
-            showFavoritesOnly: false,
+            favoriteFilterMode: 'neutral',
             isAnnotationsLoaded: false,
             activeWatchers: new Set(),
             refreshingDirectories: new Set(),

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -73,11 +73,13 @@ interface SettingsState {
   enableSafeMode: boolean;
 
   // A1111 Integration settings
+  a1111Enabled: boolean;
   a1111ServerUrl: string;
   a1111AutoStart: boolean;
   a1111LastConnectionStatus: 'unknown' | 'connected' | 'error';
 
   // ComfyUI Integration settings
+  comfyUIEnabled: boolean;
   comfyUIServerUrl: string;
   comfyUILastConnectionStatus: 'unknown' | 'connected' | 'error';
 
@@ -102,9 +104,11 @@ interface SettingsState {
   setSensitiveTags: (tags: string[]) => void;
   setBlurSensitiveImages: (value: boolean) => void;
   setEnableSafeMode: (value: boolean) => void;
+  setA1111Enabled: (value: boolean) => void;
   setA1111ServerUrl: (url: string) => void;
   toggleA1111AutoStart: () => void;
   setA1111ConnectionStatus: (status: 'unknown' | 'connected' | 'error') => void;
+  setComfyUIEnabled: (value: boolean) => void;
   setComfyUIServerUrl: (url: string) => void;
   setComfyUIConnectionStatus: (status: 'unknown' | 'connected' | 'error') => void;
   resetState: () => void;
@@ -140,11 +144,13 @@ export const useSettingsStore = create<SettingsState>()(
       enableSafeMode: true,
 
       // A1111 Integration initial state
+      a1111Enabled: true,
       a1111ServerUrl: 'http://127.0.0.1:7860',
       a1111AutoStart: false,
       a1111LastConnectionStatus: 'unknown',
 
       // ComfyUI Integration initial state
+      comfyUIEnabled: true,
       comfyUIServerUrl: 'http://127.0.0.1:8188',
       comfyUILastConnectionStatus: 'unknown',
 
@@ -194,11 +200,13 @@ export const useSettingsStore = create<SettingsState>()(
       resetKeymap: () => set({ keymap: getDefaultKeymap() }),
 
       // A1111 Integration actions
+      setA1111Enabled: (value) => set({ a1111Enabled: !!value }),
       setA1111ServerUrl: (url) => set({ a1111ServerUrl: url }),
       toggleA1111AutoStart: () => set((state) => ({ a1111AutoStart: !state.a1111AutoStart })),
       setA1111ConnectionStatus: (status) => set({ a1111LastConnectionStatus: status }),
 
       // ComfyUI Integration actions
+      setComfyUIEnabled: (value) => set({ comfyUIEnabled: !!value }),
       setComfyUIServerUrl: (url) => set({ comfyUIServerUrl: url }),
       setComfyUIConnectionStatus: (status) => set({ comfyUILastConnectionStatus: status }),
 
@@ -222,9 +230,11 @@ export const useSettingsStore = create<SettingsState>()(
         sensitiveTags: ['nsfw', 'private', 'hidden'],
         blurSensitiveImages: true,
         enableSafeMode: true,
+        a1111Enabled: true,
         a1111ServerUrl: 'http://127.0.0.1:7860',
         a1111AutoStart: false,
         a1111LastConnectionStatus: 'unknown',
+        comfyUIEnabled: true,
         comfyUIServerUrl: 'http://127.0.0.1:8188',
         comfyUILastConnectionStatus: 'unknown',
       }),
@@ -233,6 +243,22 @@ export const useSettingsStore = create<SettingsState>()(
       name: 'image-metahub-settings',
       storage: createJSONStorage(() => isElectron ? electronStorage : localStorage),
       onRehydrateStorage: () => (state) => {
+        if (state) {
+          const defaultKeymap = getDefaultKeymap();
+          state.keymap = {
+            ...defaultKeymap,
+            ...state.keymap,
+            global: {
+              ...(defaultKeymap.global as Record<string, string>),
+              ...((state.keymap?.global as Record<string, string> | undefined) ?? {}),
+            },
+            preview: {
+              ...(defaultKeymap.preview as Record<string, string>),
+              ...((state.keymap?.preview as Record<string, string> | undefined) ?? {}),
+            },
+          };
+        }
+
         // Migration: Fix invalid itemsPerPage values from older versions
         if (state && (typeof state.itemsPerPage !== 'number' || (state.itemsPerPage <= 0 && state.itemsPerPage !== -1) || state.itemsPerPage > 100)) {
           state.itemsPerPage = 100;
@@ -256,6 +282,14 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.enableSafeMode !== 'boolean') {
           state.enableSafeMode = true;
+        }
+
+        if (state && typeof state.a1111Enabled !== 'boolean') {
+          state.a1111Enabled = true;
+        }
+
+        if (state && typeof state.comfyUIEnabled !== 'boolean') {
+          state.comfyUIEnabled = true;
         }
       },
     }

--- a/types.ts
+++ b/types.ts
@@ -705,6 +705,8 @@ export interface TagInfo {
   count: number;                 // Number of images with this tag
 }
 
+export type InclusionFilterMode = 'neutral' | 'include' | 'exclude';
+
 export interface Directory {
   id: string; // A unique identifier for the directory (e.g., a UUID or a hash of the path)
   name: string;

--- a/utils/hotkeyUtils.ts
+++ b/utils/hotkeyUtils.ts
@@ -1,0 +1,60 @@
+const KEY_ALIASES: Record<string, string> = {
+  arrowleft: 'left',
+  arrowright: 'right',
+  arrowup: 'up',
+  arrowdown: 'down',
+  escape: 'esc',
+  ' ': 'space',
+};
+
+const normalizeKey = (key: string): string => {
+  const normalized = key.trim().toLowerCase();
+  return KEY_ALIASES[normalized] ?? normalized;
+};
+
+export const isTypingElement = (target: EventTarget | null | undefined): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tagName = target.tagName;
+  return Boolean(
+    tagName === 'INPUT' ||
+    tagName === 'TEXTAREA' ||
+    tagName === 'SELECT' ||
+    target.isContentEditable ||
+    target.contentEditable === 'true' ||
+    target.getAttribute('contenteditable') === 'true',
+  );
+};
+
+export const eventMatchesKeybinding = (
+  event: Pick<KeyboardEvent, 'key' | 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey'>,
+  keybinding?: string,
+): boolean => {
+  if (!keybinding) {
+    return false;
+  }
+
+  return keybinding
+    .split(',')
+    .map((combo) => combo.trim())
+    .filter(Boolean)
+    .some((combo) => {
+      const parts = combo.split('+').map((part) => part.trim().toLowerCase()).filter(Boolean);
+      if (parts.length === 0) {
+        return false;
+      }
+
+      const key = normalizeKey(parts[parts.length - 1]);
+      const modifiers = new Set(parts.slice(0, -1));
+
+      return (
+        event.ctrlKey === modifiers.has('ctrl') &&
+        event.metaKey === (modifiers.has('cmd') || modifiers.has('meta')) &&
+        event.altKey === modifiers.has('alt') &&
+        event.shiftKey === modifiers.has('shift') &&
+        normalizeKey(event.key) === key
+      );
+    });
+};


### PR DESCRIPTION
- Added support for toggling visibility of A1111 and ComfyUI actions in the Image Modal and Preview Sidebar.
- Introduced a new hook `useGenerationProviderAvailability` to manage the availability of generation providers.
- Implemented tri-state filtering for favorites and tags in the Tags and Favorites component, allowing users to include, exclude, or neutralize filters.
- Updated Settings Modal to include toggles for enabling/disabling A1111 and ComfyUI integrations.
- Improved performance and responsiveness for large libraries by optimizing thumbnail loading and directory discovery.
- Added new hotkeys for toggling favorites, focusing on the add tag field, and deleting images in the viewer.
- Enhanced metadata compatibility for ComfyUI and improved parsing for prompt-only payloads.
- Fixed various bugs related to settings persistence, search filters, and thumbnail generation during indexing.