### PR TITLE
Add collections workspace and collection management flows

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1733,7 +1733,7 @@ export default function App() {
                     }}
                   />
                 )}
-                {(libraryView === 'library' || libraryView === 'node' || libraryView === 'collections') && (
+                {(libraryView === 'library' || libraryView === 'node' || (libraryView === 'collections' && Boolean(activeCollection))) && (
                   <GridToolbar
                     selectedImages={safeSelectedImages}
                     images={libraryView === 'node' ? nodeViewVisibleImages : paginatedImages}
@@ -1836,7 +1836,7 @@ export default function App() {
                 )}
               </div>
 
-              {(libraryView === 'library' || libraryView === 'collections') && (
+              {(libraryView === 'library' || (libraryView === 'collections' && Boolean(activeCollection))) && (
                 <Footer
                   currentPage={currentPage}
                   totalPages={totalPages}

--- a/App.tsx
+++ b/App.tsx
@@ -1372,7 +1372,7 @@ export default function App() {
     }
 
     return getResolvedCollectionImages(activeCollection.id);
-  }, [activeCollection, getResolvedCollectionImages]);
+  }, [activeCollection, getResolvedCollectionImages, safeImages]);
 
   const collectionFilteredImages = useMemo(() => {
     if (!activeCollection) {
@@ -1380,7 +1380,7 @@ export default function App() {
     }
 
     return getResolvedFilteredCollectionImages(activeCollection.id);
-  }, [activeCollection, getResolvedFilteredCollectionImages]);
+  }, [activeCollection, getResolvedFilteredCollectionImages, safeFilteredImages]);
 
   const displayImages = libraryView === 'collections' ? collectionFilteredImages : safeFilteredImages;
   const canSaveCurrentFilteredAsCollection = libraryView !== 'smart' && displayImages.length > 0;

--- a/App.tsx
+++ b/App.tsx
@@ -35,6 +35,7 @@ import CollectionsWorkspace from './components/CollectionsWorkspace';
 import GridToolbar from './components/GridToolbar';
 import AnalyticsSummaryStrip from './components/AnalyticsSummaryStrip';
 import BatchExportModal from './components/BatchExportModal';
+import CollectionFormModal, { CollectionFormValues } from './components/CollectionFormModal';
 import { useA1111ProgressContext } from './contexts/A1111ProgressContext';
 import { useGenerationQueueSync } from './hooks/useGenerationQueueSync';
 import { useGenerationQueueStore } from './store/useGenerationQueueStore';
@@ -238,6 +239,7 @@ export default function App() {
   const reshuffle = useImageStore((state) => state.reshuffle);
   const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
   const getResolvedFilteredCollectionImages = useImageStore((state) => state.getResolvedFilteredCollectionImages);
+  const createCollection = useImageStore((state) => state.createCollection);
 
   const safeImages = Array.isArray(images) ? images : [];
   const safeFilteredImages = Array.isArray(filteredImages) ? filteredImages : [];
@@ -340,6 +342,7 @@ export default function App() {
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
   const [newImagesToast, setNewImagesToast] = useState<{ count: number; directoryName: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
+  const [isSaveFilteredCollectionModalOpen, setIsSaveFilteredCollectionModalOpen] = useState(false);
   const [openImageModals, setOpenImageModals] = useState<OpenImageModalState[]>([]);
   const [activeImageModalId, setActiveImageModalId] = useState<string | null>(null);
   const lastOpenedModalImageIdRef = useRef<string | null>(null);
@@ -1379,6 +1382,7 @@ export default function App() {
   }, [activeCollection, getResolvedFilteredCollectionImages]);
 
   const displayImages = libraryView === 'collections' ? collectionFilteredImages : safeFilteredImages;
+  const canSaveCurrentFilteredAsCollection = libraryView !== 'smart' && displayImages.length > 0;
 
   useEffect(() => {
     const scopedTotalPages = Math.ceil(displayImages.length / itemsPerPage);
@@ -1493,6 +1497,31 @@ export default function App() {
       );
     });
   })();
+
+  const handleSaveCurrentFilteredAsCollection = useCallback(async (values: CollectionFormValues) => {
+    const targetImageIds = displayImages.map((image) => image.id);
+    const coverImageId = targetImageIds[0] ?? null;
+
+    const collection = await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: safeCollections.length,
+      imageIds: targetImageIds,
+      snapshotImageIds: [],
+      coverImageId,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: coverImageId ?? undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setIsSaveFilteredCollectionModalOpen(false);
+    setLibraryView('collections');
+    setSuccess(`Collection "${collection.name}" created.`);
+  }, [createCollection, displayImages, safeCollections.length, setSuccess]);
+
   const shouldShowLibraryPlaceholder =
     libraryView === 'library' &&
     safeFilteredImages.length === 0 &&
@@ -1647,6 +1676,21 @@ export default function App() {
           onLibraryViewChange={setLibraryView}
         />
 
+        <CollectionFormModal
+          isOpen={isSaveFilteredCollectionModalOpen}
+          title="Save as Collection"
+          submitLabel="Save Collection"
+          initialValues={{
+            name: '',
+            description: '',
+            sourceTag: '',
+            autoUpdate: false,
+            includeTargetImages: false,
+          }}
+          onClose={() => setIsSaveFilteredCollectionModalOpen(false)}
+          onSubmit={handleSaveCurrentFilteredAsCollection}
+        />
+
         <main className="mx-auto p-4 flex-1 flex flex-col min-h-0 w-full">
           {showGeneratorSetupNotice && (
             <div className="my-4 flex items-center justify-between gap-3 rounded-lg border border-blue-700/40 bg-blue-900/30 p-3 text-blue-100">
@@ -1738,6 +1782,12 @@ export default function App() {
                     selectedImages={safeSelectedImages}
                     images={libraryView === 'node' ? nodeViewVisibleImages : paginatedImages}
                     directories={safeDirectories}
+                    onSaveCurrentFilteredAsCollection={
+                      canSaveCurrentFilteredAsCollection
+                        ? () => setIsSaveFilteredCollectionModalOpen(true)
+                        : undefined
+                    }
+                    saveCurrentFilteredCount={displayImages.length}
                     onDeleteSelected={handleDeleteSelectedImages}
                     onGenerateA1111={(image) => {
                       setSelectedImageForGeneration(image);

--- a/App.tsx
+++ b/App.tsx
@@ -1811,6 +1811,8 @@ export default function App() {
                         onImageClick={handleImageSelection}
                         selectedImages={safeSelectedImages}
                         onBatchExport={handleOpenBatchExport}
+                        activeCollection={activeCollection}
+                        isCollectionsView
                       />
                     )}
                   </CollectionsWorkspace>

--- a/App.tsx
+++ b/App.tsx
@@ -31,6 +31,7 @@ import ProOnlyModal from './components/ProOnlyModal';
 import SmartLibrary from './components/SmartLibrary';
 import { ModelView } from './components/ModelView';
 import NodeView from './components/NodeView';
+import CollectionsWorkspace from './components/CollectionsWorkspace';
 import GridToolbar from './components/GridToolbar';
 import AnalyticsSummaryStrip from './components/AnalyticsSummaryStrip';
 import BatchExportModal from './components/BatchExportModal';
@@ -158,6 +159,8 @@ export default function App() {
   const clustersCount = useImageStore((state) => state.clusters.length);
   const clusterNavigationContext = useImageStore((state) => state.clusterNavigationContext);
   const activeImageScope = useImageStore((state) => state.activeImageScope);
+  const collections = useImageStore((state) => state.collections);
+  const activeCollectionId = useImageStore((state) => state.activeCollectionId);
 
   // Loading & progress selectors
   const isLoading = useImageStore((state) => state.isLoading);
@@ -229,14 +232,18 @@ export default function App() {
   const openComparisonModal = useImageStore((state) => state.openComparisonModal);
   const initializeFolderSelection = useImageStore((state) => state.initializeFolderSelection);
   const loadAnnotations = useImageStore((state) => state.loadAnnotations);
+  const loadCollections = useImageStore((state) => state.loadCollections);
   const imageStoreSetSortOrder = useImageStore((state) => state.setSortOrder);
   const sortOrder = useImageStore((state) => state.sortOrder);
   const reshuffle = useImageStore((state) => state.reshuffle);
+  const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
+  const getResolvedFilteredCollectionImages = useImageStore((state) => state.getResolvedFilteredCollectionImages);
 
   const safeImages = Array.isArray(images) ? images : [];
   const safeFilteredImages = Array.isArray(filteredImages) ? filteredImages : [];
   const safeClusterNavigationContext = Array.isArray(clusterNavigationContext) ? clusterNavigationContext : [];
   const safeActiveImageScope = Array.isArray(activeImageScope) ? activeImageScope : null;
+  const safeCollections = Array.isArray(collections) ? collections : [];
   const safeDirectories = Array.isArray(directories) ? directories : [];
   const safeSelectedImages = selectedImages instanceof Set ? selectedImages : new Set<string>();
   const hasDirectories = safeDirectories.length > 0;
@@ -326,7 +333,7 @@ export default function App() {
   const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false);
   const [currentVersion, setCurrentVersion] = useState<string>('0.10.0');
   const [isQueueOpen, setIsQueueOpen] = useState(false);
-  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node'>('library');
+  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node' | 'collections'>('library');
   const [nodeViewVisibleImages, setNodeViewVisibleImages] = useState<IndexedImage[]>([]);
   const [isA1111GenerateModalOpen, setIsA1111GenerateModalOpen] = useState(false);
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
@@ -342,7 +349,7 @@ export default function App() {
   );
 
   useEffect(() => {
-    if (libraryView !== 'node' && activeImageScope !== null) {
+    if (libraryView !== 'node' && libraryView !== 'collections' && activeImageScope !== null) {
       setActiveImageScope(null);
     }
   }, [activeImageScope, libraryView, setActiveImageScope]);
@@ -492,6 +499,10 @@ export default function App() {
       loadAnnotations();
     }
   }, [loadAnnotations, isAnnotationsLoaded]);
+
+  useEffect(() => {
+    loadCollections();
+  }, [loadCollections]);
 
   // Initialize license and keep trial opt-in
   useEffect(() => {
@@ -1346,19 +1357,57 @@ export default function App() {
     setIsBatchExportModalOpen(true);
   }, [canUseBatchExport, showProModal]);
 
+  const activeCollection = useMemo(
+    () => safeCollections.find((collection) => collection.id === activeCollectionId) ?? null,
+    [activeCollectionId, safeCollections],
+  );
+
+  const collectionTotalImages = useMemo(() => {
+    if (!activeCollection) {
+      return [];
+    }
+
+    return getResolvedCollectionImages(activeCollection.id);
+  }, [activeCollection, getResolvedCollectionImages]);
+
+  const collectionFilteredImages = useMemo(() => {
+    if (!activeCollection) {
+      return [];
+    }
+
+    return getResolvedFilteredCollectionImages(activeCollection.id);
+  }, [activeCollection, getResolvedFilteredCollectionImages]);
+
+  const displayImages = libraryView === 'collections' ? collectionFilteredImages : safeFilteredImages;
+
+  useEffect(() => {
+    const scopedTotalPages = Math.ceil(displayImages.length / itemsPerPage);
+    if (currentPage > scopedTotalPages && scopedTotalPages > 0) {
+      setCurrentPage(1);
+    }
+  }, [currentPage, displayImages.length, itemsPerPage]);
+
+  useEffect(() => {
+    if (libraryView !== 'collections') {
+      return;
+    }
+
+    setActiveImageScope(activeCollection ? collectionFilteredImages : null);
+  }, [activeCollection, collectionFilteredImages, libraryView, setActiveImageScope]);
+
   // --- Render Logic ---
   const paginatedImages = useMemo(
     () => {
       if (itemsPerPage === -1) {
-        return safeFilteredImages;
+        return displayImages;
       }
-      return safeFilteredImages.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
+      return displayImages.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
     },
-    [safeFilteredImages, currentPage, itemsPerPage]
+    [displayImages, currentPage, itemsPerPage]
   );
   const totalPages = itemsPerPage === -1
     ? 1
-    : Math.ceil(safeFilteredImages.length / itemsPerPage);
+    : Math.ceil(displayImages.length / itemsPerPage);
   const openImageModalEntries = useMemo(() => {
     return openImageModals
       .map((modal) => {
@@ -1484,7 +1533,7 @@ export default function App() {
         isOpen={isBatchExportModalOpen}
         onClose={() => setIsBatchExportModalOpen(false)}
         selectedImageIds={safeSelectedImages}
-        filteredImages={safeFilteredImages}
+        filteredImages={displayImages}
         directories={safeDirectories}
       />
 
@@ -1684,7 +1733,7 @@ export default function App() {
                     }}
                   />
                 )}
-                {(libraryView === 'library' || libraryView === 'node') && (
+                {(libraryView === 'library' || libraryView === 'node' || libraryView === 'collections') && (
                   <GridToolbar
                     selectedImages={safeSelectedImages}
                     images={libraryView === 'node' ? nodeViewVisibleImages : paginatedImages}
@@ -1739,6 +1788,32 @@ export default function App() {
                       setLibraryView('library');
                     }}
                   />
+                ) : libraryView === 'collections' ? (
+                  <CollectionsWorkspace
+                    filteredImages={collectionFilteredImages}
+                    totalImages={collectionTotalImages}
+                  >
+                    {viewMode === 'grid' ? (
+                      <ImageGrid
+                        images={paginatedImages}
+                        onImageClick={handleGridImageClick}
+                        selectedImages={safeSelectedImages}
+                        currentPage={currentPage}
+                        totalPages={totalPages}
+                        onPageChange={setCurrentPage}
+                        onBatchExport={handleOpenBatchExport}
+                        activeCollection={activeCollection}
+                        isCollectionsView
+                      />
+                    ) : (
+                      <ImageTable
+                        images={paginatedImages}
+                        onImageClick={handleImageSelection}
+                        selectedImages={safeSelectedImages}
+                        onBatchExport={handleOpenBatchExport}
+                      />
+                    )}
+                  </CollectionsWorkspace>
                 ) : libraryView === 'node' ? (
                   <NodeView
                     images={safeFilteredImages}
@@ -1759,7 +1834,7 @@ export default function App() {
                 )}
               </div>
 
-              {libraryView === 'library' && (
+              {(libraryView === 'library' || libraryView === 'collections') && (
                 <Footer
                   currentPage={currentPage}
                   totalPages={totalPages}
@@ -1768,9 +1843,13 @@ export default function App() {
                   onItemsPerPageChange={setItemsPerPage}
                   viewMode={viewMode}
                   onViewModeChange={toggleViewMode}
-                  filteredCount={safeFilteredImages.length}
-                  totalCount={selectionTotalImages}
-                  directoryCount={selectionDirectoryCount}
+                  filteredCount={displayImages.length}
+                  totalCount={libraryView === 'collections' ? collectionTotalImages.length : selectionTotalImages}
+                  directoryCount={
+                    libraryView === 'collections'
+                      ? new Set(collectionFilteredImages.map((image) => image.directoryId).filter(Boolean)).size
+                      : selectionDirectoryCount
+                  }
                   enrichmentProgress={enrichmentProgress}
                   a1111Progress={a1111Progress}
                   transferProgress={transferProgress}

--- a/App.tsx
+++ b/App.tsx
@@ -240,6 +240,7 @@ export default function App() {
   const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
   const getResolvedFilteredCollectionImages = useImageStore((state) => state.getResolvedFilteredCollectionImages);
   const createCollection = useImageStore((state) => state.createCollection);
+  const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
 
   const safeImages = Array.isArray(images) ? images : [];
   const safeFilteredImages = Array.isArray(filteredImages) ? filteredImages : [];
@@ -1522,6 +1523,20 @@ export default function App() {
     setSuccess(`Collection "${collection.name}" created.`);
   }, [createCollection, displayImages, safeCollections.length, setSuccess]);
 
+  const handleAddCurrentFilteredToCollection = useCallback(async (collectionId: string) => {
+    const targetImageIds = displayImages.map((image) => image.id);
+    if (targetImageIds.length === 0) {
+      return;
+    }
+
+    const collection = await addImagesToCollection(collectionId, targetImageIds);
+    if (!collection) {
+      return;
+    }
+
+    setSuccess(`Added ${targetImageIds.length} image${targetImageIds.length === 1 ? '' : 's'} to "${collection.name}".`);
+  }, [addImagesToCollection, displayImages, setSuccess]);
+
   const shouldShowLibraryPlaceholder =
     libraryView === 'library' &&
     safeFilteredImages.length === 0 &&
@@ -1782,12 +1797,17 @@ export default function App() {
                     selectedImages={safeSelectedImages}
                     images={libraryView === 'node' ? nodeViewVisibleImages : paginatedImages}
                     directories={safeDirectories}
-                    onSaveCurrentFilteredAsCollection={
+                    onCreateCollectionFromFiltered={
                       canSaveCurrentFilteredAsCollection
                         ? () => setIsSaveFilteredCollectionModalOpen(true)
                         : undefined
                     }
-                    saveCurrentFilteredCount={displayImages.length}
+                    onAddCurrentFilteredToCollection={
+                      canSaveCurrentFilteredAsCollection
+                        ? handleAddCurrentFilteredToCollection
+                        : undefined
+                    }
+                    filteredImageActionCount={displayImages.length}
                     onDeleteSelected={handleDeleteSelectedImages}
                     onGenerateA1111={(image) => {
                       setSelectedImageForGeneration(image);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Collections View**: Added a dedicated `Collections` tab for building reusable image groups across indexed folders, with support for manual collections, tag-driven auto-updating collections, collection ordering, cover images, and collection management from the main workspace.
-- **Collection Creation Shortcuts**: Added `Create Collection` to the manual tag context menu plus `Collection` actions in both the grid and table context menus, including `Add to Collection`, `Create New Collection`, `Set as Cover`, and `Remove from Current Collection`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.1] - Unreleased
 
+### Added
+
+- **Collections View**: Added a dedicated `Collections` tab for building reusable image groups across indexed folders, with support for manual collections, tag-driven auto-updating collections, collection ordering, cover images, and collection management from the main workspace.
+- **Collection Creation Shortcuts**: Added `Create Collection` to the manual tag context menu plus `Collection` actions in both the grid and table context menus, including `Add to Collection`, `Create New Collection`, `Set as Cover`, and `Remove from Current Collection`.
+
 ### Fixed
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.

--- a/__tests__/CollectionsWorkspace.test.tsx
+++ b/__tests__/CollectionsWorkspace.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CollectionsWorkspace from '../components/CollectionsWorkspace';
+import { useImageStore } from '../store/useImageStore';
+
+vi.mock('../hooks/useThumbnail', () => ({
+  useThumbnail: () => undefined,
+}));
+
+vi.mock('../hooks/useResolvedThumbnail', () => ({
+  useResolvedThumbnail: (image: any) => ({
+    thumbnailUrl: image?.thumbnailUrl ?? '',
+  }),
+}));
+
+describe('CollectionsWorkspace', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      images: [
+        {
+          id: 'img-1',
+          name: 'car-1.png',
+          thumbnailUrl: 'thumb://car-1',
+          directoryId: 'dir-1',
+          tags: ['carros'],
+        } as any,
+        {
+          id: 'img-2',
+          name: 'car-2.png',
+          thumbnailUrl: 'thumb://car-2',
+          directoryId: 'dir-1',
+          tags: ['carros'],
+        } as any,
+        {
+          id: 'img-3',
+          name: 'bike-1.png',
+          thumbnailUrl: 'thumb://bike-1',
+          directoryId: 'dir-2',
+          tags: ['motos'],
+        } as any,
+      ],
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'manual',
+          name: 'Carros',
+          sortIndex: 0,
+          imageIds: ['img-1', 'img-2'],
+          snapshotImageIds: [],
+          imageCount: 2,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        {
+          id: 'collection-2',
+          kind: 'tag_rule',
+          name: 'Motos',
+          sortIndex: 1,
+          imageIds: ['img-3'],
+          sourceTag: 'motos',
+          autoUpdate: true,
+          snapshotImageIds: [],
+          imageCount: 1,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      activeCollectionId: null,
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      deleteCollectionById: vi.fn().mockResolvedValue(undefined),
+      reorderCollections: vi.fn().mockResolvedValue(undefined),
+      getResolvedCollectionImages: (collectionId: string) => {
+        const state = useImageStore.getState();
+        const collection = state.collections.find((entry) => entry.id === collectionId);
+        if (!collection) {
+          return [];
+        }
+
+        const ids =
+          collection.id === 'collection-1'
+            ? ['img-1', 'img-2']
+            : ['img-3'];
+
+        return state.images.filter((image) => ids.includes(image.id));
+      },
+      setActiveCollectionId: useImageStore.getState().setActiveCollectionId,
+    } as any);
+  });
+
+  it('shows the collection card browser when no collection is selected', () => {
+    render(
+      <CollectionsWorkspace filteredImages={[]} totalImages={[]}>
+        <div>Collection Detail</div>
+      </CollectionsWorkspace>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Open collection Carros' })).toBeTruthy();
+    expect(screen.queryByText('Collection Detail')).toBeNull();
+  });
+
+  it('selects a collection when clicking anywhere on the sidebar card', () => {
+    render(
+      <CollectionsWorkspace filteredImages={[]} totalImages={[]}>
+        <div>Collection Detail</div>
+      </CollectionsWorkspace>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select collection Carros' }));
+
+    expect(screen.getByText('Collection Detail')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'All Collections' })).toBeTruthy();
+  });
+});

--- a/__tests__/GridToolbar.test.tsx
+++ b/__tests__/GridToolbar.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import GridToolbar from '../components/GridToolbar';
+import { useImageStore } from '../store/useImageStore';
+
+vi.mock('../hooks/useFeatureAccess', () => ({
+  useFeatureAccess: () => ({
+    canUseComparison: true,
+    canUseA1111: true,
+    canUseComfyUI: true,
+    canUseBulkTagging: true,
+    showProModal: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useReparseMetadata', () => ({
+  useReparseMetadata: () => ({
+    isReparsing: false,
+    reparseImages: vi.fn(),
+  }),
+}));
+
+vi.mock('../components/ActiveFilters', () => ({
+  default: () => <div>Active Filters</div>,
+}));
+
+vi.mock('../components/TagManagerModal', () => ({
+  default: () => null,
+}));
+
+describe('GridToolbar', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+  });
+
+  it('renders the save-as-collection action in the toolbar', () => {
+    const onSaveCurrentFilteredAsCollection = vi.fn();
+
+    render(
+      <GridToolbar
+        selectedImages={new Set()}
+        images={[]}
+        directories={[]}
+        onSaveCurrentFilteredAsCollection={onSaveCurrentFilteredAsCollection}
+        saveCurrentFilteredCount={18}
+        onDeleteSelected={vi.fn()}
+        onGenerateA1111={vi.fn()}
+        onGenerateComfyUI={vi.fn()}
+        onCompare={vi.fn()}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /save as collection/i }));
+
+    expect(onSaveCurrentFilteredAsCollection).toHaveBeenCalled();
+    expect(screen.getByText('18')).toBeTruthy();
+  });
+});

--- a/__tests__/GridToolbar.test.tsx
+++ b/__tests__/GridToolbar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import GridToolbar from '../components/GridToolbar';
 import { useImageStore } from '../store/useImageStore';
 
@@ -49,7 +49,7 @@ describe('GridToolbar', () => {
     } as any);
   });
 
-  it('opens collection actions from the toolbar and creates a new collection from filtered images', () => {
+  it('opens collection actions from the toolbar and creates a new collection from filtered images', async () => {
     const onCreateCollectionFromFiltered = vi.fn();
 
     render(
@@ -69,12 +69,12 @@ describe('GridToolbar', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Collection actions' }));
-    fireEvent.click(screen.getByText('Create new collection from filtered images'));
+    fireEvent.click(await screen.findByText('Create new collection from filtered images'));
 
     expect(onCreateCollectionFromFiltered).toHaveBeenCalled();
   });
 
-  it('adds filtered images to an existing collection from the toolbar menu', () => {
+  it('adds filtered images to an existing collection from the toolbar menu', async () => {
     const onAddCurrentFilteredToCollection = vi.fn();
 
     render(
@@ -94,9 +94,11 @@ describe('GridToolbar', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Collection actions' }));
-    fireEvent.mouseEnter(screen.getByText('Add filtered images to collection'));
-    fireEvent.click(screen.getByText('Carros'));
+    fireEvent.mouseEnter(await screen.findByText('Add filtered images to collection'));
+    fireEvent.click(await screen.findByText('Carros'));
 
-    expect(onAddCurrentFilteredToCollection).toHaveBeenCalledWith('collection-1');
+    await waitFor(() => {
+      expect(onAddCurrentFilteredToCollection).toHaveBeenCalledWith('collection-1');
+    });
   });
 });

--- a/__tests__/GridToolbar.test.tsx
+++ b/__tests__/GridToolbar.test.tsx
@@ -32,18 +32,34 @@ vi.mock('../components/TagManagerModal', () => ({
 describe('GridToolbar', () => {
   beforeEach(() => {
     useImageStore.getState().resetState();
+    useImageStore.setState({
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'manual',
+          name: 'Carros',
+          sortIndex: 0,
+          imageIds: [],
+          snapshotImageIds: [],
+          imageCount: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    } as any);
   });
 
-  it('renders the save-as-collection action in the toolbar', () => {
-    const onSaveCurrentFilteredAsCollection = vi.fn();
+  it('opens collection actions from the toolbar and creates a new collection from filtered images', () => {
+    const onCreateCollectionFromFiltered = vi.fn();
 
     render(
       <GridToolbar
         selectedImages={new Set()}
         images={[]}
         directories={[]}
-        onSaveCurrentFilteredAsCollection={onSaveCurrentFilteredAsCollection}
-        saveCurrentFilteredCount={18}
+        onCreateCollectionFromFiltered={onCreateCollectionFromFiltered}
+        onAddCurrentFilteredToCollection={vi.fn()}
+        filteredImageActionCount={18}
         onDeleteSelected={vi.fn()}
         onGenerateA1111={vi.fn()}
         onGenerateComfyUI={vi.fn()}
@@ -52,9 +68,35 @@ describe('GridToolbar', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /save as collection/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Collection actions' }));
+    fireEvent.click(screen.getByText('Create new collection from filtered images'));
 
-    expect(onSaveCurrentFilteredAsCollection).toHaveBeenCalled();
-    expect(screen.getByText('18')).toBeTruthy();
+    expect(onCreateCollectionFromFiltered).toHaveBeenCalled();
+  });
+
+  it('adds filtered images to an existing collection from the toolbar menu', () => {
+    const onAddCurrentFilteredToCollection = vi.fn();
+
+    render(
+      <GridToolbar
+        selectedImages={new Set()}
+        images={[]}
+        directories={[]}
+        onCreateCollectionFromFiltered={vi.fn()}
+        onAddCurrentFilteredToCollection={onAddCurrentFilteredToCollection}
+        filteredImageActionCount={18}
+        onDeleteSelected={vi.fn()}
+        onGenerateA1111={vi.fn()}
+        onGenerateComfyUI={vi.fn()}
+        onCompare={vi.fn()}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collection actions' }));
+    fireEvent.mouseEnter(screen.getByText('Add filtered images to collection'));
+    fireEvent.click(screen.getByText('Carros'));
+
+    expect(onAddCurrentFilteredToCollection).toHaveBeenCalledWith('collection-1');
   });
 });

--- a/__tests__/Header.launch-generator.test.tsx
+++ b/__tests__/Header.launch-generator.test.tsx
@@ -102,4 +102,22 @@ describe('Header launch generator', () => {
 
     expect(launchGenerator).not.toHaveBeenCalled();
   });
+
+  it('renders and switches to the collections tab', () => {
+    const onLibraryViewChange = vi.fn();
+
+    render(
+      <Header
+        onOpenSettings={() => {}}
+        onOpenAnalytics={() => {}}
+        onOpenLicense={() => {}}
+        libraryView="library"
+        onLibraryViewChange={onLibraryViewChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /collections/i }));
+
+    expect(onLibraryViewChange).toHaveBeenCalledWith('collections');
+  });
 });

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -7,12 +7,20 @@ import { useSettingsStore } from '../store/useSettingsStore';
 import type { IndexedImage } from '../types';
 
 const showContextMenuMock = vi.fn();
+const hideContextMenuMock = vi.fn();
+const contextMenuStateMock = {
+  visible: false,
+  x: 24,
+  y: 24,
+  image: undefined as IndexedImage | undefined,
+  directoryPath: 'D:/library',
+};
 
 vi.mock('../hooks/useContextMenu', () => ({
   useContextMenu: () => ({
-    contextMenu: { visible: false, x: 0, y: 0, image: undefined, directoryPath: undefined },
+    contextMenu: contextMenuStateMock,
     showContextMenu: showContextMenuMock,
-    hideContextMenu: vi.fn(),
+    hideContextMenu: hideContextMenuMock,
     copyPrompt: vi.fn(),
     copyNegativePrompt: vi.fn(),
     copySeed: vi.fn(),
@@ -140,6 +148,9 @@ const Harness = ({ images }: { images: IndexedImage[] }) => {
 describe('ImageGrid context menu', () => {
   beforeEach(() => {
     showContextMenuMock.mockReset();
+    hideContextMenuMock.mockReset();
+    contextMenuStateMock.visible = false;
+    contextMenuStateMock.image = undefined;
     useImageStore.getState().resetState();
     useSettingsStore.getState().resetState();
     useSettingsStore.setState({
@@ -183,5 +194,80 @@ describe('ImageGrid context menu', () => {
     expect(showContextMenuMock).toHaveBeenCalledTimes(1);
     expect(showContextMenuMock.mock.calls[0]?.[1]).toMatchObject({ id: 'img-1' });
     expect(showContextMenuMock.mock.calls[0]?.[2]).toBe('D:/library');
+  });
+
+  it('shows collection actions in the image context menu', () => {
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      collections: [],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection: vi.fn().mockResolvedValue(undefined),
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      bulkAddTag: vi.fn().mockResolvedValue(undefined),
+      bulkRemoveTag: vi.fn().mockResolvedValue(undefined),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<Harness images={[image]} />);
+
+    expect(screen.getByText('Collection')).toBeTruthy();
+    fireEvent.click(screen.getByText('Collection'));
+    expect(screen.getByText('Create New Collection')).toBeTruthy();
+  });
+
+  it('adds selected images to a manual collection from the context menu', () => {
+    const addImagesToCollection = vi.fn().mockResolvedValue(undefined);
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1']),
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'manual',
+          name: 'Motos',
+          sortIndex: 0,
+          imageCount: 0,
+          imageIds: [],
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection,
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      bulkAddTag: vi.fn().mockResolvedValue(undefined),
+      bulkRemoveTag: vi.fn().mockResolvedValue(undefined),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<Harness images={[image]} />);
+
+    fireEvent.click(screen.getByText('Collection'));
+    fireEvent.click(screen.getByText('Add to Collection'));
+    fireEvent.click(screen.getByText('Motos'));
+
+    expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
   });
 });

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -270,4 +270,49 @@ describe('ImageGrid context menu', () => {
 
     expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
   });
+
+  it('adds selected images explicitly even for collections with auto-add tags', () => {
+    const addImagesToCollection = vi.fn().mockResolvedValue(undefined);
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1']),
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'tag_rule',
+          name: 'Carros',
+          sortIndex: 0,
+          imageCount: 0,
+          imageIds: [],
+          sourceTag: 'carros',
+          autoUpdate: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection,
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<Harness images={[image]} />);
+
+    fireEvent.click(screen.getByText('Collection'));
+    fireEvent.click(screen.getByText('Add to Collection'));
+    fireEvent.click(screen.getByText('Carros'));
+
+    expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
+  });
 });

--- a/__tests__/ImageTable.contextMenu.test.tsx
+++ b/__tests__/ImageTable.contextMenu.test.tsx
@@ -133,4 +133,53 @@ describe('ImageTable context menu', () => {
     fireEvent.click(screen.getByText('Collection'));
     expect(screen.getByText('Create New Collection')).toBeTruthy();
   });
+
+  it('adds selected images explicitly to collections with auto-add enabled', () => {
+    const addImagesToCollection = vi.fn().mockResolvedValue(undefined);
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1']),
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'tag_rule',
+          name: 'Carros',
+          sortIndex: 0,
+          imageCount: 0,
+          imageIds: [],
+          sourceTag: 'carros',
+          autoUpdate: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection,
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      bulkSetImageRating: vi.fn(),
+      transferProgress: null,
+    } as any);
+
+    render(
+      <ImageTable
+        images={[image]}
+        onImageClick={vi.fn()}
+        selectedImages={new Set(['img-1'])}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Collection'));
+    fireEvent.click(screen.getByText('Add to Collection'));
+    fireEvent.click(screen.getByText('Carros'));
+
+    expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
+  });
 });

--- a/__tests__/ImageTable.contextMenu.test.tsx
+++ b/__tests__/ImageTable.contextMenu.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ImageTable from '../components/ImageTable';
+import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+import type { IndexedImage } from '../types';
+
+const showContextMenuMock = vi.fn();
+const hideContextMenuMock = vi.fn();
+const contextMenuStateMock = {
+  visible: false,
+  x: 24,
+  y: 24,
+  image: undefined as IndexedImage | undefined,
+  directoryPath: 'D:/library',
+};
+
+vi.mock('../hooks/useContextMenu', () => ({
+  useContextMenu: () => ({
+    contextMenu: contextMenuStateMock,
+    showContextMenu: showContextMenuMock,
+    hideContextMenu: hideContextMenuMock,
+    copyPrompt: vi.fn(),
+    copyNegativePrompt: vi.fn(),
+    copySeed: vi.fn(),
+    copyImage: vi.fn(),
+    copyModel: vi.fn(),
+    showInFolder: vi.fn(),
+    exportImage: vi.fn(),
+    copyRawMetadata: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useThumbnail', () => ({
+  useThumbnail: vi.fn(),
+}));
+
+vi.mock('../hooks/useResolvedThumbnail', () => ({
+  useResolvedThumbnail: () => ({
+    thumbnailStatus: 'ready',
+    thumbnailUrl: 'thumb://image',
+  }),
+}));
+
+vi.mock('../hooks/useFeatureAccess', () => ({
+  useFeatureAccess: () => ({
+    canUseFileManagement: true,
+    showProModal: vi.fn(),
+    initialized: true,
+    canUseDuringTrialOrPro: true,
+  }),
+}));
+
+vi.mock('../hooks/useReparseMetadata', () => ({
+  useReparseMetadata: () => ({
+    isReparsing: false,
+    reparseImages: vi.fn(),
+  }),
+}));
+
+vi.mock('../components/ProBadge', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/TransferImagesModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/CollectionFormModal', () => ({
+  default: ({ isOpen }: { isOpen: boolean }) => (isOpen ? <div>Create Collection Modal</div> : null),
+}));
+
+const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
+  id: overrides.id ?? 'dir-1::image.png',
+  name: overrides.name ?? 'image.png',
+  handle: overrides.handle ?? ({ name: overrides.name ?? 'image.png' } as FileSystemFileHandle),
+  metadata: overrides.metadata ?? ({} as any),
+  metadataString: overrides.metadataString ?? '',
+  lastModified: overrides.lastModified ?? 1,
+  directoryId: overrides.directoryId ?? 'dir-1',
+  models: overrides.models ?? [],
+  loras: overrides.loras ?? [],
+  scheduler: overrides.scheduler ?? '',
+  workflowNodes: overrides.workflowNodes ?? [],
+  ...overrides,
+});
+
+describe('ImageTable context menu', () => {
+  beforeEach(() => {
+    showContextMenuMock.mockReset();
+    hideContextMenuMock.mockReset();
+    contextMenuStateMock.visible = false;
+    contextMenuStateMock.image = undefined;
+    useImageStore.getState().resetState();
+    useSettingsStore.getState().resetState();
+    useSettingsStore.setState({
+      disableThumbnails: false,
+      showFullFilePath: false,
+    } as any);
+  });
+
+  it('shows collection actions in the image-table context menu', () => {
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      collections: [],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection: vi.fn().mockResolvedValue(undefined),
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      bulkAddTag: vi.fn().mockResolvedValue(undefined),
+      bulkRemoveTag: vi.fn().mockResolvedValue(undefined),
+      bulkSetImageRating: vi.fn(),
+      transferProgress: null,
+    } as any);
+
+    render(
+      <ImageTable
+        images={[image]}
+        onImageClick={vi.fn()}
+        selectedImages={new Set()}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Collection')).toBeTruthy();
+    fireEvent.click(screen.getByText('Collection'));
+    expect(screen.getByText('Create New Collection')).toBeTruthy();
+  });
+});

--- a/__tests__/TagsAndFavorites.test.tsx
+++ b/__tests__/TagsAndFavorites.test.tsx
@@ -193,7 +193,7 @@ describe('TagsAndFavorites manual tag browser', () => {
     render(<TagsAndFavorites />);
     openContextMenuForTag('carros');
     fireEvent.click(screen.getByText('Create Collection'));
-    fireEvent.click(screen.getByText('Create Collection'));
+    fireEvent.click(screen.getByRole('button', { name: 'Create Collection' }));
 
     expect(createCollection).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/__tests__/TagsAndFavorites.test.tsx
+++ b/__tests__/TagsAndFavorites.test.tsx
@@ -23,6 +23,7 @@ const seedSidebarState = (overrides: Record<string, unknown> = {}) => {
   const setExcludedAutoTags = vi.fn();
   const setSelectedRatings = vi.fn();
   const refreshAvailableAutoTags = vi.fn();
+  const createCollection = vi.fn().mockResolvedValue(undefined);
 
   useImageStore.getState().resetState();
   useImageStore.setState({
@@ -30,6 +31,7 @@ const seedSidebarState = (overrides: Record<string, unknown> = {}) => {
     availableAutoTags: [],
     images: [],
     filteredImages: [],
+    collections: [],
     selectedTags: [],
     excludedTags: [],
     selectedTagsMatchMode: 'any',
@@ -48,6 +50,7 @@ const seedSidebarState = (overrides: Record<string, unknown> = {}) => {
     setExcludedAutoTags,
     setSelectedRatings,
     refreshAvailableAutoTags,
+    createCollection,
     ...overrides,
   });
 
@@ -61,6 +64,7 @@ const seedSidebarState = (overrides: Record<string, unknown> = {}) => {
     setSelectedTagsMatchMode,
     setSelectedRatings,
     refreshAvailableAutoTags,
+    createCollection,
   };
 };
 
@@ -175,6 +179,30 @@ describe('TagsAndFavorites manual tag browser', () => {
     fireEvent.click(screen.getByText('Rename'));
 
     expect(renameTag).toHaveBeenCalledWith('ghost-tag', 'fixed-tag');
+  });
+
+  it('creates a tag-rule collection from the tag context menu', async () => {
+    const { createCollection } = seedSidebarState({
+      availableTags: [{ name: 'carros', count: 2 }],
+      images: [
+        { id: 'img-1', tags: ['carros'] } as any,
+        { id: 'img-2', tags: ['carros', 'motos'] } as any,
+      ],
+    });
+
+    render(<TagsAndFavorites />);
+    openContextMenuForTag('carros');
+    fireEvent.click(screen.getByText('Create Collection'));
+    fireEvent.click(screen.getByText('Create Collection'));
+
+    expect(createCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'tag_rule',
+        name: 'carros',
+        sourceTag: 'carros',
+        autoUpdate: true,
+      }),
+    );
   });
 
   it('hides delete-empty for used tags and keeps purge available', () => {

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type FakeStoreState = {
+  keyPath: string;
+  records: Map<string, any>;
+  indexes: Map<string, { keyPath: string | string[]; options?: IDBIndexParameters }>;
+};
+
+type FakeDbState = {
+  version: number;
+  stores: Map<string, FakeStoreState>;
+};
+
+const createDomStringList = (values: () => string[]): DOMStringList =>
+  ({
+    contains: (name: string) => values().includes(name),
+    item: (index: number) => values()[index] ?? null,
+    get length() {
+      return values().length;
+    },
+    [Symbol.iterator]: function* iterator() {
+      yield* values();
+    },
+  }) as unknown as DOMStringList;
+
+const cloneValue = <T,>(value: T): T =>
+  value == null ? value : JSON.parse(JSON.stringify(value));
+
+const createFakeIndexedDb = () => {
+  const databases = new Map<string, FakeDbState>();
+  let transaction: IDBTransaction;
+
+  const makeRequest = <T,>() =>
+    ({
+      result: undefined as T | undefined,
+      error: null as unknown,
+      onsuccess: null as ((event: Event) => void) | null,
+      onerror: null as ((event: Event) => void) | null,
+      onupgradeneeded: null as ((event: IDBVersionChangeEvent) => void) | null,
+      transaction: null as IDBTransaction | null,
+      readyState: 'pending' as IDBRequestReadyState,
+    }) as unknown as IDBOpenDBRequest & IDBRequest<T>;
+
+  const completeTransaction = (activeTransaction: any) => {
+    queueMicrotask(() => {
+      activeTransaction.oncomplete?.(new Event('complete'));
+    });
+  };
+
+  const makeStore = (dbState: FakeDbState, activeTransaction: any, storeName: string) => {
+    const storeState = dbState.stores.get(storeName);
+    if (!storeState) {
+      throw new Error(`Store ${storeName} not found`);
+    }
+
+    const makeStoreRequest = <T,>(executor: () => T) => {
+      const request = makeRequest<T>();
+      queueMicrotask(() => {
+        try {
+          request.result = executor();
+          request.readyState = 'done';
+          request.onsuccess?.(new Event('success'));
+          completeTransaction(activeTransaction);
+        } catch (error) {
+          request.error = error;
+          request.readyState = 'done';
+          request.onerror?.(new Event('error'));
+        }
+      });
+      return request;
+    };
+
+    const makeIndex = (indexName: string) => {
+      const definition = storeState.indexes.get(indexName);
+      if (!definition) {
+        throw new Error(`Index ${indexName} not found`);
+      }
+
+      return {
+        getAll: (query?: unknown) =>
+          makeStoreRequest(() => {
+            const results = Array.from(storeState.records.values()).filter((record) => {
+              const value = (record as Record<string, any>)[definition.keyPath as string];
+              if (definition.options?.multiEntry && Array.isArray(value)) {
+                return query === undefined || value.includes(query);
+              }
+              return query === undefined || value === query;
+            });
+
+            return cloneValue(results);
+          }),
+      } as unknown as IDBIndex;
+    };
+
+    return {
+      keyPath: storeState.keyPath,
+      indexNames: createDomStringList(() => Array.from(storeState.indexes.keys())),
+      createIndex: (name: string, keyPath: string | string[], options?: IDBIndexParameters) => {
+        storeState.indexes.set(name, { keyPath, options });
+        return makeIndex(name);
+      },
+      index: (name: string) => makeIndex(name),
+      get: (key: string) => makeStoreRequest(() => cloneValue(storeState.records.get(key))),
+      getAll: () => makeStoreRequest(() => cloneValue(Array.from(storeState.records.values()))),
+      put: (value: Record<string, any>) =>
+        makeStoreRequest(() => {
+          const key = String(value[storeState.keyPath]);
+          storeState.records.set(key, cloneValue(value));
+          return key;
+        }),
+      delete: (key: string) =>
+        makeStoreRequest(() => {
+          storeState.records.delete(String(key));
+          return undefined;
+        }),
+    } as unknown as IDBObjectStore;
+  };
+
+  const makeTransaction = (dbState: FakeDbState, storeNames: string | string[]) =>
+    ({
+      error: null,
+      oncomplete: null,
+      onabort: null,
+      onerror: null,
+      objectStore: (name: string) => {
+        const allowedStores = Array.isArray(storeNames) ? storeNames : [storeNames];
+        if (!allowedStores.includes(name)) {
+          throw new Error(`Store ${name} not in transaction scope`);
+        }
+        return makeStore(dbState, transaction, name);
+      },
+    } as unknown as IDBTransaction);
+
+  const makeDatabase = (dbState: FakeDbState) =>
+    ({
+      objectStoreNames: createDomStringList(() => Array.from(dbState.stores.keys())),
+      createObjectStore: (name: string, options?: IDBObjectStoreParameters) => {
+        const keyPath = typeof options?.keyPath === 'string' ? options.keyPath : 'id';
+        const storeState: FakeStoreState = {
+          keyPath,
+          records: new Map(),
+          indexes: new Map(),
+        };
+        dbState.stores.set(name, storeState);
+        return makeStore(dbState, { oncomplete: null, onabort: null, onerror: null }, name);
+      },
+      transaction: (storeNames: string | string[]) => {
+        transaction = makeTransaction(dbState, storeNames);
+        return transaction;
+      },
+      close: () => undefined,
+      onversionchange: null,
+      get version() {
+        return dbState.version;
+      },
+      get name() {
+        return 'image-metahub-preferences';
+      },
+    }) as unknown as IDBDatabase;
+
+  return {
+    open: (name: string, version?: number) => {
+      const request = makeRequest<IDBDatabase>();
+
+      queueMicrotask(() => {
+        const existing = databases.get(name) ?? { version: 0, stores: new Map<string, FakeStoreState>() };
+        const requestedVersion = version ?? existing.version ?? 1;
+
+        databases.set(name, existing);
+        const db = makeDatabase(existing);
+        request.result = db;
+
+        if (requestedVersion > existing.version) {
+          const oldVersion = existing.version;
+          existing.version = requestedVersion;
+          request.transaction = makeTransaction(existing, Array.from(existing.stores.keys()));
+          request.onupgradeneeded?.({ oldVersion } as IDBVersionChangeEvent);
+        }
+
+        request.readyState = 'done';
+        request.onsuccess?.(new Event('success'));
+      });
+
+      return request;
+    },
+    deleteDatabase: (name: string) => {
+      const request = makeRequest<undefined>();
+      queueMicrotask(() => {
+        databases.delete(name);
+        request.result = undefined;
+        request.readyState = 'done';
+        request.onsuccess?.(new Event('success'));
+      });
+      return request;
+    },
+  } as unknown as IDBFactory;
+};
+
+const installFakeIndexedDb = () => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: createFakeIndexedDb(),
+    configurable: true,
+    writable: true,
+  });
+};
+
+describe('smart collection storage', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    installFakeIndexedDb();
+  });
+
+  it('round-trips manual and tag_rule collections through IndexedDB', async () => {
+    const {
+      getAllSmartCollections,
+      getSmartCollection,
+      saveSmartCollection,
+    } = await import('../services/imageAnnotationsStorage');
+
+    await saveSmartCollection({
+      id: 'manual-1',
+      kind: 'manual',
+      name: 'Motos',
+      sortIndex: 1,
+      imageIds: ['img-1', 'img-2', 'img-2'],
+      imageCount: 2,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    await saveSmartCollection({
+      id: 'tag-1',
+      kind: 'tag_rule',
+      name: 'Carros',
+      sortIndex: 0,
+      sourceTag: 'carros',
+      autoUpdate: true,
+      snapshotImageIds: ['img-3'],
+      imageCount: 99,
+      createdAt: 2,
+      updatedAt: 2,
+    });
+
+    const collections = await getAllSmartCollections();
+    const tagRuleCollection = await getSmartCollection('tag-1');
+
+    expect(collections.map((collection) => collection.id)).toEqual(['tag-1', 'manual-1']);
+    expect(collections[1]?.imageIds).toEqual(['img-1', 'img-2']);
+    expect(tagRuleCollection).toMatchObject({
+      id: 'tag-1',
+      kind: 'tag_rule',
+      sourceTag: 'carros',
+      autoUpdate: true,
+    });
+  });
+
+  it('normalizes legacy smart-collection records with safe defaults', async () => {
+    const { normalizeSmartCollection } = await import('../services/imageAnnotationsStorage');
+
+    const normalized = normalizeSmartCollection({
+      id: 'legacy-1',
+      name: 'Legacy Collection',
+      type: 'custom',
+      query: { userTags: ['carros'] },
+      createdAt: 10,
+      updatedAt: 20,
+      imageCount: 0,
+    });
+
+    expect(normalized).toMatchObject({
+      id: 'legacy-1',
+      kind: 'manual',
+      sortIndex: 0,
+      imageIds: [],
+      snapshotImageIds: [],
+      query: { userTags: ['carros'] },
+      type: 'custom',
+    });
+  });
+
+  it('resolves live and frozen tag-rule memberships from the current image set', async () => {
+    const { resolveSmartCollectionImageIds } = await import('../services/imageAnnotationsStorage');
+
+    const images = [
+      { id: 'img-1', tags: ['carros'] },
+      { id: 'img-2', tags: ['carros', 'motos'] },
+      { id: 'img-3', tags: ['motos'] },
+    ] as any;
+
+    expect(
+      resolveSmartCollectionImageIds(
+        {
+          id: 'tag-live',
+          kind: 'tag_rule',
+          name: 'Carros',
+          sortIndex: 0,
+          sourceTag: 'carros',
+          autoUpdate: true,
+          imageCount: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        images,
+      ),
+    ).toEqual(['img-1', 'img-2']);
+
+    expect(
+      resolveSmartCollectionImageIds(
+        {
+          id: 'tag-frozen',
+          kind: 'tag_rule',
+          name: 'Carros',
+          sortIndex: 0,
+          sourceTag: 'carros',
+          autoUpdate: false,
+          snapshotImageIds: ['img-2'],
+          imageCount: 1,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        images,
+      ),
+    ).toEqual(['img-2']);
+  });
+});

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -324,4 +324,29 @@ describe('smart collection storage', () => {
       ),
     ).toEqual(['img-1', 'img-2']);
   });
+
+  it('removes images from both manual and frozen snapshot membership sources', async () => {
+    const { removeImagesFromSmartCollection } = await import('../services/imageAnnotationsStorage');
+
+    const updated = await removeImagesFromSmartCollection(
+      {
+        id: 'tag-frozen',
+        kind: 'tag_rule',
+        name: 'Carros',
+        sortIndex: 0,
+        sourceTag: 'carros',
+        autoUpdate: false,
+        imageIds: ['img-1', 'img-2'],
+        snapshotImageIds: ['img-2', 'img-3'],
+        imageCount: 3,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      ['img-2', 'img-3'],
+    );
+
+    expect(updated.imageIds).toEqual(['img-1']);
+    expect(updated.snapshotImageIds).toEqual([]);
+    expect(updated.imageCount).toBe(1);
+  });
 });

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -296,13 +296,14 @@ describe('smart collection storage', () => {
           sortIndex: 0,
           sourceTag: 'carros',
           autoUpdate: true,
+          imageIds: ['img-3'],
           imageCount: 0,
           createdAt: 1,
           updatedAt: 1,
         },
         images,
       ),
-    ).toEqual(['img-1', 'img-2']);
+    ).toEqual(['img-3', 'img-1', 'img-2']);
 
     expect(
       resolveSmartCollectionImageIds(
@@ -313,6 +314,7 @@ describe('smart collection storage', () => {
           sortIndex: 0,
           sourceTag: 'carros',
           autoUpdate: false,
+          imageIds: ['img-1'],
           snapshotImageIds: ['img-2'],
           imageCount: 1,
           createdAt: 1,
@@ -320,6 +322,6 @@ describe('smart collection storage', () => {
         },
         images,
       ),
-    ).toEqual(['img-2']);
+    ).toEqual(['img-1', 'img-2']);
   });
 });

--- a/components/CollectionCard.tsx
+++ b/components/CollectionCard.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { FolderOpen, Sparkles } from 'lucide-react';
+import { IndexedImage, SmartCollection } from '../types';
+import { useThumbnail } from '../hooks/useThumbnail';
+import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+
+interface CollectionCardProps {
+  collection: SmartCollection;
+  images: IndexedImage[];
+  imageCount: number;
+  onClick: () => void;
+}
+
+const CollectionCard: React.FC<CollectionCardProps> = ({
+  collection,
+  images,
+  imageCount,
+  onClick,
+}) => {
+  const cardRef = useRef<HTMLButtonElement | null>(null);
+  const [previewIndex, setPreviewIndex] = useState(0);
+  const rafRef = useRef<number | null>(null);
+  const pendingIndexRef = useRef(0);
+
+  const previewImage = images[previewIndex] ?? images[0] ?? null;
+  const thumbnail = useResolvedThumbnail(previewImage);
+  useThumbnail(previewImage);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  const updatePreviewIndex = (nextIndex: number) => {
+    pendingIndexRef.current = nextIndex;
+    if (rafRef.current !== null) {
+      return;
+    }
+
+    rafRef.current = requestAnimationFrame(() => {
+      setPreviewIndex(pendingIndexRef.current);
+      rafRef.current = null;
+    });
+  };
+
+  const handlePointerMove = (event: React.PointerEvent) => {
+    if (!cardRef.current || images.length < 2) {
+      return;
+    }
+
+    const rect = cardRef.current.getBoundingClientRect();
+    const relativeX = Math.min(Math.max(event.clientX - rect.left, 0), rect.width);
+    const ratio = rect.width > 0 ? relativeX / rect.width : 0;
+    const index = Math.floor(ratio * (images.length - 1));
+    updatePreviewIndex(index);
+  };
+
+  const handlePointerLeave = () => {
+    updatePreviewIndex(0);
+  };
+
+  const coverUrl = thumbnail?.thumbnailUrl || '';
+  const description = collection.description?.trim() || null;
+  const autoAddLabel = collection.sourceTag
+    ? collection.autoUpdate !== false
+      ? `Auto-add: ${collection.sourceTag}`
+      : `Linked tag: ${collection.sourceTag}`
+    : null;
+
+  return (
+    <button
+      ref={cardRef}
+      type="button"
+      aria-label={`Open collection ${collection.name}`}
+      onClick={onClick}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={handlePointerLeave}
+      className="group overflow-hidden rounded-2xl border border-gray-800 bg-gray-900/60 text-left shadow-lg transition-all hover:border-blue-500/30 hover:shadow-xl hover:shadow-blue-500/20"
+    >
+      <div className="relative aspect-[4/5] overflow-hidden">
+        {coverUrl ? (
+          <img
+            src={coverUrl}
+            alt={collection.name}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-gray-800 via-gray-900 to-gray-800 text-gray-500">
+            <FolderOpen className="h-8 w-8 opacity-70" />
+          </div>
+        )}
+
+        <div className="absolute left-3 top-3 flex items-center gap-1.5 rounded-full bg-black/60 px-2.5 py-1 text-[11px] font-semibold text-gray-100">
+          <FolderOpen className="h-3.5 w-3.5" />
+          {imageCount}
+        </div>
+
+        {collection.sourceTag && (
+          <div className="absolute right-3 top-3 flex items-center gap-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/15 px-2.5 py-1 text-[11px] font-semibold text-emerald-100">
+            <Sparkles className="h-3.5 w-3.5" />
+            {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+          </div>
+        )}
+
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/80 to-transparent" />
+
+        {images.length > 1 && (
+          <div className="absolute bottom-3 left-3 right-3 z-10 h-1 overflow-hidden rounded-full bg-black/40">
+            <div
+              className="h-full bg-blue-400/80 transition-all duration-100"
+              style={{
+                width: images.length > 1 ? `${(previewIndex / (images.length - 1)) * 100}%` : '0%',
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="p-4">
+        <p className="truncate text-sm font-semibold text-gray-100" title={collection.name}>
+          {collection.name}
+        </p>
+        {description && (
+          <p className="mt-1 line-clamp-2 min-h-[2.5rem] text-xs text-gray-400">
+            {description}
+          </p>
+        )}
+        {!description && (
+          <p className="mt-1 min-h-[2.5rem] text-xs text-gray-500">
+            {imageCount} image{imageCount !== 1 ? 's' : ''}
+          </p>
+        )}
+        {autoAddLabel && (
+          <p className="mt-2 truncate text-[11px] uppercase tracking-wide text-gray-500">
+            {autoAddLabel}
+          </p>
+        )}
+      </div>
+    </button>
+  );
+};
+
+export default CollectionCard;

--- a/components/CollectionFormModal.tsx
+++ b/components/CollectionFormModal.tsx
@@ -121,15 +121,16 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
 
           {showSourceTag && (
             <label className="block">
-              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Auto-Add Tag</span>
+              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Auto-Add Tags</span>
               <input
                 type="text"
                 value={values.sourceTag}
                 disabled={disableSourceTag}
                 onChange={(event) => setValues((current) => ({ ...current, sourceTag: event.target.value }))}
                 className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-70"
-                placeholder="tag name"
+                placeholder="motos, carros, barcos"
               />
+              <span className="mt-1 block text-xs text-gray-500">Separate tags with commas.</span>
             </label>
           )}
 

--- a/components/CollectionFormModal.tsx
+++ b/components/CollectionFormModal.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { SmartCollection } from '../types';
 
 export interface CollectionFormValues {
   name: string;
@@ -16,12 +15,12 @@ interface CollectionFormModalProps {
   initialValues: CollectionFormValues;
   onClose: () => void;
   onSubmit: (values: CollectionFormValues) => Promise<void> | void;
+  subtitle?: string;
   showSourceTag?: boolean;
   disableSourceTag?: boolean;
   showAutoUpdate?: boolean;
   showIncludeTargetImages?: boolean;
   includeTargetImagesLabel?: string;
-  collectionKind?: SmartCollection['kind'];
 }
 
 const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
@@ -31,15 +30,16 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
   initialValues,
   onClose,
   onSubmit,
+  subtitle,
   showSourceTag = false,
   disableSourceTag = false,
   showAutoUpdate = false,
   showIncludeTargetImages = false,
   includeTargetImagesLabel = 'Add the current images now',
-  collectionKind = 'manual',
 }) => {
   const [values, setValues] = useState<CollectionFormValues>(initialValues);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const hasSourceTag = values.sourceTag.trim().length > 0;
 
   useEffect(() => {
     if (!isOpen) {
@@ -86,11 +86,7 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
       >
         <div className="mb-4">
           <h3 className="text-base font-semibold text-white">{title}</h3>
-          <p className="mt-1 text-xs text-gray-400">
-            {collectionKind === 'tag_rule'
-              ? 'Tag-based collections can stay in sync automatically or freeze the current membership.'
-              : 'Manual collections keep only the images you explicitly add.'}
-          </p>
+          {subtitle && <p className="mt-1 text-xs text-gray-400">{subtitle}</p>}
         </div>
 
         <div className="space-y-4">
@@ -125,7 +121,7 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
 
           {showSourceTag && (
             <label className="block">
-              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Source Tag</span>
+              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Auto-Add Tag</span>
               <input
                 type="text"
                 value={values.sourceTag}
@@ -141,14 +137,17 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
             <label className="flex items-start gap-3 rounded-xl border border-gray-700 bg-gray-800/50 px-3 py-3">
               <input
                 type="checkbox"
-                checked={values.autoUpdate}
+                checked={hasSourceTag ? values.autoUpdate : false}
+                disabled={!hasSourceTag}
                 onChange={(event) => setValues((current) => ({ ...current, autoUpdate: event.target.checked }))}
-                className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500"
+                className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
               />
               <span>
-                <span className="block text-sm font-medium text-gray-100">Auto-update from future tags</span>
+                <span className="block text-sm font-medium text-gray-100">Add matching tagged images automatically</span>
                 <span className="mt-1 block text-xs text-gray-400">
-                  Keep the collection synced with future images tagged with this source tag.
+                  {hasSourceTag
+                    ? 'New images with this tag will appear here automatically.'
+                    : 'Choose a tag above to enable this.'}
                 </span>
               </span>
             </label>
@@ -164,9 +163,6 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
               />
               <span>
                 <span className="block text-sm font-medium text-gray-100">{includeTargetImagesLabel}</span>
-                <span className="mt-1 block text-xs text-gray-400">
-                  The current context-menu target can be added immediately when the collection is created.
-                </span>
               </span>
             </label>
           )}

--- a/components/CollectionFormModal.tsx
+++ b/components/CollectionFormModal.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useState } from 'react';
+import { SmartCollection } from '../types';
+
+export interface CollectionFormValues {
+  name: string;
+  description: string;
+  sourceTag: string;
+  autoUpdate: boolean;
+  includeTargetImages: boolean;
+}
+
+interface CollectionFormModalProps {
+  isOpen: boolean;
+  title: string;
+  submitLabel: string;
+  initialValues: CollectionFormValues;
+  onClose: () => void;
+  onSubmit: (values: CollectionFormValues) => Promise<void> | void;
+  showSourceTag?: boolean;
+  disableSourceTag?: boolean;
+  showAutoUpdate?: boolean;
+  showIncludeTargetImages?: boolean;
+  includeTargetImagesLabel?: string;
+  collectionKind?: SmartCollection['kind'];
+}
+
+const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
+  isOpen,
+  title,
+  submitLabel,
+  initialValues,
+  onClose,
+  onSubmit,
+  showSourceTag = false,
+  disableSourceTag = false,
+  showAutoUpdate = false,
+  showIncludeTargetImages = false,
+  includeTargetImagesLabel = 'Add the current images now',
+  collectionKind = 'manual',
+}) => {
+  const [values, setValues] = useState<CollectionFormValues>(initialValues);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setValues(initialValues);
+    setIsSubmitting(false);
+  }, [initialValues, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = async () => {
+    if (!values.name.trim()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        ...values,
+        name: values.name.trim(),
+        description: values.description.trim(),
+        sourceTag: values.sourceTag.trim().toLowerCase(),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl border border-gray-700 bg-gray-900 p-5 shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mb-4">
+          <h3 className="text-base font-semibold text-white">{title}</h3>
+          <p className="mt-1 text-xs text-gray-400">
+            {collectionKind === 'tag_rule'
+              ? 'Tag-based collections can stay in sync automatically or freeze the current membership.'
+              : 'Manual collections keep only the images you explicitly add.'}
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Title</span>
+            <input
+              autoFocus
+              type="text"
+              value={values.name}
+              onChange={(event) => setValues((current) => ({ ...current, name: event.target.value }))}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  void handleSubmit();
+                }
+              }}
+              className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              placeholder="Collection name"
+            />
+          </label>
+
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Description</span>
+            <textarea
+              value={values.description}
+              onChange={(event) => setValues((current) => ({ ...current, description: event.target.value }))}
+              rows={3}
+              className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              placeholder="Optional notes about this collection"
+            />
+          </label>
+
+          {showSourceTag && (
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Source Tag</span>
+              <input
+                type="text"
+                value={values.sourceTag}
+                disabled={disableSourceTag}
+                onChange={(event) => setValues((current) => ({ ...current, sourceTag: event.target.value }))}
+                className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-70"
+                placeholder="tag name"
+              />
+            </label>
+          )}
+
+          {showAutoUpdate && (
+            <label className="flex items-start gap-3 rounded-xl border border-gray-700 bg-gray-800/50 px-3 py-3">
+              <input
+                type="checkbox"
+                checked={values.autoUpdate}
+                onChange={(event) => setValues((current) => ({ ...current, autoUpdate: event.target.checked }))}
+                className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500"
+              />
+              <span>
+                <span className="block text-sm font-medium text-gray-100">Auto-update from future tags</span>
+                <span className="mt-1 block text-xs text-gray-400">
+                  Keep the collection synced with future images tagged with this source tag.
+                </span>
+              </span>
+            </label>
+          )}
+
+          {showIncludeTargetImages && (
+            <label className="flex items-start gap-3 rounded-xl border border-gray-700 bg-gray-800/50 px-3 py-3">
+              <input
+                type="checkbox"
+                checked={values.includeTargetImages}
+                onChange={(event) => setValues((current) => ({ ...current, includeTargetImages: event.target.checked }))}
+                className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500"
+              />
+              <span>
+                <span className="block text-sm font-medium text-gray-100">{includeTargetImagesLabel}</span>
+                <span className="mt-1 block text-xs text-gray-400">
+                  The current context-menu target can be added immediately when the collection is created.
+                </span>
+              </span>
+            </label>
+          )}
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-700 px-3 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={isSubmitting || !values.name.trim()}
+            onClick={() => void handleSubmit()}
+            className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CollectionFormModal;

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useState } from 'react';
-import { ArrowDown, ArrowUp, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react';
 import { IndexedImage, SmartCollection } from '../types';
 import { useImageStore } from '../store/useImageStore';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
+import CollectionCard from './CollectionCard';
 
 interface CollectionsWorkspaceProps {
   filteredImages: IndexedImage[];
@@ -50,6 +51,22 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
 
     return getResolvedCollectionImages(selectedCollection.id);
   }, [getResolvedCollectionImages, selectedCollection]);
+
+  const collectionPreviewImages = useMemo(() => {
+    const imageById = new Map(images.map((image) => [image.id, image]));
+
+    return new Map(
+      collections.map((collection) => {
+        const resolvedImages = getResolvedCollectionImages(collection.id);
+        const explicitCover = collection.coverImageId ? imageById.get(collection.coverImageId) ?? null : null;
+        const orderedImages = explicitCover
+          ? [explicitCover, ...resolvedImages.filter((image) => image.id !== explicitCover.id)]
+          : resolvedImages;
+
+        return [collection.id, orderedImages];
+      }),
+    );
+  }, [collections, getResolvedCollectionImages, images]);
 
   const coverImage = useMemo(() => {
     if (!selectedCollection) {
@@ -166,38 +183,45 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
               return (
                 <div
                   key={collection.id}
-                  className={`rounded-xl border p-3 transition-colors ${
+                  role="button"
+                  aria-label={`Select collection ${collection.name}`}
+                  tabIndex={0}
+                  onClick={() => setActiveCollectionId(collection.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setActiveCollectionId(collection.id);
+                    }
+                  }}
+                  className={`cursor-pointer rounded-xl border p-3 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500/50 ${
                     isActive
                       ? 'border-blue-500/50 bg-blue-500/10'
                       : 'border-gray-800 bg-gray-900/60 hover:border-gray-700 hover:bg-gray-900'
                   }`}
                 >
-                  <button
-                    type="button"
-                    onClick={() => setActiveCollectionId(collection.id)}
-                    className="w-full text-left"
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-medium text-gray-100">{collection.name}</div>
-                        {collection.sourceTag && (
-                          <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
-                            {collection.autoUpdate !== false
-                              ? `Auto-add · ${collection.sourceTag}`
-                              : `Tag link · ${collection.sourceTag}`}
-                          </div>
-                        )}
-                      </div>
-                      <span className="rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[11px] text-gray-300">
-                        {collection.imageCount}
-                      </span>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-gray-100">{collection.name}</div>
+                      {collection.sourceTag && (
+                        <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
+                          {collection.autoUpdate !== false
+                            ? `Auto-add · ${collection.sourceTag}`
+                            : `Tag link · ${collection.sourceTag}`}
+                        </div>
+                      )}
                     </div>
-                  </button>
+                    <span className="rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[11px] text-gray-300">
+                      {collection.imageCount}
+                    </span>
+                  </div>
 
                   <div className="mt-3 flex items-center justify-end gap-1">
                     <button
                       type="button"
-                      onClick={() => void moveCollection(collection.id, -1)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void moveCollection(collection.id, -1);
+                      }}
                       disabled={index === 0}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
                       title="Move up"
@@ -206,7 +230,10 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                     </button>
                     <button
                       type="button"
-                      onClick={() => void moveCollection(collection.id, 1)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void moveCollection(collection.id, 1);
+                      }}
                       disabled={index === collections.length - 1}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
                       title="Move down"
@@ -215,7 +242,10 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                     </button>
                     <button
                       type="button"
-                      onClick={() => setEditingCollection(collection)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setEditingCollection(collection);
+                      }}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800"
                       title="Collection settings"
                     >
@@ -223,7 +253,10 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                     </button>
                     <button
                       type="button"
-                      onClick={() => void handleDeleteCollection(collection.id)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void handleDeleteCollection(collection.id);
+                      }}
                       className="rounded-md border border-red-900/40 p-1.5 text-red-300 transition-colors hover:bg-red-900/20"
                       title="Delete collection"
                     >
@@ -241,6 +274,17 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
         {selectedCollection ? (
           <>
             <div className="border-b border-gray-800 px-5 py-4">
+              <div className="mb-4 flex items-center justify-between gap-3">
+                <button
+                  type="button"
+                  onClick={() => setActiveCollectionId(null)}
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-900/70 px-3 py-2 text-sm text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-800 hover:text-white"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  All Collections
+                </button>
+              </div>
+
               <div className="flex items-start gap-4">
                 <div className="h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-gray-800 bg-gray-900">
                   {coverImage ? (
@@ -282,9 +326,36 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
             <div className="min-h-0 flex-1 p-4">{children}</div>
           </>
         ) : (
-          <div className="flex h-full flex-col items-center justify-center px-6 text-center text-gray-400">
-            <FolderOpen className="mb-4 h-10 w-10 text-gray-600" />
-            <h3 className="text-base font-semibold text-gray-200">Choose a collection</h3>
+          <div className="flex min-h-0 flex-1 flex-col p-5">
+            <div className="mb-5 flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold text-white">Collections</h2>
+              </div>
+              <div className="rounded-full border border-gray-700 bg-gray-900 px-3 py-1 text-xs text-gray-300">
+                {filteredCollections.length} visible
+              </div>
+            </div>
+
+            {filteredCollections.length === 0 ? (
+              <div className="flex flex-1 flex-col items-center justify-center px-6 text-center text-gray-400">
+                <FolderOpen className="mb-4 h-10 w-10 text-gray-600" />
+                <h3 className="text-base font-semibold text-gray-200">No collections found</h3>
+              </div>
+            ) : (
+              <div className="min-h-0 flex-1 overflow-auto pr-1">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+                  {filteredCollections.map((collection) => (
+                    <CollectionCard
+                      key={collection.id}
+                      collection={collection}
+                      images={collectionPreviewImages.get(collection.id) ?? []}
+                      imageCount={collection.imageCount}
+                      onClick={() => setActiveCollectionId(collection.id)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
       </section>

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -6,6 +6,7 @@ import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal
 import CollectionCard from './CollectionCard';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useThumbnail } from '../hooks/useThumbnail';
+import { normalizeCollectionTagNames } from '../services/imageAnnotationsStorage';
 
 interface CollectionsWorkspaceProps {
   filteredImages: IndexedImage[];
@@ -109,12 +110,17 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
       return;
     }
 
-    const normalizedSourceTag = values.sourceTag.trim().toLowerCase();
-    const hasAutoAddSettings = normalizedSourceTag.length > 0;
+    const normalizedSourceTags = normalizeCollectionTagNames(values.sourceTag);
+    const normalizedSourceTag = normalizedSourceTags.join(', ');
+    const hasAutoAddSettings = normalizedSourceTags.length > 0;
     const snapshotImageIds =
       hasAutoAddSettings && values.autoUpdate === false
         ? images
-            .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedSourceTag))
+            .filter(
+              (image) =>
+                Array.isArray(image.tags) &&
+                normalizedSourceTags.some((sourceTag) => image.tags.includes(sourceTag)),
+            )
             .map((image) => image.id)
         : [];
 

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -1,0 +1,333 @@
+import React, { useMemo, useState } from 'react';
+import { ArrowDown, ArrowUp, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react';
+import { IndexedImage, SmartCollection } from '../types';
+import { useImageStore } from '../store/useImageStore';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
+
+interface CollectionsWorkspaceProps {
+  filteredImages: IndexedImage[];
+  totalImages: IndexedImage[];
+  children: React.ReactNode;
+}
+
+const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
+  filteredImages,
+  totalImages,
+  children,
+}) => {
+  const images = useImageStore((state) => state.images);
+  const collections = useImageStore((state) => state.collections);
+  const activeCollectionId = useImageStore((state) => state.activeCollectionId);
+  const setActiveCollectionId = useImageStore((state) => state.setActiveCollectionId);
+  const createCollection = useImageStore((state) => state.createCollection);
+  const updateCollection = useImageStore((state) => state.updateCollection);
+  const deleteCollectionById = useImageStore((state) => state.deleteCollectionById);
+  const reorderCollections = useImageStore((state) => state.reorderCollections);
+  const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [editingCollection, setEditingCollection] = useState<SmartCollection | null>(null);
+
+  const selectedCollection = useMemo(
+    () => collections.find((collection) => collection.id === activeCollectionId) ?? null,
+    [activeCollectionId, collections],
+  );
+
+  const filteredCollections = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return collections;
+    }
+
+    return collections.filter((collection) => collection.name.toLowerCase().includes(normalizedQuery));
+  }, [collections, searchQuery]);
+
+  const selectedCollectionResolvedImages = useMemo(() => {
+    if (!selectedCollection) {
+      return [];
+    }
+
+    return getResolvedCollectionImages(selectedCollection.id);
+  }, [getResolvedCollectionImages, selectedCollection]);
+
+  const coverImage = useMemo(() => {
+    if (!selectedCollection) {
+      return null;
+    }
+
+    if (selectedCollection.coverImageId) {
+      return images.find((image) => image.id === selectedCollection.coverImageId) ?? null;
+    }
+
+    return selectedCollectionResolvedImages[0] ?? null;
+  }, [images, selectedCollection, selectedCollectionResolvedImages]);
+
+  const moveCollection = async (collectionId: string, direction: -1 | 1) => {
+    const currentIndex = collections.findIndex((collection) => collection.id === collectionId);
+    const nextIndex = currentIndex + direction;
+    if (currentIndex === -1 || nextIndex < 0 || nextIndex >= collections.length) {
+      return;
+    }
+
+    const ordered = [...collections];
+    const [movedCollection] = ordered.splice(currentIndex, 1);
+    ordered.splice(nextIndex, 0, movedCollection);
+    await reorderCollections(ordered.map((collection) => collection.id));
+  };
+
+  const handleCreateManualCollection = async (values: CollectionFormValues) => {
+    await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: collections.length,
+      imageIds: [],
+      snapshotImageIds: [],
+      coverImageId: null,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: undefined,
+      type: 'custom',
+      query: undefined,
+    });
+    setIsCreateModalOpen(false);
+  };
+
+  const handleSaveCollection = async (values: CollectionFormValues) => {
+    if (!editingCollection) {
+      return;
+    }
+
+    const normalizedSourceTag = values.sourceTag.trim().toLowerCase();
+    const snapshotImageIds =
+      editingCollection.kind === 'tag_rule' && values.autoUpdate === false
+        ? images
+            .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedSourceTag))
+            .map((image) => image.id)
+        : editingCollection.snapshotImageIds;
+
+    await updateCollection(editingCollection.id, {
+      name: values.name,
+      description: values.description || undefined,
+      sourceTag: editingCollection.kind === 'tag_rule' ? normalizedSourceTag : editingCollection.sourceTag,
+      autoUpdate: editingCollection.kind === 'tag_rule' ? values.autoUpdate : editingCollection.autoUpdate,
+      snapshotImageIds,
+    });
+    setEditingCollection(null);
+  };
+
+  const handleDeleteCollection = async (collectionId: string) => {
+    const confirmed = window.confirm('Delete this collection? This will not delete the underlying images.');
+    if (!confirmed) {
+      return;
+    }
+
+    await deleteCollectionById(collectionId);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 gap-4">
+      <aside className="flex w-[320px] flex-shrink-0 flex-col rounded-2xl border border-gray-800 bg-gray-950/40">
+        <div className="border-b border-gray-800 px-4 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-base font-semibold text-white">Collections</h2>
+              <p className="mt-1 text-xs text-gray-400">Group images by tag rules or manual curation.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsCreateModalOpen(true)}
+              className="inline-flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-blue-500"
+            >
+              <Plus className="h-4 w-4" />
+              New
+            </button>
+          </div>
+
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search collections..."
+            className="mt-3 w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        <div className="flex-1 space-y-2 overflow-y-auto px-3 py-3">
+          {filteredCollections.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-gray-700 bg-gray-900/50 px-4 py-5 text-center text-sm text-gray-500">
+              No collections yet.
+            </div>
+          ) : (
+            filteredCollections.map((collection, index) => {
+              const isActive = collection.id === selectedCollection?.id;
+              return (
+                <div
+                  key={collection.id}
+                  className={`rounded-xl border p-3 transition-colors ${
+                    isActive
+                      ? 'border-blue-500/50 bg-blue-500/10'
+                      : 'border-gray-800 bg-gray-900/60 hover:border-gray-700 hover:bg-gray-900'
+                  }`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setActiveCollectionId(collection.id)}
+                    className="w-full text-left"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-gray-100">{collection.name}</div>
+                        <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
+                          {collection.kind === 'tag_rule'
+                            ? collection.autoUpdate !== false
+                              ? `Tag rule · ${collection.sourceTag ?? 'no tag'}`
+                              : `Frozen tag rule · ${collection.sourceTag ?? 'no tag'}`
+                            : 'Manual'}
+                        </div>
+                      </div>
+                      <span className="rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[11px] text-gray-300">
+                        {collection.imageCount}
+                      </span>
+                    </div>
+                  </button>
+
+                  <div className="mt-3 flex items-center justify-end gap-1">
+                    <button
+                      type="button"
+                      onClick={() => void moveCollection(collection.id, -1)}
+                      disabled={index === 0}
+                      className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+                      title="Move up"
+                    >
+                      <ArrowUp className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void moveCollection(collection.id, 1)}
+                      disabled={index === collections.length - 1}
+                      className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+                      title="Move down"
+                    >
+                      <ArrowDown className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditingCollection(collection)}
+                      className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800"
+                      title="Manage collection"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void handleDeleteCollection(collection.id)}
+                      className="rounded-md border border-red-900/40 p-1.5 text-red-300 transition-colors hover:bg-red-900/20"
+                      title="Delete collection"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </aside>
+
+      <section className="flex min-w-0 flex-1 flex-col rounded-2xl border border-gray-800 bg-gray-950/20">
+        {selectedCollection ? (
+          <>
+            <div className="border-b border-gray-800 px-5 py-4">
+              <div className="flex items-start gap-4">
+                <div className="h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-gray-800 bg-gray-900">
+                  {coverImage ? (
+                    <img
+                      src={coverImage.thumbnailUrl}
+                      alt={selectedCollection.name}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-gray-600">
+                      <FolderOpen className="h-6 w-6" />
+                    </div>
+                  )}
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="text-lg font-semibold text-white">{selectedCollection.name}</h2>
+                    <span className="rounded-full border border-gray-700 bg-gray-900 px-2 py-0.5 text-[11px] uppercase tracking-wide text-gray-300">
+                      {selectedCollection.kind === 'tag_rule' ? 'Tag Rule' : 'Manual'}
+                    </span>
+                    {selectedCollection.kind === 'tag_rule' && selectedCollection.autoUpdate !== false && (
+                      <span className="rounded-full border border-emerald-600/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-emerald-300">
+                        Auto
+                      </span>
+                    )}
+                  </div>
+                  {selectedCollection.description && (
+                    <p className="mt-2 text-sm text-gray-300">{selectedCollection.description}</p>
+                  )}
+                  <div className="mt-3 flex flex-wrap gap-3 text-xs text-gray-400">
+                    <span>{totalImages.length} total in collection</span>
+                    <span>{filteredImages.length} after current filters</span>
+                    {selectedCollection.kind === 'tag_rule' && selectedCollection.sourceTag && (
+                      <span>Source tag: {selectedCollection.sourceTag}</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="min-h-0 flex-1 p-4">{children}</div>
+          </>
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center px-6 text-center text-gray-400">
+            <FolderOpen className="mb-4 h-10 w-10 text-gray-600" />
+            <h3 className="text-base font-semibold text-gray-200">Choose a collection</h3>
+            <p className="mt-2 max-w-md text-sm text-gray-500">
+              Create manual sets for hand-picked images or tag-rule collections that stay in sync automatically.
+            </p>
+          </div>
+        )}
+      </section>
+
+      <CollectionFormModal
+        isOpen={isCreateModalOpen}
+        title="Create Collection"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: '',
+          description: '',
+          sourceTag: '',
+          autoUpdate: false,
+          includeTargetImages: false,
+        }}
+        onClose={() => setIsCreateModalOpen(false)}
+        onSubmit={handleCreateManualCollection}
+      />
+
+      <CollectionFormModal
+        isOpen={editingCollection !== null}
+        title={editingCollection?.kind === 'tag_rule' ? 'Edit Tag Collection' : 'Edit Collection'}
+        submitLabel="Save Changes"
+        initialValues={{
+          name: editingCollection?.name ?? '',
+          description: editingCollection?.description ?? '',
+          sourceTag: editingCollection?.sourceTag ?? '',
+          autoUpdate: editingCollection?.autoUpdate ?? false,
+          includeTargetImages: false,
+        }}
+        onClose={() => setEditingCollection(null)}
+        onSubmit={handleSaveCollection}
+        collectionKind={editingCollection?.kind ?? 'manual'}
+        showSourceTag={editingCollection?.kind === 'tag_rule'}
+        showAutoUpdate={editingCollection?.kind === 'tag_rule'}
+      />
+    </div>
+  );
+};
+
+export default CollectionsWorkspace;

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -100,18 +100,20 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
     }
 
     const normalizedSourceTag = values.sourceTag.trim().toLowerCase();
+    const hasAutoAddSettings = normalizedSourceTag.length > 0;
     const snapshotImageIds =
-      editingCollection.kind === 'tag_rule' && values.autoUpdate === false
+      hasAutoAddSettings && values.autoUpdate === false
         ? images
             .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedSourceTag))
             .map((image) => image.id)
-        : editingCollection.snapshotImageIds;
+        : [];
 
     await updateCollection(editingCollection.id, {
       name: values.name,
       description: values.description || undefined,
-      sourceTag: editingCollection.kind === 'tag_rule' ? normalizedSourceTag : editingCollection.sourceTag,
-      autoUpdate: editingCollection.kind === 'tag_rule' ? values.autoUpdate : editingCollection.autoUpdate,
+      kind: hasAutoAddSettings ? 'tag_rule' : 'manual',
+      sourceTag: hasAutoAddSettings ? normalizedSourceTag : null,
+      autoUpdate: hasAutoAddSettings ? values.autoUpdate : false,
       snapshotImageIds,
     });
     setEditingCollection(null);
@@ -133,7 +135,6 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
           <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="text-base font-semibold text-white">Collections</h2>
-              <p className="mt-1 text-xs text-gray-400">Group images by tag rules or manual curation.</p>
             </div>
             <button
               type="button"
@@ -179,13 +180,13 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                     <div className="flex items-center justify-between gap-3">
                       <div className="min-w-0">
                         <div className="truncate text-sm font-medium text-gray-100">{collection.name}</div>
-                        <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
-                          {collection.kind === 'tag_rule'
-                            ? collection.autoUpdate !== false
-                              ? `Tag rule · ${collection.sourceTag ?? 'no tag'}`
-                              : `Frozen tag rule · ${collection.sourceTag ?? 'no tag'}`
-                            : 'Manual'}
-                        </div>
+                        {collection.sourceTag && (
+                          <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
+                            {collection.autoUpdate !== false
+                              ? `Auto-add · ${collection.sourceTag}`
+                              : `Tag link · ${collection.sourceTag}`}
+                          </div>
+                        )}
                       </div>
                       <span className="rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[11px] text-gray-300">
                         {collection.imageCount}
@@ -216,7 +217,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                       type="button"
                       onClick={() => setEditingCollection(collection)}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800"
-                      title="Manage collection"
+                      title="Collection settings"
                     >
                       <Pencil className="h-3.5 w-3.5" />
                     </button>
@@ -258,10 +259,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
                     <h2 className="text-lg font-semibold text-white">{selectedCollection.name}</h2>
-                    <span className="rounded-full border border-gray-700 bg-gray-900 px-2 py-0.5 text-[11px] uppercase tracking-wide text-gray-300">
-                      {selectedCollection.kind === 'tag_rule' ? 'Tag Rule' : 'Manual'}
-                    </span>
-                    {selectedCollection.kind === 'tag_rule' && selectedCollection.autoUpdate !== false && (
+                    {selectedCollection.sourceTag && selectedCollection.autoUpdate !== false && (
                       <span className="rounded-full border border-emerald-600/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-emerald-300">
                         Auto
                       </span>
@@ -273,8 +271,8 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                   <div className="mt-3 flex flex-wrap gap-3 text-xs text-gray-400">
                     <span>{totalImages.length} total in collection</span>
                     <span>{filteredImages.length} after current filters</span>
-                    {selectedCollection.kind === 'tag_rule' && selectedCollection.sourceTag && (
-                      <span>Source tag: {selectedCollection.sourceTag}</span>
+                    {selectedCollection.sourceTag && (
+                      <span>Auto-add tag: {selectedCollection.sourceTag}</span>
                     )}
                   </div>
                 </div>
@@ -287,9 +285,6 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
           <div className="flex h-full flex-col items-center justify-center px-6 text-center text-gray-400">
             <FolderOpen className="mb-4 h-10 w-10 text-gray-600" />
             <h3 className="text-base font-semibold text-gray-200">Choose a collection</h3>
-            <p className="mt-2 max-w-md text-sm text-gray-500">
-              Create manual sets for hand-picked images or tag-rule collections that stay in sync automatically.
-            </p>
           </div>
         )}
       </section>
@@ -311,7 +306,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
 
       <CollectionFormModal
         isOpen={editingCollection !== null}
-        title={editingCollection?.kind === 'tag_rule' ? 'Edit Tag Collection' : 'Edit Collection'}
+        title="Collection Settings"
         submitLabel="Save Changes"
         initialValues={{
           name: editingCollection?.name ?? '',
@@ -322,9 +317,8 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
         }}
         onClose={() => setEditingCollection(null)}
         onSubmit={handleSaveCollection}
-        collectionKind={editingCollection?.kind ?? 'manual'}
-        showSourceTag={editingCollection?.kind === 'tag_rule'}
-        showAutoUpdate={editingCollection?.kind === 'tag_rule'}
+        showSourceTag
+        showAutoUpdate
       />
     </div>
   );

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -4,6 +4,8 @@ import { IndexedImage, SmartCollection } from '../types';
 import { useImageStore } from '../store/useImageStore';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 import CollectionCard from './CollectionCard';
+import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+import { useThumbnail } from '../hooks/useThumbnail';
 
 interface CollectionsWorkspaceProps {
   filteredImages: IndexedImage[];
@@ -44,14 +46,6 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
     return collections.filter((collection) => collection.name.toLowerCase().includes(normalizedQuery));
   }, [collections, searchQuery]);
 
-  const selectedCollectionResolvedImages = useMemo(() => {
-    if (!selectedCollection) {
-      return [];
-    }
-
-    return getResolvedCollectionImages(selectedCollection.id);
-  }, [getResolvedCollectionImages, selectedCollection]);
-
   const collectionPreviewImages = useMemo(() => {
     const imageById = new Map(images.map((image) => [image.id, image]));
 
@@ -73,12 +67,11 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
       return null;
     }
 
-    if (selectedCollection.coverImageId) {
-      return images.find((image) => image.id === selectedCollection.coverImageId) ?? null;
-    }
-
-    return selectedCollectionResolvedImages[0] ?? null;
-  }, [images, selectedCollection, selectedCollectionResolvedImages]);
+    const previewImages = collectionPreviewImages.get(selectedCollection.id) ?? [];
+    return previewImages[0] ?? null;
+  }, [collectionPreviewImages, selectedCollection]);
+  const coverThumbnail = useResolvedThumbnail(coverImage);
+  useThumbnail(coverImage);
 
   const moveCollection = async (collectionId: string, direction: -1 | 1) => {
     const currentIndex = collections.findIndex((collection) => collection.id === collectionId);
@@ -287,9 +280,9 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
 
               <div className="flex items-start gap-4">
                 <div className="h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-gray-800 bg-gray-900">
-                  {coverImage ? (
+                  {coverImage && coverThumbnail?.thumbnailUrl ? (
                     <img
-                      src={coverImage.thumbnailUrl}
+                      src={coverThumbnail.thumbnailUrl}
                       alt={selectedCollection.name}
                       className="h-full w-full object-cover"
                     />

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -449,7 +449,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                             </button>
 
                             {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
-                              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
+                              <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
                                 {collections.length === 0 ? (
                                   <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
                                 ) : (

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useMemo } from 'react';
 import {
   Copy,
   Folder,
+  FolderPlus,
   Download,
   Heart,
   GitCompare,
@@ -25,6 +26,8 @@ interface GridToolbarProps {
   selectedImages: Set<string>;
   images: IndexedImage[];
   directories: { id: string; path: string }[];
+  onSaveCurrentFilteredAsCollection?: () => void;
+  saveCurrentFilteredCount?: number;
   onDeleteSelected: () => void;
   onGenerateA1111: (image: IndexedImage) => void;
   onGenerateComfyUI: (image: IndexedImage) => void;
@@ -48,6 +51,8 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   selectedImages,
   images,
   directories,
+  onSaveCurrentFilteredAsCollection,
+  saveCurrentFilteredCount = 0,
   onDeleteSelected,
   onGenerateA1111,
   onGenerateComfyUI,
@@ -223,6 +228,8 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   const selectedRatings = useImageStore((state) => state.selectedRatings);
 
   const advancedFilters = useImageStore((state) => state.advancedFilters);
+  const canSaveCurrentFilteredAsCollection =
+    Boolean(onSaveCurrentFilteredAsCollection) && saveCurrentFilteredCount > 0;
 
   const hasActiveFilters = 
       selectedModels.length > 0 ||
@@ -246,7 +253,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters) {
+  if (selectedCount === 0 && !hasActiveFilters && !canSaveCurrentFilteredAsCollection) {
     return null;
   }
 
@@ -385,6 +392,24 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                 </button>
                 
                 {/* Divider between selection tools and filters if both exist */}
+                {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
+              </>
+            )}
+
+            {canSaveCurrentFilteredAsCollection && (
+              <>
+                <button
+                  onClick={onSaveCurrentFilteredAsCollection}
+                  className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition-all duration-200 hover:border-amber-400/60 hover:bg-amber-500/20"
+                  title={`Save ${saveCurrentFilteredCount} filtered image${saveCurrentFilteredCount === 1 ? '' : 's'} as a collection`}
+                >
+                  <FolderPlus className="h-4 w-4" />
+                  <span>Save as Collection</span>
+                  <span className="rounded-full bg-black/20 px-1.5 py-0.5 text-[10px]">
+                    {saveCurrentFilteredCount}
+                  </span>
+                </button>
+
                 {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
               </>
             )}

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect, useMemo } from 'react';
 import {
   Copy,
   Folder,
-  FolderPlus,
   Download,
   Heart,
   GitCompare,
@@ -10,12 +9,13 @@ import {
   Trash2,
   ChevronDown,
   Tag,
-  RefreshCw
+  RefreshCw,
+  Plus
 } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
-import { type IndexedImage } from '../types';
+import { SmartCollection, type IndexedImage } from '../types';
 
 import ActiveFilters from './ActiveFilters';
 import TagManagerModal from './TagManagerModal';
@@ -26,8 +26,9 @@ interface GridToolbarProps {
   selectedImages: Set<string>;
   images: IndexedImage[];
   directories: { id: string; path: string }[];
-  onSaveCurrentFilteredAsCollection?: () => void;
-  saveCurrentFilteredCount?: number;
+  onCreateCollectionFromFiltered?: () => void;
+  onAddCurrentFilteredToCollection?: (collectionId: string) => Promise<void> | void;
+  filteredImageActionCount?: number;
   onDeleteSelected: () => void;
   onGenerateA1111: (image: IndexedImage) => void;
   onGenerateComfyUI: (image: IndexedImage) => void;
@@ -51,8 +52,9 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   selectedImages,
   images,
   directories,
-  onSaveCurrentFilteredAsCollection,
-  saveCurrentFilteredCount = 0,
+  onCreateCollectionFromFiltered,
+  onAddCurrentFilteredToCollection,
+  filteredImageActionCount = 0,
   onDeleteSelected,
   onGenerateA1111,
   onGenerateComfyUI,
@@ -60,9 +62,13 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   onBatchExport,
 }) => {
   const [generateDropdownOpen, setGenerateDropdownOpen] = useState(false);
+  const [isCollectionActionsOpen, setIsCollectionActionsOpen] = useState(false);
+  const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
   const [isTagModalOpen, setIsTagModalOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const collectionActionsRef = useRef<HTMLDivElement>(null);
   const toggleFavorite = useImageStore((state) => state.toggleFavorite);
+  const collections = useImageStore((state) => state.collections);
   const { canUseComparison, canUseA1111, canUseComfyUI, showProModal, canUseBulkTagging } = useFeatureAccess();
   const { isReparsing, reparseImages } = useReparseMetadata();
 
@@ -91,6 +97,10 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setGenerateDropdownOpen(false);
+      }
+      if (collectionActionsRef.current && !collectionActionsRef.current.contains(event.target as Node)) {
+        setIsCollectionActionsOpen(false);
+        setIsAddToCollectionSubmenuOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
@@ -228,8 +238,9 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   const selectedRatings = useImageStore((state) => state.selectedRatings);
 
   const advancedFilters = useImageStore((state) => state.advancedFilters);
-  const canSaveCurrentFilteredAsCollection =
-    Boolean(onSaveCurrentFilteredAsCollection) && saveCurrentFilteredCount > 0;
+  const canUseFilteredCollectionActions =
+    filteredImageActionCount > 0 &&
+    (Boolean(onCreateCollectionFromFiltered) || Boolean(onAddCurrentFilteredToCollection));
 
   const hasActiveFilters = 
       selectedModels.length > 0 ||
@@ -253,9 +264,25 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters && !canSaveCurrentFilteredAsCollection) {
+  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions) {
     return null;
   }
+
+  const handleAddToCollection = async (collection: SmartCollection) => {
+    if (!onAddCurrentFilteredToCollection) {
+      return;
+    }
+
+    await onAddCurrentFilteredToCollection(collection.id);
+    setIsCollectionActionsOpen(false);
+    setIsAddToCollectionSubmenuOpen(false);
+  };
+
+  const handleCreateCollectionFromFiltered = () => {
+    onCreateCollectionFromFiltered?.();
+    setIsCollectionActionsOpen(false);
+    setIsAddToCollectionSubmenuOpen(false);
+  };
 
   return (
     <>
@@ -396,19 +423,68 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
               </>
             )}
 
-            {canSaveCurrentFilteredAsCollection && (
+            {canUseFilteredCollectionActions && (
               <>
-                <button
-                  onClick={onSaveCurrentFilteredAsCollection}
-                  className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition-all duration-200 hover:border-amber-400/60 hover:bg-amber-500/20"
-                  title={`Save ${saveCurrentFilteredCount} filtered image${saveCurrentFilteredCount === 1 ? '' : 's'} as a collection`}
-                >
-                  <FolderPlus className="h-4 w-4" />
-                  <span>Save as Collection</span>
-                  <span className="rounded-full bg-black/20 px-1.5 py-0.5 text-[10px]">
-                    {saveCurrentFilteredCount}
-                  </span>
-                </button>
+                <div className="relative" ref={collectionActionsRef}>
+                  <button
+                    onClick={() => setIsCollectionActionsOpen((open) => !open)}
+                    className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
+                    title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
+                    aria-label="Collection actions"
+                  >
+                    <Plus className="w-4 h-4" />
+                  </button>
+
+                  {isCollectionActionsOpen && (
+                    <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
+                      <div
+                        className="relative"
+                        onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                        onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                      >
+                        <button
+                          onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                          disabled={!onAddCurrentFilteredToCollection}
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                        >
+                          <span>Add filtered images to collection</span>
+                          <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
+                        </button>
+
+                        {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
+                          <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
+                            {collections.length === 0 ? (
+                              <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
+                            ) : (
+                              collections.map((collection) => (
+                                <button
+                                  key={collection.id}
+                                  onClick={() => void handleAddToCollection(collection)}
+                                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                                >
+                                  <span className="truncate">{collection.name}</span>
+                                  {collection.sourceTag && (
+                                    <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                      {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                                    </span>
+                                  )}
+                                </button>
+                              ))
+                            )}
+                          </div>
+                        )}
+                      </div>
+
+                      <button
+                        onClick={handleCreateCollectionFromFiltered}
+                        disabled={!onCreateCollectionFromFiltered}
+                        className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                      >
+                        Create new collection from filtered images
+                      </button>
+                    </div>
+                  )}
+                </div>
 
                 {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
               </>

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -239,6 +239,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
 
   const advancedFilters = useImageStore((state) => state.advancedFilters);
   const canUseFilteredCollectionActions =
+    selectedCount > 0 &&
     filteredImageActionCount > 0 &&
     (Boolean(onCreateCollectionFromFiltered) || Boolean(onAddCurrentFilteredToCollection));
 
@@ -264,7 +265,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions) {
+  if (selectedCount === 0 && !hasActiveFilters) {
     return null;
   }
 
@@ -288,7 +289,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
     <>
       <div className="flex items-center justify-between gap-2 mb-1 px-5 min-h-[36px]">
         {/* Selection Context Toolbar - Centered or justified as needed */}
-        <div className="flex items-center gap-1 flex-1 overflow-hidden">
+        <div className="flex items-center gap-1 flex-1 min-w-0">
             {selectedCount > 0 && (
               <>
                 <span className="text-[11px] text-gray-400 mr-2 whitespace-nowrap">{selectedCount} selected</span>
@@ -419,79 +420,78 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                 </button>
                 
                 {/* Divider between selection tools and filters if both exist */}
-                {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
-              </>
-            )}
-
-            {canUseFilteredCollectionActions && (
-              <>
-                <div className="relative" ref={collectionActionsRef}>
-                  <button
-                    onClick={() => setIsCollectionActionsOpen((open) => !open)}
-                    className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
-                    title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
-                    aria-label="Collection actions"
-                  >
-                    <Plus className="w-4 h-4" />
-                  </button>
-
-                  {isCollectionActionsOpen && (
-                    <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
-                      <div
-                        className="relative"
-                        onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
-                        onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                {canUseFilteredCollectionActions && (
+                  <>
+                    <div className="relative" ref={collectionActionsRef}>
+                      <button
+                        onClick={() => setIsCollectionActionsOpen((open) => !open)}
+                        className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
+                        title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
+                        aria-label="Collection actions"
                       >
-                        <button
-                          onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
-                          disabled={!onAddCurrentFilteredToCollection}
-                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
-                        >
-                          <span>Add filtered images to collection</span>
-                          <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
-                        </button>
+                        <Plus className="w-4 h-4" />
+                      </button>
 
-                        {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
-                          <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
-                            {collections.length === 0 ? (
-                              <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
-                            ) : (
-                              collections.map((collection) => (
-                                <button
-                                  key={collection.id}
-                                  onClick={() => void handleAddToCollection(collection)}
-                                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
-                                >
-                                  <span className="truncate">{collection.name}</span>
-                                  {collection.sourceTag && (
-                                    <span className="text-[10px] uppercase tracking-wide text-gray-500">
-                                      {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
-                                    </span>
-                                  )}
-                                </button>
-                              ))
+                      {isCollectionActionsOpen && (
+                        <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
+                          <div
+                            className="relative"
+                            onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                            onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                          >
+                            <button
+                              onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                              disabled={!onAddCurrentFilteredToCollection}
+                              className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                            >
+                              <span>Add filtered images to collection</span>
+                              <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
+                            </button>
+
+                            {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
+                              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
+                                {collections.length === 0 ? (
+                                  <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
+                                ) : (
+                                  collections.map((collection) => (
+                                    <button
+                                      key={collection.id}
+                                      onClick={() => void handleAddToCollection(collection)}
+                                      className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                                    >
+                                      <span className="truncate">{collection.name}</span>
+                                      {collection.sourceTag && (
+                                        <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                          {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                                        </span>
+                                      )}
+                                    </button>
+                                  ))
+                                )}
+                              </div>
                             )}
                           </div>
-                        )}
-                      </div>
 
-                      <button
-                        onClick={handleCreateCollectionFromFiltered}
-                        disabled={!onCreateCollectionFromFiltered}
-                        className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
-                      >
-                        Create new collection from filtered images
-                      </button>
+                          <button
+                            onClick={handleCreateCollectionFromFiltered}
+                            disabled={!onCreateCollectionFromFiltered}
+                            className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                          >
+                            Create new collection from filtered images
+                          </button>
+                        </div>
+                      )}
                     </div>
-                  )}
-                </div>
+
+                  </>
+                )}
 
                 {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
               </>
             )}
 
             {/* Active Filters */}
-            <div className="flex-1 min-w-0">
+            <div className="flex-1 min-w-0 overflow-hidden">
                <ActiveFilters />
             </div>
         </div>

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -239,7 +239,6 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
 
   const advancedFilters = useImageStore((state) => state.advancedFilters);
   const canUseFilteredCollectionActions =
-    selectedCount > 0 &&
     filteredImageActionCount > 0 &&
     (Boolean(onCreateCollectionFromFiltered) || Boolean(onAddCurrentFilteredToCollection));
 
@@ -265,7 +264,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters) {
+  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions) {
     return null;
   }
 
@@ -419,73 +418,73 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                   <Trash2 className="w-4 h-4" />
                 </button>
                 
-                {/* Divider between selection tools and filters if both exist */}
-                {canUseFilteredCollectionActions && (
-                  <>
-                    <div className="relative" ref={collectionActionsRef}>
-                      <button
-                        onClick={() => setIsCollectionActionsOpen((open) => !open)}
-                        className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
-                        title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
-                        aria-label="Collection actions"
+                {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
+              </>
+            )}
+
+            {canUseFilteredCollectionActions && (
+              <>
+                {selectedCount > 0 && <div className="w-px h-4 bg-gray-700 mx-1" />}
+                <div className="relative" ref={collectionActionsRef}>
+                  <button
+                    onClick={() => setIsCollectionActionsOpen((open) => !open)}
+                    className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
+                    title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
+                    aria-label="Collection actions"
+                  >
+                    <Plus className="w-4 h-4" />
+                  </button>
+
+                  {isCollectionActionsOpen && (
+                    <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
+                      <div
+                        className="relative"
+                        onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                        onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
                       >
-                        <Plus className="w-4 h-4" />
-                      </button>
+                        <button
+                          onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                          disabled={!onAddCurrentFilteredToCollection}
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                        >
+                          <span>Add filtered images to collection</span>
+                          <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
+                        </button>
 
-                      {isCollectionActionsOpen && (
-                        <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
-                          <div
-                            className="relative"
-                            onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
-                            onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
-                          >
-                            <button
-                              onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
-                              disabled={!onAddCurrentFilteredToCollection}
-                              className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
-                            >
-                              <span>Add filtered images to collection</span>
-                              <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
-                            </button>
-
-                            {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
-                              <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
-                                {collections.length === 0 ? (
-                                  <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
-                                ) : (
-                                  collections.map((collection) => (
-                                    <button
-                                      key={collection.id}
-                                      onClick={() => void handleAddToCollection(collection)}
-                                      className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
-                                    >
-                                      <span className="truncate">{collection.name}</span>
-                                      {collection.sourceTag && (
-                                        <span className="text-[10px] uppercase tracking-wide text-gray-500">
-                                          {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
-                                        </span>
-                                      )}
-                                    </button>
-                                  ))
-                                )}
-                              </div>
+                        {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
+                          <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
+                            {collections.length === 0 ? (
+                              <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
+                            ) : (
+                              collections.map((collection) => (
+                                <button
+                                  key={collection.id}
+                                  onClick={() => void handleAddToCollection(collection)}
+                                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                                >
+                                  <span className="truncate">{collection.name}</span>
+                                  {collection.sourceTag && (
+                                    <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                      {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                                    </span>
+                                  )}
+                                </button>
+                              ))
                             )}
                           </div>
+                        )}
+                      </div>
 
-                          <button
-                            onClick={handleCreateCollectionFromFiltered}
-                            disabled={!onCreateCollectionFromFiltered}
-                            className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
-                          >
-                            Create new collection from filtered images
-                          </button>
-                        </div>
-                      )}
+                      <button
+                        onClick={handleCreateCollectionFromFiltered}
+                        disabled={!onCreateCollectionFromFiltered}
+                        className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                      >
+                        Create new collection from filtered images
+                      </button>
                     </div>
-
-                  </>
-                )}
-
+                  )}
+                </div>
                 {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
               </>
             )}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Settings, Bug, BarChart3, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft, Boxes } from 'lucide-react';
+import { Settings, Bug, BarChart3, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft } from 'lucide-react';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
@@ -7,13 +7,15 @@ import { A1111ApiClient } from '../services/a1111ApiClient';
 import { ComfyUIApiClient } from '../services/comfyUIApiClient';
 import { detectGeneratorFromLaunchCommand } from '../utils/detectGeneratorLaunch';
 
+type LibraryView = 'library' | 'smart' | 'model' | 'node' | 'collections';
+
 interface HeaderProps {
     onOpenSettings: () => void;
     onOpenAnalytics: () => void;
     onOpenLicense: () => void;
     onGeneratorSetupNeeded?: () => void;
-    libraryView?: 'library' | 'smart' | 'model' | 'node' | 'collections';
-    onLibraryViewChange?: (view: 'library' | 'smart' | 'model' | 'node' | 'collections') => void;
+    libraryView?: LibraryView;
+    onLibraryViewChange?: (view: LibraryView) => void;
 }
 
 const Header: React.FC<HeaderProps> = ({ 
@@ -251,18 +253,17 @@ const Header: React.FC<HeaderProps> = ({
 
   const generatorButtonClassName = useMemo(() => {
     if (isLaunchingGenerator) {
-      return 'bg-amber-600 border-amber-500/60 shadow-amber-900/20 cursor-wait';
+      return 'border-accent/40 bg-accent/15 text-accent cursor-wait hover:border-accent/40 hover:bg-accent/20 hover:text-accent';
     }
 
-    if (relevantConnectionStatus === 'connected' && hasRelevantServerUrl) {
-      return 'hover:bg-emerald-500 bg-emerald-600 shadow-emerald-900/20 border-emerald-500/50';
+    if (
+      (relevantConnectionStatus === 'connected' && hasRelevantServerUrl) ||
+      hasLaunchCommand
+    ) {
+      return 'border-accent/60 bg-accent text-white hover:border-accent/60 hover:bg-accent/90 hover:text-white';
     }
 
-    if (hasLaunchCommand) {
-      return 'hover:bg-blue-500 bg-blue-600 shadow-blue-900/20 border-blue-500/50';
-    }
-
-    return 'bg-gray-700 border-gray-600 text-gray-200 hover:bg-gray-600';
+    return 'text-gray-200';
   }, [hasLaunchCommand, hasRelevantServerUrl, isLaunchingGenerator, relevantConnectionStatus]);
 
   const generatorButtonTitle = useMemo(() => {
@@ -288,235 +289,178 @@ const Header: React.FC<HeaderProps> = ({
   const statusConfig = (() => {
     if (!initialized) {
       return {
-        label: 'Status: Checking license…',
-        classes: 'text-gray-300 bg-gray-800/70 border-gray-700',
+        label: 'Checking license',
+        classes: 'text-gray-300',
       };
     }
     if (isPro) {
       return {
-        label: 'Status: Pro License',
-        classes: 'text-green-300 bg-green-900/30 border-green-600/50',
+        label: 'Pro',
+        classes: 'text-gray-100',
       };
     }
     if (isTrialActive) {
       const daysLabel = `${trialDaysRemaining} ${trialDaysRemaining === 1 ? 'day' : 'days'} left`;
       return {
-        label: `Status: Pro Trial (${daysLabel})`,
-        classes: 'text-amber-400 bg-amber-900/30 border-amber-500/50',
+        label: `Trial • ${daysLabel}`,
+        classes: 'border-amber-500/40 bg-amber-500/15 text-amber-200 hover:border-amber-400/50 hover:bg-amber-500/20 hover:text-amber-100',
       };
     }
     if (isExpired) {
       return {
-        label: 'Status: Trial expired',
-        classes: 'text-red-300 bg-red-900/30 border-red-600/50',
+        label: 'Trial expired',
+        classes: 'border-amber-600/30 bg-amber-500/10 text-amber-200 hover:border-amber-500/40 hover:bg-amber-500/15 hover:text-amber-100',
       };
     }
     return {
-      label: 'Status: Free Version',
-      classes: 'text-gray-300 bg-gray-800/60 border-gray-700',
+      label: 'Free',
+      classes: 'border-amber-700/30 bg-amber-500/10 text-amber-200 hover:border-amber-600/40 hover:bg-amber-500/15 hover:text-amber-100',
     };
   })();
 
-  const analyticsBadgeClass = isPro
-    ? 'text-green-300'
-    : isTrialActive
-    ? 'text-amber-400'
-    : 'text-purple-400';
+  const analyticsBadgeClass = canUseAnalytics ? 'text-gray-500' : 'text-amber-400';
+  const viewTabs = useMemo(
+    () => [
+      { id: 'library' as const, label: 'Library' },
+      { id: 'smart' as const, label: 'Smart Library', count: clustersCount > 0 ? clustersCount : null },
+      { id: 'model' as const, label: 'Model View' },
+      { id: 'node' as const, label: 'Node View' },
+      { id: 'collections' as const, label: 'Collections' },
+    ],
+    [clustersCount]
+  );
+  const utilityButtonClassName = 'app-top-icon-button';
 
   return (
-    <header className="bg-gray-900/80 backdrop-blur-md sticky top-0 z-50 px-4 py-2 border-b border-gray-800/60 shadow-lg transition-all duration-300">
-      <div className="container mx-auto flex items-center justify-between gap-4">
-        
-        {/* Left Side - Status Indicator */}
-        <div className="flex items-center gap-4">
-            <button
-              onClick={onOpenLicense}
-              className={`inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded-full border transition-all duration-300 hover:scale-105 ${statusConfig.classes}`}
-              title={isFree ? 'Start trial or activate license' : 'Manage license and status'}
-            >
-              <Crown className="w-3 h-3" />
-              {statusConfig.label.replace('Status: ', '')}
-            </button>
+    <header className="sticky top-0 z-50 border-b border-gray-800/70 bg-gray-900/85 px-4 py-2.5 backdrop-blur-md shadow-lg shadow-black/20 transition-all duration-300">
+      <div className="container mx-auto flex items-center gap-4">
+        <div className="shrink-0">
+          <button
+            onClick={onOpenLicense}
+            className={`app-top-pill text-[10px] uppercase tracking-[0.18em] ${statusConfig.classes}`}
+            title={isFree ? 'Start trial or activate license' : 'Manage license and status'}
+          >
+            <Crown className="h-3 w-3" />
+            <span>{statusConfig.label}</span>
+          </button>
         </div>
 
-        {/* Center Side - View Controls (Only visible if libraryView is provided) */}
+        <div className="flex min-w-0 flex-1 justify-center">
         {libraryView && onLibraryViewChange && (
-            <div className="flex items-center gap-3">
-                <div className="flex items-center bg-gray-800/50 rounded-full p-1 border border-gray-700/50">
-                    <button
-                        onClick={() => onLibraryViewChange('library')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 ${
-                            libraryView === 'library' 
-                            ? 'bg-blue-600 text-white shadow-md shadow-blue-900/20' 
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        Library
-                    </button>
-                    <button
-                        onClick={() => onLibraryViewChange('smart')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
-                            libraryView === 'smart' 
-                            ? 'bg-purple-600 text-white shadow-md shadow-purple-900/20' 
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        Smart Library
-                        {clustersCount > 0 && (
-                            <span className="bg-black/20 px-1.5 rounded-full text-[10px]">{clustersCount}</span>
-                        )}
-                    </button>
-                    <button
-                        onClick={() => onLibraryViewChange('model')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
-                            libraryView === 'model' 
-                            ? 'bg-emerald-600 text-white shadow-md shadow-emerald-900/20' 
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        Model View
-                    </button>
-                    <button
-                        onClick={() => onLibraryViewChange('node')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
-                            libraryView === 'node'
-                            ? 'bg-cyan-600 text-white shadow-md shadow-cyan-900/20'
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        <Boxes className="h-3.5 w-3.5" />
-                        Node View
-                    </button>
-                    <button
-                        onClick={() => onLibraryViewChange('collections')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
-                            libraryView === 'collections'
-                            ? 'bg-amber-600 text-white shadow-md shadow-amber-900/20'
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        Collections
-                    </button>
-                </div>
-
-            </div>
+          <div className="app-top-segmented max-w-full">
+            {viewTabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => onLibraryViewChange(tab.id)}
+                className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
+              >
+                <span>{tab.label}</span>
+                {tab.count ? (
+                  <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${
+                    libraryView === tab.id
+                      ? 'border-white/20 bg-black/20 text-white/90'
+                      : 'border-gray-700/80 bg-gray-950/80 text-gray-500'
+                  }`}>
+                    {tab.count}
+                  </span>
+                ) : null}
+              </button>
+            ))}
+          </div>
         )}
+        </div>
 
+        <div className="flex shrink-0 items-center gap-2">
+          {(libraryView === 'library' || libraryView === 'node') && (
+            <>
+              <button
+                onClick={() => setStackingEnabled(!isStackingEnabled)}
+                className={`${utilityButtonClassName} ${isStackingEnabled ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : ''}`}
+                title={isStackingEnabled ? 'Disable stacking' : 'Stack items by identical prompt'}
+              >
+                {isStackingEnabled ? <Layers2 size={16} /> : <Layers size={16} />}
+              </button>
 
-        {/* Right Side - Actions */}
-        <div className="flex items-center gap-3">
-            
-                   {/* Stacking Toggle - Only relevant for Library view */}
-                   {(libraryView === 'library' || libraryView === 'node') && (
-                     <>
-                        <button
-                          onClick={() => setStackingEnabled(!isStackingEnabled)}
-                          className={`p-1.5 rounded-lg transition-all duration-200 ${
-                              isStackingEnabled 
-                              ? 'text-blue-400 bg-blue-500/10' 
-                              : 'text-gray-500 hover:text-gray-300 hover:bg-white/5'
-                          }`}
-                          title={isStackingEnabled ? "Disable stacking" : "Stack items by identical prompt"}
-                        >
-                          {isStackingEnabled ? <Layers2 size={16} /> : <Layers size={16} />}
-                        </button>
-                        
-                         {/* Back from Stack Button */}
-                        {viewingStackPrompt && (
-                            <button
-                                onClick={() => {
-                                setSearchQuery('');
-                                setStackingEnabled(true);
-                                setViewingStackPrompt(null);
-                                }}
-                                className="flex items-center gap-1 px-2 py-1 bg-blue-500/10 text-blue-400 rounded-md hover:bg-blue-500/20 transition-colors text-xs font-medium"
-                            >
-                                <ArrowLeft size={12} />
-                                Back
-                            </button>
-                        )}
-                        <div className="w-px h-4 bg-gray-700/50 mx-1"></div>
-                     </>
-                   )}
-
-                   {/* Safe Mode Toggle */}
-                   <button
-                     onClick={() => setEnableSafeMode(!enableSafeMode)}
-                     className={`p-1.5 rounded-lg transition-all duration-200 ${
-                         enableSafeMode
-                         ? 'text-gray-400 hover:text-white'
-                         : 'text-gray-600 hover:text-gray-400'
-                     }`}
-                     title={enableSafeMode ? 'Safe Mode on' : 'Safe Mode off'}
-                   >
-                     {enableSafeMode ? <Eye size={16} /> : <EyeOff size={16} />}
-                   </button>
-           
-          {/* Smart Library Actions (Contextual) */}
-          {libraryView === 'smart' && (
-             <div className="flex items-center gap-2 mr-2 animate-in fade-in duration-300">
+              {viewingStackPrompt && (
                 <button
-                    onClick={handleGenerateClusters}
-                    disabled={!hasDirectories || isClustering}
-                    className={`inline-flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-xs font-semibold transition-all ${
-                        isClustering ? 'text-blue-400/50 cursor-wait' : 'text-blue-400 hover:bg-blue-500/10 hover:text-blue-300'
-                    }`}
-                    title="Generate Clusters"
+                  onClick={() => {
+                    setSearchQuery('');
+                    setStackingEnabled(true);
+                    setViewingStackPrompt(null);
+                  }}
+                  className="app-top-pill px-2.5 text-gray-300"
+                  title="Return to the stacked results"
                 >
-                    <Layers size={14} className={isClustering ? 'animate-pulse' : ''}/>
-                    <span className="hidden xl:inline">Cluster</span>
+                  <ArrowLeft size={12} />
+                  <span>Back</span>
                 </button>
-                <button
-                    onClick={handleGenerateAutoTags}
-                    disabled={!hasDirectories || isAutoTagging}
-                    className={`inline-flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-xs font-semibold transition-all ${
-                        isAutoTagging ? 'text-purple-400/50 cursor-wait' : 'text-purple-400 hover:bg-purple-500/10 hover:text-purple-300'
-                    }`}
-                    title="Generate Auto-Tags"
-                >
-                    <Sparkles size={14} className={isAutoTagging ? 'animate-pulse' : ''}/>
-                    <span className="hidden xl:inline">Auto-Tag</span>
-                </button>
-                 <div className="w-px h-5 bg-gray-700/50 mx-1"></div>
-             </div>
+              )}
+            </>
           )}
 
-          <a
-            href="https://github.com/LuqP2/Image-MetaHub/issues/new"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="px-2 py-1.5 rounded-lg transition-all duration-200 text-xs font-medium text-gray-400 hover:bg-white/5 hover:text-white flex items-center gap-2 group"
-            title="Report a bug or provide feedback"
-          >
-            <Bug size={14} className="group-hover:text-red-400 transition-colors" />
-            <span className="hidden sm:inline">Feedback</span>
-          </a>
-          
-          <div className="w-px h-5 bg-gray-700/50 mx-1"></div>
+          {libraryView === 'smart' && (
+            <div className="app-top-segmented animate-in fade-in duration-300">
+              <button
+                onClick={handleGenerateClusters}
+                disabled={!hasDirectories || isClustering}
+                className={`app-top-segment ${isClustering ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
+                title="Generate clusters"
+              >
+                <Layers size={14} className={isClustering ? 'animate-pulse' : ''} />
+                <span>Cluster</span>
+              </button>
+              <button
+                onClick={handleGenerateAutoTags}
+                disabled={!hasDirectories || isAutoTagging}
+                className={`app-top-segment ${isAutoTagging ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
+                title="Generate auto-tags"
+              >
+                <Sparkles size={14} className={isAutoTagging ? 'animate-pulse' : ''} />
+                <span>Auto-Tag</span>
+              </button>
+            </div>
+          )}
+
+          <span className="app-top-divider" />
 
           <button
             onClick={handleLaunchGenerator}
             disabled={isLaunchingGenerator}
-            className={`px-3 py-1.5 rounded-lg transition-all duration-300 text-xs font-bold text-white shadow-md border flex items-center gap-2 ${generatorButtonClassName}`}
+            className={`app-top-pill h-10 px-4 text-sm font-semibold shadow-sm ${generatorButtonClassName}`}
             title={generatorButtonTitle}
           >
-            <Sparkles size={14} className={`text-white/90 transition-colors ${isLaunchingGenerator ? 'animate-pulse' : ''}`} />
+            <Sparkles size={14} className={isLaunchingGenerator ? 'animate-pulse' : ''} />
             {generatorButtonLabel}
           </button>
-          
-          {/* Discreet Get Pro link - Unified Amber Theme */}
+
           {!isPro && (
             <a
               href="https://imagemetahub.com/getpro"
               target="_blank"
               rel="noopener noreferrer"
-              className="hidden lg:inline-flex text-[10px] font-bold uppercase tracking-wider text-amber-400 hover:text-amber-300 transition-colors px-3 py-1.5 rounded-full bg-amber-900/20 border border-amber-600/30 hover:bg-amber-900/40 hover:border-amber-500/50"
+              className="app-top-pill hidden border-amber-700/30 bg-amber-500/10 text-[10px] uppercase tracking-[0.18em] text-amber-200 hover:border-amber-600/40 hover:bg-amber-500/15 hover:text-amber-100 lg:inline-flex"
             >
               Get Pro
             </a>
           )}
-          
-          <div className="flex items-center bg-gray-800/50 rounded-full p-0.5 border border-gray-700/50">
+
+          <div className="app-top-segmented">
+            <button
+              onClick={() => setEnableSafeMode(!enableSafeMode)}
+              className={`${utilityButtonClassName} h-8 w-8 border-transparent bg-transparent ${enableSafeMode ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : 'text-gray-500 hover:text-gray-200'}`}
+              title={enableSafeMode ? 'Safe Mode on' : 'Safe Mode off'}
+            >
+              {enableSafeMode ? <Eye size={16} /> : <EyeOff size={16} />}
+            </button>
+            <a
+              href="https://github.com/LuqP2/Image-MetaHub/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${utilityButtonClassName} h-8 w-8 border-transparent bg-transparent`}
+              title="Report a bug or provide feedback"
+            >
+              <Bug size={16} />
+            </a>
             <button
               onClick={() => {
                 if (canUseAnalytics) {
@@ -525,17 +469,17 @@ const Header: React.FC<HeaderProps> = ({
                   showProModal('analytics');
                 }
               }}
-              className="p-1.5 rounded-full hover:bg-gray-700/80 text-gray-400 hover:text-white transition-all hover:shadow-lg relative group"
+              className={`${utilityButtonClassName} relative h-8 w-8 border-transparent bg-transparent`}
               title={canUseAnalytics ? 'Analytics (Pro)' : 'Analytics (Pro Feature) - start trial'}
             >
               <BarChart3 size={16} />
-              <div className="absolute -top-0.5 -right-0.5 transition-transform group-hover:scale-110">
+              <div className="absolute -right-0.5 -top-0.5">
                 <Crown className={`w-2.5 h-2.5 ${analyticsBadgeClass}`} />
               </div>
             </button>
             <button
               onClick={onOpenSettings}
-              className="p-1.5 rounded-full hover:bg-gray-700/80 text-gray-400 hover:text-white transition-all hover:rotate-45"
+              className={`${utilityButtonClassName} h-8 w-8 border-transparent bg-transparent`}
               title="Open Settings"
             >
               <Settings size={16} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,8 +12,8 @@ interface HeaderProps {
     onOpenAnalytics: () => void;
     onOpenLicense: () => void;
     onGeneratorSetupNeeded?: () => void;
-    libraryView?: 'library' | 'smart' | 'model' | 'node';
-    onLibraryViewChange?: (view: 'library' | 'smart' | 'model' | 'node') => void;
+    libraryView?: 'library' | 'smart' | 'model' | 'node' | 'collections';
+    onLibraryViewChange?: (view: 'library' | 'smart' | 'model' | 'node' | 'collections') => void;
 }
 
 const Header: React.FC<HeaderProps> = ({ 
@@ -386,6 +386,16 @@ const Header: React.FC<HeaderProps> = ({
                     >
                         <Boxes className="h-3.5 w-3.5" />
                         Node View
+                    </button>
+                    <button
+                        onClick={() => onLibraryViewChange('collections')}
+                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
+                            libraryView === 'collections'
+                            ? 'bg-amber-600 text-white shadow-md shadow-amber-900/20'
+                            : 'text-gray-400 hover:text-white hover:bg-white/5'
+                        }`}
+                    >
+                        Collections
                     </button>
                 </div>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -253,14 +253,14 @@ const Header: React.FC<HeaderProps> = ({
 
   const generatorButtonClassName = useMemo(() => {
     if (isLaunchingGenerator) {
-      return 'border-accent/40 bg-accent/15 text-accent cursor-wait hover:border-accent/40 hover:bg-accent/20 hover:text-accent';
+      return 'border-accent/45 bg-accent/15 text-accent cursor-wait hover:border-accent/45 hover:bg-accent/20 hover:text-accent';
     }
 
     if (
       (relevantConnectionStatus === 'connected' && hasRelevantServerUrl) ||
       hasLaunchCommand
     ) {
-      return 'border-accent/60 bg-accent text-white hover:border-accent/60 hover:bg-accent/90 hover:text-white';
+      return 'border-accent/45 bg-accent/12 text-accent hover:border-accent/55 hover:bg-accent/18 hover:text-accent';
     }
 
     return 'text-gray-200';
@@ -333,49 +333,48 @@ const Header: React.FC<HeaderProps> = ({
 
   return (
     <header className="sticky top-0 z-50 border-b border-gray-800/70 bg-gray-900/85 px-4 py-2.5 backdrop-blur-md shadow-lg shadow-black/20 transition-all duration-300">
-      <div className="container mx-auto flex items-center gap-4">
-        <div className="shrink-0">
+      <div className="container mx-auto flex items-center justify-between gap-4">
+        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
           <button
             onClick={onOpenLicense}
-            className={`app-top-pill text-[10px] uppercase tracking-[0.18em] ${statusConfig.classes}`}
+            className={`app-top-pill shrink-0 text-[10px] uppercase tracking-[0.18em] ${statusConfig.classes}`}
             title={isFree ? 'Start trial or activate license' : 'Manage license and status'}
           >
             <Crown className="h-3 w-3" />
             <span>{statusConfig.label}</span>
           </button>
-        </div>
 
-        <div className="flex min-w-0 flex-1 justify-center">
-        {libraryView && onLibraryViewChange && (
-          <div className="app-top-segmented max-w-full">
-            {viewTabs.map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => onLibraryViewChange(tab.id)}
-                className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
-              >
-                <span>{tab.label}</span>
-                {tab.count ? (
-                  <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${
-                    libraryView === tab.id
-                      ? 'border-white/20 bg-black/20 text-white/90'
-                      : 'border-gray-700/80 bg-gray-950/80 text-gray-500'
-                  }`}>
-                    {tab.count}
-                  </span>
-                ) : null}
-              </button>
-            ))}
-          </div>
-        )}
-        </div>
+          {libraryView && onLibraryViewChange && (
+            <div className="min-w-0 max-w-full overflow-x-auto scrollbar-thin">
+              <div className="app-top-segmented w-max">
+                {viewTabs.map((tab) => (
+                  <button
+                    key={tab.id}
+                    onClick={() => onLibraryViewChange(tab.id)}
+                    className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
+                  >
+                    <span>{tab.label}</span>
+                    {tab.count ? (
+                      <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${
+                        libraryView === tab.id
+                          ? 'border-white/20 bg-black/20 text-white/90'
+                          : 'border-gray-700/80 bg-gray-950/80 text-gray-500'
+                      }`}>
+                        {tab.count}
+                      </span>
+                    ) : null}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
-        <div className="flex shrink-0 items-center gap-2">
           {(libraryView === 'library' || libraryView === 'node') && (
             <>
+              <span className="app-top-divider shrink-0" />
               <button
                 onClick={() => setStackingEnabled(!isStackingEnabled)}
-                className={`${utilityButtonClassName} ${isStackingEnabled ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : ''}`}
+                className={`${utilityButtonClassName} shrink-0 ${isStackingEnabled ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : ''}`}
                 title={isStackingEnabled ? 'Disable stacking' : 'Stack items by identical prompt'}
               >
                 {isStackingEnabled ? <Layers2 size={16} /> : <Layers size={16} />}
@@ -388,7 +387,7 @@ const Header: React.FC<HeaderProps> = ({
                     setStackingEnabled(true);
                     setViewingStackPrompt(null);
                   }}
-                  className="app-top-pill px-2.5 text-gray-300"
+                  className="app-top-pill shrink-0 px-2.5 text-gray-300"
                   title="Return to the stacked results"
                 >
                   <ArrowLeft size={12} />
@@ -399,34 +398,39 @@ const Header: React.FC<HeaderProps> = ({
           )}
 
           {libraryView === 'smart' && (
-            <div className="app-top-segmented animate-in fade-in duration-300">
-              <button
-                onClick={handleGenerateClusters}
-                disabled={!hasDirectories || isClustering}
-                className={`app-top-segment ${isClustering ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
-                title="Generate clusters"
-              >
-                <Layers size={14} className={isClustering ? 'animate-pulse' : ''} />
-                <span>Cluster</span>
-              </button>
-              <button
-                onClick={handleGenerateAutoTags}
-                disabled={!hasDirectories || isAutoTagging}
-                className={`app-top-segment ${isAutoTagging ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
-                title="Generate auto-tags"
-              >
-                <Sparkles size={14} className={isAutoTagging ? 'animate-pulse' : ''} />
-                <span>Auto-Tag</span>
-              </button>
-            </div>
+            <>
+              <span className="app-top-divider shrink-0" />
+              <div className="app-top-segmented animate-in fade-in shrink-0 duration-300">
+                <button
+                  onClick={handleGenerateClusters}
+                  disabled={!hasDirectories || isClustering}
+                  className={`app-top-segment ${isClustering ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
+                  title="Generate clusters"
+                >
+                  <Layers size={14} className={isClustering ? 'animate-pulse' : ''} />
+                  <span>Cluster</span>
+                </button>
+                <button
+                  onClick={handleGenerateAutoTags}
+                  disabled={!hasDirectories || isAutoTagging}
+                  className={`app-top-segment ${isAutoTagging ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
+                  title="Generate auto-tags"
+                >
+                  <Sparkles size={14} className={isAutoTagging ? 'animate-pulse' : ''} />
+                  <span>Auto-Tag</span>
+                </button>
+              </div>
+            </>
           )}
+        </div>
 
+        <div className="flex shrink-0 items-center gap-2">
           <span className="app-top-divider" />
 
           <button
             onClick={handleLaunchGenerator}
             disabled={isLaunchingGenerator}
-            className={`app-top-pill h-10 px-4 text-sm font-semibold shadow-sm ${generatorButtonClassName}`}
+            className={`app-top-pill h-9 px-3 text-xs font-semibold shadow-sm ${generatorButtonClassName}`}
             title={generatorButtonTitle}
           >
             <Sparkles size={14} className={isLaunchingGenerator ? 'animate-pulse' : ''} />
@@ -438,7 +442,7 @@ const Header: React.FC<HeaderProps> = ({
               href="https://imagemetahub.com/getpro"
               target="_blank"
               rel="noopener noreferrer"
-              className="app-top-pill hidden border-amber-700/30 bg-amber-500/10 text-[10px] uppercase tracking-[0.18em] text-amber-200 hover:border-amber-600/40 hover:bg-amber-500/15 hover:text-amber-100 lg:inline-flex"
+              className="app-top-pill hidden h-9 border-amber-700/30 bg-amber-500/10 px-3 text-xs font-semibold text-amber-200 hover:border-amber-600/40 hover:bg-amber-500/15 hover:text-amber-100 lg:inline-flex"
             >
               Get Pro
             </a>

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -2,7 +2,7 @@ import { FixedSizeGrid as Grid, GridChildComponentProps, areEqual } from 'react-
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { type IndexedImage, type BaseMetadata, type Directory, ImageStack } from '../types';
+import { type IndexedImage, type BaseMetadata, type Directory, ImageStack, SmartCollection } from '../types';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
 import { useContextMenu } from '../hooks/useContextMenu';
@@ -33,6 +33,7 @@ import ProBadge from './ProBadge';
 import { useImageStacking } from '../hooks/useImageStacking';
 import TagManagerModal from './TagManagerModal';
 import TransferImagesModal from './TransferImagesModal';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 import { transferIndexedImages } from '../services/fileTransferService';
 import { thumbnailManager } from '../services/thumbnailManager';
 import { getContextMenuRatingTargetIds } from '../utils/ratingSelection';
@@ -673,6 +674,8 @@ interface ImageGridProps {
   totalPages: number;
   onPageChange: (page: number) => void;
   onBatchExport: () => void;
+  activeCollection?: SmartCollection | null;
+  isCollectionsView?: boolean;
   // Deduplication support (optional)
   markedBestIds?: Set<string>;      // IDs of images marked as best
   markedArchivedIds?: Set<string>;  // IDs of images marked for archive
@@ -683,7 +686,19 @@ const InnerGridElement = React.forwardRef<HTMLDivElement, React.HTMLAttributes<H
   <div ref={ref} {...props} data-grid-background="true" />
 ));
 
-const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedImages, currentPage, totalPages, onPageChange, onBatchExport, markedBestIds, markedArchivedIds }) => {
+const ImageGrid: React.FC<ImageGridProps> = ({
+  images,
+  onImageClick,
+  selectedImages,
+  currentPage,
+  totalPages,
+  onPageChange,
+  onBatchExport,
+  activeCollection = null,
+  isCollectionsView = false,
+  markedBestIds,
+  markedArchivedIds,
+}) => {
   const imageSize = useSettingsStore((state) => state.imageSize);
   const itemsPerPage = useSettingsStore((state) => state.itemsPerPage);
   const showFilenames = useSettingsStore((state) => state.showFilenames);
@@ -737,7 +752,17 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isTransferring, setIsTransferring] = useState(false);
   const [isCopySubmenuOpen, setIsCopySubmenuOpen] = useState(false);
+  const [isCollectionSubmenuOpen, setIsCollectionSubmenuOpen] = useState(false);
+  const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
+  const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
   const [transferStatusText, setTransferStatusText] = useState<string>('');
+  const collections = useImageStore((state) => state.collections);
+  const createCollection = useImageStore((state) => state.createCollection);
+  const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
+  const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
+  const updateCollection = useImageStore((state) => state.updateCollection);
+  const bulkAddTag = useImageStore((state) => state.bulkAddTag);
+  const bulkRemoveTag = useImageStore((state) => state.bulkRemoveTag);
   const { canUseComparison, showProModal, canUseA1111, canUseComfyUI, canUseBatchExport, canUseBulkTagging, canUseFileManagement, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
   const selectedCount = selectedImages.size;
   const sensitiveTagSet = useMemo(() => {
@@ -780,7 +805,13 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
     if (!contextMenu.visible && isCopySubmenuOpen) {
       setIsCopySubmenuOpen(false);
     }
-  }, [contextMenu.visible, isCopySubmenuOpen]);
+    if (!contextMenu.visible && isCollectionSubmenuOpen) {
+      setIsCollectionSubmenuOpen(false);
+    }
+    if (!contextMenu.visible && isAddToCollectionSubmenuOpen) {
+      setIsAddToCollectionSubmenuOpen(false);
+    }
+  }, [contextMenu.visible, isAddToCollectionSubmenuOpen, isCollectionSubmenuOpen, isCopySubmenuOpen]);
 
   const queuedComparisonFirstImageId = queuedComparisonImages[0]?.id;
 
@@ -866,6 +897,98 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
 
     return [contextMenu.image];
   }, [contextMenu.image, images, selectedImages]);
+
+  const handleAddToExistingCollection = useCallback(async (collection: SmartCollection) => {
+    const targetImages = getContextTargetImages();
+    if (targetImages.length === 0) {
+      hideContextMenu();
+      return;
+    }
+
+    if (collection.kind === 'tag_rule') {
+      if (!collection.sourceTag) {
+        hideContextMenu();
+        return;
+      }
+
+      await bulkAddTag(targetImages.map((image) => image.id), collection.sourceTag);
+    } else {
+      await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
+    }
+
+    hideContextMenu();
+  }, [addImagesToCollection, bulkAddTag, getContextTargetImages, hideContextMenu]);
+
+  const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
+    const targetImages = getContextTargetImages();
+    const targetImageIds = values.includeTargetImages ? targetImages.map((image) => image.id) : [];
+    const coverImageId = targetImageIds.length > 0 ? targetImageIds[0] : null;
+
+    await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: collections.length,
+      imageIds: targetImageIds,
+      snapshotImageIds: [],
+      coverImageId,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: coverImageId ?? undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setIsCollectionModalOpen(false);
+    hideContextMenu();
+  }, [collections.length, createCollection, getContextTargetImages, hideContextMenu]);
+
+  const handleSetCollectionCover = useCallback(async () => {
+    if (!activeCollection || !contextMenu.image) {
+      hideContextMenu();
+      return;
+    }
+
+    await updateCollection(activeCollection.id, {
+      coverImageId: contextMenu.image.id,
+      thumbnailId: contextMenu.image.id,
+    });
+    hideContextMenu();
+  }, [activeCollection, contextMenu.image, hideContextMenu, updateCollection]);
+
+  const handleRemoveFromCurrentCollection = useCallback(async () => {
+    if (!activeCollection) {
+      hideContextMenu();
+      return;
+    }
+
+    const targetImages = getContextTargetImages();
+    if (targetImages.length === 0) {
+      hideContextMenu();
+      return;
+    }
+
+    if (activeCollection.kind === 'tag_rule') {
+      const sourceTag = activeCollection.sourceTag;
+      if (!sourceTag) {
+        hideContextMenu();
+        return;
+      }
+
+      const confirmed = window.confirm(
+        `Remove the "${sourceTag}" tag from ${targetImages.length} image(s) in this collection?`,
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      await bulkRemoveTag(targetImages.map((image) => image.id), sourceTag);
+    } else {
+      await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
+    }
+
+    hideContextMenu();
+  }, [activeCollection, bulkRemoveTag, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
 
   const handleSetRating = useCallback((rating: 1 | 2 | 3 | 4 | 5 | null) => {
     const targetImageIds = getContextMenuRatingTargetIds(selectedImages, contextMenu.image?.id);
@@ -1311,6 +1434,93 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
             {!canUseBulkTagging && selectedCount > 1 && initialized && !canUseDuringTrialOrPro && <ProBadge size="sm" />}
           </button>
 
+          <div
+            className="relative"
+            onMouseEnter={() => setIsCollectionSubmenuOpen(true)}
+            onMouseLeave={() => {
+              setIsCollectionSubmenuOpen(false);
+              setIsAddToCollectionSubmenuOpen(false);
+            }}
+          >
+            <button
+              onClick={() => setIsCollectionSubmenuOpen((open) => !open)}
+              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+            >
+              <Folder className="w-4 h-4" />
+              <span className="flex-1">Collection</span>
+              <ChevronRight className="w-4 h-4 text-gray-400" />
+            </button>
+
+            {isCollectionSubmenuOpen && (
+              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                <div
+                  className="relative"
+                  onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                  onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                >
+                  <button
+                    onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                    className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                  >
+                    <span className="flex-1">Add to Collection</span>
+                    <ChevronRight className="h-4 w-4 text-gray-400" />
+                  </button>
+
+                  {isAddToCollectionSubmenuOpen && (
+                    <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                      {collections.length === 0 ? (
+                        <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
+                      ) : (
+                        collections.map((collection) => (
+                          <button
+                            key={collection.id}
+                            onClick={() => void handleAddToExistingCollection(collection)}
+                            className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                          >
+                            <span className="truncate">{collection.name}</span>
+                            <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                              {collection.kind === 'tag_rule' ? 'Tag' : 'Manual'}
+                            </span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <button
+                  onClick={() => {
+                    setIsCollectionModalOpen(true);
+                    hideContextMenu();
+                  }}
+                  className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                >
+                  Create New Collection
+                </button>
+              </div>
+            )}
+          </div>
+
+          {isCollectionsView && activeCollection && (
+            <>
+              <button
+                onClick={() => void handleSetCollectionCover()}
+                className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+              >
+                <Folder className="w-4 h-4" />
+                Set as Cover
+              </button>
+
+              <button
+                onClick={() => void handleRemoveFromCurrentCollection()}
+                className="w-full text-left px-4 py-2 text-sm text-amber-200 hover:bg-amber-900/20 hover:text-amber-100 transition-colors flex items-center gap-2"
+              >
+                <Folder className="w-4 h-4" />
+                <span className="flex-1">Remove from Current Collection</span>
+              </button>
+            </>
+          )}
+
           <div className="px-4 py-2">
             <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-500">Set Rating</div>
             <div className="flex flex-wrap gap-1.5">
@@ -1507,6 +1717,22 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
 
   const modalsContent = (
     <>
+      <CollectionFormModal
+        isOpen={isCollectionModalOpen}
+        title="Create Collection"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: '',
+          description: '',
+          sourceTag: '',
+          autoUpdate: false,
+          includeTargetImages: getContextTargetImages().length > 0,
+        }}
+        onClose={() => setIsCollectionModalOpen(false)}
+        onSubmit={handleCreateCollectionFromContext}
+        showIncludeTargetImages={getContextTargetImages().length > 0}
+      />
+
       <TagManagerModal
         isOpen={isTagManagerOpen}
         onClose={() => setIsTagManagerOpen(false)}

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -761,8 +761,6 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
   const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
   const updateCollection = useImageStore((state) => state.updateCollection);
-  const bulkAddTag = useImageStore((state) => state.bulkAddTag);
-  const bulkRemoveTag = useImageStore((state) => state.bulkRemoveTag);
   const { canUseComparison, showProModal, canUseA1111, canUseComfyUI, canUseBatchExport, canUseBulkTagging, canUseFileManagement, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
   const selectedCount = selectedImages.size;
   const sensitiveTagSet = useMemo(() => {
@@ -905,19 +903,10 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       return;
     }
 
-    if (collection.kind === 'tag_rule') {
-      if (!collection.sourceTag) {
-        hideContextMenu();
-        return;
-      }
-
-      await bulkAddTag(targetImages.map((image) => image.id), collection.sourceTag);
-    } else {
-      await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
-    }
+    await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
 
     hideContextMenu();
-  }, [addImagesToCollection, bulkAddTag, getContextTargetImages, hideContextMenu]);
+  }, [addImagesToCollection, getContextTargetImages, hideContextMenu]);
 
   const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
     const targetImages = getContextTargetImages();
@@ -968,27 +957,10 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       return;
     }
 
-    if (activeCollection.kind === 'tag_rule') {
-      const sourceTag = activeCollection.sourceTag;
-      if (!sourceTag) {
-        hideContextMenu();
-        return;
-      }
-
-      const confirmed = window.confirm(
-        `Remove the "${sourceTag}" tag from ${targetImages.length} image(s) in this collection?`,
-      );
-      if (!confirmed) {
-        return;
-      }
-
-      await bulkRemoveTag(targetImages.map((image) => image.id), sourceTag);
-    } else {
-      await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
-    }
+    await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
 
     hideContextMenu();
-  }, [activeCollection, bulkRemoveTag, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
+  }, [activeCollection, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
 
   const handleSetRating = useCallback((rating: 1 | 2 | 3 | 4 | 5 | null) => {
     const targetImageIds = getContextMenuRatingTargetIds(selectedImages, contextMenu.image?.id);
@@ -1478,9 +1450,11 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                             className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
                           >
                             <span className="truncate">{collection.name}</span>
-                            <span className="text-[10px] uppercase tracking-wide text-gray-500">
-                              {collection.kind === 'tag_rule' ? 'Tag' : 'Manual'}
-                            </span>
+                            {collection.sourceTag && (
+                              <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                              </span>
+                            )}
                           </button>
                         ))
                       )}

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1424,7 +1424,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             </button>
 
             {isCollectionSubmenuOpen && (
-              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+              <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                 <div
                   className="relative"
                   onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
@@ -1439,7 +1439,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                   </button>
 
                   {isAddToCollectionSubmenuOpen && (
-                    <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                    <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                       {collections.length === 0 ? (
                         <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
                       ) : (
@@ -1535,7 +1535,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             </button>
 
             {isCopySubmenuOpen && (
-              <div className="absolute left-full top-0 ml-1 min-w-[190px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+              <div className="absolute left-full top-0 min-w-[190px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                 <button
                   onClick={copyPrompt}
                   className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, FC, useCallback, useMemo, useRef } from 'react';
-import { type IndexedImage, type BaseMetadata, type LoRAInfo } from '../types';
+import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollection } from '../types';
 import { FileOperations } from '../services/fileOperations';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
 import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2 } from 'lucide-react';
@@ -27,6 +27,7 @@ import { MetadataEditorModal } from './MetadataEditorModal';
 import ImageLineageSection from './ImageLineageSection';
 import { getGenerationTypeLabel } from '../utils/imageLineage';
 import RatingStars from './RatingStars';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 
 
 const TAG_SUGGESTION_LIMIT = 5;
@@ -531,6 +532,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
     kind: 'media',
     selectionText: '',
   });
+  const [isCollectionSubmenuOpen, setIsCollectionSubmenuOpen] = useState(false);
+  const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
+  const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
   const [showDetails, setShowDetails] = useState(true);
   const [showPerformance, setShowPerformance] = useState(true);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
@@ -589,6 +593,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const recentTags = useImageStore((state) => state.recentTags);
   const setSelectedImage = useImageStore((state) => state.setSelectedImage);
   const setPreviewImage = useImageStore((state) => state.setPreviewImage);
+  const collections = useImageStore((state) => state.collections);
+  const createCollection = useImageStore((state) => state.createCollection);
+  const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
 
   // Shadow Metadata Hook
   const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata, deleteMetadata: deleteShadowMetadata } = useShadowMetadata(image.id);
@@ -633,6 +640,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
     ? `${directoryPath}${/[\\/]$/.test(directoryPath) ? '' : '\\'}${image.name}`
     : image.name;
   const mediaOverlayVisibilityClass = isMediaOverlayVisible ? 'opacity-100' : 'opacity-0 pointer-events-none';
+
+  useEffect(() => {
+    if (contextMenu.visible) {
+      return;
+    }
+
+    setIsCollectionSubmenuOpen(false);
+    setIsAddToCollectionSubmenuOpen(false);
+  }, [contextMenu.visible]);
 
   const applyModalWindowStyles = useCallback((windowState: ModalWindowState) => {
     if (isFullscreen || !modalShellRef.current) {
@@ -1086,6 +1102,34 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const hideContextMenu = () => {
     setContextMenu({ x: 0, y: 0, visible: false, kind: 'media', selectionText: '' });
   };
+
+  const handleAddToExistingCollection = useCallback(async (collection: SmartCollection) => {
+    await addImagesToCollection(collection.id, [image.id]);
+    hideContextMenu();
+  }, [addImagesToCollection, image.id]);
+
+  const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
+    const targetImageIds = values.includeTargetImages ? [image.id] : [];
+    const coverImageId = targetImageIds.length > 0 ? targetImageIds[0] : null;
+
+    await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: collections.length,
+      imageIds: targetImageIds,
+      snapshotImageIds: [],
+      coverImageId,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: coverImageId ?? undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setIsCollectionModalOpen(false);
+    hideContextMenu();
+  }, [collections.length, createCollection, image.id]);
 
   const copyPrompt = () => {
     copyToClipboardElectron(nMeta?.prompt || '', 'Prompt');
@@ -2689,6 +2733,22 @@ const ImageModal: React.FC<ImageModalProps> = ({
         imageId={image.id}
       />
 
+      <CollectionFormModal
+        isOpen={isCollectionModalOpen}
+        title="Create Collection"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: '',
+          description: '',
+          sourceTag: '',
+          autoUpdate: false,
+          includeTargetImages: true,
+        }}
+        onClose={() => setIsCollectionModalOpen(false)}
+        onSubmit={handleCreateCollectionFromContext}
+        showIncludeTargetImages
+      />
+
       {/* Context Menu */}
       {contextMenu.visible && (
         <div
@@ -2723,6 +2783,75 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 <Copy className="w-4 h-4" />
                 Copy to Clipboard
               </button>
+
+              <div
+                className="relative"
+                onMouseEnter={() => setIsCollectionSubmenuOpen(true)}
+                onMouseLeave={() => {
+                  setIsCollectionSubmenuOpen(false);
+                  setIsAddToCollectionSubmenuOpen(false);
+                }}
+              >
+                <button
+                  onClick={() => setIsCollectionSubmenuOpen((open) => !open)}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+                >
+                  <Folder className="w-4 h-4" />
+                  <span className="flex-1">Collection</span>
+                  <ChevronRight className="w-4 h-4 text-gray-400" />
+                </button>
+
+                {isCollectionSubmenuOpen && (
+                  <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                    <div
+                      className="relative"
+                      onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                      onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                    >
+                      <button
+                        onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                        className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                      >
+                        <span className="flex-1">Add to Collection</span>
+                        <ChevronRight className="h-4 w-4 text-gray-400" />
+                      </button>
+
+                      {isAddToCollectionSubmenuOpen && (
+                        <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                          {collections.length === 0 ? (
+                            <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
+                          ) : (
+                            collections.map((collection) => (
+                              <button
+                                key={collection.id}
+                                onClick={() => void handleAddToExistingCollection(collection)}
+                                className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                              >
+                                <span className="truncate">{collection.name}</span>
+                                {collection.sourceTag && (
+                                  <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                    {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                                  </span>
+                                )}
+                              </button>
+                            ))
+                          )}
+                        </div>
+                      )}
+                    </div>
+
+                    <button
+                      onClick={() => {
+                        setIsCollectionModalOpen(true);
+                        hideContextMenu();
+                      }}
+                      className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                    >
+                      Create New Collection
+                    </button>
+                  </div>
+                )}
+              </div>
 
               <div className="border-t border-gray-600 my-1"></div>
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2806,7 +2806,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 </button>
 
                 {isCollectionSubmenuOpen && (
-                  <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                  <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                     <div
                       className="relative"
                       onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
@@ -2821,7 +2821,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                       </button>
 
                       {isAddToCollectionSubmenuOpen && (
-                        <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                        <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                           {collections.length === 0 ? (
                             <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
                           ) : (

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2725,34 +2725,38 @@ const ImageModal: React.FC<ImageModalProps> = ({
       </div>
 
       {/* Metadata Editor Modal */}
-      <MetadataEditorModal
-        isOpen={isMetadataEditorOpen}
-        onClose={() => setIsMetadataEditorOpen(false)}
-        initialMetadata={shadowMetadata}
-        onSave={async (m) => { await saveShadowMetadata(m); }}
-        imageId={image.id}
-      />
+      <div className="pointer-events-auto">
+        <MetadataEditorModal
+          isOpen={isMetadataEditorOpen}
+          onClose={() => setIsMetadataEditorOpen(false)}
+          initialMetadata={shadowMetadata}
+          onSave={async (m) => { await saveShadowMetadata(m); }}
+          imageId={image.id}
+        />
+      </div>
 
-      <CollectionFormModal
-        isOpen={isCollectionModalOpen}
-        title="Create Collection"
-        submitLabel="Create Collection"
-        initialValues={{
-          name: '',
-          description: '',
-          sourceTag: '',
-          autoUpdate: false,
-          includeTargetImages: true,
-        }}
-        onClose={() => setIsCollectionModalOpen(false)}
-        onSubmit={handleCreateCollectionFromContext}
-        showIncludeTargetImages
-      />
+      <div className="pointer-events-auto">
+        <CollectionFormModal
+          isOpen={isCollectionModalOpen}
+          title="Create Collection"
+          submitLabel="Create Collection"
+          initialValues={{
+            name: '',
+            description: '',
+            sourceTag: '',
+            autoUpdate: false,
+            includeTargetImages: true,
+          }}
+          onClose={() => setIsCollectionModalOpen(false)}
+          onSubmit={handleCreateCollectionFromContext}
+          showIncludeTargetImages
+        />
+      </div>
 
       {/* Context Menu */}
       {contextMenu.visible && (
         <div
-          className="fixed z-[60] bg-gray-800 border border-gray-600 rounded-lg shadow-xl py-1 min-w-[160px]"
+          className="pointer-events-auto fixed z-[60] bg-gray-800 border border-gray-600 rounded-lg shadow-xl py-1 min-w-[160px]"
           style={{ left: contextMenu.x, top: contextMenu.y }}
           onClick={(e) => e.stopPropagation()}
         >

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -504,7 +504,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
             </button>
 
             {isCollectionSubmenuOpen && (
-              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+              <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                 <div
                   className="relative"
                   onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
@@ -519,7 +519,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
                   </button>
 
                   {isAddToCollectionSubmenuOpen && (
-                    <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                    <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                       {collections.length === 0 ? (
                         <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
                       ) : (
@@ -590,7 +590,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
             </button>
 
             {isCopySubmenuOpen && (
-              <div className="absolute left-full top-0 ml-1 min-w-[190px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+              <div className="absolute left-full top-0 min-w-[190px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                 <button
                   onClick={copyPrompt}
                   className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { FixedSizeList as List } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { type IndexedImage, type Directory } from '../types';
+import { type IndexedImage, type Directory, SmartCollection } from '../types';
 import { useContextMenu } from '../hooks/useContextMenu';
 import { useImageStore } from '../store/useImageStore';
 import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, RefreshCw, Star } from 'lucide-react';
@@ -15,12 +15,15 @@ import { transferIndexedImages } from '../services/fileTransferService';
 import { RATING_VALUES, RatingValueIcons, getRatingBadgeClasses, getRatingChipClasses, getRatingLabel } from './RatingStars';
 import { getContextMenuRatingTargetIds } from '../utils/ratingSelection';
 import { useReparseMetadata } from '../hooks/useReparseMetadata';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 
 interface ImageTableProps {
   images: IndexedImage[];
   onImageClick: (image: IndexedImage, event: React.MouseEvent) => void;
   selectedImages: Set<string>;
   onBatchExport: () => void;
+  activeCollection?: SmartCollection | null;
+  isCollectionsView?: boolean;
 }
 
 type SortField = 'filename' | 'model' | 'steps' | 'cfg' | 'size' | 'seed';
@@ -56,7 +59,14 @@ const joinDisplayPath = (basePath: string, relativePath: string): string => {
   return `${normalizedBase}/${normalizedRelative}`;
 };
 
-const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedImages, onBatchExport }) => {
+const ImageTable: React.FC<ImageTableProps> = ({
+  images,
+  onImageClick,
+  selectedImages,
+  onBatchExport,
+  activeCollection = null,
+  isCollectionsView = false,
+}) => {
   const directories = useImageStore((state) => state.directories);
   const transferProgress = useImageStore((state) => state.transferProgress);
   const [sortField, setSortField] = useState<SortField | null>(null);
@@ -66,8 +76,18 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isTransferring, setIsTransferring] = useState(false);
   const [isCopySubmenuOpen, setIsCopySubmenuOpen] = useState(false);
+  const [isCollectionSubmenuOpen, setIsCollectionSubmenuOpen] = useState(false);
+  const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
+  const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
   const [transferStatusText, setTransferStatusText] = useState<string>('');
   const bulkSetImageRating = useImageStore((state) => state.bulkSetImageRating);
+  const collections = useImageStore((state) => state.collections);
+  const createCollection = useImageStore((state) => state.createCollection);
+  const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
+  const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
+  const updateCollection = useImageStore((state) => state.updateCollection);
+  const bulkAddTag = useImageStore((state) => state.bulkAddTag);
+  const bulkRemoveTag = useImageStore((state) => state.bulkRemoveTag);
   const { canUseFileManagement, showProModal, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
   const { isReparsing, reparseImages } = useReparseMetadata();
 
@@ -89,7 +109,13 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
     if (!contextMenu.visible && isCopySubmenuOpen) {
       setIsCopySubmenuOpen(false);
     }
-  }, [contextMenu.visible, isCopySubmenuOpen]);
+    if (!contextMenu.visible && isCollectionSubmenuOpen) {
+      setIsCollectionSubmenuOpen(false);
+    }
+    if (!contextMenu.visible && isAddToCollectionSubmenuOpen) {
+      setIsAddToCollectionSubmenuOpen(false);
+    }
+  }, [contextMenu.visible, isAddToCollectionSubmenuOpen, isCollectionSubmenuOpen, isCopySubmenuOpen]);
 
   const selectedCount = selectedImages.size;
 
@@ -125,6 +151,98 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
     bulkSetImageRating(targetImageIds, rating);
     hideContextMenu();
   }, [bulkSetImageRating, contextMenu.image?.id, hideContextMenu, selectedImages]);
+
+  const handleAddToExistingCollection = useCallback(async (collection: SmartCollection) => {
+    const targetImages = getContextTargetImages();
+    if (!targetImages.length) {
+      hideContextMenu();
+      return;
+    }
+
+    if (collection.kind === 'tag_rule') {
+      if (!collection.sourceTag) {
+        hideContextMenu();
+        return;
+      }
+
+      await bulkAddTag(targetImages.map((image) => image.id), collection.sourceTag);
+    } else {
+      await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
+    }
+
+    hideContextMenu();
+  }, [addImagesToCollection, bulkAddTag, getContextTargetImages, hideContextMenu]);
+
+  const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
+    const targetImages = getContextTargetImages();
+    const targetImageIds = values.includeTargetImages ? targetImages.map((image) => image.id) : [];
+    const coverImageId = targetImageIds.length > 0 ? targetImageIds[0] : null;
+
+    await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: collections.length,
+      imageIds: targetImageIds,
+      snapshotImageIds: [],
+      coverImageId,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: coverImageId ?? undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setIsCollectionModalOpen(false);
+    hideContextMenu();
+  }, [collections.length, createCollection, getContextTargetImages, hideContextMenu]);
+
+  const handleSetCollectionCover = useCallback(async () => {
+    if (!activeCollection || !contextMenu.image) {
+      hideContextMenu();
+      return;
+    }
+
+    await updateCollection(activeCollection.id, {
+      coverImageId: contextMenu.image.id,
+      thumbnailId: contextMenu.image.id,
+    });
+    hideContextMenu();
+  }, [activeCollection, contextMenu.image, hideContextMenu, updateCollection]);
+
+  const handleRemoveFromCurrentCollection = useCallback(async () => {
+    if (!activeCollection) {
+      hideContextMenu();
+      return;
+    }
+
+    const targetImages = getContextTargetImages();
+    if (!targetImages.length) {
+      hideContextMenu();
+      return;
+    }
+
+    if (activeCollection.kind === 'tag_rule') {
+      const sourceTag = activeCollection.sourceTag;
+      if (!sourceTag) {
+        hideContextMenu();
+        return;
+      }
+
+      const confirmed = window.confirm(
+        `Remove the "${sourceTag}" tag from ${targetImages.length} image(s) in this collection?`,
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      await bulkRemoveTag(targetImages.map((image) => image.id), sourceTag);
+    } else {
+      await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
+    }
+
+    hideContextMenu();
+  }, [activeCollection, bulkRemoveTag, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
 
   const handleReparseMetadata = useCallback(async () => {
     const targetImages = getContextTargetImages();
@@ -398,6 +516,93 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
 
           <div
             className="relative"
+            onMouseEnter={() => setIsCollectionSubmenuOpen(true)}
+            onMouseLeave={() => {
+              setIsCollectionSubmenuOpen(false);
+              setIsAddToCollectionSubmenuOpen(false);
+            }}
+          >
+            <button
+              onClick={() => setIsCollectionSubmenuOpen((open) => !open)}
+              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+            >
+              <Folder className="w-4 h-4" />
+              <span className="flex-1">Collection</span>
+              <ChevronRight className="w-4 h-4 text-gray-400" />
+            </button>
+
+            {isCollectionSubmenuOpen && (
+              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                <div
+                  className="relative"
+                  onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                  onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                >
+                  <button
+                    onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                    className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                  >
+                    <span className="flex-1">Add to Collection</span>
+                    <ChevronRight className="h-4 w-4 text-gray-400" />
+                  </button>
+
+                  {isAddToCollectionSubmenuOpen && (
+                    <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                      {collections.length === 0 ? (
+                        <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
+                      ) : (
+                        collections.map((collection) => (
+                          <button
+                            key={collection.id}
+                            onClick={() => void handleAddToExistingCollection(collection)}
+                            className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                          >
+                            <span className="truncate">{collection.name}</span>
+                            <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                              {collection.kind === 'tag_rule' ? 'Tag' : 'Manual'}
+                            </span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <button
+                  onClick={() => {
+                    setIsCollectionModalOpen(true);
+                    hideContextMenu();
+                  }}
+                  className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                >
+                  Create New Collection
+                </button>
+              </div>
+            )}
+          </div>
+
+          {isCollectionsView && activeCollection && (
+            <>
+              <button
+                onClick={() => void handleSetCollectionCover()}
+                className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+              >
+                <Folder className="w-4 h-4" />
+                Set as Cover
+              </button>
+
+              <button
+                onClick={() => void handleRemoveFromCurrentCollection()}
+                className="w-full text-left px-4 py-2 text-sm text-amber-200 hover:bg-amber-900/20 hover:text-amber-100 transition-colors flex items-center gap-2"
+              >
+                <Folder className="w-4 h-4" />
+                <span className="flex-1">Remove from Current Collection</span>
+              </button>
+            </>
+          )}
+
+          <div
+            className="relative"
             onMouseEnter={() => setIsCopySubmenuOpen(true)}
             onMouseLeave={() => setIsCopySubmenuOpen(false)}
           >
@@ -537,6 +742,22 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
             )}
           </div>
         )}
+
+      <CollectionFormModal
+        isOpen={isCollectionModalOpen}
+        title="Create Collection"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: '',
+          description: '',
+          sourceTag: '',
+          autoUpdate: false,
+          includeTargetImages: getContextTargetImages().length > 0,
+        }}
+        onClose={() => setIsCollectionModalOpen(false)}
+        onSubmit={handleCreateCollectionFromContext}
+        showIncludeTargetImages={getContextTargetImages().length > 0}
+      />
 
       <TransferImagesModal
         isOpen={isTransferModalOpen && !!transferMode}

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -86,8 +86,6 @@ const ImageTable: React.FC<ImageTableProps> = ({
   const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
   const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
   const updateCollection = useImageStore((state) => state.updateCollection);
-  const bulkAddTag = useImageStore((state) => state.bulkAddTag);
-  const bulkRemoveTag = useImageStore((state) => state.bulkRemoveTag);
   const { canUseFileManagement, showProModal, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
   const { isReparsing, reparseImages } = useReparseMetadata();
 
@@ -159,19 +157,10 @@ const ImageTable: React.FC<ImageTableProps> = ({
       return;
     }
 
-    if (collection.kind === 'tag_rule') {
-      if (!collection.sourceTag) {
-        hideContextMenu();
-        return;
-      }
-
-      await bulkAddTag(targetImages.map((image) => image.id), collection.sourceTag);
-    } else {
-      await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
-    }
+    await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
 
     hideContextMenu();
-  }, [addImagesToCollection, bulkAddTag, getContextTargetImages, hideContextMenu]);
+  }, [addImagesToCollection, getContextTargetImages, hideContextMenu]);
 
   const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
     const targetImages = getContextTargetImages();
@@ -222,27 +211,10 @@ const ImageTable: React.FC<ImageTableProps> = ({
       return;
     }
 
-    if (activeCollection.kind === 'tag_rule') {
-      const sourceTag = activeCollection.sourceTag;
-      if (!sourceTag) {
-        hideContextMenu();
-        return;
-      }
-
-      const confirmed = window.confirm(
-        `Remove the "${sourceTag}" tag from ${targetImages.length} image(s) in this collection?`,
-      );
-      if (!confirmed) {
-        return;
-      }
-
-      await bulkRemoveTag(targetImages.map((image) => image.id), sourceTag);
-    } else {
-      await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
-    }
+    await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
 
     hideContextMenu();
-  }, [activeCollection, bulkRemoveTag, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
+  }, [activeCollection, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
 
   const handleReparseMetadata = useCallback(async () => {
     const targetImages = getContextTargetImages();
@@ -558,9 +530,11 @@ const ImageTable: React.FC<ImageTableProps> = ({
                             className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
                           >
                             <span className="truncate">{collection.name}</span>
-                            <span className="text-[10px] uppercase tracking-wide text-gray-500">
-                              {collection.kind === 'tag_rule' ? 'Tag' : 'Manual'}
-                            </span>
+                            {collection.sourceTag && (
+                              <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                              </span>
+                            )}
                           </button>
                         ))
                       )}

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -84,11 +84,14 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 md:p-6"
+      className="fixed inset-0 z-50 overflow-y-auto bg-black/60 p-3 md:p-6"
       onClick={onClose}
     >
       <div
-        className="flex h-[92vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-800 text-gray-100 shadow-2xl"
+        className="mx-auto my-3 flex min-h-0 w-full max-w-6xl max-h-[calc(100vh-1.5rem)] flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-800 text-gray-100 shadow-2xl md:my-6 md:max-h-[calc(100vh-3rem)]"
+        style={{
+          minHeight: 'min(720px, calc(100vh - 1.5rem))',
+        }}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-gray-700/80 px-4 py-4 md:px-6">

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -284,10 +284,10 @@ const Sidebar: React.FC<SidebarProps> = ({
         className="fixed left-0 top-0 z-40 flex h-full w-16 flex-col items-center border-r border-gray-800/70 bg-gray-900/90 py-6 backdrop-blur-md shadow-lg shadow-black/20 transition-all duration-300 ease-in-out">
         <button
           onClick={onToggleCollapse}
-          className="app-top-icon-button mt-4 mb-6 h-10 w-10 overflow-hidden p-0"
+          className="mt-4 mb-6 rounded-xl p-0 text-gray-400 transition-colors duration-200 hover:bg-gray-800/50 hover:text-gray-100"
           title="Expand sidebar"
         >
-           <img src="logo1.png" alt="Expand" className="h-9 w-9 rounded-lg object-cover" />
+           <img src="logo1.png" alt="Expand" className="h-10 w-10 rounded-xl object-contain" />
         </button>
         <div className="flex flex-col space-y-3">
           {(selectedModels.length > 0 ||
@@ -336,9 +336,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       {/* Header with collapse button */}
       <div className="flex flex-col border-b border-gray-800/70 bg-gray-900/55">
         <div className="flex items-center gap-3 px-4 py-3">
-          <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl border border-gray-800/80 bg-gray-950/70 p-1">
-            <img src="logo1.png" alt="Image MetaHub" className="h-9 w-9 rounded-lg object-cover" />
-          </div>
+          <img src="logo1.png" alt="Image MetaHub" className="h-11 w-11 flex-shrink-0 rounded-xl object-contain" />
           <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
             <h1 className="truncate text-lg font-semibold tracking-tight text-white">Image MetaHub</h1>
             <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.14.0</span>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -281,14 +281,13 @@ const Sidebar: React.FC<SidebarProps> = ({
       <div
         data-area="sidebar"
         tabIndex={-1}
-        className="fixed left-0 top-0 h-full w-16 bg-gray-900/90 backdrop-blur-md border-r border-gray-800/60 z-40 flex flex-col items-center py-6 transition-all duration-300 ease-in-out shadow-lg shadow-black/20">
+        className="fixed left-0 top-0 z-40 flex h-full w-16 flex-col items-center border-r border-gray-800/70 bg-gray-900/90 py-6 backdrop-blur-md shadow-lg shadow-black/20 transition-all duration-300 ease-in-out">
         <button
           onClick={onToggleCollapse}
-          className="mt-4 mb-6 relative group"
+          className="app-top-icon-button mt-4 mb-6 h-10 w-10 overflow-hidden p-0"
           title="Expand sidebar"
         >
-           <div className="absolute inset-0 bg-blue-500/20 blur-md rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-           <img src="logo1.png" alt="Expand" className="h-10 w-10 rounded-xl shadow-lg relative z-10 transition-transform duration-200 group-hover:scale-105" />
+           <img src="logo1.png" alt="Expand" className="h-9 w-9 rounded-lg object-cover" />
         </button>
         <div className="flex flex-col space-y-3">
           {(selectedModels.length > 0 ||
@@ -323,7 +322,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       data-area="sidebar"
       tabIndex={-1}
       style={{ width }}
-      className={`fixed left-0 top-0 h-full bg-gray-900/90 backdrop-blur-md border-r border-gray-800/60 z-40 flex flex-col shadow-2xl shadow-black/40 ${isResizing ? 'transition-none' : 'transition-[width] duration-300 ease-in-out'}`}>
+      className={`fixed left-0 top-0 z-40 flex h-full flex-col border-r border-gray-800/70 bg-gray-900/90 backdrop-blur-md shadow-2xl shadow-black/40 ${isResizing ? 'transition-none' : 'transition-[width] duration-300 ease-in-out'}`}>
       <div
         role="separator"
         aria-label="Resize filters sidebar"
@@ -335,19 +334,18 @@ const Sidebar: React.FC<SidebarProps> = ({
         <div className={`h-16 w-1 rounded-full transition-colors duration-150 ${isResizing ? 'bg-blue-400/90 shadow-[0_0_16px_rgba(96,165,250,0.55)]' : 'bg-gray-600/70 hover:bg-blue-400/80'}`} />
       </div>
       {/* Header with collapse button */}
-      <div className="flex flex-col border-b border-gray-800/60 bg-gray-900/40">
-        <div className="flex items-center gap-3.5 px-4 pt-2.5 pb-2">
-          <div className="relative flex-shrink-0">
-            <div className="absolute inset-0 rounded-full bg-blue-500/20 blur-xl opacity-50" />
-            <img src="logo1.png" alt="Image MetaHub" className="relative z-10 h-12 w-12 rounded-xl shadow-2xl" />
+      <div className="flex flex-col border-b border-gray-800/70 bg-gray-900/55">
+        <div className="flex items-center gap-3 px-4 py-3">
+          <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl border border-gray-800/80 bg-gray-950/70 p-1">
+            <img src="logo1.png" alt="Image MetaHub" className="h-9 w-9 rounded-lg object-cover" />
           </div>
           <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
-            <h1 className="truncate text-xl font-bold tracking-tight text-white">Image MetaHub</h1>
-            <span className="text-xs font-mono font-normal text-gray-500">v0.14.0</span>
+            <h1 className="truncate text-lg font-semibold tracking-tight text-white">Image MetaHub</h1>
+            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.14.0</span>
           </div>
           <button
             onClick={onToggleCollapse}
-            className="ml-auto rounded-lg border border-gray-700 bg-gray-800/40 p-1.5 text-gray-400 transition-colors hover:bg-gray-700/60 hover:text-white hover:shadow-lg hover:shadow-blue-500/20"
+            className="app-top-icon-button ml-auto h-8 w-8"
             title="Collapse sidebar"
           >
             <ChevronLeft className="w-4 h-4" />

--- a/components/TagsAndFavorites.tsx
+++ b/components/TagsAndFavorites.tsx
@@ -775,7 +775,7 @@ const TagsAndFavorites: React.FC = () => {
 
       <CollectionFormModal
         isOpen={collectionSourceTag !== null}
-        title="Create Collection from Tag"
+        title="Create Collection"
         submitLabel="Create Collection"
         initialValues={{
           name: collectionSourceTag ?? '',
@@ -786,7 +786,6 @@ const TagsAndFavorites: React.FC = () => {
         }}
         onClose={() => setCollectionSourceTag(null)}
         onSubmit={handleCreateCollection}
-        collectionKind="tag_rule"
         showSourceTag
         disableSourceTag
         showAutoUpdate

--- a/components/TagsAndFavorites.tsx
+++ b/components/TagsAndFavorites.tsx
@@ -5,6 +5,7 @@ import { useImageStore } from '../store/useImageStore';
 import { InclusionFilterMode, TagInfo } from '../types';
 import TriStateToggle, { getFilterModeLabel, getNextFilterMode } from './TriStateToggle';
 import { getRatingChipClasses, getRatingLabel, RatingValueIcons } from './RatingStars';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 
 type TagContextMenuState = {
   x: number;
@@ -43,6 +44,8 @@ const TagsAndFavorites: React.FC = () => {
   const filteredImages = useImageStore((state) => state.filteredImages);
   const images = useImageStore((state) => state.images);
   const indexingState = useImageStore((state) => state.indexingState);
+  const collections = useImageStore((state) => state.collections);
+  const createCollection = useImageStore((state) => state.createCollection);
 
   const [isExpanded, setIsExpanded] = useState(true);
   const [tagSearchQuery, setTagSearchQuery] = useState('');
@@ -53,6 +56,7 @@ const TagsAndFavorites: React.FC = () => {
     sourceTag: '',
     value: '',
   });
+  const [collectionSourceTag, setCollectionSourceTag] = useState<string | null>(null);
   const contextMenuRef = React.useRef<HTMLDivElement>(null);
   const renameInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -275,6 +279,45 @@ const TagsAndFavorites: React.FC = () => {
   const handleTagAction = async (action: () => Promise<void>) => {
     closeContextMenu();
     await action();
+  };
+
+  const openCreateCollectionDialog = () => {
+    if (!contextMenu) {
+      return;
+    }
+
+    setCollectionSourceTag(contextMenu.tag.name);
+    closeContextMenu();
+  };
+
+  const handleCreateCollection = async (values: CollectionFormValues) => {
+    if (!collectionSourceTag) {
+      return;
+    }
+
+    const normalizedTag = collectionSourceTag.trim().toLowerCase();
+    const snapshotImageIds = values.autoUpdate
+      ? []
+      : images
+          .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedTag))
+          .map((image) => image.id);
+
+    await createCollection({
+      kind: 'tag_rule',
+      name: values.name,
+      description: values.description || undefined,
+      sourceTag: normalizedTag,
+      autoUpdate: values.autoUpdate,
+      imageIds: [],
+      snapshotImageIds,
+      sortIndex: collections.length,
+      coverImageId: null,
+      thumbnailId: undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setCollectionSourceTag(null);
   };
 
   const handleClearFromMenu = async () => {
@@ -685,6 +728,13 @@ const TagsAndFavorites: React.FC = () => {
           >
             Rename Tag
           </button>
+          <button
+            type="button"
+            className="w-full px-4 py-2 text-left text-sm text-gray-300 transition-colors hover:bg-gray-700"
+            onClick={openCreateCollectionDialog}
+          >
+            Create Collection
+          </button>
           {contextMenu.tag.count > 0 && (
             <button
               type="button"
@@ -722,6 +772,25 @@ const TagsAndFavorites: React.FC = () => {
           )}
         </div>
       )}
+
+      <CollectionFormModal
+        isOpen={collectionSourceTag !== null}
+        title="Create Collection from Tag"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: collectionSourceTag ?? '',
+          description: '',
+          sourceTag: collectionSourceTag ?? '',
+          autoUpdate: true,
+          includeTargetImages: false,
+        }}
+        onClose={() => setCollectionSourceTag(null)}
+        onSubmit={handleCreateCollection}
+        collectionKind="tag_rule"
+        showSourceTag
+        disableSourceTag
+        showAutoUpdate
+      />
 
       {renameDialog.isOpen && (
         <div

--- a/components/TagsAndFavorites.tsx
+++ b/components/TagsAndFavorites.tsx
@@ -6,6 +6,7 @@ import { InclusionFilterMode, TagInfo } from '../types';
 import TriStateToggle, { getFilterModeLabel, getNextFilterMode } from './TriStateToggle';
 import { getRatingChipClasses, getRatingLabel, RatingValueIcons } from './RatingStars';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
+import { normalizeCollectionTagNames } from '../services/imageAnnotationsStorage';
 
 type TagContextMenuState = {
   x: number;
@@ -295,11 +296,16 @@ const TagsAndFavorites: React.FC = () => {
       return;
     }
 
-    const normalizedTag = collectionSourceTag.trim().toLowerCase();
+    const normalizedTag = normalizeCollectionTagNames(collectionSourceTag).join(', ');
+    const normalizedTags = normalizeCollectionTagNames(collectionSourceTag);
     const snapshotImageIds = values.autoUpdate
       ? []
       : images
-          .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedTag))
+          .filter(
+            (image) =>
+              Array.isArray(image.tags) &&
+              normalizedTags.some((tag) => image.tags.includes(tag)),
+          )
           .map((image) => image.id);
 
     await createCollection({

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,50 +5,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.0] - 2026-04-06
+## [0.14.1] - Unreleased
 
 ### Added
 
-- **Visual ComfyUI Workflow Inspector**: Added a visual node-based editor inside both the ComfyUI generation modal and the Image Details Modal, with zoom/pan controls, editable node fields, embedded-layout support, and an advanced JSON fallback for debugging edge cases.
-- **ComfyUI Node View**: Added a dedicated `Node View` alongside Library, Smart Library, and Model View, with exact node-type catalogs, per-node result counts, search, and multi-select OR filtering for images containing embedded ComfyUI workflows.
-- **Image Lineage for Transformations**: Added explicit lineage support for `img2img`, `inpaint`, and `outpaint`, so transformed images are no longer treated as generic generations. The viewer now shows generation type, source/input image status, denoise strength when available, and direct navigation between source and result when the original image can be recovered confidently.
-- **Analytics Explorer**: Rebuilt analytics as an interactive explorer with `Overview`, `Resources`, `Time`, `Performance`, and `Curation` views, scope switching between current results and full library, cohort comparison tools, and one-click promotion of insights into live filters.
-- **Windowed Image Viewer**: Added support for multiple open image windows with drag, resize, minimize/maximize, and dockable or collapsible details for more flexible comparison and inspection.
-- **Image Ratings**: Added persistent 1-5 ratings for images, including viewer controls, library badges, bulk rating actions, and multi-select rating filters in the sidebar and advanced filters.
-- **Startup Verification Modes**: Added configurable startup verification modes for saved folders, allowing the app to open from cache only, reconcile in the background, or verify folders strictly before startup completes.
-- **Manual Tag Management**: Added a persistent manual tag catalog so empty tags remain visible in the sidebar, along with right-click tag actions for renaming, clearing tags from images, removing unused tags, and clearing or deleting used tags.
+- **Collections View**: Added a dedicated `Collections` tab for building reusable image groups across indexed folders, with support for manual collections, tag-driven auto-updating collections, collection ordering, cover images, and collection management from the main workspace.
+
+### Fixed
+
+- **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+
+## [0.14.0] - Unreleased
+
+### Added
+
+- **Visual ComfyUI Workflow Inspector**: Added a visual node-based editor inside the ComfyUI generation modal and Image Details Modal, with zoom/pan controls, editable node fields, embedded-layout support, and an advanced JSON fallback for debugging edge cases.
+- **ComfyUI Node View**: Added a dedicated `Node View` alongside Library, Smart Library, and Model View, with searchable exact node-type catalogs, per-node result counts, and multi-select OR filtering for images that contain embedded ComfyUI workflows.
+- **Image Lineage for Transformations**: Added explicit lineage support for `img2img`, `inpaint`, and `outpaint`, so transformed images are no longer treated as generic generations. The viewer now shows the generation type, source/input image status, denoise strength when available, and direct navigation between source and result when the original image can be recovered with confidence.
+- **Analytics Explorer**: Rebuilt analytics into an interactive explorer with `Overview`, `Resources`, `Time`, `Performance`, and `Curation` views, scope switching between the current results and full library, cohort comparison tools, and one-click promotion of analytics insights into live filters.
+- **Windowed Image Viewer**: Added support for multiple open image windows with drag, resize, minimize/maximize, and dockable or collapsible details so images can be compared and inspected more flexibly.
+- **Image Ratings**: Added persistent 1-5 ratings for images, including star controls in the viewer, badges in the library views, bulk rating actions, and multi-select rating filters in the sidebar and advanced filters.
+- **Startup Verification Modes**: Added configurable startup verification modes for saved folders, so the app can now open from cache only, reconcile in the background, or verify folders strictly before startup completes.
+- **Manual Tag Management**: Added a persistent manual tag catalog so empty tags remain visible in the sidebar, plus right-click tag actions for renaming, clearing tags from images, removing unused tags, and clearing/deleting used tags in one step.
 - **Metadata Type Filters**: Added checkbox filters for `txt2img` / `img2img` generation modes and `Images` / `Videos` file types in `Metadata & File Filters`.
-- **Manual Metadata Recovery**: Added `Reparse Metadata` actions for single images and multi-selection workflows, reprocessing only the chosen files without requiring a full folder refresh or cache clear.
+- **Manual Metadata Recovery**: Added `Reparse Metadata` actions for single images and multi-selection workflows, reprocessing only the chosen files and updating their cached metadata without requiring a full folder refresh or cache clear.
 - **Expanded Compare View**: Added support for comparing up to 4 images at once, with new `Side Strip` and `2x2 Grid` layouts for 3-4 image sets, plus improved Compare integration with the windowed viewer workflow.
 
 ### Improved
 
-- **Electron Privileged IPC Hardening**: Restricted renderer-driven write operations to app-internal paths or user-approved export destinations, tightened generator launch requests to match saved integration settings, and limited test-only update dialog exposure to development builds.
-- **Offline License Integrity**: Revalidated persisted Pro/Lifetime state on startup, removed the temporary "unlock during initialization" window for paid features, and limited the `IMH_DEV_LICENSE` shortcut to development builds.
+- **Electron Privileged IPC Hardening**: Restricted renderer-driven write operations to app-internal paths or user-approved export destinations, tightened generator launch requests so they must match the saved integration settings, and limited test-only update dialog exposure to development builds.
+- **Offline License Integrity**: Revalidated persisted Pro/Lifetime state on startup, removed the temporary "unlock during initialization" window for paid features, and limited the `IMH_DEV_LICENSE` shortcut to development builds only.
 - **Background Worker Guardrails**: Added validation and sane limits for clustering and auto-tagging worker payloads so malformed or extreme jobs fail fast instead of consuming excessive CPU or memory.
 - **ComfyUI Variation Controls**: Expanded the ComfyUI generation modal with workflow mode selection, model-family aware resource overrides, LoRA controls, source image policy for transform workflows, and better handling for original-graph assets.
-- **Favorites Icon Refresh**: Replaced favorite stars with heart icons to clearly distinguish favorites from ratings.
+- **Favorites Icon Refresh**: Updated favorite actions and indicators to use a heart icon instead of a star for clearer separation from the new rating system.
 - **Sidebar Faceted Filters**: Reworked the sidebar filter experience around dedicated facet sections for checkpoints, LoRAs, samplers, and schedulers, with per-value include/exclude actions, result counts, in-section search, and clearer active-filter chips.
-- **Tag Match Mode**: Added an `Any / All` toggle for included manual tag filters in the sidebar, allowing searches to match any selected tag or require all selected tags.
-- **Large Library Responsiveness**: Improved responsiveness on large libraries by moving lineage resolution out of the image modal hot path, reducing expensive modal navigation lookups, and cutting renderer churn during indexing and filtering.
+- **Tag Match Mode**: Added an `Any / All` toggle for included manual tag filters in the sidebar, allowing tag searches to match any selected tag or require all selected tags for narrower curation workflows.
+- **Large Library Responsiveness**: Significantly improved responsiveness for large libraries by moving lineage resolution out of the image modal hot path, reducing expensive modal navigation lookups, and cutting renderer churn during indexing and filtering.
 - **Cached Startup Stability**: Reduced reopen instability on large libraries and made startup verification less intrusive by default, improving launches from cache on heavy libraries.
-- **Sidebar Visual Cohesion**: Simplified sidebar styling into a more consistent, subdued visual system and made the `Generation Parameters` section collapsible like the other filter groups.
-- **Resizable Side Panels**: The left filter sidebar, Image Preview sidebar, generation queue, and Image Details Modal sidebar can now be resized by dragging their edges for a more adaptable workspace.
-- **Generation Queue Compatibility**: Updated the generation queue to persist and retry the new workflow-native ComfyUI parameters, including workflow mode, source image policy, advanced JSON overrides, and mask inputs.
+- **Sidebar Visual Cohesion**: Simplified the sidebar styling into a more consistent, subdued visual system and made the `Generation Parameters` section collapsible like the other filter groups.
+- **Resizable Side Panels**: The left filter sidebar, Image Preview sidebar, generation queue, and Image Details Modal sidebar can now be resized by dragging their edges, with widths preserved between sessions for a more adaptable workspace.
+- **Generation Queue Compatibility**: Updated the existing generation queue to persist and retry the new workflow-native ComfyUI parameters, including workflow mode, source image policy, advanced JSON overrides, and mask inputs.
 - **Cross-Generator Transformation Detection**: Improved metadata parsing for ComfyUI, Automatic1111, Forge, SD.Next, InvokeAI, and Draw Things to detect transformation workflows more reliably, preserve lineage references during indexing, and surface img2img-specific parameters in a normalized way.
-- **Sampler & Scheduler Faceting**: Added sampler-aware caching and filtering support so sampler and scheduler metadata can be browsed more accurately from the sidebar and advanced filters.
-- **Analytics Cohorts & Coverage**: Improved analytics summaries to account more accurately for favorites, ratings, GPU devices, telemetry presence, and bucketed performance ranges, making curation and performance comparisons more useful on mixed libraries.
+- **Generator Faceting**: Added sampler-aware caching and filtering support so sampler and scheduler metadata can be browsed more accurately from the sidebar and advanced filters.
+- **Analytics Cohorts & Coverage**: Analytics summaries now account for favorites, ratings, GPU devices, telemetry presence, and bucketed performance ranges more accurately, making curation and performance comparisons more useful on mixed libraries.
 - **Task-Based Settings Navigation**: Reorganized the Settings modal into focused Library, Viewer, Integrations, Appearance, Privacy, and Shortcuts panels with sidebar navigation and compatibility for legacy deep links.
-- **Lineage Fallback Clarity**: When a transformation is detected but the original image cannot be recovered confidently, the UI now says so explicitly instead of implying a weak match.
+- **Lineage Fallback Clarity**: When a transformation is detected but the original image cannot be recovered with confidence, the UI now states that clearly instead of implying a weak or uncertain match.
 - **Grid Filename Readability**: Thumbnail captions now support a two-line layout, making long filenames and full-path display more usable without requiring fullscreen zoom.
-- **Copy Submenu in Grid Context Menu**: Grouped grid copy actions under a `Copy` submenu, including prompt, negative prompt, seed, and checkpoint.
+- **Copy Submenu in Grid Context Menu**: Grouped copy actions under a `Copy` submenu in the image grid, including prompt, negative prompt, seed, and checkpoint.
 - **Cross-Platform Path Handling**: Replaced hardcoded Windows path joins in Electron viewer utilities with platform-aware path resolution to keep desktop-only actions working more reliably on macOS and Linux.
 
 ### Fixed
 
-- **ComfyUI Payload Parsing Safety**: Added size limits around base64 decode, regex fallback scanning, and zlib inflate paths to prevent oversized metadata payloads from causing memory or responsiveness spikes during parsing and indexing.
+- **ComfyUI Payload Parsing Safety**: Added size limits around base64 decode, regex fallback scanning, and zlib inflate paths to avoid oversized metadata payloads causing memory or responsiveness spikes during parsing and indexing.
 - **Watcher Lifecycle IPC**: File watcher notifications now guard against destroyed renderer windows before sending events, avoiding shutdown-time errors and stray IPC churn.
-- **Deduplication Helper Feedback**: Applying or clearing deduplication suggestions now surfaces visible success or error feedback instead of failing silently in the UI.
+- **Deduplication Helper Feedback**: Applying or clearing deduplication suggestions now surfaces visible success/error feedback instead of failing silently in the UI.
 - **Electron Window Restore**: The desktop window now reopens on the last monitor with the previous size and position when that display is still available, while safely falling back to a visible screen when monitor layouts change.
 - **Startup Folder Reconciliation**: Cached folders are now silently reconciled against disk on launch, so files created while the app was closed are indexed automatically instead of requiring a manual folder refresh.
 - **Open-Ended Advanced Ranges**: Step and CFG filters now preserve min-only or max-only searches instead of dropping partially filled ranges.

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -41,14 +41,23 @@ function normalizeManualTagName(tagName: string): string {
   return tagName.trim().toLowerCase();
 }
 
-const normalizeCollectionTagName = (tagName: string | null | undefined): string | null => {
-  if (typeof tagName !== 'string') {
-    return null;
+export const normalizeCollectionTagNames = (tagNames: string | null | undefined): string[] => {
+  if (typeof tagNames !== 'string') {
+    return [];
   }
 
-  const normalized = tagName.trim().toLowerCase();
-  return normalized.length > 0 ? normalized : null;
+  return Array.from(
+    new Set(
+      tagNames
+        .split(',')
+        .map((tagName) => tagName.trim().toLowerCase())
+        .filter((tagName) => tagName.length > 0),
+    ),
+  );
 };
+
+const serializeCollectionTagNames = (tagNames: string[]): string | null =>
+  tagNames.length > 0 ? tagNames.join(', ') : null;
 
 const uniqueImageIds = (imageIds: unknown): string[] => {
   if (!Array.isArray(imageIds)) {
@@ -946,7 +955,7 @@ export function normalizeSmartCollection(
 ): SmartCollection {
   const imageIds = uniqueImageIds(collection.imageIds);
   const snapshotImageIds = uniqueImageIds(collection.snapshotImageIds);
-  const sourceTag = normalizeCollectionTagName(collection.sourceTag);
+  const sourceTag = serializeCollectionTagNames(normalizeCollectionTagNames(collection.sourceTag));
   const kind = collection.kind === 'tag_rule' ? 'tag_rule' : 'manual';
   const autoUpdate = kind === 'tag_rule' ? collection.autoUpdate !== false : false;
   const coverImageId =
@@ -989,15 +998,19 @@ export function resolveSmartCollectionImageIds(collection: SmartCollection, imag
   }
 
   if (collection.autoUpdate !== false) {
-    const sourceTag = normalizeCollectionTagName(collection.sourceTag);
-    if (!sourceTag) {
+    const sourceTags = normalizeCollectionTagNames(collection.sourceTag);
+    if (sourceTags.length === 0) {
       return manualImageIds;
     }
 
     return uniqueImageIds([
       ...manualImageIds,
       ...images
-        .filter((image) => Array.isArray(image.tags) && image.tags.includes(sourceTag))
+        .filter(
+          (image) =>
+            Array.isArray(image.tags) &&
+            sourceTags.some((sourceTag) => image.tags.includes(sourceTag)),
+        )
         .map((image) => image.id),
     ]);
   }

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -1199,11 +1199,19 @@ export async function removeImagesFromSmartCollection(
 ): Promise<SmartCollection> {
   const targetIdSet = new Set(uniqueImageIds(imageIds));
   const nextIds = uniqueImageIds(collection.imageIds).filter((imageId) => !targetIdSet.has(imageId));
+  const nextSnapshotIds = uniqueImageIds(collection.snapshotImageIds).filter(
+    (imageId) => !targetIdSet.has(imageId),
+  );
+  const nextImageCount =
+    collection.kind === 'tag_rule' && collection.autoUpdate === false
+      ? uniqueImageIds([...nextIds, ...nextSnapshotIds]).length
+      : nextIds.length;
   const nextCollection = normalizeSmartCollection(
     {
       ...collection,
       imageIds: nextIds,
-      imageCount: nextIds.length,
+      snapshotImageIds: nextSnapshotIds,
+      imageCount: nextImageCount,
       updatedAt: Date.now(),
     },
     collection.sortIndex,

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -982,22 +982,27 @@ export function normalizeSmartCollection(
 }
 
 export function resolveSmartCollectionImageIds(collection: SmartCollection, images: IndexedImage[]): string[] {
+  const manualImageIds = uniqueImageIds(collection.imageIds);
+
   if (collection.kind === 'manual') {
-    return uniqueImageIds(collection.imageIds);
+    return manualImageIds;
   }
 
   if (collection.autoUpdate !== false) {
     const sourceTag = normalizeCollectionTagName(collection.sourceTag);
     if (!sourceTag) {
-      return [];
+      return manualImageIds;
     }
 
-    return images
-      .filter((image) => Array.isArray(image.tags) && image.tags.includes(sourceTag))
-      .map((image) => image.id);
+    return uniqueImageIds([
+      ...manualImageIds,
+      ...images
+        .filter((image) => Array.isArray(image.tags) && image.tags.includes(sourceTag))
+        .map((image) => image.id),
+    ]);
   }
 
-  return uniqueImageIds(collection.snapshotImageIds);
+  return uniqueImageIds([...manualImageIds, ...uniqueImageIds(collection.snapshotImageIds)]);
 }
 
 export function resolveSmartCollectionImages(collection: SmartCollection, images: IndexedImage[]): IndexedImage[] {

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom" />
 
-import type { ClusterPreference, ImageAnnotations, ShadowMetadata, SmartCollection, TagInfo } from '../types';
+import type { ClusterPreference, ImageAnnotations, IndexedImage, ShadowMetadata, SmartCollection, TagInfo } from '../types';
 import {
   getIndexedDbErrorName,
   openPreferencesDatabase,
@@ -40,6 +40,29 @@ function disablePersistence(error?: unknown) {
 function normalizeManualTagName(tagName: string): string {
   return tagName.trim().toLowerCase();
 }
+
+const normalizeCollectionTagName = (tagName: string | null | undefined): string | null => {
+  if (typeof tagName !== 'string') {
+    return null;
+  }
+
+  const normalized = tagName.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+};
+
+const uniqueImageIds = (imageIds: unknown): string[] => {
+  if (!Array.isArray(imageIds)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      imageIds
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+        .map((value) => value.trim()),
+    ),
+  );
+};
 
 async function openDatabase({ allowReset = true }: { allowReset?: boolean } = {}): Promise<IDBDatabase | null> {
   const db = await openPreferencesDatabase({
@@ -917,6 +940,77 @@ export async function markForArchive(clusterId: string, imageIds: string[]): Pro
 
 // ===== Smart Collections Functions (Phase 1) =====
 
+export function normalizeSmartCollection(
+  collection: Partial<SmartCollection> & Pick<SmartCollection, 'id' | 'name' | 'createdAt' | 'updatedAt'>,
+  fallbackSortIndex = 0,
+): SmartCollection {
+  const imageIds = uniqueImageIds(collection.imageIds);
+  const snapshotImageIds = uniqueImageIds(collection.snapshotImageIds);
+  const sourceTag = normalizeCollectionTagName(collection.sourceTag);
+  const kind = collection.kind === 'tag_rule' ? 'tag_rule' : 'manual';
+  const autoUpdate = kind === 'tag_rule' ? collection.autoUpdate !== false : false;
+  const coverImageId =
+    typeof collection.coverImageId === 'string'
+      ? collection.coverImageId
+      : typeof collection.thumbnailId === 'string'
+      ? collection.thumbnailId
+      : null;
+  const normalizedCount = Number.isFinite(collection.imageCount)
+    ? Math.max(0, Number(collection.imageCount))
+    : kind === 'tag_rule'
+    ? (autoUpdate ? 0 : snapshotImageIds.length)
+    : imageIds.length;
+
+  return {
+    id: collection.id,
+    kind,
+    name: collection.name.trim(),
+    description: collection.description?.trim() || undefined,
+    coverImageId,
+    sortIndex: Number.isFinite(collection.sortIndex) ? Number(collection.sortIndex) : fallbackSortIndex,
+    sourceTag,
+    autoUpdate,
+    imageIds,
+    snapshotImageIds,
+    imageCount: normalizedCount,
+    thumbnailId: coverImageId ?? undefined,
+    createdAt: collection.createdAt,
+    updatedAt: collection.updatedAt,
+    type: collection.type,
+    query: collection.query,
+  };
+}
+
+export function resolveSmartCollectionImageIds(collection: SmartCollection, images: IndexedImage[]): string[] {
+  if (collection.kind === 'manual') {
+    return uniqueImageIds(collection.imageIds);
+  }
+
+  if (collection.autoUpdate !== false) {
+    const sourceTag = normalizeCollectionTagName(collection.sourceTag);
+    if (!sourceTag) {
+      return [];
+    }
+
+    return images
+      .filter((image) => Array.isArray(image.tags) && image.tags.includes(sourceTag))
+      .map((image) => image.id);
+  }
+
+  return uniqueImageIds(collection.snapshotImageIds);
+}
+
+export function resolveSmartCollectionImages(collection: SmartCollection, images: IndexedImage[]): IndexedImage[] {
+  const imageLookup = new Map(images.map((image) => [image.id, image]));
+  return resolveSmartCollectionImageIds(collection, images)
+    .map((imageId) => imageLookup.get(imageId))
+    .filter((image): image is IndexedImage => Boolean(image));
+}
+
+export function resolveSmartCollectionImageCount(collection: SmartCollection, images: IndexedImage[]): number {
+  return resolveSmartCollectionImageIds(collection, images).length;
+}
+
 /**
  * Get smart collection by ID
  */
@@ -929,7 +1023,10 @@ export async function getSmartCollection(id: string): Promise<SmartCollection | 
     const store = transaction.objectStore(SMART_COLLECTIONS_STORE_NAME);
     const request = store.get(id);
 
-    request.onsuccess = () => resolve(request.result || null);
+    request.onsuccess = () => {
+      const result = request.result as SmartCollection | undefined;
+      resolve(result ? normalizeSmartCollection(result) : null);
+    };
     request.onerror = () => {
       console.error('Error getting smart collection:', request.error);
       resolve(null);
@@ -944,12 +1041,18 @@ export async function saveSmartCollection(collection: SmartCollection): Promise<
   const db = await openDatabase();
   if (!db) return;
 
-  collection.updatedAt = Date.now();
+  const normalizedCollection = normalizeSmartCollection(
+    {
+      ...collection,
+      updatedAt: Date.now(),
+    },
+    collection.sortIndex,
+  );
 
   return new Promise((resolve, reject) => {
     const transaction = db.transaction([SMART_COLLECTIONS_STORE_NAME], 'readwrite');
     const store = transaction.objectStore(SMART_COLLECTIONS_STORE_NAME);
-    const request = store.put(collection);
+    const request = store.put(normalizedCollection);
 
     request.onsuccess = () => resolve();
     request.onerror = () => {
@@ -991,7 +1094,19 @@ export async function getAllSmartCollections(): Promise<SmartCollection[]> {
     const store = transaction.objectStore(SMART_COLLECTIONS_STORE_NAME);
     const request = store.getAll();
 
-    request.onsuccess = () => resolve(request.result || []);
+    request.onsuccess = () => {
+      const collections = ((request.result || []) as SmartCollection[])
+        .map((collection, index) => normalizeSmartCollection(collection, index))
+        .sort((a, b) => {
+          const sortDelta = a.sortIndex - b.sortIndex;
+          if (sortDelta !== 0) {
+            return sortDelta;
+          }
+          return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+        });
+
+      resolve(collections);
+    };
     request.onerror = () => {
       console.error('Error getting all smart collections:', request.error);
       resolve([]);
@@ -1012,12 +1127,72 @@ export async function getSmartCollectionsByType(type: SmartCollection['type']): 
     const index = store.index('type');
     const request = index.getAll(type);
 
-    request.onsuccess = () => resolve(request.result || []);
+    request.onsuccess = () =>
+      resolve(
+        ((request.result || []) as SmartCollection[]).map((collection, index) =>
+          normalizeSmartCollection(collection, index),
+        ),
+      );
     request.onerror = () => {
       console.error('Error getting smart collections by type:', request.error);
       resolve([]);
     };
   });
+}
+
+export async function reorderSmartCollections(collections: SmartCollection[]): Promise<SmartCollection[]> {
+  const normalizedCollections = collections.map((collection, index) =>
+    normalizeSmartCollection(
+      {
+        ...collection,
+        sortIndex: index,
+        updatedAt: Date.now(),
+      },
+      index,
+    ),
+  );
+
+  await Promise.all(normalizedCollections.map((collection) => saveSmartCollection(collection)));
+  return normalizedCollections;
+}
+
+export async function addImagesToSmartCollection(
+  collection: SmartCollection,
+  imageIds: string[],
+): Promise<SmartCollection> {
+  const targetIds = uniqueImageIds(imageIds);
+  const nextCollection = normalizeSmartCollection(
+    {
+      ...collection,
+      imageIds: [...uniqueImageIds(collection.imageIds), ...targetIds],
+      imageCount: uniqueImageIds([...(collection.imageIds ?? []), ...targetIds]).length,
+      updatedAt: Date.now(),
+    },
+    collection.sortIndex,
+  );
+
+  await saveSmartCollection(nextCollection);
+  return nextCollection;
+}
+
+export async function removeImagesFromSmartCollection(
+  collection: SmartCollection,
+  imageIds: string[],
+): Promise<SmartCollection> {
+  const targetIdSet = new Set(uniqueImageIds(imageIds));
+  const nextIds = uniqueImageIds(collection.imageIds).filter((imageId) => !targetIdSet.has(imageId));
+  const nextCollection = normalizeSmartCollection(
+    {
+      ...collection,
+      imageIds: nextIds,
+      imageCount: nextIds.length,
+      updatedAt: Date.now(),
+    },
+    collection.sortIndex,
+  );
+
+  await saveSmartCollection(nextCollection);
+  return nextCollection;
 }
 
 // ===== Shadow Metadata Functions =====

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,32 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .app-top-segmented {
+    @apply inline-flex items-center gap-1 rounded-xl border border-gray-700/70 bg-gray-900/60 p-1;
+  }
+
+  .app-top-segment {
+    @apply inline-flex h-9 items-center gap-2 rounded-lg border border-transparent px-3 text-xs font-semibold text-gray-400 transition-colors duration-200 hover:bg-gray-800/80 hover:text-gray-100;
+  }
+
+  .app-top-segment-active {
+    @apply border-accent/40 bg-accent/15 text-gray-50 shadow-sm;
+  }
+
+  .app-top-pill {
+    @apply inline-flex h-9 items-center gap-2 rounded-lg border border-gray-700/70 bg-gray-900/60 px-3 text-xs font-semibold text-gray-300 transition-colors duration-200 hover:border-gray-600 hover:bg-gray-800/80 hover:text-gray-100;
+  }
+
+  .app-top-icon-button {
+    @apply inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-700/70 bg-gray-900/60 text-gray-400 transition-colors duration-200 hover:border-gray-600 hover:bg-gray-800/80 hover:text-gray-100;
+  }
+
+  .app-top-divider {
+    @apply h-5 w-px bg-gray-800/80;
+  }
+}
+
 .masonry-grid {
   display: -webkit-box;
   display: -ms-flexbox;

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, AutoTag, IndexedImageTransferProgress, InclusionFilterMode, ImageRating, type AdvancedFilters, type FilterOptions, type SelectedFiltersUpdate, type TagMatchMode } from '../types';
+import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, AutoTag, IndexedImageTransferProgress, InclusionFilterMode, ImageRating, SmartCollection, type AdvancedFilters, type FilterOptions, type SelectedFiltersUpdate, type TagMatchMode } from '../types';
 import { loadSelectedFolders, saveSelectedFolders, loadExcludedFolders, saveExcludedFolders } from '../services/folderSelectionStorage';
 import {
   loadAllAnnotations,
@@ -9,6 +9,16 @@ import {
   ensureManualTagExists,
   renameManualTag,
   deleteManualTag,
+  addImagesToSmartCollection,
+  deleteSmartCollection,
+  getAllSmartCollections,
+  normalizeSmartCollection,
+  removeImagesFromSmartCollection,
+  reorderSmartCollections,
+  resolveSmartCollectionImageCount,
+  resolveSmartCollectionImageIds,
+  resolveSmartCollectionImages,
+  saveSmartCollection,
 } from '../services/imageAnnotationsStorage';
 import { normalizeFacetValue, sanitizeIndexedImageFacets } from '../utils/facetNormalization';
 import { parseLocalDateFilterEndExclusive, parseLocalDateFilterStart } from '../utils/dateFilterUtils';
@@ -217,6 +227,29 @@ const renameAnnotationTag = (tags: string[], sourceTag: string, targetTag: strin
     return Array.from(new Set(tags.map(tag => tag === normalizedSource ? normalizedTarget : tag)));
 };
 
+const sortCollections = (collections: SmartCollection[]): SmartCollection[] =>
+    [...collections].sort((a, b) => {
+        const sortDelta = a.sortIndex - b.sortIndex;
+        if (sortDelta !== 0) {
+            return sortDelta;
+        }
+
+        return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    });
+
+const syncCollectionCounts = (collections: SmartCollection[], images: IndexedImage[]): SmartCollection[] =>
+    sortCollections(
+        collections.map((collection, index) =>
+            normalizeSmartCollection(
+                {
+                    ...collection,
+                    imageCount: resolveSmartCollectionImageCount(collection, images),
+                },
+                Number.isFinite(collection.sortIndex) ? collection.sortIndex : index,
+            ),
+        ),
+    );
+
 const normalizePath = (path: string) => {
     if (!path) return '';
     return path.replace(/\\/g, '/').replace(/[\\/]+$/, '');
@@ -344,6 +377,8 @@ interface ImageState {
   selectedImage: IndexedImage | null;
   selectedImages: Set<string>;
   activeImageScope: IndexedImage[] | null;
+  collections: SmartCollection[];
+  activeCollectionId: string | null;
   previewImage: IndexedImage | null;
   focusedImageIndex: number | null;
   isStackingEnabled: boolean;
@@ -473,6 +508,18 @@ interface ImageState {
   setPreviewImage: (image: IndexedImage | null) => void;
   setSelectedImage: (image: IndexedImage | null) => void;
   setActiveImageScope: (images: IndexedImage[] | null) => void;
+  loadCollections: () => Promise<void>;
+  createCollection: (collection: Omit<SmartCollection, 'id' | 'imageCount' | 'createdAt' | 'updatedAt'> & { id?: string }) => Promise<SmartCollection>;
+  updateCollection: (collectionId: string, updates: Partial<Omit<SmartCollection, 'id' | 'createdAt'>>) => Promise<SmartCollection | null>;
+  deleteCollectionById: (collectionId: string) => Promise<void>;
+  setActiveCollectionId: (collectionId: string | null) => void;
+  reorderCollections: (orderedCollectionIds: string[]) => Promise<void>;
+  addImagesToCollection: (collectionId: string, imageIds: string[]) => Promise<SmartCollection | null>;
+  removeImagesFromCollection: (collectionId: string, imageIds: string[]) => Promise<SmartCollection | null>;
+  getCollectionById: (collectionId: string) => SmartCollection | null;
+  getResolvedCollectionImages: (collectionId: string) => IndexedImage[];
+  getResolvedFilteredCollectionImages: (collectionId: string) => IndexedImage[];
+  getCollectionImageCount: (collectionId: string) => number;
   toggleImageSelection: (imageId: string) => void;
   selectAllImages: () => void;
   clearImageSelection: () => void;
@@ -1173,11 +1220,17 @@ export const useImageStore = create<ImageState>((set, get) => {
 
         // Then, recalculate available filters based on the filtered images (after folder selection)
         const availableFilters = recalculateAvailableFilters(filteredResult.filteredImages);
+        const syncedCollections = syncCollectionCounts(combinedState.collections, imagesWithAnnotations);
+        const activeCollectionId = syncedCollections.some((collection) => collection.id === combinedState.activeCollectionId)
+            ? combinedState.activeCollectionId
+            : null;
 
         return {
             ...combinedState,
             ...filteredResult,
             ...availableFilters,
+            collections: syncedCollections,
+            activeCollectionId,
             ...(imagesWithAnnotations.length === 0
                 ? {
                     lineageResolvedByImageId: {},
@@ -1690,6 +1743,8 @@ export const useImageStore = create<ImageState>((set, get) => {
         previewImage: null,
         selectedImages: new Set(),
         activeImageScope: null,
+        collections: [],
+        activeCollectionId: null,
         focusedImageIndex: null,
         isStackingEnabled: false,
         searchQuery: '',
@@ -2469,6 +2524,176 @@ export const useImageStore = create<ImageState>((set, get) => {
             }
             return { activeImageScope: images };
         }),
+        loadCollections: async () => {
+            const persistedCollections = await getAllSmartCollections();
+            set((state) => {
+                const collections = syncCollectionCounts(persistedCollections, state.images);
+                const activeCollectionId = collections.some((collection) => collection.id === state.activeCollectionId)
+                    ? state.activeCollectionId
+                    : collections[0]?.id ?? null;
+
+                return {
+                    collections,
+                    activeCollectionId,
+                };
+            });
+        },
+        createCollection: async (collection) => {
+            const state = get();
+            const nextCollection = normalizeSmartCollection(
+                {
+                    ...collection,
+                    id: collection.id ?? crypto.randomUUID(),
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                    imageCount: collection.kind === 'tag_rule'
+                        ? resolveSmartCollectionImageCount(collection as SmartCollection, state.images)
+                        : (collection.imageIds?.length ?? 0),
+                    sortIndex: Number.isFinite(collection.sortIndex) ? collection.sortIndex : state.collections.length,
+                },
+                state.collections.length,
+            );
+
+            await saveSmartCollection(nextCollection);
+
+            set((currentState) => {
+                const collections = syncCollectionCounts([...currentState.collections, nextCollection], currentState.images);
+                return {
+                    collections,
+                    activeCollectionId: nextCollection.id,
+                };
+            });
+
+            return nextCollection;
+        },
+        updateCollection: async (collectionId, updates) => {
+            const currentCollection = get().collections.find((collection) => collection.id === collectionId);
+            if (!currentCollection) {
+                return null;
+            }
+
+            const nextCollection = normalizeSmartCollection(
+                {
+                    ...currentCollection,
+                    ...updates,
+                    updatedAt: Date.now(),
+                },
+                currentCollection.sortIndex,
+            );
+
+            await saveSmartCollection(nextCollection);
+
+            set((state) => ({
+                collections: syncCollectionCounts(
+                    state.collections.map((collection) => collection.id === collectionId ? nextCollection : collection),
+                    state.images,
+                ),
+            }));
+
+            return nextCollection;
+        },
+        deleteCollectionById: async (collectionId) => {
+            await deleteSmartCollection(collectionId);
+
+            set((state) => {
+                const remainingCollections = syncCollectionCounts(
+                    state.collections.filter((collection) => collection.id !== collectionId),
+                    state.images,
+                );
+                const activeCollectionId = state.activeCollectionId === collectionId
+                    ? remainingCollections[0]?.id ?? null
+                    : state.activeCollectionId;
+
+                return {
+                    collections: remainingCollections,
+                    activeCollectionId,
+                };
+            });
+        },
+        setActiveCollectionId: (collectionId) => set((state) => ({
+            activeCollectionId: collectionId && state.collections.some((collection) => collection.id === collectionId)
+                ? collectionId
+                : null,
+        })),
+        reorderCollections: async (orderedCollectionIds) => {
+            const state = get();
+            const orderMap = new Map(orderedCollectionIds.map((collectionId, index) => [collectionId, index]));
+            const reordered = sortCollections(
+                state.collections.map((collection, index) =>
+                    normalizeSmartCollection(
+                        {
+                            ...collection,
+                            sortIndex: orderMap.get(collection.id) ?? (orderedCollectionIds.length + index),
+                        },
+                        index,
+                    ),
+                ),
+            );
+
+            const persistedCollections = await reorderSmartCollections(reordered);
+            set((currentState) => ({
+                collections: syncCollectionCounts(persistedCollections, currentState.images),
+            }));
+        },
+        addImagesToCollection: async (collectionId, imageIds) => {
+            const collection = get().collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return null;
+            }
+
+            const nextCollection = await addImagesToSmartCollection(collection, imageIds);
+            set((state) => ({
+                collections: syncCollectionCounts(
+                    state.collections.map((entry) => entry.id === collectionId ? nextCollection : entry),
+                    state.images,
+                ),
+            }));
+            return nextCollection;
+        },
+        removeImagesFromCollection: async (collectionId, imageIds) => {
+            const collection = get().collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return null;
+            }
+
+            const nextCollection = await removeImagesFromSmartCollection(collection, imageIds);
+            set((state) => ({
+                collections: syncCollectionCounts(
+                    state.collections.map((entry) => entry.id === collectionId ? nextCollection : entry),
+                    state.images,
+                ),
+            }));
+            return nextCollection;
+        },
+        getCollectionById: (collectionId) => get().collections.find((collection) => collection.id === collectionId) ?? null,
+        getResolvedCollectionImages: (collectionId) => {
+            const state = get();
+            const collection = state.collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return [];
+            }
+
+            return resolveSmartCollectionImages(collection, state.images);
+        },
+        getResolvedFilteredCollectionImages: (collectionId) => {
+            const state = get();
+            const collection = state.collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return [];
+            }
+
+            const visibleIds = new Set(state.filteredImages.map((image) => image.id));
+            return resolveSmartCollectionImages(collection, state.images).filter((image) => visibleIds.has(image.id));
+        },
+        getCollectionImageCount: (collectionId) => {
+            const state = get();
+            const collection = state.collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return 0;
+            }
+
+            return resolveSmartCollectionImageIds(collection, state.images).length;
+        },
         setFocusedImageIndex: (index) => set({ focusedImageIndex: index }),
         setFullscreenMode: (isFullscreen) => set({ isFullscreenMode: isFullscreen }),
 
@@ -3182,8 +3407,20 @@ export const useImageStore = create<ImageState>((set, get) => {
                 return;
             }
 
-            const { annotations } = get();
+            const { annotations, collections } = get();
             const updatedAnnotations: ImageAnnotations[] = [];
+            const updatedCollections = collections
+                .filter((collection) => collection.kind === 'tag_rule' && collection.sourceTag === normalizedSource)
+                .map((collection) =>
+                    normalizeSmartCollection(
+                        {
+                            ...collection,
+                            sourceTag: normalizedTarget,
+                            updatedAt: Date.now(),
+                        },
+                        collection.sortIndex,
+                    ),
+                );
 
             for (const annotation of annotations.values()) {
                 if (!annotation.tags.includes(normalizedSource)) {
@@ -3212,11 +3449,16 @@ export const useImageStore = create<ImageState>((set, get) => {
 
                 const filteredState = transferManualTagFilters(state, normalizedSource, normalizedTarget);
                 const updatedImages = applyAnnotationsToImages(state.images, newAnnotations);
+                const collectionMap = new Map(updatedCollections.map((collection) => [collection.id, collection]));
                 const newState = {
                     ...state,
                     ...filteredState,
                     annotations: newAnnotations,
                     images: updatedImages,
+                    collections: syncCollectionCounts(
+                        state.collections.map((collection) => collectionMap.get(collection.id) ?? collection),
+                        updatedImages,
+                    ),
                     recentTags: nextRecentTags,
                 };
 
@@ -3228,6 +3470,7 @@ export const useImageStore = create<ImageState>((set, get) => {
             await Promise.all([
                 updatedAnnotations.length > 0 ? bulkSaveAnnotations(updatedAnnotations) : Promise.resolve(),
                 renameManualTag(normalizedSource, normalizedTarget),
+                ...updatedCollections.map((collection) => saveSmartCollection(collection)),
             ]).catch(error => {
                 console.error('Failed to rename tag:', error);
             });
@@ -3606,6 +3849,8 @@ export const useImageStore = create<ImageState>((set, get) => {
             selectedImage: null,
             selectedImages: new Set(),
             activeImageScope: null,
+            collections: [],
+            activeCollectionId: null,
             searchQuery: '',
             availableModels: [],
             availableLoras: [],

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -13,6 +13,7 @@ import {
   deleteSmartCollection,
   getAllSmartCollections,
   normalizeSmartCollection,
+  normalizeCollectionTagNames,
   removeImagesFromSmartCollection,
   reorderSmartCollections,
   resolveSmartCollectionImageCount,
@@ -3410,12 +3411,20 @@ export const useImageStore = create<ImageState>((set, get) => {
             const { annotations, collections } = get();
             const updatedAnnotations: ImageAnnotations[] = [];
             const updatedCollections = collections
-                .filter((collection) => collection.kind === 'tag_rule' && collection.sourceTag === normalizedSource)
+                .filter((collection) => {
+                    if (collection.kind !== 'tag_rule') {
+                        return false;
+                    }
+
+                    return normalizeCollectionTagNames(collection.sourceTag).includes(normalizedSource);
+                })
                 .map((collection) =>
                     normalizeSmartCollection(
                         {
                             ...collection,
-                            sourceTag: normalizedTarget,
+                            sourceTag: normalizeCollectionTagNames(collection.sourceTag)
+                                .map((tag) => tag === normalizedSource ? normalizedTarget : tag)
+                                .join(', '),
                             updatedAt: Date.now(),
                         },
                         collection.sortIndex,

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -2530,7 +2530,7 @@ export const useImageStore = create<ImageState>((set, get) => {
                 const collections = syncCollectionCounts(persistedCollections, state.images);
                 const activeCollectionId = collections.some((collection) => collection.id === state.activeCollectionId)
                     ? state.activeCollectionId
-                    : collections[0]?.id ?? null;
+                    : null;
 
                 return {
                     collections,
@@ -2601,7 +2601,7 @@ export const useImageStore = create<ImageState>((set, get) => {
                     state.images,
                 );
                 const activeCollectionId = state.activeCollectionId === collectionId
-                    ? remainingCollections[0]?.id ?? null
+                    ? null
                     : state.activeCollectionId;
 
                 return {

--- a/types.ts
+++ b/types.ts
@@ -887,22 +887,11 @@ export interface AutoTag {
   sourceType: 'prompt' | 'metadata';  // Origin of tag
 }
 
-/**
- * Smart collection - virtual folder based on filters
- */
-export interface SmartCollection {
-  id: string;                      // Unique collection ID
-  name: string;                    // Display name
-  type: 'model' | 'style' | 'subject' | 'custom';  // Collection category
-  query: SmartCollectionQuery;     // Filter criteria
-  imageCount: number;              // Cached count
-  thumbnailId?: string;            // Cover image ID
-  createdAt: number;
-  updatedAt: number;
-}
+export type LegacySmartCollectionType = 'model' | 'style' | 'subject' | 'custom';
 
 /**
- * Query criteria for smart collections
+ * Query criteria for legacy smart collections.
+ * Kept optional for backward-compatible loading of older records.
  */
 export interface SmartCollectionQuery {
   models?: string[];
@@ -910,6 +899,32 @@ export interface SmartCollectionQuery {
   userTags?: string[];
   clusters?: string[];
   dateRange?: { from: number; to: number };
+}
+
+export type CollectionKind = 'manual' | 'tag_rule';
+
+/**
+ * Persisted collection record used by the Collections view.
+ */
+export interface SmartCollection {
+  id: string;                      // Unique collection ID
+  kind: CollectionKind;            // Manual or tag-driven collection
+  name: string;                    // Display name
+  description?: string;
+  coverImageId?: string | null;    // Explicit cover image
+  sortIndex: number;               // Manual ordering in the sidebar
+  sourceTag?: string | null;       // Tag source for tag_rule collections
+  autoUpdate?: boolean;            // Live tag membership toggle
+  imageIds?: string[];             // Explicit membership for manual collections
+  snapshotImageIds?: string[];     // Frozen membership for tag_rule collections
+  imageCount: number;              // Cached count for list rendering
+  thumbnailId?: string;            // Legacy alias for cover image
+  createdAt: number;
+  updatedAt: number;
+
+  // Legacy fields kept optional for backward-compatible loading.
+  type?: LegacySmartCollectionType;
+  query?: SmartCollectionQuery;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a first-class Collections workspace with sidebar browsing, card previews, collection detail view, and changelog notes for 0.14.1
- extend collection storage and app state to support explicit membership, optional tag-based auto-add rules, frozen snapshots, multi-tag matching, covers, and manual ordering
- add collection actions across the image grid, image table, image modal, tags sidebar, and selection toolbar so images can be added to existing collections or used to create new ones from the current context
- refine related UX details including clickable collection cards, toolbar collection actions, header polish, realtime collection filter updates, and submenu/context-menu interaction fixes

## Why
Collections need to work as a top-level organizing surface instead of feeling like an extension of tags or folders. This branch adds the missing creation and management flows, keeps the collection workflow consistent across the app, and fixes the interaction regressions that showed up while polishing the feature.

## User Impact
- users can create and browse collections directly from the top navigation
- collections can be populated manually, from filtered selections, or from auto-add tag rules
- collection management is available from the same places users already work: tags, grid, table, modal, and toolbar
- collection filtering and context menus now update and behave correctly in place

## Validation
- `npx tsc --noEmit`