### PR TITLE
Tagging UX improvements for 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.1] - Unreleased
 
+### Improved
+
+- **Unified Tag Entry UX**: Manual tag entry in `ImageModal`, `ImagePreviewSidebar`, and `Tag Manager` now shares the same suggestion combobox, keyboard navigation, mouse selection behavior, and match ranking, making tag suggestions feel consistent everywhere.
+- **Tagging Controls in Settings**: Added viewer settings for tag suggestion count and visible recent-tag chips, while keeping a larger internal recent-tag history so quick picks stay useful without overwhelming the UI.
+- **Safer Bulk Tag Suggestions**: The Tag Manager's comma-separated input now applies autocomplete only to the active CSV token, making multi-tag edits faster and less error-prone.
+
 ### Fixed
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+- **Sidebar Filter Layout Regression**: Restored the single-scroll sidebar flow after the experimental split-pane filter layout proved confusing and interfered with normal folder and tag browsing.
 
 ## [0.14.0] - Unreleased
 

--- a/__tests__/Sidebar.layout.test.tsx
+++ b/__tests__/Sidebar.layout.test.tsx
@@ -33,7 +33,7 @@ describe('Sidebar layout', () => {
     cleanup();
   });
 
-  it('renders the left sidebar in three independently resizable panes', () => {
+  it('renders the left sidebar with the main scrollable filter content', () => {
     const FolderPane = (_props: Record<string, unknown>) => <div>Folder content</div>;
 
     render(
@@ -76,10 +76,8 @@ describe('Sidebar layout', () => {
       </Sidebar>,
     );
 
-    expect(screen.getByRole('region', { name: 'Folders pane' })).toBeTruthy();
-    expect(screen.getByRole('region', { name: 'Tags and favorites pane' })).toBeTruthy();
-    expect(screen.getByRole('region', { name: 'Filters pane' })).toBeTruthy();
-    expect(screen.getByRole('separator', { name: 'Resize Folders pane' })).toBeTruthy();
-    expect(screen.getByRole('separator', { name: 'Resize Tags and favorites pane' })).toBeTruthy();
+    expect(screen.getByText('Folder content')).toBeTruthy();
+    expect(screen.getByText('Ratings, Favorites & Tags')).toBeTruthy();
+    expect(screen.getByText('Sort Order')).toBeTruthy();
   });
 });

--- a/__tests__/Sidebar.layout.test.tsx
+++ b/__tests__/Sidebar.layout.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Sidebar from '../components/Sidebar';
+import { useImageStore } from '../store/useImageStore';
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  },
+}));
+
+describe('Sidebar layout', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      images: [],
+      filteredImages: [],
+      availableTags: [],
+      availableAutoTags: [],
+      selectedTags: [],
+      excludedTags: [],
+      selectedAutoTags: [],
+      excludedAutoTags: [],
+      selectedRatings: [],
+      favoriteFilterMode: 'neutral',
+    });
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the left sidebar in three independently resizable panes', () => {
+    const FolderPane = (_props: Record<string, unknown>) => <div>Folder content</div>;
+
+    render(
+      <Sidebar
+        searchQuery=""
+        onSearchChange={() => {}}
+        availableModels={[]}
+        availableLoras={[]}
+        availableSamplers={[]}
+        availableSchedulers={[]}
+        availableDimensions={[]}
+        selectedModels={[]}
+        selectedLoras={[]}
+        selectedSamplers={[]}
+        selectedSchedulers={[]}
+        onModelChange={() => {}}
+        onLoraChange={() => {}}
+        onSamplerChange={() => {}}
+        onSchedulerChange={() => {}}
+        onClearAllFilters={() => {}}
+        advancedFilters={{}}
+        onAdvancedFiltersChange={() => {}}
+        onClearAdvancedFilters={() => {}}
+        selectedRatings={[]}
+        onSelectedRatingsChange={() => {}}
+        isCollapsed={false}
+        onToggleCollapse={() => {}}
+        width={360}
+        isResizing={false}
+        onResizeStart={() => {}}
+        isIndexing={false}
+        scanSubfolders={true}
+        excludedFolders={new Set<string>()}
+        onExcludeFolder={() => {}}
+        onIncludeFolder={() => {}}
+        sortOrder="date-desc"
+        onSortOrderChange={() => {}}
+      >
+        <FolderPane />
+      </Sidebar>,
+    );
+
+    expect(screen.getByRole('region', { name: 'Folders pane' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Tags and favorites pane' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Filters pane' })).toBeTruthy();
+    expect(screen.getByRole('separator', { name: 'Resize Folders pane' })).toBeTruthy();
+    expect(screen.getByRole('separator', { name: 'Resize Tags and favorites pane' })).toBeTruthy();
+  });
+});

--- a/__tests__/TagInputCombobox.test.tsx
+++ b/__tests__/TagInputCombobox.test.tsx
@@ -70,6 +70,16 @@ describe('TagInputCombobox', () => {
     expect(escapeSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('delegates escape immediately when the current token has no matches', () => {
+    const { input, escapeSpy } = renderHarness();
+
+    fireEvent.change(input, { target: { value: 'zzz' } });
+    expect(screen.queryByRole('listbox')).toBeNull();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(escapeSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('applies mouse-selected suggestions without losing the action', () => {
     const { input, submitSpy } = renderHarness({ value: 'mac' });
 

--- a/__tests__/TagInputCombobox.test.tsx
+++ b/__tests__/TagInputCombobox.test.tsx
@@ -84,11 +84,9 @@ describe('TagInputCombobox', () => {
   it('replaces the last CSV token instead of submitting immediately in csv mode', async () => {
     const { input, submitSpy } = renderHarness({
       mode: 'csv',
-      value: 'macro, por',
     });
 
-    fireEvent.focus(input);
-    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.change(input, { target: { value: 'macro, por' } });
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeTruthy();
     });

--- a/__tests__/TagInputCombobox.test.tsx
+++ b/__tests__/TagInputCombobox.test.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import TagInputCombobox from '../components/TagInputCombobox';
+
+const renderHarness = (props: Partial<React.ComponentProps<typeof TagInputCombobox>> = {}) => {
+  const submitSpy = vi.fn();
+  const escapeSpy = vi.fn();
+  const { value: initialValue, ...restProps } = props;
+
+  const Harness = () => {
+    const [value, setValue] = useState(initialValue ?? '');
+
+    return (
+      <TagInputCombobox
+        value={value}
+        onValueChange={setValue}
+        onSubmit={(nextValue) => submitSpy(nextValue)}
+        onEscape={escapeSpy}
+        recentTags={['portrait', 'landscape', 'macro']}
+        availableTags={[
+          { name: 'portrait', count: 8 },
+          { name: 'landscape', count: 4 },
+          { name: 'macro', count: 2 },
+        ]}
+        suggestionLimit={10}
+        placeholder="Add tag..."
+        inputClassName="w-full"
+        {...restProps}
+      />
+    );
+  };
+
+  render(<Harness />);
+
+  return {
+    submitSpy,
+    escapeSpy,
+    input: screen.getByPlaceholderText('Add tag...'),
+  };
+};
+
+describe('TagInputCombobox', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('supports arrow-key navigation and enter-to-select', () => {
+    const { input, submitSpy } = renderHarness();
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(submitSpy).toHaveBeenCalledWith('landscape');
+  });
+
+  it('closes the open list on escape before delegating to the caller', () => {
+    const { input, escapeSpy } = renderHarness({ value: 'por' });
+
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeTruthy();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(escapeSpy).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(escapeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies mouse-selected suggestions without losing the action', () => {
+    const { input, submitSpy } = renderHarness({ value: 'mac' });
+
+    fireEvent.focus(input);
+    const option = screen.getByRole('option', { name: /macro/i });
+    fireEvent.pointerDown(option);
+    fireEvent.click(option);
+
+    expect(submitSpy).toHaveBeenCalledWith('macro');
+  });
+
+  it('replaces the last CSV token instead of submitting immediately in csv mode', async () => {
+    const { input, submitSpy } = renderHarness({
+      mode: 'csv',
+      value: 'macro, por',
+    });
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeTruthy();
+    });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect((input as HTMLInputElement).value).toBe('macro, portrait, ');
+    });
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/TagManagerModal.test.tsx
+++ b/__tests__/TagManagerModal.test.tsx
@@ -17,6 +17,7 @@ describe('TagManagerModal', () => {
     useImageStore.getState().resetState();
     useImageStore.setState({
       availableTags: [{ name: 'portrait', count: 2 }],
+      recentTags: ['portrait'],
       bulkAddTag,
       bulkRemoveTag,
       images: [

--- a/__tests__/VerticalSplitPanels.test.tsx
+++ b/__tests__/VerticalSplitPanels.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import VerticalSplitPanels from '../components/VerticalSplitPanels';
+
+describe('VerticalSplitPanels', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the configured panes and persists resized pane sizes', async () => {
+    const { getByTestId, rerender } = render(
+      <VerticalSplitPanels
+        storageKey="test-pane-sizes"
+        defaultSizes={[36, 34, 30]}
+        panes={[
+          { id: 'one', ariaLabel: 'Pane one', content: <div>One</div> },
+          { id: 'two', ariaLabel: 'Pane two', content: <div>Two</div> },
+          { id: 'three', ariaLabel: 'Pane three', content: <div>Three</div> },
+        ]}
+      />,
+    );
+
+    const layout = getByTestId('vertical-split-panels');
+    Object.defineProperty(layout, 'getBoundingClientRect', {
+      value: () => ({ width: 320, height: 600, top: 0, left: 0, right: 320, bottom: 600 }),
+    });
+
+    expect(screen.getByRole('region', { name: 'Pane one' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Pane two' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Pane three' })).toBeTruthy();
+
+    const firstHandle = screen.getByRole('separator', { name: 'Resize Pane one' });
+    fireEvent.pointerDown(firstHandle, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientY: -300 });
+    fireEvent.pointerUp(window);
+
+    await waitFor(() => {
+      const firstPane = screen.getByRole('region', { name: 'Pane one' }) as HTMLElement;
+      expect(parseFloat(firstPane.style.flexBasis)).toBe(20);
+    });
+
+    const stored = JSON.parse(window.localStorage.getItem('test-pane-sizes') ?? '[]') as number[];
+    expect(stored).toHaveLength(3);
+    expect(Math.round(stored[0])).toBe(20);
+
+    rerender(
+      <VerticalSplitPanels
+        storageKey="test-pane-sizes"
+        defaultSizes={[36, 34, 30]}
+        panes={[
+          { id: 'one', ariaLabel: 'Pane one', content: <div>One</div> },
+          { id: 'two', ariaLabel: 'Pane two', content: <div>Two</div> },
+          { id: 'three', ariaLabel: 'Pane three', content: <div>Three</div> },
+        ]}
+      />,
+    );
+
+    const reloadedFirstPane = screen.getByRole('region', { name: 'Pane one' }) as HTMLElement;
+    expect(Math.round(parseFloat(reloadedFirstPane.style.flexBasis))).toBe(20);
+  });
+});

--- a/__tests__/tagSuggestions.test.ts
+++ b/__tests__/tagSuggestions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getRecentTagChips, getTagSuggestions } from '../utils/tagSuggestions';
+
+describe('tagSuggestions utilities', () => {
+  it('orders prefix matches before substring matches and prioritizes recent tags within the same tier', () => {
+    const suggestions = getTagSuggestions({
+      query: 'art',
+      recentTags: ['smart-light', 'cinematic'],
+      availableTags: [
+        { name: 'transport', count: 2 },
+        { name: 'art', count: 5 },
+        { name: 'cartoon', count: 3 },
+        { name: 'smart-light', count: 8 },
+      ],
+      limit: 10,
+    });
+
+    expect(suggestions.map((entry) => entry.name)).toEqual([
+      'art',
+      'smart-light',
+      'cartoon',
+    ]);
+  });
+
+  it('dedupes, excludes already-applied tags, and respects the suggestion limit', () => {
+    const suggestions = getTagSuggestions({
+      query: '',
+      recentTags: ['portrait', 'portrait', 'landscape', 'macro', 'editorial', 'studio'],
+      availableTags: [
+        { name: 'portrait', count: 4 },
+        { name: 'landscape', count: 3 },
+        { name: 'macro', count: 2 },
+      ],
+      excludedTags: ['landscape'],
+      limit: 5,
+    });
+
+    expect(suggestions.map((entry) => entry.name)).toEqual(['portrait', 'macro', 'editorial', 'studio']);
+  });
+
+  it('limits recent tag chips independently from stored history', () => {
+    const chips = getRecentTagChips({
+      recentTags: ['portrait', 'macro', 'landscape', 'editorial', 'studio', 'warm'],
+      excludedTags: ['macro'],
+      limit: 5,
+    });
+
+    expect(chips).toEqual(['portrait', 'landscape', 'editorial', 'studio', 'warm']);
+  });
+});

--- a/__tests__/useSettingsStore.tagging.test.ts
+++ b/__tests__/useSettingsStore.tagging.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSettingsStore } from '../store/useSettingsStore';
+import {
+  DEFAULT_RECENT_TAG_CHIP_LIMIT,
+  DEFAULT_TAG_SUGGESTION_LIMIT,
+  MAX_TAG_UI_LIMIT,
+  MIN_TAG_UI_LIMIT,
+} from '../utils/tagSuggestions';
+
+describe('useSettingsStore tagging preferences', () => {
+  beforeEach(() => {
+    useSettingsStore.getState().resetState();
+  });
+
+  it('starts with the expected tagging defaults', () => {
+    const state = useSettingsStore.getState();
+
+    expect(state.tagSuggestionLimit).toBe(DEFAULT_TAG_SUGGESTION_LIMIT);
+    expect(state.recentTagChipLimit).toBe(DEFAULT_RECENT_TAG_CHIP_LIMIT);
+  });
+
+  it('clamps tagging preference setters to the supported range', () => {
+    useSettingsStore.getState().setTagSuggestionLimit(MAX_TAG_UI_LIMIT + 100);
+    useSettingsStore.getState().setRecentTagChipLimit(MIN_TAG_UI_LIMIT - 10);
+
+    expect(useSettingsStore.getState().tagSuggestionLimit).toBe(MAX_TAG_UI_LIMIT);
+    expect(useSettingsStore.getState().recentTagChipLimit).toBe(MIN_TAG_UI_LIMIT);
+  });
+});

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -28,37 +28,8 @@ import { MetadataEditorModal } from './MetadataEditorModal';
 import ImageLineageSection from './ImageLineageSection';
 import { getGenerationTypeLabel } from '../utils/imageLineage';
 import RatingStars from './RatingStars';
-
-
-const TAG_SUGGESTION_LIMIT = 5;
-
-const buildTagSuggestions = (
-  recentTags: string[],
-  availableTags: { name: string }[],
-  currentTags: string[],
-): string[] => {
-  const suggestions: string[] = [];
-
-  for (const tag of recentTags) {
-    if (!currentTags.includes(tag) && !suggestions.includes(tag)) {
-      suggestions.push(tag);
-      if (suggestions.length >= TAG_SUGGESTION_LIMIT) {
-        return suggestions;
-      }
-    }
-  }
-
-  for (const tag of availableTags) {
-    if (!currentTags.includes(tag.name) && !suggestions.includes(tag.name)) {
-      suggestions.push(tag.name);
-      if (suggestions.length >= TAG_SUGGESTION_LIMIT) {
-        break;
-      }
-    }
-  }
-
-  return suggestions;
-};
+import TagInputCombobox from './TagInputCombobox';
+import { getRecentTagChips } from '../utils/tagSuggestions';
 
 interface ImageModalProps {
   image: IndexedImage;
@@ -591,6 +562,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const recentTags = useImageStore((state) => state.recentTags);
   const setSelectedImage = useImageStore((state) => state.setSelectedImage);
   const setPreviewImage = useImageStore((state) => state.setPreviewImage);
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
+  const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
 
   // Shadow Metadata Hook
   const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata, deleteMetadata: deleteShadowMetadata } = useShadowMetadata(image.id);
@@ -616,12 +589,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const currentIsFavorite = liveImage.isFavorite ?? false;
   const currentRating = liveImage.rating ?? null;
   const preferredThumbnailUrl = thumbnail?.thumbnailUrl ?? null;
-  const tagSuggestions = buildTagSuggestions(recentTags, availableTags, currentTags);
+  const recentTagSuggestions = useMemo(() => getRecentTagChips({
+    recentTags,
+    excludedTags: currentTags,
+    limit: recentTagChipLimit,
+  }), [currentTags, recentTagChipLimit, recentTags]);
   const createdAtLabel = useMemo(() => new Date(image.lastModified).toLocaleString(), [image.lastModified]);
 
   // State for tag input
   const [tagInput, setTagInput] = useState('');
-  const [showTagAutocomplete, setShowTagAutocomplete] = useState(false);
   const [isMediaOverlayVisible, setIsMediaOverlayVisible] = useState(false);
   const tagInputRef = useRef<HTMLInputElement>(null);
   const imageContainerRef = useRef<HTMLDivElement>(null);
@@ -1378,7 +1354,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
     const focusInput = () => {
       tagInputRef.current?.focus();
       tagInputRef.current?.select();
-      setShowTagAutocomplete((tagInputRef.current?.value ?? '').trim().length > 0);
     };
 
     if (isFullscreen) {
@@ -1603,11 +1578,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
   };
 
   // Tag management handlers
-  const handleAddTag = () => {
-    if (!tagInput.trim()) return;
-    addTagToImage(image.id, tagInput);
+  const handleAddTag = (value = tagInput) => {
+    if (!value.trim()) return;
+    addTagToImage(image.id, value);
     setTagInput('');
-    setShowTagAutocomplete(false);
   };
 
   const handleRemoveTag = (tag: string) => {
@@ -1623,16 +1597,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
     await addTagToImage(image.id, tag);
     removeAutoTagFromImage(image.id, tag);
   };
-
-  // Filter autocomplete tags
-  const autocompleteOptions = tagInput
-    ? availableTags
-        .filter(tag =>
-          tag.name.includes(tagInput.toLowerCase()) &&
-          !currentTags.includes(tag.name)
-        )
-        .slice(0, 5)
-    : [];
 
   if (isMinimized) {
     return null;
@@ -1996,51 +1960,26 @@ const ImageModal: React.FC<ImageModalProps> = ({
               {/* Tags Pills */}
               <div className="flex-1 space-y-2">
                 {/* Add Tag Input */}
-                <div className="relative">
-                  <input
-                    ref={tagInputRef}
-                    type="text"
-                    placeholder="Add tag..."
-                    value={tagInput}
-                    onChange={(e) => {
-                      setTagInput(e.target.value);
-                      setShowTagAutocomplete(e.target.value.length > 0);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault();
-                        handleAddTag();
-                      }
-                      if (e.key === 'Escape') {
-                        setTagInput('');
-                        setShowTagAutocomplete(false);
-                      }
-                    }}
-                    onFocus={() => tagInput && setShowTagAutocomplete(true)}
-                    onBlur={() => setTimeout(() => setShowTagAutocomplete(false), 200)}
-                    className="w-full bg-gray-700/50 text-gray-200 border border-gray-600 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-500"
-                  />
-
-                  {/* Autocomplete Dropdown */}
-                  {showTagAutocomplete && autocompleteOptions.length > 0 && (
-                    <div className="absolute z-10 w-full mt-1 bg-gray-800 border border-gray-600 rounded-lg shadow-lg max-h-32 overflow-y-auto">
-                      {autocompleteOptions.map(tag => (
-                        <button
-                          key={tag.name}
-                          onClick={() => {
-                            addTagToImage(image.id, tag.name);
-                            setTagInput('');
-                            setShowTagAutocomplete(false);
-                          }}
-                          className="w-full text-left px-2 py-1.5 text-xs text-gray-200 hover:bg-gray-700 flex justify-between items-center"
-                        >
-                          <span>{tag.name}</span>
-                          <span className="text-xs text-gray-500">({tag.count})</span>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                <TagInputCombobox
+                  ref={tagInputRef}
+                  value={tagInput}
+                  onValueChange={setTagInput}
+                  onSubmit={handleAddTag}
+                  recentTags={recentTags}
+                  availableTags={availableTags}
+                  excludedTags={currentTags}
+                  suggestionLimit={tagSuggestionLimit}
+                  placeholder="Add tag..."
+                  inputClassName="w-full bg-gray-700/50 text-gray-200 border border-gray-600 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-500"
+                  dropdownClassName="absolute z-10 mt-1 max-h-32 w-full overflow-y-auto rounded-lg border border-gray-600 bg-gray-800 shadow-lg"
+                  optionClassName="w-full text-left px-2 py-1.5 text-xs text-gray-200 hover:bg-gray-700 flex justify-between items-center"
+                  activeOptionClassName="bg-gray-700 text-white"
+                  metaClassName="text-xs text-gray-500"
+                  onEscape={() => {
+                    setTagInput('');
+                    tagInputRef.current?.focus();
+                  }}
+                />
 
                 {/* Current Tags */}
                 {currentTags && currentTags.length > 0 && (
@@ -2060,9 +1999,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 )}
 
                 {/* Tag Suggestions */}
-                {tagInput.trim().length === 0 && tagSuggestions.length > 0 && (
+                {tagInput.trim().length === 0 && recentTagSuggestions.length > 0 && (
                   <div className="flex flex-wrap gap-1">
-                    {tagSuggestions.map(tag => (
+                    {recentTagSuggestions.map(tag => (
                       <button
                         key={tag}
                         onClick={() => addTagToImage(image.id, tag)}

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useState, FC, useCallback, useMemo, useRef } from 're
 import { type IndexedImage, type BaseMetadata, type LoRAInfo } from '../types';
 import { FileOperations } from '../services/fileOperations';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
-import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2 } from 'lucide-react';
+import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw } from 'lucide-react';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
 import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
 import { comparisonWillAutoOpen, useImageComparison } from '../hooks/useImageComparison';
+import { useReparseMetadata } from '../hooks/useReparseMetadata';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useGenerationProviderAvailability } from '../hooks/useGenerationProviderAvailability';
 import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } from './A1111GenerateModal';
@@ -573,6 +574,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   // Image comparison hook
   const { addImage, comparisonCount } = useImageComparison();
+  const { isReparsing, reparseImages } = useReparseMetadata();
 
   // Feature access (license/trial gating)
   const { canUseA1111, canUseComfyUI, canUseComparison, showProModal, initialized } = useFeatureAccess();
@@ -1147,6 +1149,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }
     // The showInExplorer utility can handle the full path directly
     showInExplorer(`${directoryPath}/${image.name}`);
+  };
+
+  const handleReparseMetadata = async () => {
+    hideContextMenu();
+    await reparseImages([liveImage]);
   };
 
   const exportImage = async () => {
@@ -2757,6 +2764,17 @@ const ImageModal: React.FC<ImageModalProps> = ({
               >
                 <Copy className="w-4 h-4" />
                 Copy Model
+              </button>
+
+              <div className="border-t border-gray-600 my-1"></div>
+
+              <button
+                onClick={handleReparseMetadata}
+                className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={isReparsing}
+              >
+                <RefreshCw className={`w-4 h-4 ${isReparsing ? 'animate-spin' : ''}`} />
+                Reparse Metadata
               </button>
 
               <div className="border-t border-gray-600 my-1"></div>

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, FC } from 'react';
+import React, { useEffect, useMemo, useRef, useState, FC } from 'react';
 import { Clipboard, Sparkles, ChevronDown, ChevronRight, Heart, X, Zap, CheckCircle, ArrowUp, Copy, Search } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { type BaseMetadata, type LoRAInfo } from '../types';
@@ -17,36 +17,9 @@ import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import ImageLineageSection from './ImageLineageSection';
 import { getGenerationTypeLabel } from '../utils/imageLineage';
 import RatingStars from './RatingStars';
-
-const TAG_SUGGESTION_LIMIT = 5;
-
-const buildTagSuggestions = (
-  recentTags: string[],
-  availableTags: { name: string }[],
-  currentTags: string[],
-): string[] => {
-  const suggestions: string[] = [];
-
-  for (const tag of recentTags) {
-    if (!currentTags.includes(tag) && !suggestions.includes(tag)) {
-      suggestions.push(tag);
-      if (suggestions.length >= TAG_SUGGESTION_LIMIT) {
-        return suggestions;
-      }
-    }
-  }
-
-  for (const tag of availableTags) {
-    if (!currentTags.includes(tag.name) && !suggestions.includes(tag.name)) {
-      suggestions.push(tag.name);
-      if (suggestions.length >= TAG_SUGGESTION_LIMIT) {
-        break;
-      }
-    }
-  }
-
-  return suggestions;
-};
+import TagInputCombobox from './TagInputCombobox';
+import { useSettingsStore } from '../store/useSettingsStore';
+import { getRecentTagChips } from '../utils/tagSuggestions';
 
 // Helper function to format LoRA with weight
 const formatLoRA = (lora: string | LoRAInfo): string => {
@@ -190,7 +163,6 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
   const [tagInput, setTagInput] = useState('');
-  const [showTagAutocomplete, setShowTagAutocomplete] = useState(false);
   const [showPerformance, setShowPerformance] = useState(true);
   const [showRawMetadata, setShowRawMetadata] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
@@ -199,6 +171,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     visible: false,
     selectionText: '',
   });
+  const tagInputRef = useRef<HTMLInputElement>(null);
 
   const { copyToA1111, isCopying, copyStatus } = useCopyToA1111();
   const { generateWithA1111, isGenerating, generateStatus } = useGenerateWithA1111();
@@ -218,7 +191,13 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const a1111GenerateLabel = singleVisibleProvider?.id === 'a1111' ? 'Generate' : 'Generate with A1111';
   const comfyGenerateLabel = singleVisibleProvider?.id === 'comfyui' ? 'Generate' : 'Generate with ComfyUI';
   const preferredThumbnailUrl = thumbnail?.thumbnailUrl ?? null;
-  const tagSuggestions = buildTagSuggestions(recentTags, availableTags, activeImage?.tags ?? []);
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
+  const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
+  const recentTagSuggestions = useMemo(() => getRecentTagChips({
+    recentTags,
+    excludedTags: activeImage?.tags ?? [],
+    limit: recentTagChipLimit,
+  }), [activeImage?.tags, recentTagChipLimit, recentTags]);
 
   useEffect(() => {
     let isMounted = true;
@@ -340,11 +319,10 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   };
 
   // Tag management handlers
-  const handleAddTag = () => {
-    if (!tagInput.trim() || !activeImage) return;
-    addTagToImage(activeImage.id, tagInput);
+  const handleAddTag = (value = tagInput) => {
+    if (!value.trim() || !activeImage) return;
+    addTagToImage(activeImage.id, value);
     setTagInput('');
-    setShowTagAutocomplete(false);
   };
 
   const handleRemoveTag = (tag: string) => {
@@ -373,16 +351,6 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     if (!activeImage) return;
     setImageRating(activeImage.id, rating);
   };
-
-  // Filter autocomplete tags
-  const autocompleteOptions = tagInput && activeImage
-    ? availableTags
-        .filter(tag =>
-          tag.name.includes(tagInput.toLowerCase()) &&
-          !(activeImage.tags || []).includes(tag.name)
-        )
-        .slice(0, 5)
-    : [];
 
   return (
     <div
@@ -478,50 +446,26 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
             {/* Tags Pills */}
             <div className="flex-1 space-y-2">
               {/* Add Tag Input */}
-              <div className="relative">
-                <input
-                  type="text"
-                  placeholder="Add tag..."
-                  value={tagInput}
-                  onChange={(e) => {
-                    setTagInput(e.target.value);
-                    setShowTagAutocomplete(e.target.value.length > 0);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      handleAddTag();
-                    }
-                    if (e.key === 'Escape') {
-                      setTagInput('');
-                      setShowTagAutocomplete(false);
-                    }
-                  }}
-                  onFocus={() => tagInput && setShowTagAutocomplete(true)}
-                  onBlur={() => setTimeout(() => setShowTagAutocomplete(false), 200)}
-                  className="w-full bg-white dark:bg-gray-700/50 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-400 dark:placeholder-gray-500"
-                />
-
-                {/* Autocomplete Dropdown */}
-                {showTagAutocomplete && autocompleteOptions.length > 0 && (
-                  <div className="absolute z-10 w-full mt-1 bg-gray-800 border border-gray-600 rounded-lg shadow-lg max-h-32 overflow-y-auto">
-                    {autocompleteOptions.map(tag => (
-                      <button
-                        key={tag.name}
-                        onClick={() => {
-                          addTagToImage(activeImage.id, tag.name);
-                          setTagInput('');
-                          setShowTagAutocomplete(false);
-                        }}
-                        className="w-full text-left px-2 py-1.5 text-xs text-gray-200 hover:bg-gray-700 flex justify-between items-center"
-                      >
-                        <span>{tag.name}</span>
-                        <span className="text-xs text-gray-500">({tag.count})</span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+              <TagInputCombobox
+                ref={tagInputRef}
+                value={tagInput}
+                onValueChange={setTagInput}
+                onSubmit={handleAddTag}
+                recentTags={recentTags}
+                availableTags={availableTags}
+                excludedTags={activeImage.tags ?? []}
+                suggestionLimit={tagSuggestionLimit}
+                placeholder="Add tag..."
+                inputClassName="w-full bg-white dark:bg-gray-700/50 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-400 dark:placeholder-gray-500"
+                dropdownClassName="absolute z-10 mt-1 max-h-32 w-full overflow-y-auto rounded-lg border border-gray-600 bg-gray-800 shadow-lg"
+                optionClassName="w-full text-left px-2 py-1.5 text-xs text-gray-200 hover:bg-gray-700 flex justify-between items-center"
+                activeOptionClassName="bg-gray-700 text-white"
+                metaClassName="text-xs text-gray-500"
+                onEscape={() => {
+                  setTagInput('');
+                  tagInputRef.current?.focus();
+                }}
+              />
 
               {/* Current Tags */}
               {activeImage.tags && activeImage.tags.length > 0 && (
@@ -541,9 +485,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
               )}
 
               {/* Tag Suggestions */}
-              {tagInput.trim().length === 0 && tagSuggestions.length > 0 && (
+              {tagInput.trim().length === 0 && recentTagSuggestions.length > 0 && (
                 <div className="flex flex-wrap gap-1">
-                  {tagSuggestions.map(tag => (
+                  {recentTagSuggestions.map(tag => (
                     <button
                       key={tag}
                       onClick={() => addTagToImage(activeImage.id, tag)}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,12 +6,8 @@ import AdvancedFilters from './AdvancedFilters';
 import TagsAndFavorites from './TagsAndFavorites';
 import ActiveFilters from './ActiveFilters';
 import FacetFilterSection from './FacetFilterSection';
-import VerticalSplitPanels from './VerticalSplitPanels';
 import { useImageStore } from '../store/useImageStore';
 import type { AdvancedFilters as AdvancedFilterState, ImageRating } from '../types';
-
-const SIDEBAR_PANE_SIZES_STORAGE_KEY = 'image-metahub-sidebar-pane-sizes';
-const DEFAULT_SIDEBAR_PANE_SIZES = [36, 34, 30];
 
 const toFacetLabel = (value: unknown): string | null => {
   if (typeof value === 'string') {
@@ -279,57 +275,6 @@ const Sidebar: React.FC<SidebarProps> = ({
     favoriteFilterMode !== 'neutral' ||
     selectedRatings.length > 0 ||
     Object.keys(advancedFilters || {}).length > 0;
-  const directoryPaneContent = children && React.isValidElement(children)
-    ? React.cloneElement(children as React.ReactElement<any>, {
-        isIndexing,
-        scanSubfolders,
-        excludedFolders,
-        onExcludeFolder,
-        onIncludeFolder
-      })
-    : children;
-  const secondaryFiltersPane = (
-    <div className="space-y-4 pb-4">
-      {generationFacets.length > 0 && (
-        <section className="border-b border-gray-800/80 bg-gray-950/20">
-          <button
-            type="button"
-            onClick={() => setIsGenerationParametersExpanded((prev) => !prev)}
-            className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors hover:bg-gray-800/40"
-          >
-            <h3 className="text-base font-medium text-gray-200">Generation Parameters</h3>
-            <ChevronDown
-              className={`h-4 w-4 text-gray-500 transition-transform ${isGenerationParametersExpanded ? 'rotate-180' : ''}`}
-            />
-          </button>
-          {isGenerationParametersExpanded && (
-            <div className="space-y-3 px-4 pb-4">
-              {generationFacets.map((facet) => (
-                <FacetFilterSection
-                  key={facet.title}
-                  title={facet.title}
-                  items={facet.items}
-                  counts={facet.counts}
-                  selectedValues={facet.selectedValues}
-                  excludedValues={facet.excludedValues}
-                  onIncludeToggle={facet.onIncludeToggle}
-                  onExcludeToggle={facet.onExcludeToggle}
-                  onClear={facet.onClear}
-                />
-              ))}
-            </div>
-          )}
-        </section>
-      )}
-
-      <AdvancedFilters
-        advancedFilters={advancedFilters}
-        onAdvancedFiltersChange={onAdvancedFiltersChange}
-        onClearAdvancedFilters={onClearAdvancedFilters}
-        availableDimensions={availableDimensions}
-      />
-    </div>
-  );
 
   if (isCollapsed) {
     return (
@@ -418,76 +363,107 @@ const Sidebar: React.FC<SidebarProps> = ({
         />
       </div>
 
-      <div className="border-b border-gray-800/80">
-        <ActiveFilters />
-      </div>
+      <div className="flex-1 overflow-y-auto scrollbar-sidebar">
+        <div className="border-b border-gray-800/80">
+          <ActiveFilters />
+        </div>
 
-      <div className="px-4 py-3 border-b border-gray-700">
-        <label htmlFor="sidebar-sort" className="block text-gray-400 text-xs font-medium mb-2">Sort Order</label>
-        <div className="flex items-center">
-        <select
-          id="sidebar-sort"
-          value={sortOrder}
-          onChange={(e) => onSortOrderChange(e.target.value)}
-          className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <option value="date-desc">Newest First</option>
-          <option value="date-asc">Oldest First</option>
-          <option value="asc">A-Z</option>
-          <option value="desc">Z-A</option>
-          <option value="random">Random</option>
-        </select>
-        {sortOrder === 'random' && onReshuffle && (
-          <button
-              onClick={onReshuffle}
-              className="ml-2 p-2 text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-md border border-gray-600 transition-colors"
-              title="Reshuffle Random Order"
+        <div className="px-4 py-3 border-b border-gray-700">
+          <label htmlFor="sidebar-sort" className="block text-gray-400 text-xs font-medium mb-2">Sort Order</label>
+          <div className="flex items-center">
+          <select
+            id="sidebar-sort"
+            value={sortOrder}
+            onChange={(e) => onSortOrderChange(e.target.value)}
+            className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-              <RefreshCw className="h-5 w-5" />
-          </button>
+            <option value="date-desc">Newest First</option>
+            <option value="date-asc">Oldest First</option>
+            <option value="asc">A-Z</option>
+            <option value="desc">Z-A</option>
+            <option value="random">Random</option>
+          </select>
+          {sortOrder === 'random' && onReshuffle && (
+            <button
+                onClick={onReshuffle}
+                className="ml-2 p-2 text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-md border border-gray-600 transition-colors"
+                title="Reshuffle Random Order"
+            >
+                <RefreshCw className="h-5 w-5" />
+            </button>
+          )}
+          </div>
+        </div>
+
+        {onAddFolder && (
+          <div className="px-3 py-2 border-b border-gray-700">
+            <button
+              onClick={onAddFolder}
+              disabled={isIndexing}
+              className={`w-full flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
+                isIndexing
+                  ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
+                  : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
+              }`}
+              title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
+            >
+              <Plus size={14} />
+              <span>Add Folder</span>
+            </button>
+          </div>
         )}
-        </div>
-      </div>
 
-      {onAddFolder && (
-        <div className="px-3 py-2 border-b border-gray-700">
-          <button
-            onClick={onAddFolder}
-            disabled={isIndexing}
-            className={`w-full flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
-              isIndexing
-                ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
-                : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
-            }`}
-            title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
-          >
-            <Plus size={14} />
-            <span>Add Folder</span>
-          </button>
-        </div>
-      )}
+        {children && React.isValidElement(children) ? (
+          React.cloneElement(children as React.ReactElement<any>, {
+            isIndexing,
+            scanSubfolders,
+            excludedFolders,
+            onExcludeFolder,
+            onIncludeFolder
+          })
+        ) : (
+          children
+        )}
 
-      <div className="min-h-0 flex-1 px-3 py-3">
-        <VerticalSplitPanels
-          storageKey={SIDEBAR_PANE_SIZES_STORAGE_KEY}
-          defaultSizes={DEFAULT_SIDEBAR_PANE_SIZES}
-          panes={[
-            {
-              id: 'directories',
-              ariaLabel: 'Folders pane',
-              content: directoryPaneContent,
-            },
-            {
-              id: 'tags',
-              ariaLabel: 'Tags and favorites pane',
-              content: <TagsAndFavorites />,
-            },
-            {
-              id: 'filters',
-              ariaLabel: 'Filters pane',
-              content: secondaryFiltersPane,
-            },
-          ]}
+        <TagsAndFavorites />
+
+        {generationFacets.length > 0 && (
+          <section className="border-y border-gray-800/80 bg-gray-950/20">
+            <button
+              type="button"
+              onClick={() => setIsGenerationParametersExpanded((prev) => !prev)}
+              className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors hover:bg-gray-800/40"
+            >
+              <h3 className="text-base font-medium text-gray-200">Generation Parameters</h3>
+              <ChevronDown
+                className={`h-4 w-4 text-gray-500 transition-transform ${isGenerationParametersExpanded ? 'rotate-180' : ''}`}
+              />
+            </button>
+            {isGenerationParametersExpanded && (
+              <div className="space-y-3 px-4 pb-4">
+                {generationFacets.map((facet) => (
+                  <FacetFilterSection
+                    key={facet.title}
+                    title={facet.title}
+                    items={facet.items}
+                    counts={facet.counts}
+                    selectedValues={facet.selectedValues}
+                    excludedValues={facet.excludedValues}
+                    onIncludeToggle={facet.onIncludeToggle}
+                    onExcludeToggle={facet.onExcludeToggle}
+                    onClear={facet.onClear}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        <AdvancedFilters
+          advancedFilters={advancedFilters}
+          onAdvancedFiltersChange={onAdvancedFiltersChange}
+          onClearAdvancedFilters={onClearAdvancedFilters}
+          availableDimensions={availableDimensions}
         />
       </div>
 

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,8 +6,12 @@ import AdvancedFilters from './AdvancedFilters';
 import TagsAndFavorites from './TagsAndFavorites';
 import ActiveFilters from './ActiveFilters';
 import FacetFilterSection from './FacetFilterSection';
+import VerticalSplitPanels from './VerticalSplitPanels';
 import { useImageStore } from '../store/useImageStore';
 import type { AdvancedFilters as AdvancedFilterState, ImageRating } from '../types';
+
+const SIDEBAR_PANE_SIZES_STORAGE_KEY = 'image-metahub-sidebar-pane-sizes';
+const DEFAULT_SIDEBAR_PANE_SIZES = [36, 34, 30];
 
 const toFacetLabel = (value: unknown): string | null => {
   if (typeof value === 'string') {
@@ -275,6 +279,57 @@ const Sidebar: React.FC<SidebarProps> = ({
     favoriteFilterMode !== 'neutral' ||
     selectedRatings.length > 0 ||
     Object.keys(advancedFilters || {}).length > 0;
+  const directoryPaneContent = children && React.isValidElement(children)
+    ? React.cloneElement(children as React.ReactElement<any>, {
+        isIndexing,
+        scanSubfolders,
+        excludedFolders,
+        onExcludeFolder,
+        onIncludeFolder
+      })
+    : children;
+  const secondaryFiltersPane = (
+    <div className="space-y-4 pb-4">
+      {generationFacets.length > 0 && (
+        <section className="border-b border-gray-800/80 bg-gray-950/20">
+          <button
+            type="button"
+            onClick={() => setIsGenerationParametersExpanded((prev) => !prev)}
+            className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors hover:bg-gray-800/40"
+          >
+            <h3 className="text-base font-medium text-gray-200">Generation Parameters</h3>
+            <ChevronDown
+              className={`h-4 w-4 text-gray-500 transition-transform ${isGenerationParametersExpanded ? 'rotate-180' : ''}`}
+            />
+          </button>
+          {isGenerationParametersExpanded && (
+            <div className="space-y-3 px-4 pb-4">
+              {generationFacets.map((facet) => (
+                <FacetFilterSection
+                  key={facet.title}
+                  title={facet.title}
+                  items={facet.items}
+                  counts={facet.counts}
+                  selectedValues={facet.selectedValues}
+                  excludedValues={facet.excludedValues}
+                  onIncludeToggle={facet.onIncludeToggle}
+                  onExcludeToggle={facet.onExcludeToggle}
+                  onClear={facet.onClear}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      <AdvancedFilters
+        advancedFilters={advancedFilters}
+        onAdvancedFiltersChange={onAdvancedFiltersChange}
+        onClearAdvancedFilters={onClearAdvancedFilters}
+        availableDimensions={availableDimensions}
+      />
+    </div>
+  );
 
   if (isCollapsed) {
     return (
@@ -363,111 +418,76 @@ const Sidebar: React.FC<SidebarProps> = ({
         />
       </div>
 
-      {/* Scrollable Content - includes DirectoryList AND Filters */}
-      <div className="flex-1 overflow-y-auto scrollbar-sidebar">
-        <div className="border-b border-gray-800/80">
-          <ActiveFilters />
-        </div>
+      <div className="border-b border-gray-800/80">
+        <ActiveFilters />
+      </div>
 
-        <div className="px-4 py-3 border-b border-gray-700">
-          <label htmlFor="sidebar-sort" className="block text-gray-400 text-xs font-medium mb-2">Sort Order</label>
-          <div className="flex items-center">
-          <select
-            id="sidebar-sort"
-            value={sortOrder}
-            onChange={(e) => onSortOrderChange(e.target.value)}
-            className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+      <div className="px-4 py-3 border-b border-gray-700">
+        <label htmlFor="sidebar-sort" className="block text-gray-400 text-xs font-medium mb-2">Sort Order</label>
+        <div className="flex items-center">
+        <select
+          id="sidebar-sort"
+          value={sortOrder}
+          onChange={(e) => onSortOrderChange(e.target.value)}
+          className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="date-desc">Newest First</option>
+          <option value="date-asc">Oldest First</option>
+          <option value="asc">A-Z</option>
+          <option value="desc">Z-A</option>
+          <option value="random">Random</option>
+        </select>
+        {sortOrder === 'random' && onReshuffle && (
+          <button
+              onClick={onReshuffle}
+              className="ml-2 p-2 text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-md border border-gray-600 transition-colors"
+              title="Reshuffle Random Order"
           >
-            <option value="date-desc">Newest First</option>
-            <option value="date-asc">Oldest First</option>
-            <option value="asc">A-Z</option>
-            <option value="desc">Z-A</option>
-            <option value="random">Random</option>
-          </select>
-          {sortOrder === 'random' && onReshuffle && (
-            <button
-                onClick={onReshuffle}
-                className="ml-2 p-2 text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-md border border-gray-600 transition-colors"
-                title="Reshuffle Random Order"
-            >
-                <RefreshCw className="h-5 w-5" />
-            </button>
-          )}
-          </div>
+              <RefreshCw className="h-5 w-5" />
+          </button>
+        )}
         </div>
+      </div>
 
-        {/* Add Folder Button - Subtle and discrete */}
-        {onAddFolder && (
-          <div className="px-3 py-2 border-b border-gray-700">
-            <button
-              onClick={onAddFolder}
-              disabled={isIndexing}
-              className={`w-full flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
-                isIndexing
-                  ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
-                  : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
-              }`}
-              title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
-            >
-              <Plus size={14} />
-              <span>Add Folder</span>
-            </button>
-          </div>
-        )}
+      {onAddFolder && (
+        <div className="px-3 py-2 border-b border-gray-700">
+          <button
+            onClick={onAddFolder}
+            disabled={isIndexing}
+            className={`w-full flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
+              isIndexing
+                ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
+                : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
+            }`}
+            title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
+          >
+            <Plus size={14} />
+            <span>Add Folder</span>
+          </button>
+        </div>
+      )}
 
-        {/* Render children, which will be the DirectoryList */}
-        {children && React.isValidElement(children) ? (
-          React.cloneElement(children as React.ReactElement<any>, {
-            isIndexing,
-            scanSubfolders,
-            excludedFolders,
-            onExcludeFolder,
-            onIncludeFolder
-          })
-        ) : (
-          children
-        )}
-
-        {/* Tags and Favorites Section */}
-        <TagsAndFavorites />
-
-        {generationFacets.length > 0 && (
-          <section className="border-y border-gray-800/80 bg-gray-950/20">
-            <button
-              type="button"
-              onClick={() => setIsGenerationParametersExpanded((prev) => !prev)}
-              className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors hover:bg-gray-800/40"
-            >
-              <h3 className="text-base font-medium text-gray-200">Generation Parameters</h3>
-              <ChevronDown
-                className={`h-4 w-4 text-gray-500 transition-transform ${isGenerationParametersExpanded ? 'rotate-180' : ''}`}
-              />
-            </button>
-            {isGenerationParametersExpanded && (
-              <div className="space-y-3 px-4 pb-4">
-                {generationFacets.map((facet) => (
-                  <FacetFilterSection
-                    key={facet.title}
-                    title={facet.title}
-                    items={facet.items}
-                    counts={facet.counts}
-                    selectedValues={facet.selectedValues}
-                    excludedValues={facet.excludedValues}
-                    onIncludeToggle={facet.onIncludeToggle}
-                    onExcludeToggle={facet.onExcludeToggle}
-                    onClear={facet.onClear}
-                  />
-                ))}
-              </div>
-            )}
-          </section>
-        )}
-
-        <AdvancedFilters
-          advancedFilters={advancedFilters}
-          onAdvancedFiltersChange={onAdvancedFiltersChange}
-          onClearAdvancedFilters={onClearAdvancedFilters}
-          availableDimensions={availableDimensions}
+      <div className="min-h-0 flex-1 px-3 py-3">
+        <VerticalSplitPanels
+          storageKey={SIDEBAR_PANE_SIZES_STORAGE_KEY}
+          defaultSizes={DEFAULT_SIDEBAR_PANE_SIZES}
+          panes={[
+            {
+              id: 'directories',
+              ariaLabel: 'Folders pane',
+              content: directoryPaneContent,
+            },
+            {
+              id: 'tags',
+              ariaLabel: 'Tags and favorites pane',
+              content: <TagsAndFavorites />,
+            },
+            {
+              id: 'filters',
+              ariaLabel: 'Filters pane',
+              content: secondaryFiltersPane,
+            },
+          ]}
         />
       </div>
 

--- a/components/TagInputCombobox.tsx
+++ b/components/TagInputCombobox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useId, useMemo, useState } from 'react';
+import React, { forwardRef, useEffect, useId, useMemo, useState } from 'react';
 import type { TagInfo } from '../types';
 import { getTagSearchToken, getTagSuggestions, replaceLastCsvToken, type TagInputMode } from '../utils/tagSuggestions';
 
@@ -61,6 +61,13 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
     [availableTags, excludedTags, recentTags, searchToken, suggestionLimit],
   );
 
+  useEffect(() => {
+    if (isOpen && suggestions.length === 0) {
+      setIsOpen(false);
+      setActiveIndex(0);
+    }
+  }, [isOpen, suggestions.length]);
+
   const closeSuggestions = () => {
     setIsOpen(false);
     setActiveIndex(0);
@@ -101,8 +108,17 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
         aria-controls={isOpen ? listboxId : undefined}
         onChange={(event) => {
           const nextValue = event.target.value;
+          const nextSearchToken = getTagSearchToken(nextValue, mode);
+          const nextSuggestions = getTagSuggestions({
+            query: nextSearchToken,
+            recentTags,
+            availableTags,
+            excludedTags,
+            limit: suggestionLimit,
+          });
+
           onValueChange(nextValue);
-          if (getTagSearchToken(nextValue, mode)) {
+          if (nextSearchToken && nextSuggestions.length > 0) {
             setIsOpen(true);
             setActiveIndex(0);
           } else {

--- a/components/TagInputCombobox.tsx
+++ b/components/TagInputCombobox.tsx
@@ -1,0 +1,201 @@
+import React, { forwardRef, useId, useMemo, useState } from 'react';
+import type { TagInfo } from '../types';
+import { getTagSearchToken, getTagSuggestions, replaceLastCsvToken, type TagInputMode } from '../utils/tagSuggestions';
+
+interface TagInputComboboxProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  onSubmit: (value: string) => void | Promise<void>;
+  recentTags: string[];
+  availableTags: TagInfo[];
+  excludedTags?: string[];
+  suggestionLimit: number;
+  mode?: TagInputMode;
+  placeholder?: string;
+  disabled?: boolean;
+  wrapperClassName?: string;
+  inputClassName?: string;
+  dropdownClassName?: string;
+  optionClassName?: string;
+  activeOptionClassName?: string;
+  metaClassName?: string;
+  trailingContent?: React.ReactNode;
+  onEscape?: () => void;
+}
+
+const defaultOptionClassName =
+  'w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white flex justify-between items-center';
+
+const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
+  value,
+  onValueChange,
+  onSubmit,
+  recentTags,
+  availableTags,
+  excludedTags = [],
+  suggestionLimit,
+  mode = 'single',
+  placeholder = 'Add tag...',
+  disabled = false,
+  wrapperClassName = 'relative',
+  inputClassName = '',
+  dropdownClassName = 'absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-gray-700 bg-gray-800 shadow-xl',
+  optionClassName = defaultOptionClassName,
+  activeOptionClassName = 'bg-gray-700 text-white',
+  metaClassName = 'text-xs text-gray-500',
+  trailingContent,
+  onEscape,
+}, ref) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listboxId = useId();
+  const searchToken = getTagSearchToken(value, mode);
+  const suggestions = useMemo(
+    () => getTagSuggestions({
+      query: searchToken,
+      recentTags,
+      availableTags,
+      excludedTags,
+      limit: suggestionLimit,
+    }),
+    [availableTags, excludedTags, recentTags, searchToken, suggestionLimit],
+  );
+
+  const closeSuggestions = () => {
+    setIsOpen(false);
+    setActiveIndex(0);
+  };
+
+  const openSuggestions = (nextIndex = 0) => {
+    if (suggestions.length === 0) {
+      closeSuggestions();
+      return;
+    }
+
+    setIsOpen(true);
+    setActiveIndex(Math.min(Math.max(nextIndex, 0), suggestions.length - 1));
+  };
+
+  const applySuggestion = (tagName: string) => {
+    if (mode === 'csv') {
+      onValueChange(replaceLastCsvToken(value, tagName));
+      closeSuggestions();
+      return;
+    }
+
+    void onSubmit(tagName);
+    closeSuggestions();
+  };
+
+  return (
+    <div className={wrapperClassName}>
+      <input
+        ref={ref}
+        type="text"
+        value={value}
+        disabled={disabled}
+        placeholder={placeholder}
+        autoComplete="off"
+        aria-autocomplete="list"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? listboxId : undefined}
+        onChange={(event) => {
+          const nextValue = event.target.value;
+          onValueChange(nextValue);
+          if (getTagSearchToken(nextValue, mode)) {
+            setIsOpen(true);
+            setActiveIndex(0);
+          } else {
+            closeSuggestions();
+          }
+        }}
+        onFocus={() => {
+          if (searchToken && suggestions.length > 0) {
+            openSuggestions(0);
+          }
+        }}
+        onBlur={() => {
+          closeSuggestions();
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            if (!isOpen) {
+              openSuggestions(0);
+              return;
+            }
+
+            openSuggestions(activeIndex + 1);
+            return;
+          }
+
+          if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            if (!isOpen) {
+              openSuggestions(suggestions.length - 1);
+              return;
+            }
+
+            openSuggestions(activeIndex - 1);
+            return;
+          }
+
+          if (event.key === 'Enter') {
+            if (isOpen && suggestions[activeIndex]) {
+              event.preventDefault();
+              applySuggestion(suggestions[activeIndex].name);
+              return;
+            }
+
+            if (value.trim()) {
+              event.preventDefault();
+              void onSubmit(value);
+            }
+            return;
+          }
+
+          if (event.key === 'Escape') {
+            if (isOpen) {
+              event.preventDefault();
+              closeSuggestions();
+              return;
+            }
+
+            onEscape?.();
+          }
+        }}
+        className={inputClassName}
+      />
+
+      {trailingContent}
+
+      {isOpen && suggestions.length > 0 && (
+        <div id={listboxId} role="listbox" className={dropdownClassName}>
+          {suggestions.map((suggestion, index) => {
+            const isActive = index === activeIndex;
+            return (
+              <button
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                key={suggestion.name}
+                onPointerDown={(event) => {
+                  event.preventDefault();
+                }}
+                onClick={() => applySuggestion(suggestion.name)}
+                className={`${optionClassName} ${isActive ? activeOptionClassName : ''}`.trim()}
+              >
+                <span>{suggestion.name}</span>
+                <span className={metaClassName}>{suggestion.count}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+});
+
+TagInputCombobox.displayName = 'TagInputCombobox';
+
+export default TagInputCombobox;

--- a/components/TagManagerModal.tsx
+++ b/components/TagManagerModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { X, Plus, Tag } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+import TagInputCombobox from './TagInputCombobox';
 
 interface TagManagerModalProps {
   isOpen: boolean;
@@ -14,6 +16,8 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
   selectedImageIds,
 }) => {
   const { availableTags, bulkAddTag, bulkRemoveTag, images } = useImageStore();
+  const recentTags = useImageStore((state) => state.recentTags);
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
   const [inputValue, setInputValue] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [pendingRemoveTag, setPendingRemoveTag] = useState<string | null>(null);
@@ -64,23 +68,6 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
       }));
   }, [existingTagsStats, selectedImages.length]);
 
-  // Filter suggestions based on input (last part after comma)
-  const suggestions = useMemo(() => {
-    if (!inputValue.trim()) return [];
-    
-    const parts = inputValue.split(',');
-    const currentSearch = parts[parts.length - 1].trim().toLowerCase();
-    
-    if (!currentSearch) return [];
-
-    return availableTags
-      .filter(tag => 
-        tag.name.toLowerCase().includes(currentSearch) && 
-        !existingTagsStats.has(tag.name)
-      )
-      .slice(0, 5);
-  }, [inputValue, availableTags, existingTagsStats]);
-
   const handleAddTag = async (input: string) => {
     if (!input.trim()) return;
     
@@ -104,16 +91,6 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
       setIsSubmitting(false);
       focusInput();
     }
-  };
-
-  const handleSuggestionClick = (tagName: string) => {
-    const parts = inputValue.split(',');
-    parts.pop(); // Remove the partial chunk
-    parts.push(tagName); // Add the selected tag
-    // Join with comma and space, and add a trailing comma space for convenience to type next
-    const newValue = parts.map(p => p.trim()).join(', ') + ', ';
-    setInputValue(newValue);
-    focusInput();
   };
 
   const handleRemoveTagRequest = (tag: string, e?: React.MouseEvent) => {
@@ -140,12 +117,7 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      if (inputValue.trim()) {
-        handleAddTag(inputValue);
-      }
-    } else if (e.key === 'Escape') {
+    if (e.key === 'Escape') {
       if (pendingRemoveTag) {
         setPendingRemoveTag(null);
         focusInput();
@@ -185,42 +157,43 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
           
           {/* Input Section */}
           <div className="relative">
-            <input
+            <TagInputCombobox
               ref={inputRef}
-              type="text"
               value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={handleKeyDown}
+              onValueChange={setInputValue}
+              onSubmit={handleAddTag}
+              recentTags={recentTags}
+              availableTags={availableTags}
+              excludedTags={Array.from(existingTagsStats.keys())}
+              suggestionLimit={tagSuggestionLimit}
+              mode="csv"
               placeholder="Type tags separated by commas..."
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg pl-3 pr-10 py-2.5 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none"
-              autoComplete="off"
-            />
-            <button
-              type="button"
-              onClick={() => handleAddTag(inputValue)}
-              disabled={!inputValue.trim() || isSubmitting}
-              className="absolute right-1.5 top-1.5 p-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              aria-label="Add tags"
-            >
-              <Plus size={16} />
-            </button>
+              onEscape={() => {
+                if (pendingRemoveTag) {
+                  setPendingRemoveTag(null);
+                  focusInput();
+                  return;
+                }
 
-            {/* Suggestions Dropdown */}
-            {suggestions.length > 0 && (
-              <div className="absolute z-10 w-full mt-1 bg-gray-800 border border-gray-700 rounded-lg shadow-xl overflow-hidden">
-                {suggestions.map(tag => (
-                  <button
-                    type="button"
-                    key={tag.name}
-                    onClick={() => handleSuggestionClick(tag.name)}
-                    className="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white flex justify-between items-center group"
-                  >
-                    <span>{tag.name}</span>
-                    <span className="text-xs text-gray-500 group-hover:text-gray-400">{tag.count}</span>
-                  </button>
-                ))}
-              </div>
-            )}
+                onClose();
+              }}
+              wrapperClassName="relative"
+              inputClassName="w-full bg-gray-800 border border-gray-700 rounded-lg pl-3 pr-10 py-2.5 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none"
+              dropdownClassName="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-gray-700 bg-gray-800 shadow-xl"
+              metaClassName="text-xs text-gray-500"
+              trailingContent={
+                <button
+                  type="button"
+                  onClick={() => handleAddTag(inputValue)}
+                  onKeyDown={handleKeyDown}
+                  disabled={!inputValue.trim() || isSubmitting}
+                  className="absolute right-1.5 top-1.5 p-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  aria-label="Add tags"
+                >
+                  <Plus size={16} />
+                </button>
+              }
+            />
           </div>
 
           {pendingRemoveTag && (

--- a/components/VerticalSplitPanels.tsx
+++ b/components/VerticalSplitPanels.tsx
@@ -130,7 +130,11 @@ const VerticalSplitPanels: React.FC<VerticalSplitPanelsProps> = ({
   })), [minPaneHeight, sizes]);
 
   return (
-    <div ref={containerRef} data-testid="vertical-split-panels" className={`flex min-h-0 flex-1 flex-col ${className}`.trim()}>
+    <div
+      ref={containerRef}
+      data-testid="vertical-split-panels"
+      className={`flex min-h-0 flex-1 flex-col ${className}`.trim()}
+    >
       {panes.map((pane, index) => (
         <React.Fragment key={pane.id}>
           <section

--- a/components/VerticalSplitPanels.tsx
+++ b/components/VerticalSplitPanels.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+export interface VerticalSplitPane {
+  id: string;
+  content: React.ReactNode;
+  ariaLabel: string;
+}
+
+interface VerticalSplitPanelsProps {
+  panes: VerticalSplitPane[];
+  storageKey: string;
+  defaultSizes: number[];
+  minPaneHeight?: number;
+  className?: string;
+}
+
+const normalizeSizes = (sizes: number[]): number[] => {
+  const total = sizes.reduce((sum, size) => sum + size, 0);
+  if (!Number.isFinite(total) || total <= 0) {
+    return sizes;
+  }
+
+  return sizes.map((size) => (size / total) * 100);
+};
+
+export const sanitizeStoredPaneSizes = (
+  rawSizes: unknown,
+  expectedLength: number,
+  fallbackSizes: number[],
+): number[] => {
+  if (!Array.isArray(rawSizes) || rawSizes.length !== expectedLength) {
+    return normalizeSizes(fallbackSizes);
+  }
+
+  const parsed = rawSizes.map((value) => Number(value));
+  if (parsed.some((value) => !Number.isFinite(value) || value <= 0)) {
+    return normalizeSizes(fallbackSizes);
+  }
+
+  return normalizeSizes(parsed);
+};
+
+const VerticalSplitPanels: React.FC<VerticalSplitPanelsProps> = ({
+  panes,
+  storageKey,
+  defaultSizes,
+  minPaneHeight = 120,
+  className = '',
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [sizes, setSizes] = useState<number[]>(() => {
+    if (typeof window === 'undefined') {
+      return normalizeSizes(defaultSizes);
+    }
+
+    try {
+      const storedSizes = JSON.parse(window.localStorage.getItem(storageKey) ?? 'null');
+      return sanitizeStoredPaneSizes(storedSizes, panes.length, defaultSizes);
+    } catch {
+      return normalizeSizes(defaultSizes);
+    }
+  });
+  const [dragState, setDragState] = useState<{
+    handleIndex: number;
+    startY: number;
+    startSizes: number[];
+  } | null>(null);
+
+  useEffect(() => {
+    setSizes((currentSizes) => sanitizeStoredPaneSizes(currentSizes, panes.length, defaultSizes));
+  }, [defaultSizes, panes.length]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(storageKey, JSON.stringify(sizes));
+  }, [sizes, storageKey]);
+
+  useEffect(() => {
+    if (!dragState || typeof window === 'undefined') {
+      return;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const containerHeight = containerRef.current?.getBoundingClientRect().height ?? 0;
+      if (containerHeight <= 0) {
+        return;
+      }
+
+      const pairStart = dragState.startSizes[dragState.handleIndex] + dragState.startSizes[dragState.handleIndex + 1];
+      const minPercent = Math.min((minPaneHeight / containerHeight) * 100, pairStart / 2);
+      const deltaPercent = ((event.clientY - dragState.startY) / containerHeight) * 100;
+      const proposedFirst = dragState.startSizes[dragState.handleIndex] + deltaPercent;
+      const clampedFirst = Math.min(Math.max(proposedFirst, minPercent), pairStart - minPercent);
+      const nextSizes = [...dragState.startSizes];
+
+      nextSizes[dragState.handleIndex] = clampedFirst;
+      nextSizes[dragState.handleIndex + 1] = pairStart - clampedFirst;
+      setSizes(nextSizes);
+    };
+
+    const handlePointerUp = () => {
+      setDragState(null);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerUp);
+    window.addEventListener('blur', handlePointerUp);
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handlePointerUp);
+      window.removeEventListener('blur', handlePointerUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [dragState, minPaneHeight]);
+
+  const paneStyles = useMemo(() => sizes.map((size) => ({
+    flexBasis: `${size}%`,
+    flexGrow: 0,
+    flexShrink: 0,
+    minHeight: `${minPaneHeight}px`,
+  })), [minPaneHeight, sizes]);
+
+  return (
+    <div ref={containerRef} data-testid="vertical-split-panels" className={`flex min-h-0 flex-1 flex-col ${className}`.trim()}>
+      {panes.map((pane, index) => (
+        <React.Fragment key={pane.id}>
+          <section
+            role="region"
+            aria-label={pane.ariaLabel}
+            className="min-h-0 overflow-y-auto scrollbar-sidebar"
+            style={paneStyles[index]}
+          >
+            {pane.content}
+          </section>
+
+          {index < panes.length - 1 && (
+            <div
+              role="separator"
+              aria-label={`Resize ${pane.ariaLabel}`}
+              aria-orientation="horizontal"
+              onPointerDown={(event) => {
+                event.preventDefault();
+                event.currentTarget.setPointerCapture?.(event.pointerId);
+                setDragState({
+                  handleIndex: index,
+                  startY: event.clientY,
+                  startSizes: sizes,
+                });
+              }}
+              className="group flex h-4 shrink-0 cursor-row-resize items-center justify-center touch-none"
+              title="Drag to resize pane"
+            >
+              <div className={`h-1 w-16 rounded-full transition-colors ${dragState?.handleIndex === index ? 'bg-blue-400/90 shadow-[0_0_16px_rgba(96,165,250,0.55)]' : 'bg-gray-700/80 group-hover:bg-blue-400/80'}`} />
+            </div>
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default VerticalSplitPanels;

--- a/components/settings/ViewerSettingsPanel.tsx
+++ b/components/settings/ViewerSettingsPanel.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 import { useSettingsStore } from '../../store/useSettingsStore';
+import {
+  DEFAULT_RECENT_TAG_CHIP_LIMIT,
+  DEFAULT_TAG_SUGGESTION_LIMIT,
+  MAX_TAG_UI_LIMIT,
+  MIN_TAG_UI_LIMIT,
+} from '../../utils/tagSuggestions';
 import { SettingRow } from './SettingRow';
 import { SettingsPanel } from './SettingsPanel';
 import { SettingsSectionCard } from './SettingsSectionCard';
@@ -12,6 +18,10 @@ export const ViewerSettingsPanel: React.FC = () => {
   const setShowFullFilePath = useSettingsStore((state) => state.setShowFullFilePath);
   const doubleClickToOpen = useSettingsStore((state) => state.doubleClickToOpen);
   const setDoubleClickToOpen = useSettingsStore((state) => state.setDoubleClickToOpen);
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
+  const setTagSuggestionLimit = useSettingsStore((state) => state.setTagSuggestionLimit);
+  const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
+  const setRecentTagChipLimit = useSettingsStore((state) => state.setRecentTagChipLimit);
 
   return (
     <SettingsPanel title="Viewer" description="Control what appears in the library and how images open.">
@@ -30,6 +40,37 @@ export const ViewerSettingsPanel: React.FC = () => {
           label="Double-click to open"
           description="Keep single click for selection and open details on double click."
           control={<SettingSwitch checked={doubleClickToOpen} onChange={setDoubleClickToOpen} />}
+        />
+      </SettingsSectionCard>
+
+      <SettingsSectionCard title="Tagging">
+        <SettingRow
+          label="Suggestion list size"
+          description={`How many tag suggestions to show while typing. Range ${MIN_TAG_UI_LIMIT}-${MAX_TAG_UI_LIMIT}.`}
+          control={
+            <input
+              type="number"
+              min={MIN_TAG_UI_LIMIT}
+              max={MAX_TAG_UI_LIMIT}
+              value={tagSuggestionLimit}
+              onChange={(event) => setTagSuggestionLimit(Number(event.target.value) || DEFAULT_TAG_SUGGESTION_LIMIT)}
+              className="w-24 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-right text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+            />
+          }
+        />
+        <SettingRow
+          label="Recent tag chips"
+          description={`How many recent tags to show as quick-add chips. Range ${MIN_TAG_UI_LIMIT}-${MAX_TAG_UI_LIMIT}.`}
+          control={
+            <input
+              type="number"
+              min={MIN_TAG_UI_LIMIT}
+              max={MAX_TAG_UI_LIMIT}
+              value={recentTagChipLimit}
+              onChange={(event) => setRecentTagChipLimit(Number(event.target.value) || DEFAULT_RECENT_TAG_CHIP_LIMIT)}
+              className="w-24 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-right text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+            />
+          }
         />
       </SettingsSectionCard>
     </SettingsPanel>

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,50 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.0] - 2026-04-06
+## [0.14.1] - Unreleased
+
+### Fixed
+
+- **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+
+## [0.14.0] - Unreleased
 
 ### Added
 
-- **Visual ComfyUI Workflow Inspector**: Added a visual node-based editor inside both the ComfyUI generation modal and the Image Details Modal, with zoom/pan controls, editable node fields, embedded-layout support, and an advanced JSON fallback for debugging edge cases.
-- **ComfyUI Node View**: Added a dedicated `Node View` alongside Library, Smart Library, and Model View, with exact node-type catalogs, per-node result counts, search, and multi-select OR filtering for images containing embedded ComfyUI workflows.
-- **Image Lineage for Transformations**: Added explicit lineage support for `img2img`, `inpaint`, and `outpaint`, so transformed images are no longer treated as generic generations. The viewer now shows generation type, source/input image status, denoise strength when available, and direct navigation between source and result when the original image can be recovered confidently.
-- **Analytics Explorer**: Rebuilt analytics as an interactive explorer with `Overview`, `Resources`, `Time`, `Performance`, and `Curation` views, scope switching between current results and full library, cohort comparison tools, and one-click promotion of insights into live filters.
-- **Windowed Image Viewer**: Added support for multiple open image windows with drag, resize, minimize/maximize, and dockable or collapsible details for more flexible comparison and inspection.
-- **Image Ratings**: Added persistent 1-5 ratings for images, including viewer controls, library badges, bulk rating actions, and multi-select rating filters in the sidebar and advanced filters.
-- **Startup Verification Modes**: Added configurable startup verification modes for saved folders, allowing the app to open from cache only, reconcile in the background, or verify folders strictly before startup completes.
-- **Manual Tag Management**: Added a persistent manual tag catalog so empty tags remain visible in the sidebar, along with right-click tag actions for renaming, clearing tags from images, removing unused tags, and clearing or deleting used tags.
+- **Visual ComfyUI Workflow Inspector**: Added a visual node-based editor inside the ComfyUI generation modal and Image Details Modal, with zoom/pan controls, editable node fields, embedded-layout support, and an advanced JSON fallback for debugging edge cases.
+- **ComfyUI Node View**: Added a dedicated `Node View` alongside Library, Smart Library, and Model View, with searchable exact node-type catalogs, per-node result counts, and multi-select OR filtering for images that contain embedded ComfyUI workflows.
+- **Image Lineage for Transformations**: Added explicit lineage support for `img2img`, `inpaint`, and `outpaint`, so transformed images are no longer treated as generic generations. The viewer now shows the generation type, source/input image status, denoise strength when available, and direct navigation between source and result when the original image can be recovered with confidence.
+- **Analytics Explorer**: Rebuilt analytics into an interactive explorer with `Overview`, `Resources`, `Time`, `Performance`, and `Curation` views, scope switching between the current results and full library, cohort comparison tools, and one-click promotion of analytics insights into live filters.
+- **Windowed Image Viewer**: Added support for multiple open image windows with drag, resize, minimize/maximize, and dockable or collapsible details so images can be compared and inspected more flexibly.
+- **Image Ratings**: Added persistent 1-5 ratings for images, including star controls in the viewer, badges in the library views, bulk rating actions, and multi-select rating filters in the sidebar and advanced filters.
+- **Startup Verification Modes**: Added configurable startup verification modes for saved folders, so the app can now open from cache only, reconcile in the background, or verify folders strictly before startup completes.
+- **Manual Tag Management**: Added a persistent manual tag catalog so empty tags remain visible in the sidebar, plus right-click tag actions for renaming, clearing tags from images, removing unused tags, and clearing/deleting used tags in one step.
 - **Metadata Type Filters**: Added checkbox filters for `txt2img` / `img2img` generation modes and `Images` / `Videos` file types in `Metadata & File Filters`.
-- **Manual Metadata Recovery**: Added `Reparse Metadata` actions for single images and multi-selection workflows, reprocessing only the chosen files without requiring a full folder refresh or cache clear.
+- **Manual Metadata Recovery**: Added `Reparse Metadata` actions for single images and multi-selection workflows, reprocessing only the chosen files and updating their cached metadata without requiring a full folder refresh or cache clear.
 - **Expanded Compare View**: Added support for comparing up to 4 images at once, with new `Side Strip` and `2x2 Grid` layouts for 3-4 image sets, plus improved Compare integration with the windowed viewer workflow.
 
 ### Improved
 
-- **Electron Privileged IPC Hardening**: Restricted renderer-driven write operations to app-internal paths or user-approved export destinations, tightened generator launch requests to match saved integration settings, and limited test-only update dialog exposure to development builds.
-- **Offline License Integrity**: Revalidated persisted Pro/Lifetime state on startup, removed the temporary "unlock during initialization" window for paid features, and limited the `IMH_DEV_LICENSE` shortcut to development builds.
+- **Electron Privileged IPC Hardening**: Restricted renderer-driven write operations to app-internal paths or user-approved export destinations, tightened generator launch requests so they must match the saved integration settings, and limited test-only update dialog exposure to development builds.
+- **Offline License Integrity**: Revalidated persisted Pro/Lifetime state on startup, removed the temporary "unlock during initialization" window for paid features, and limited the `IMH_DEV_LICENSE` shortcut to development builds only.
 - **Background Worker Guardrails**: Added validation and sane limits for clustering and auto-tagging worker payloads so malformed or extreme jobs fail fast instead of consuming excessive CPU or memory.
 - **ComfyUI Variation Controls**: Expanded the ComfyUI generation modal with workflow mode selection, model-family aware resource overrides, LoRA controls, source image policy for transform workflows, and better handling for original-graph assets.
-- **Favorites Icon Refresh**: Replaced favorite stars with heart icons to clearly distinguish favorites from ratings.
+- **Favorites Icon Refresh**: Updated favorite actions and indicators to use a heart icon instead of a star for clearer separation from the new rating system.
 - **Sidebar Faceted Filters**: Reworked the sidebar filter experience around dedicated facet sections for checkpoints, LoRAs, samplers, and schedulers, with per-value include/exclude actions, result counts, in-section search, and clearer active-filter chips.
-- **Tag Match Mode**: Added an `Any / All` toggle for included manual tag filters in the sidebar, allowing searches to match any selected tag or require all selected tags.
-- **Large Library Responsiveness**: Improved responsiveness on large libraries by moving lineage resolution out of the image modal hot path, reducing expensive modal navigation lookups, and cutting renderer churn during indexing and filtering.
+- **Tag Match Mode**: Added an `Any / All` toggle for included manual tag filters in the sidebar, allowing tag searches to match any selected tag or require all selected tags for narrower curation workflows.
+- **Large Library Responsiveness**: Significantly improved responsiveness for large libraries by moving lineage resolution out of the image modal hot path, reducing expensive modal navigation lookups, and cutting renderer churn during indexing and filtering.
 - **Cached Startup Stability**: Reduced reopen instability on large libraries and made startup verification less intrusive by default, improving launches from cache on heavy libraries.
-- **Sidebar Visual Cohesion**: Simplified sidebar styling into a more consistent, subdued visual system and made the `Generation Parameters` section collapsible like the other filter groups.
-- **Resizable Side Panels**: The left filter sidebar, Image Preview sidebar, generation queue, and Image Details Modal sidebar can now be resized by dragging their edges for a more adaptable workspace.
-- **Generation Queue Compatibility**: Updated the generation queue to persist and retry the new workflow-native ComfyUI parameters, including workflow mode, source image policy, advanced JSON overrides, and mask inputs.
+- **Sidebar Visual Cohesion**: Simplified the sidebar styling into a more consistent, subdued visual system and made the `Generation Parameters` section collapsible like the other filter groups.
+- **Resizable Side Panels**: The left filter sidebar, Image Preview sidebar, generation queue, and Image Details Modal sidebar can now be resized by dragging their edges, with widths preserved between sessions for a more adaptable workspace.
+- **Generation Queue Compatibility**: Updated the existing generation queue to persist and retry the new workflow-native ComfyUI parameters, including workflow mode, source image policy, advanced JSON overrides, and mask inputs.
 - **Cross-Generator Transformation Detection**: Improved metadata parsing for ComfyUI, Automatic1111, Forge, SD.Next, InvokeAI, and Draw Things to detect transformation workflows more reliably, preserve lineage references during indexing, and surface img2img-specific parameters in a normalized way.
-- **Sampler & Scheduler Faceting**: Added sampler-aware caching and filtering support so sampler and scheduler metadata can be browsed more accurately from the sidebar and advanced filters.
-- **Analytics Cohorts & Coverage**: Improved analytics summaries to account more accurately for favorites, ratings, GPU devices, telemetry presence, and bucketed performance ranges, making curation and performance comparisons more useful on mixed libraries.
+- **Generator Faceting**: Added sampler-aware caching and filtering support so sampler and scheduler metadata can be browsed more accurately from the sidebar and advanced filters.
+- **Analytics Cohorts & Coverage**: Analytics summaries now account for favorites, ratings, GPU devices, telemetry presence, and bucketed performance ranges more accurately, making curation and performance comparisons more useful on mixed libraries.
 - **Task-Based Settings Navigation**: Reorganized the Settings modal into focused Library, Viewer, Integrations, Appearance, Privacy, and Shortcuts panels with sidebar navigation and compatibility for legacy deep links.
-- **Lineage Fallback Clarity**: When a transformation is detected but the original image cannot be recovered confidently, the UI now says so explicitly instead of implying a weak match.
+- **Lineage Fallback Clarity**: When a transformation is detected but the original image cannot be recovered with confidence, the UI now states that clearly instead of implying a weak or uncertain match.
 - **Grid Filename Readability**: Thumbnail captions now support a two-line layout, making long filenames and full-path display more usable without requiring fullscreen zoom.
-- **Copy Submenu in Grid Context Menu**: Grouped grid copy actions under a `Copy` submenu, including prompt, negative prompt, seed, and checkpoint.
+- **Copy Submenu in Grid Context Menu**: Grouped copy actions under a `Copy` submenu in the image grid, including prompt, negative prompt, seed, and checkpoint.
 - **Cross-Platform Path Handling**: Replaced hardcoded Windows path joins in Electron viewer utilities with platform-aware path resolution to keep desktop-only actions working more reliably on macOS and Linux.
 
 ### Fixed
 
-- **ComfyUI Payload Parsing Safety**: Added size limits around base64 decode, regex fallback scanning, and zlib inflate paths to prevent oversized metadata payloads from causing memory or responsiveness spikes during parsing and indexing.
+- **ComfyUI Payload Parsing Safety**: Added size limits around base64 decode, regex fallback scanning, and zlib inflate paths to avoid oversized metadata payloads causing memory or responsiveness spikes during parsing and indexing.
 - **Watcher Lifecycle IPC**: File watcher notifications now guard against destroyed renderer windows before sending events, avoiding shutdown-time errors and stray IPC churn.
-- **Deduplication Helper Feedback**: Applying or clearing deduplication suggestions now surfaces visible success or error feedback instead of failing silently in the UI.
+- **Deduplication Helper Feedback**: Applying or clearing deduplication suggestions now surfaces visible success/error feedback instead of failing silently in the UI.
 - **Electron Window Restore**: The desktop window now reopens on the last monitor with the previous size and position when that display is still available, while safely falling back to a visible screen when monitor layouts change.
 - **Startup Folder Reconciliation**: Cached folders are now silently reconciled against disk on launch, so files created while the app was closed are indexed automatically instead of requiring a manual folder refresh.
 - **Open-Ended Advanced Ranges**: Step and CFG filters now preserve min-only or max-only searches instead of dropping partially filled ranges.

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -28,9 +28,10 @@ import {
     toLightweightLineageImage,
 } from '../services/lineageRegistry';
 import { loadLineageRegistrySnapshot, saveLineageRegistrySnapshot } from '../services/lineageRegistryCache';
+import { MAX_RECENT_TAG_HISTORY } from '../utils/tagSuggestions';
 
 const RECENT_TAGS_STORAGE_KEY = 'image-metahub-recent-tags';
-const MAX_RECENT_TAGS = 12;
+const MAX_RECENT_TAGS = MAX_RECENT_TAG_HISTORY;
 
 type ThumbnailEntryState = {
     lastModified: number;

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage, StateStorage } from 'zustand/middleware';
+import {
+  DEFAULT_RECENT_TAG_CHIP_LIMIT,
+  DEFAULT_TAG_SUGGESTION_LIMIT,
+  sanitizeTagUiLimit,
+} from '../utils/tagSuggestions';
 
 export const stripLicenseFromSettings = <T extends Record<string, unknown>>(settings: T | null | undefined): Omit<T, 'license'> => {
   if (!settings) {
@@ -93,6 +98,8 @@ interface SettingsState {
   globalAutoWatch: boolean;
   startupVerificationMode: StartupVerificationMode;
   doubleClickToOpen: boolean;
+  tagSuggestionLimit: number;
+  recentTagChipLimit: number;
   sensitiveTags: string[];
   blurSensitiveImages: boolean;
   enableSafeMode: boolean;
@@ -129,6 +136,8 @@ interface SettingsState {
   toggleGlobalAutoWatch: () => void;
   setStartupVerificationMode: (value: StartupVerificationMode) => void;
   setDoubleClickToOpen: (value: boolean) => void;
+  setTagSuggestionLimit: (value: number) => void;
+  setRecentTagChipLimit: (value: number) => void;
   setSensitiveTags: (tags: string[]) => void;
   setBlurSensitiveImages: (value: boolean) => void;
   setEnableSafeMode: (value: boolean) => void;
@@ -170,6 +179,8 @@ export const useSettingsStore = create<SettingsState>()(
       globalAutoWatch: true,
       startupVerificationMode: 'off',
       doubleClickToOpen: false,
+      tagSuggestionLimit: DEFAULT_TAG_SUGGESTION_LIMIT,
+      recentTagChipLimit: DEFAULT_RECENT_TAG_CHIP_LIMIT,
       sensitiveTags: ['nsfw', 'private', 'hidden'],
       blurSensitiveImages: true,
       enableSafeMode: true,
@@ -213,6 +224,8 @@ export const useSettingsStore = create<SettingsState>()(
       toggleGlobalAutoWatch: () => set((state) => ({ globalAutoWatch: !state.globalAutoWatch })),
       setStartupVerificationMode: (value) => set({ startupVerificationMode: value }),
       setDoubleClickToOpen: (value) => set({ doubleClickToOpen: !!value }),
+      setTagSuggestionLimit: (value) => set({ tagSuggestionLimit: sanitizeTagUiLimit(value, DEFAULT_TAG_SUGGESTION_LIMIT) }),
+      setRecentTagChipLimit: (value) => set({ recentTagChipLimit: sanitizeTagUiLimit(value, DEFAULT_RECENT_TAG_CHIP_LIMIT) }),
       setSensitiveTags: (tags) => {
         const normalized = (Array.isArray(tags) ? tags : [])
           .map(tag => (typeof tag === 'string' ? tag.trim().toLowerCase() : ''))
@@ -264,6 +277,8 @@ export const useSettingsStore = create<SettingsState>()(
         globalAutoWatch: true,
         startupVerificationMode: 'off',
         doubleClickToOpen: false,
+        tagSuggestionLimit: DEFAULT_TAG_SUGGESTION_LIMIT,
+        recentTagChipLimit: DEFAULT_RECENT_TAG_CHIP_LIMIT,
         sensitiveTags: ['nsfw', 'private', 'hidden'],
         blurSensitiveImages: true,
         enableSafeMode: true,
@@ -309,6 +324,11 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.showFullFilePath !== 'boolean') {
           state.showFullFilePath = false;
+        }
+
+        if (state) {
+          state.tagSuggestionLimit = sanitizeTagUiLimit(state.tagSuggestionLimit, DEFAULT_TAG_SUGGESTION_LIMIT);
+          state.recentTagChipLimit = sanitizeTagUiLimit(state.recentTagChipLimit, DEFAULT_RECENT_TAG_CHIP_LIMIT);
         }
 
         if (

--- a/utils/tagSuggestions.ts
+++ b/utils/tagSuggestions.ts
@@ -1,0 +1,176 @@
+import type { TagInfo } from '../types';
+
+export const DEFAULT_TAG_SUGGESTION_LIMIT = 10;
+export const DEFAULT_RECENT_TAG_CHIP_LIMIT = 10;
+export const MIN_TAG_UI_LIMIT = 5;
+export const MAX_TAG_UI_LIMIT = 20;
+export const MAX_RECENT_TAG_HISTORY = 50;
+
+export type TagInputMode = 'single' | 'csv';
+
+export interface TagSuggestion {
+  name: string;
+  count: number;
+  isRecent: boolean;
+  recentIndex: number;
+}
+
+interface BuildTagSuggestionsOptions {
+  query: string;
+  recentTags: string[];
+  availableTags: Array<Pick<TagInfo, 'name' | 'count'>>;
+  excludedTags?: string[];
+  limit: number;
+}
+
+interface RecentTagChipOptions {
+  recentTags: string[];
+  excludedTags?: string[];
+  limit: number;
+}
+
+const normalizeTag = (tag: string) => tag.trim().toLowerCase();
+
+export const sanitizeTagUiLimit = (value: number | null | undefined, fallback: number): number => {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.min(MAX_TAG_UI_LIMIT, Math.max(MIN_TAG_UI_LIMIT, Math.round(value as number)));
+};
+
+export const getTagSearchToken = (value: string, mode: TagInputMode): string => {
+  if (mode === 'csv') {
+    const parts = value.split(',');
+    return normalizeTag(parts[parts.length - 1] ?? '');
+  }
+
+  return normalizeTag(value);
+};
+
+export const replaceLastCsvToken = (value: string, nextTag: string): string => {
+  const parts = value.split(',');
+  parts.pop();
+  const preservedParts = parts
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  return [...preservedParts, normalizeTag(nextTag)].join(', ') + ', ';
+};
+
+export const getRecentTagChips = ({
+  recentTags,
+  excludedTags = [],
+  limit,
+}: RecentTagChipOptions): string[] => {
+  const normalizedExcluded = new Set(excludedTags.map(normalizeTag).filter(Boolean));
+  const normalizedLimit = sanitizeTagUiLimit(limit, DEFAULT_RECENT_TAG_CHIP_LIMIT);
+  const suggestions: string[] = [];
+
+  for (const tag of recentTags) {
+    const normalizedTag = normalizeTag(tag);
+    if (!normalizedTag || normalizedExcluded.has(normalizedTag) || suggestions.includes(normalizedTag)) {
+      continue;
+    }
+
+    suggestions.push(normalizedTag);
+
+    if (suggestions.length >= normalizedLimit) {
+      break;
+    }
+  }
+
+  return suggestions;
+};
+
+export const getTagSuggestions = ({
+  query,
+  recentTags,
+  availableTags,
+  excludedTags = [],
+  limit,
+}: BuildTagSuggestionsOptions): TagSuggestion[] => {
+  const normalizedQuery = normalizeTag(query);
+  const normalizedExcluded = new Set(excludedTags.map(normalizeTag).filter(Boolean));
+  const normalizedLimit = sanitizeTagUiLimit(limit, DEFAULT_TAG_SUGGESTION_LIMIT);
+  const availableTagCounts = new Map<string, number>();
+
+  for (const tag of availableTags) {
+    const normalizedName = normalizeTag(tag.name);
+    if (!normalizedName) {
+      continue;
+    }
+
+    availableTagCounts.set(normalizedName, tag.count ?? 0);
+  }
+
+  const candidates = new Map<string, TagSuggestion>();
+
+  recentTags.forEach((tag, index) => {
+    const normalizedTag = normalizeTag(tag);
+    if (!normalizedTag || normalizedExcluded.has(normalizedTag) || candidates.has(normalizedTag)) {
+      return;
+    }
+
+    if (normalizedQuery && !normalizedTag.includes(normalizedQuery)) {
+      return;
+    }
+
+    candidates.set(normalizedTag, {
+      name: normalizedTag,
+      count: availableTagCounts.get(normalizedTag) ?? 0,
+      isRecent: true,
+      recentIndex: index,
+    });
+  });
+
+  if (normalizedQuery) {
+    for (const tag of availableTags) {
+      const normalizedName = normalizeTag(tag.name);
+      if (!normalizedName || normalizedExcluded.has(normalizedName) || !normalizedName.includes(normalizedQuery)) {
+        continue;
+      }
+
+      const existing = candidates.get(normalizedName);
+      if (existing) {
+        candidates.set(normalizedName, { ...existing, count: tag.count ?? existing.count });
+        continue;
+      }
+
+      candidates.set(normalizedName, {
+        name: normalizedName,
+        count: tag.count ?? 0,
+        isRecent: false,
+        recentIndex: Number.POSITIVE_INFINITY,
+      });
+    }
+  }
+
+  const suggestions = Array.from(candidates.values());
+
+  if (!normalizedQuery) {
+    return suggestions.slice(0, normalizedLimit);
+  }
+
+  suggestions.sort((left, right) => {
+    const leftPrefix = left.name.startsWith(normalizedQuery) ? 0 : 1;
+    const rightPrefix = right.name.startsWith(normalizedQuery) ? 0 : 1;
+    if (leftPrefix !== rightPrefix) {
+      return leftPrefix - rightPrefix;
+    }
+
+    const leftRecent = left.isRecent ? 0 : 1;
+    const rightRecent = right.isRecent ? 0 : 1;
+    if (leftRecent !== rightRecent) {
+      return leftRecent - rightRecent;
+    }
+
+    if (left.isRecent && right.isRecent && left.recentIndex !== right.recentIndex) {
+      return left.recentIndex - right.recentIndex;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+
+  return suggestions.slice(0, normalizedLimit);
+};


### PR DESCRIPTION
## Summary
This PR bundles the tagging UX work for `0.14.1` into a single pass across the viewer, preview sidebar, and tag manager.

It also keeps the sidebar on the stable single-scroll layout after the experimental split-pane version proved too confusing in practice.

## What changed
- added a shared `TagInputCombobox` used by `ImageModal`, `ImagePreviewSidebar`, and `TagManagerModal`
- unified suggestion ranking and matching in `utils/tagSuggestions.ts`
- standardized keyboard navigation and mouse selection for manual tag suggestions
- fixed CSV autocomplete behavior in the Tag Manager so suggestions apply to the active token only
- added viewer settings for tag suggestion count and visible recent-tag chips
- expanded internal recent-tag history while keeping the visible chip count configurable
- updated the changelog for the tagging improvements included in this branch
- restored the sidebar to the stable single-scroll layout instead of shipping the split-pane experiment
- includes the pending `Reparse Metadata` context-menu improvement already present on this branch

## Why
The original requests were all centered on tagging, but implementing them independently would have scattered similar logic across multiple UI surfaces.

This refactor centralizes the tag-entry behavior so suggestions, ranking, keyboard controls, and CSV handling all behave the same way, while avoiding shipping a sidebar redesign that hurt usability.

## Impact
- tag entry feels consistent everywhere manual tags can be added
- users can tune suggestion density without adding lots of new settings complexity
- bulk tagging in the Tag Manager is safer and more predictable
- the sidebar stays familiar and easier to browse during `0.14.1`

## Root cause for the sidebar rollback
The split-pane sidebar looked interesting on paper, but in practice it introduced a more rigid and confusing browsing experience than the original continuous sidebar flow. This PR keeps the tagging work and drops that UX regression from the shipped experience.

## Validation
- not rerun during the final PR pass
- the final sidebar restore was committed without rerunning build/tests per request during the last iteration
