### PR TITLE
Release 0.14.1 collections and tagging refinements

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ### Current Stack
 
-* **Version:** 0.14.0
+* **Version:** 0.14.1
 * **Renderer:** React 18 + TypeScript
 * **Desktop shell:** Electron 38
 * **State management:** Zustand

--- a/App.tsx
+++ b/App.tsx
@@ -1733,7 +1733,7 @@ export default function App() {
                     }}
                   />
                 )}
-                {(libraryView === 'library' || libraryView === 'node' || libraryView === 'collections') && (
+                {(libraryView === 'library' || libraryView === 'node' || (libraryView === 'collections' && Boolean(activeCollection))) && (
                   <GridToolbar
                     selectedImages={safeSelectedImages}
                     images={libraryView === 'node' ? nodeViewVisibleImages : paginatedImages}
@@ -1836,7 +1836,7 @@ export default function App() {
                 )}
               </div>
 
-              {(libraryView === 'library' || libraryView === 'collections') && (
+              {(libraryView === 'library' || (libraryView === 'collections' && Boolean(activeCollection))) && (
                 <Footer
                   currentPage={currentPage}
                   totalPages={totalPages}

--- a/App.tsx
+++ b/App.tsx
@@ -1372,7 +1372,7 @@ export default function App() {
     }
 
     return getResolvedCollectionImages(activeCollection.id);
-  }, [activeCollection, getResolvedCollectionImages]);
+  }, [activeCollection, getResolvedCollectionImages, safeImages]);
 
   const collectionFilteredImages = useMemo(() => {
     if (!activeCollection) {
@@ -1380,7 +1380,7 @@ export default function App() {
     }
 
     return getResolvedFilteredCollectionImages(activeCollection.id);
-  }, [activeCollection, getResolvedFilteredCollectionImages]);
+  }, [activeCollection, getResolvedFilteredCollectionImages, safeFilteredImages]);
 
   const displayImages = libraryView === 'collections' ? collectionFilteredImages : safeFilteredImages;
   const canSaveCurrentFilteredAsCollection = libraryView !== 'smart' && displayImages.length > 0;

--- a/App.tsx
+++ b/App.tsx
@@ -35,6 +35,7 @@ import CollectionsWorkspace from './components/CollectionsWorkspace';
 import GridToolbar from './components/GridToolbar';
 import AnalyticsSummaryStrip from './components/AnalyticsSummaryStrip';
 import BatchExportModal from './components/BatchExportModal';
+import CollectionFormModal, { CollectionFormValues } from './components/CollectionFormModal';
 import { useA1111ProgressContext } from './contexts/A1111ProgressContext';
 import { useGenerationQueueSync } from './hooks/useGenerationQueueSync';
 import { useGenerationQueueStore } from './store/useGenerationQueueStore';
@@ -238,6 +239,7 @@ export default function App() {
   const reshuffle = useImageStore((state) => state.reshuffle);
   const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
   const getResolvedFilteredCollectionImages = useImageStore((state) => state.getResolvedFilteredCollectionImages);
+  const createCollection = useImageStore((state) => state.createCollection);
 
   const safeImages = Array.isArray(images) ? images : [];
   const safeFilteredImages = Array.isArray(filteredImages) ? filteredImages : [];
@@ -340,6 +342,7 @@ export default function App() {
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
   const [newImagesToast, setNewImagesToast] = useState<{ count: number; directoryName: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
+  const [isSaveFilteredCollectionModalOpen, setIsSaveFilteredCollectionModalOpen] = useState(false);
   const [openImageModals, setOpenImageModals] = useState<OpenImageModalState[]>([]);
   const [activeImageModalId, setActiveImageModalId] = useState<string | null>(null);
   const lastOpenedModalImageIdRef = useRef<string | null>(null);
@@ -1379,6 +1382,7 @@ export default function App() {
   }, [activeCollection, getResolvedFilteredCollectionImages]);
 
   const displayImages = libraryView === 'collections' ? collectionFilteredImages : safeFilteredImages;
+  const canSaveCurrentFilteredAsCollection = libraryView !== 'smart' && displayImages.length > 0;
 
   useEffect(() => {
     const scopedTotalPages = Math.ceil(displayImages.length / itemsPerPage);
@@ -1493,6 +1497,31 @@ export default function App() {
       );
     });
   })();
+
+  const handleSaveCurrentFilteredAsCollection = useCallback(async (values: CollectionFormValues) => {
+    const targetImageIds = displayImages.map((image) => image.id);
+    const coverImageId = targetImageIds[0] ?? null;
+
+    const collection = await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: safeCollections.length,
+      imageIds: targetImageIds,
+      snapshotImageIds: [],
+      coverImageId,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: coverImageId ?? undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setIsSaveFilteredCollectionModalOpen(false);
+    setLibraryView('collections');
+    setSuccess(`Collection "${collection.name}" created.`);
+  }, [createCollection, displayImages, safeCollections.length, setSuccess]);
+
   const shouldShowLibraryPlaceholder =
     libraryView === 'library' &&
     safeFilteredImages.length === 0 &&
@@ -1647,6 +1676,21 @@ export default function App() {
           onLibraryViewChange={setLibraryView}
         />
 
+        <CollectionFormModal
+          isOpen={isSaveFilteredCollectionModalOpen}
+          title="Save as Collection"
+          submitLabel="Save Collection"
+          initialValues={{
+            name: '',
+            description: '',
+            sourceTag: '',
+            autoUpdate: false,
+            includeTargetImages: false,
+          }}
+          onClose={() => setIsSaveFilteredCollectionModalOpen(false)}
+          onSubmit={handleSaveCurrentFilteredAsCollection}
+        />
+
         <main className="mx-auto p-4 flex-1 flex flex-col min-h-0 w-full">
           {showGeneratorSetupNotice && (
             <div className="my-4 flex items-center justify-between gap-3 rounded-lg border border-blue-700/40 bg-blue-900/30 p-3 text-blue-100">
@@ -1738,6 +1782,12 @@ export default function App() {
                     selectedImages={safeSelectedImages}
                     images={libraryView === 'node' ? nodeViewVisibleImages : paginatedImages}
                     directories={safeDirectories}
+                    onSaveCurrentFilteredAsCollection={
+                      canSaveCurrentFilteredAsCollection
+                        ? () => setIsSaveFilteredCollectionModalOpen(true)
+                        : undefined
+                    }
+                    saveCurrentFilteredCount={displayImages.length}
                     onDeleteSelected={handleDeleteSelectedImages}
                     onGenerateA1111={(image) => {
                       setSelectedImageForGeneration(image);

--- a/App.tsx
+++ b/App.tsx
@@ -1811,6 +1811,8 @@ export default function App() {
                         onImageClick={handleImageSelection}
                         selectedImages={safeSelectedImages}
                         onBatchExport={handleOpenBatchExport}
+                        activeCollection={activeCollection}
+                        isCollectionsView
                       />
                     )}
                   </CollectionsWorkspace>

--- a/App.tsx
+++ b/App.tsx
@@ -338,6 +338,7 @@ export default function App() {
   const [isQueueOpen, setIsQueueOpen] = useState(false);
   const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node' | 'collections'>('library');
   const [nodeViewVisibleImages, setNodeViewVisibleImages] = useState<IndexedImage[]>([]);
+  const [nodeViewResultImages, setNodeViewResultImages] = useState<IndexedImage[]>([]);
   const [isA1111GenerateModalOpen, setIsA1111GenerateModalOpen] = useState(false);
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
@@ -357,6 +358,12 @@ export default function App() {
       setActiveImageScope(null);
     }
   }, [activeImageScope, libraryView, setActiveImageScope]);
+
+  useEffect(() => {
+    if (libraryView !== 'node' && nodeViewResultImages.length > 0) {
+      setNodeViewResultImages([]);
+    }
+  }, [libraryView, nodeViewResultImages.length]);
   const hasRightSidebar = Boolean(previewImage || isQueueOpen);
   const { leftWidth: sidebarWidth, rightWidth: rightSidebarWidth } = useMemo(
     () =>
@@ -1382,7 +1389,20 @@ export default function App() {
     return getResolvedFilteredCollectionImages(activeCollection.id);
   }, [activeCollection, getResolvedFilteredCollectionImages, safeFilteredImages]);
 
-  const displayImages = libraryView === 'collections' ? collectionFilteredImages : safeFilteredImages;
+  const handleNodeViewResultImagesChange = useCallback(
+    (images: IndexedImage[]) => {
+      setNodeViewResultImages(images);
+      setActiveImageScope(images);
+    },
+    [setActiveImageScope],
+  );
+
+  const displayImages =
+    libraryView === 'collections'
+      ? collectionFilteredImages
+      : libraryView === 'node'
+      ? nodeViewResultImages
+      : safeFilteredImages;
   const canSaveCurrentFilteredAsCollection = libraryView !== 'smart' && displayImages.length > 0;
 
   useEffect(() => {
@@ -1895,7 +1915,7 @@ export default function App() {
                     isQueueOpen={isQueueOpen}
                     onToggleQueue={() => setIsQueueOpen((prev) => !prev)}
                     onVisibleImagesChange={setNodeViewVisibleImages}
-                    onResultImagesChange={setActiveImageScope}
+                    onResultImagesChange={handleNodeViewResultImagesChange}
                   />
                 ) : (
                   <SmartLibrary

--- a/App.tsx
+++ b/App.tsx
@@ -31,6 +31,7 @@ import ProOnlyModal from './components/ProOnlyModal';
 import SmartLibrary from './components/SmartLibrary';
 import { ModelView } from './components/ModelView';
 import NodeView from './components/NodeView';
+import CollectionsWorkspace from './components/CollectionsWorkspace';
 import GridToolbar from './components/GridToolbar';
 import AnalyticsSummaryStrip from './components/AnalyticsSummaryStrip';
 import BatchExportModal from './components/BatchExportModal';
@@ -158,6 +159,8 @@ export default function App() {
   const clustersCount = useImageStore((state) => state.clusters.length);
   const clusterNavigationContext = useImageStore((state) => state.clusterNavigationContext);
   const activeImageScope = useImageStore((state) => state.activeImageScope);
+  const collections = useImageStore((state) => state.collections);
+  const activeCollectionId = useImageStore((state) => state.activeCollectionId);
 
   // Loading & progress selectors
   const isLoading = useImageStore((state) => state.isLoading);
@@ -229,14 +232,18 @@ export default function App() {
   const openComparisonModal = useImageStore((state) => state.openComparisonModal);
   const initializeFolderSelection = useImageStore((state) => state.initializeFolderSelection);
   const loadAnnotations = useImageStore((state) => state.loadAnnotations);
+  const loadCollections = useImageStore((state) => state.loadCollections);
   const imageStoreSetSortOrder = useImageStore((state) => state.setSortOrder);
   const sortOrder = useImageStore((state) => state.sortOrder);
   const reshuffle = useImageStore((state) => state.reshuffle);
+  const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
+  const getResolvedFilteredCollectionImages = useImageStore((state) => state.getResolvedFilteredCollectionImages);
 
   const safeImages = Array.isArray(images) ? images : [];
   const safeFilteredImages = Array.isArray(filteredImages) ? filteredImages : [];
   const safeClusterNavigationContext = Array.isArray(clusterNavigationContext) ? clusterNavigationContext : [];
   const safeActiveImageScope = Array.isArray(activeImageScope) ? activeImageScope : null;
+  const safeCollections = Array.isArray(collections) ? collections : [];
   const safeDirectories = Array.isArray(directories) ? directories : [];
   const safeSelectedImages = selectedImages instanceof Set ? selectedImages : new Set<string>();
   const hasDirectories = safeDirectories.length > 0;
@@ -326,7 +333,7 @@ export default function App() {
   const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false);
   const [currentVersion, setCurrentVersion] = useState<string>('0.10.0');
   const [isQueueOpen, setIsQueueOpen] = useState(false);
-  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node'>('library');
+  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node' | 'collections'>('library');
   const [nodeViewVisibleImages, setNodeViewVisibleImages] = useState<IndexedImage[]>([]);
   const [isA1111GenerateModalOpen, setIsA1111GenerateModalOpen] = useState(false);
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
@@ -342,7 +349,7 @@ export default function App() {
   );
 
   useEffect(() => {
-    if (libraryView !== 'node' && activeImageScope !== null) {
+    if (libraryView !== 'node' && libraryView !== 'collections' && activeImageScope !== null) {
       setActiveImageScope(null);
     }
   }, [activeImageScope, libraryView, setActiveImageScope]);
@@ -492,6 +499,10 @@ export default function App() {
       loadAnnotations();
     }
   }, [loadAnnotations, isAnnotationsLoaded]);
+
+  useEffect(() => {
+    loadCollections();
+  }, [loadCollections]);
 
   // Initialize license and keep trial opt-in
   useEffect(() => {
@@ -1346,19 +1357,57 @@ export default function App() {
     setIsBatchExportModalOpen(true);
   }, [canUseBatchExport, showProModal]);
 
+  const activeCollection = useMemo(
+    () => safeCollections.find((collection) => collection.id === activeCollectionId) ?? null,
+    [activeCollectionId, safeCollections],
+  );
+
+  const collectionTotalImages = useMemo(() => {
+    if (!activeCollection) {
+      return [];
+    }
+
+    return getResolvedCollectionImages(activeCollection.id);
+  }, [activeCollection, getResolvedCollectionImages]);
+
+  const collectionFilteredImages = useMemo(() => {
+    if (!activeCollection) {
+      return [];
+    }
+
+    return getResolvedFilteredCollectionImages(activeCollection.id);
+  }, [activeCollection, getResolvedFilteredCollectionImages]);
+
+  const displayImages = libraryView === 'collections' ? collectionFilteredImages : safeFilteredImages;
+
+  useEffect(() => {
+    const scopedTotalPages = Math.ceil(displayImages.length / itemsPerPage);
+    if (currentPage > scopedTotalPages && scopedTotalPages > 0) {
+      setCurrentPage(1);
+    }
+  }, [currentPage, displayImages.length, itemsPerPage]);
+
+  useEffect(() => {
+    if (libraryView !== 'collections') {
+      return;
+    }
+
+    setActiveImageScope(activeCollection ? collectionFilteredImages : null);
+  }, [activeCollection, collectionFilteredImages, libraryView, setActiveImageScope]);
+
   // --- Render Logic ---
   const paginatedImages = useMemo(
     () => {
       if (itemsPerPage === -1) {
-        return safeFilteredImages;
+        return displayImages;
       }
-      return safeFilteredImages.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
+      return displayImages.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
     },
-    [safeFilteredImages, currentPage, itemsPerPage]
+    [displayImages, currentPage, itemsPerPage]
   );
   const totalPages = itemsPerPage === -1
     ? 1
-    : Math.ceil(safeFilteredImages.length / itemsPerPage);
+    : Math.ceil(displayImages.length / itemsPerPage);
   const openImageModalEntries = useMemo(() => {
     return openImageModals
       .map((modal) => {
@@ -1484,7 +1533,7 @@ export default function App() {
         isOpen={isBatchExportModalOpen}
         onClose={() => setIsBatchExportModalOpen(false)}
         selectedImageIds={safeSelectedImages}
-        filteredImages={safeFilteredImages}
+        filteredImages={displayImages}
         directories={safeDirectories}
       />
 
@@ -1684,7 +1733,7 @@ export default function App() {
                     }}
                   />
                 )}
-                {(libraryView === 'library' || libraryView === 'node') && (
+                {(libraryView === 'library' || libraryView === 'node' || libraryView === 'collections') && (
                   <GridToolbar
                     selectedImages={safeSelectedImages}
                     images={libraryView === 'node' ? nodeViewVisibleImages : paginatedImages}
@@ -1739,6 +1788,32 @@ export default function App() {
                       setLibraryView('library');
                     }}
                   />
+                ) : libraryView === 'collections' ? (
+                  <CollectionsWorkspace
+                    filteredImages={collectionFilteredImages}
+                    totalImages={collectionTotalImages}
+                  >
+                    {viewMode === 'grid' ? (
+                      <ImageGrid
+                        images={paginatedImages}
+                        onImageClick={handleGridImageClick}
+                        selectedImages={safeSelectedImages}
+                        currentPage={currentPage}
+                        totalPages={totalPages}
+                        onPageChange={setCurrentPage}
+                        onBatchExport={handleOpenBatchExport}
+                        activeCollection={activeCollection}
+                        isCollectionsView
+                      />
+                    ) : (
+                      <ImageTable
+                        images={paginatedImages}
+                        onImageClick={handleImageSelection}
+                        selectedImages={safeSelectedImages}
+                        onBatchExport={handleOpenBatchExport}
+                      />
+                    )}
+                  </CollectionsWorkspace>
                 ) : libraryView === 'node' ? (
                   <NodeView
                     images={safeFilteredImages}
@@ -1759,7 +1834,7 @@ export default function App() {
                 )}
               </div>
 
-              {libraryView === 'library' && (
+              {(libraryView === 'library' || libraryView === 'collections') && (
                 <Footer
                   currentPage={currentPage}
                   totalPages={totalPages}
@@ -1768,9 +1843,13 @@ export default function App() {
                   onItemsPerPageChange={setItemsPerPage}
                   viewMode={viewMode}
                   onViewModeChange={toggleViewMode}
-                  filteredCount={safeFilteredImages.length}
-                  totalCount={selectionTotalImages}
-                  directoryCount={selectionDirectoryCount}
+                  filteredCount={displayImages.length}
+                  totalCount={libraryView === 'collections' ? collectionTotalImages.length : selectionTotalImages}
+                  directoryCount={
+                    libraryView === 'collections'
+                      ? new Set(collectionFilteredImages.map((image) => image.directoryId).filter(Boolean)).size
+                      : selectionDirectoryCount
+                  }
                   enrichmentProgress={enrichmentProgress}
                   a1111Progress={a1111Progress}
                   transferProgress={transferProgress}

--- a/App.tsx
+++ b/App.tsx
@@ -240,6 +240,7 @@ export default function App() {
   const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
   const getResolvedFilteredCollectionImages = useImageStore((state) => state.getResolvedFilteredCollectionImages);
   const createCollection = useImageStore((state) => state.createCollection);
+  const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
 
   const safeImages = Array.isArray(images) ? images : [];
   const safeFilteredImages = Array.isArray(filteredImages) ? filteredImages : [];
@@ -1522,6 +1523,20 @@ export default function App() {
     setSuccess(`Collection "${collection.name}" created.`);
   }, [createCollection, displayImages, safeCollections.length, setSuccess]);
 
+  const handleAddCurrentFilteredToCollection = useCallback(async (collectionId: string) => {
+    const targetImageIds = displayImages.map((image) => image.id);
+    if (targetImageIds.length === 0) {
+      return;
+    }
+
+    const collection = await addImagesToCollection(collectionId, targetImageIds);
+    if (!collection) {
+      return;
+    }
+
+    setSuccess(`Added ${targetImageIds.length} image${targetImageIds.length === 1 ? '' : 's'} to "${collection.name}".`);
+  }, [addImagesToCollection, displayImages, setSuccess]);
+
   const shouldShowLibraryPlaceholder =
     libraryView === 'library' &&
     safeFilteredImages.length === 0 &&
@@ -1782,12 +1797,17 @@ export default function App() {
                     selectedImages={safeSelectedImages}
                     images={libraryView === 'node' ? nodeViewVisibleImages : paginatedImages}
                     directories={safeDirectories}
-                    onSaveCurrentFilteredAsCollection={
+                    onCreateCollectionFromFiltered={
                       canSaveCurrentFilteredAsCollection
                         ? () => setIsSaveFilteredCollectionModalOpen(true)
                         : undefined
                     }
-                    saveCurrentFilteredCount={displayImages.length}
+                    onAddCurrentFilteredToCollection={
+                      canSaveCurrentFilteredAsCollection
+                        ? handleAddCurrentFilteredToCollection
+                        : undefined
+                    }
+                    filteredImageActionCount={displayImages.length}
                     onDeleteSelected={handleDeleteSelectedImages}
                     onGenerateA1111={(image) => {
                       setSelectedImageForGeneration(image);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Manual Collection Counts**: Fixed manual collection membership and counts so deleted or unindexed images no longer remain in resolved collection results.
 - **Collection Sort Ordering**: Fixed new collection ordering after deleted collections so sort indexes are allocated from the current maximum instead of reusing stale positions.
 - **Filtered Collection Reordering**: Fixed collection move buttons while searching collections so they reflect the collection's global order instead of the filtered list position.
+- **Tag Input Enter Behavior**: Fixed tag combobox Enter handling so typed tags submit as entered unless the user explicitly navigates to a suggestion first.
 - **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.
 - **Preview Sidebar Opening Unexpectedly**: Fixed the Image Preview sidebar opening by itself after search/filter changes or view switches by limiting automatic preview restoration to active grid keyboard navigation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.1] - Unreleased
+## [0.14.1] - 2026-04-10
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
 - **Live Collection Removal**: Fixed removing images from auto-updating tag collections so removed images stay excluded unless explicitly added back.
 - **Collection Settings Conversion**: Fixed clearing Auto-Add Tags in Collection Settings so tag-rule collections keep their currently resolved images when converted to manual collections.
+- **Frozen Collection Membership**: Fixed disabling auto-update on tag-driven collections so the frozen snapshot preserves the resolved, curated membership instead of reintroducing previously removed tag matches.
+- **Manual Collection Counts**: Fixed manual collection membership and counts so deleted or unindexed images no longer remain in resolved collection results.
 - **Collection Sort Ordering**: Fixed new collection ordering after deleted collections so sort indexes are allocated from the current maximum instead of reusing stale positions.
 - **Filtered Collection Reordering**: Fixed collection move buttons while searching collections so they reflect the collection's global order instead of the filtered list position.
 - **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.1] - Unreleased
 
+### Improved
+
+- **Unified Tag Entry UX**: Manual tag entry in `ImageModal`, `ImagePreviewSidebar`, and `Tag Manager` now shares the same suggestion combobox, keyboard navigation, mouse selection behavior, and match ranking, making tag suggestions feel consistent everywhere.
+- **Tagging Controls in Settings**: Added viewer settings for tag suggestion count and visible recent-tag chips, while keeping a larger internal recent-tag history so quick picks stay useful without overwhelming the UI.
+- **Safer Bulk Tag Suggestions**: The Tag Manager's comma-separated input now applies autocomplete only to the active CSV token, making multi-tag edits faster and less error-prone.
+
 ### Fixed
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+- **Sidebar Filter Layout Regression**: Restored the single-scroll sidebar flow after the experimental split-pane filter layout proved confusing and interfered with normal folder and tag browsing.
 
 ## [0.14.0] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+- **Live Collection Removal**: Fixed removing images from auto-updating tag collections so removed images stay excluded unless explicitly added back.
+- **Filtered Collection Reordering**: Fixed collection move buttons while searching collections so they reflect the collection's global order instead of the filtered list position.
 - **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.
 - **Preview Sidebar Opening Unexpectedly**: Fixed the Image Preview sidebar opening by itself after search/filter changes or view switches by limiting automatic preview restoration to active grid keyboard navigation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Collections View**: Added a dedicated `Collections` tab for building reusable image groups across indexed folders, with support for manual collections, tag-driven auto-updating collections, collection ordering, cover images, and collection management from the main workspace.
-- **Collection Creation Shortcuts**: Added `Create Collection` to the manual tag context menu plus `Collection` actions in both the grid and table context menus, including `Add to Collection`, `Create New Collection`, `Set as Cover`, and `Remove from Current Collection`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
 - **Live Collection Removal**: Fixed removing images from auto-updating tag collections so removed images stay excluded unless explicitly added back.
+- **Collection Settings Conversion**: Fixed clearing Auto-Add Tags in Collection Settings so tag-rule collections keep their currently resolved images when converted to manual collections.
+- **Collection Sort Ordering**: Fixed new collection ordering after deleted collections so sort indexes are allocated from the current maximum instead of reusing stale positions.
 - **Filtered Collection Reordering**: Fixed collection move buttons while searching collections so they reflect the collection's global order instead of the filtered list position.
 - **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.
 - **Preview Sidebar Opening Unexpectedly**: Fixed the Image Preview sidebar opening by itself after search/filter changes or view switches by limiting automatic preview restoration to active grid keyboard navigation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Collections View**: Added a dedicated `Collections` tab for building reusable image groups across indexed folders, with support for manual collections, tag-driven auto-updating collections, collection ordering, cover images, and collection management from the main workspace.
+- **Collections**: Added a dedicated `Collections` tab for reusable image groups, with manual and tag-driven collections, multi-tag rules, ordering, cover images, collection cards, in-place settings, and collection actions across the grid, table, Image Modal, and toolbar, including saving or adding the current filtered result set.
+
 ### Improved
 
 - **Unified Tag Entry UX**: Manual tag entry in `ImageModal`, `ImagePreviewSidebar`, and `Tag Manager` now shares the same suggestion combobox, keyboard navigation, mouse selection behavior, and match ranking, making tag suggestions feel consistent everywhere.
 - **Tagging Controls in Settings**: Added viewer settings for tag suggestion count and visible recent-tag chips, while keeping a larger internal recent-tag history so quick picks stay useful without overwhelming the UI.
 - **Safer Bulk Tag Suggestions**: The Tag Manager's comma-separated input now applies autocomplete only to the active CSV token, making multi-tag edits faster and less error-prone.
+- **Viewer Annotation Layout**: Moved the star rating control above the tag editor in the full image view and preview sidebar so tags have more horizontal space.
+- **Header and Navigation Polish**: Refreshed the header layout, aligned view navigation more cleanly, added Collections to the main view switcher, and reduced overlay issues around Settings and other top-level controls.
+- **Stable Sidebar Layout**: Restored the single-scroll sidebar filter flow and tightened sidebar sizing so folder, tag, and filter browsing remains predictable.
 
 ### Fixed
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
-- **Sidebar Filter Layout Regression**: Restored the single-scroll sidebar flow after the experimental split-pane filter layout proved confusing and interfered with normal folder and tag browsing.
+- **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.
+- **Preview Sidebar Opening Unexpectedly**: Fixed the Image Preview sidebar opening by itself after search/filter changes or view switches by limiting automatic preview restoration to active grid keyboard navigation.
 
-## [0.14.0] - Unreleased
+## [0.14.0] - 2026-04-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - Unreleased
+
+### Fixed
+
+- **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+
 ## [0.14.0] - Unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.1] - Unreleased
 
+### Added
+
+- **Collections View**: Added a dedicated `Collections` tab for building reusable image groups across indexed folders, with support for manual collections, tag-driven auto-updating collections, collection ordering, cover images, and collection management from the main workspace.
+- **Collection Creation Shortcuts**: Added `Create Collection` to the manual tag context menu plus `Collection` actions in both the grid and table context menus, including `Add to Collection`, `Create New Collection`, `Set as Cover`, and `Remove from Current Collection`.
+
 ### Fixed
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.

--- a/__tests__/CollectionFormModal.test.tsx
+++ b/__tests__/CollectionFormModal.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import CollectionFormModal, { type CollectionFormValues } from '../components/CollectionFormModal';
+import hotkeyManager from '../services/hotkeyManager';
+
+vi.mock('../services/hotkeyManager', () => ({
+  default: {
+    pauseHotkeys: vi.fn(),
+    resumeHotkeys: vi.fn(),
+  },
+}));
+
+const emptyValues = (): CollectionFormValues => ({
+  name: '',
+  description: '',
+  sourceTag: '',
+  autoUpdate: false,
+  includeTargetImages: false,
+});
+
+const renderModal = (initialValues: CollectionFormValues = emptyValues()) =>
+  render(
+    <CollectionFormModal
+      isOpen
+      title="Save as Collection"
+      submitLabel="Save Collection"
+      initialValues={initialValues}
+      onClose={vi.fn()}
+      onSubmit={vi.fn()}
+    />,
+  );
+
+describe('CollectionFormModal', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('keeps typed values when the parent rerenders with equivalent initial values', () => {
+    const { rerender } = renderModal(emptyValues());
+
+    const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: 'Filtered keepers' } });
+
+    rerender(
+      <CollectionFormModal
+        isOpen
+        title="Save as Collection"
+        submitLabel="Save Collection"
+        initialValues={emptyValues()}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('Filtered keepers');
+  });
+
+  it('resets when the actual initial values change while open', () => {
+    const { rerender } = renderModal(emptyValues());
+
+    const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: 'Draft title' } });
+
+    rerender(
+      <CollectionFormModal
+        isOpen
+        title="Collection Settings"
+        submitLabel="Save Changes"
+        initialValues={{
+          ...emptyValues(),
+          name: 'Existing collection',
+          description: 'Saved notes',
+        }}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('Existing collection');
+    expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe('Saved notes');
+  });
+
+  it('pauses global hotkeys while open', () => {
+    const { unmount } = renderModal(emptyValues());
+
+    expect(hotkeyManager.pauseHotkeys).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(hotkeyManager.resumeHotkeys).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on Escape without relying on global hotkeys', () => {
+    const onClose = vi.fn();
+    render(
+      <CollectionFormModal
+        isOpen
+        title="Save as Collection"
+        submitLabel="Save Collection"
+        initialValues={emptyValues()}
+        onClose={onClose}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByLabelText('Title'), { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/CollectionsWorkspace.test.tsx
+++ b/__tests__/CollectionsWorkspace.test.tsx
@@ -158,7 +158,6 @@ describe('CollectionsWorkspace', () => {
         includeTargetImages: false,
       },
       images: state.images,
-      resolvedImageIds: ['img-3'],
     });
 
     expect(update).toMatchObject({
@@ -168,6 +167,43 @@ describe('CollectionsWorkspace', () => {
       imageIds: ['img-3'],
       snapshotImageIds: [],
       excludedImageIds: [],
+    });
+  });
+
+  it('freezes tag-rule collections from resolved members instead of rebuilding excluded matches', () => {
+    const update = buildCollectionSettingsUpdate({
+      collection: {
+        id: 'collection-live',
+        kind: 'tag_rule',
+        name: 'Carros',
+        sortIndex: 0,
+        sourceTag: 'carros',
+        autoUpdate: true,
+        imageIds: [],
+        snapshotImageIds: [],
+        excludedImageIds: ['img-2'],
+        imageCount: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      values: {
+        name: 'Carros',
+        description: '',
+        sourceTag: 'carros',
+        autoUpdate: false,
+        includeTargetImages: false,
+      },
+      images: [
+        { id: 'img-1', tags: ['carros'] },
+        { id: 'img-2', tags: ['carros'] },
+      ] as any,
+    });
+
+    expect(update).toMatchObject({
+      kind: 'tag_rule',
+      autoUpdate: false,
+      snapshotImageIds: ['img-1'],
+      excludedImageIds: ['img-2'],
     });
   });
 });

--- a/__tests__/CollectionsWorkspace.test.tsx
+++ b/__tests__/CollectionsWorkspace.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CollectionsWorkspace from '../components/CollectionsWorkspace';
+import { useImageStore } from '../store/useImageStore';
+
+vi.mock('../hooks/useThumbnail', () => ({
+  useThumbnail: () => undefined,
+}));
+
+vi.mock('../hooks/useResolvedThumbnail', () => ({
+  useResolvedThumbnail: (image: any) => ({
+    thumbnailUrl: image?.thumbnailUrl ?? '',
+  }),
+}));
+
+describe('CollectionsWorkspace', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      images: [
+        {
+          id: 'img-1',
+          name: 'car-1.png',
+          thumbnailUrl: 'thumb://car-1',
+          directoryId: 'dir-1',
+          tags: ['carros'],
+        } as any,
+        {
+          id: 'img-2',
+          name: 'car-2.png',
+          thumbnailUrl: 'thumb://car-2',
+          directoryId: 'dir-1',
+          tags: ['carros'],
+        } as any,
+        {
+          id: 'img-3',
+          name: 'bike-1.png',
+          thumbnailUrl: 'thumb://bike-1',
+          directoryId: 'dir-2',
+          tags: ['motos'],
+        } as any,
+      ],
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'manual',
+          name: 'Carros',
+          sortIndex: 0,
+          imageIds: ['img-1', 'img-2'],
+          snapshotImageIds: [],
+          imageCount: 2,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        {
+          id: 'collection-2',
+          kind: 'tag_rule',
+          name: 'Motos',
+          sortIndex: 1,
+          imageIds: ['img-3'],
+          sourceTag: 'motos',
+          autoUpdate: true,
+          snapshotImageIds: [],
+          imageCount: 1,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      activeCollectionId: null,
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      deleteCollectionById: vi.fn().mockResolvedValue(undefined),
+      reorderCollections: vi.fn().mockResolvedValue(undefined),
+      getResolvedCollectionImages: (collectionId: string) => {
+        const state = useImageStore.getState();
+        const collection = state.collections.find((entry) => entry.id === collectionId);
+        if (!collection) {
+          return [];
+        }
+
+        const ids =
+          collection.id === 'collection-1'
+            ? ['img-1', 'img-2']
+            : ['img-3'];
+
+        return state.images.filter((image) => ids.includes(image.id));
+      },
+      setActiveCollectionId: useImageStore.getState().setActiveCollectionId,
+    } as any);
+  });
+
+  it('shows the collection card browser when no collection is selected', () => {
+    render(
+      <CollectionsWorkspace filteredImages={[]} totalImages={[]}>
+        <div>Collection Detail</div>
+      </CollectionsWorkspace>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Open collection Carros' })).toBeTruthy();
+    expect(screen.queryByText('Collection Detail')).toBeNull();
+  });
+
+  it('selects a collection when clicking anywhere on the sidebar card', () => {
+    render(
+      <CollectionsWorkspace filteredImages={[]} totalImages={[]}>
+        <div>Collection Detail</div>
+      </CollectionsWorkspace>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select collection Carros' }));
+
+    expect(screen.getByText('Collection Detail')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'All Collections' })).toBeTruthy();
+  });
+});

--- a/__tests__/CollectionsWorkspace.test.tsx
+++ b/__tests__/CollectionsWorkspace.test.tsx
@@ -113,4 +113,29 @@ describe('CollectionsWorkspace', () => {
     expect(screen.getByText('Collection Detail')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'All Collections' })).toBeTruthy();
   });
+
+  it('uses global collection order for move buttons while the sidebar list is filtered', () => {
+    const reorderCollections = vi.fn().mockResolvedValue(undefined);
+    useImageStore.setState({ reorderCollections } as any);
+
+    render(
+      <CollectionsWorkspace filteredImages={[]} totalImages={[]}>
+        <div>Collection Detail</div>
+      </CollectionsWorkspace>,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search collections...'), {
+      target: { value: 'Motos' },
+    });
+
+    const moveUpButton = screen.getByTitle('Move up') as HTMLButtonElement;
+    const moveDownButton = screen.getByTitle('Move down') as HTMLButtonElement;
+
+    expect(moveUpButton.disabled).toBe(false);
+    expect(moveDownButton.disabled).toBe(true);
+
+    fireEvent.click(moveUpButton);
+
+    expect(reorderCollections).toHaveBeenCalledWith(['collection-2', 'collection-1']);
+  });
 });

--- a/__tests__/CollectionsWorkspace.test.tsx
+++ b/__tests__/CollectionsWorkspace.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import CollectionsWorkspace from '../components/CollectionsWorkspace';
+import CollectionsWorkspace, { buildCollectionSettingsUpdate } from '../components/CollectionsWorkspace';
 import { useImageStore } from '../store/useImageStore';
 
 vi.mock('../hooks/useThumbnail', () => ({
@@ -137,5 +137,37 @@ describe('CollectionsWorkspace', () => {
     fireEvent.click(moveUpButton);
 
     expect(reorderCollections).toHaveBeenCalledWith(['collection-2', 'collection-1']);
+  });
+
+  it('preserves resolved tag-rule members when clearing auto-add tags', () => {
+    const state = useImageStore.getState();
+    const collection = state.collections.find((entry) => entry.id === 'collection-2');
+    expect(collection).toBeTruthy();
+
+    const update = buildCollectionSettingsUpdate({
+      collection: {
+        ...collection!,
+        imageIds: [],
+        excludedImageIds: [],
+      },
+      values: {
+        name: 'Motos',
+        description: '',
+        sourceTag: '',
+        autoUpdate: false,
+        includeTargetImages: false,
+      },
+      images: state.images,
+      resolvedImageIds: ['img-3'],
+    });
+
+    expect(update).toMatchObject({
+      kind: 'manual',
+      sourceTag: null,
+      autoUpdate: false,
+      imageIds: ['img-3'],
+      snapshotImageIds: [],
+      excludedImageIds: [],
+    });
   });
 });

--- a/__tests__/GridToolbar.test.tsx
+++ b/__tests__/GridToolbar.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import GridToolbar from '../components/GridToolbar';
+import { useImageStore } from '../store/useImageStore';
+
+vi.mock('../hooks/useFeatureAccess', () => ({
+  useFeatureAccess: () => ({
+    canUseComparison: true,
+    canUseA1111: true,
+    canUseComfyUI: true,
+    canUseBulkTagging: true,
+    showProModal: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useReparseMetadata', () => ({
+  useReparseMetadata: () => ({
+    isReparsing: false,
+    reparseImages: vi.fn(),
+  }),
+}));
+
+vi.mock('../components/ActiveFilters', () => ({
+  default: () => <div>Active Filters</div>,
+}));
+
+vi.mock('../components/TagManagerModal', () => ({
+  default: () => null,
+}));
+
+describe('GridToolbar', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+  });
+
+  it('renders the save-as-collection action in the toolbar', () => {
+    const onSaveCurrentFilteredAsCollection = vi.fn();
+
+    render(
+      <GridToolbar
+        selectedImages={new Set()}
+        images={[]}
+        directories={[]}
+        onSaveCurrentFilteredAsCollection={onSaveCurrentFilteredAsCollection}
+        saveCurrentFilteredCount={18}
+        onDeleteSelected={vi.fn()}
+        onGenerateA1111={vi.fn()}
+        onGenerateComfyUI={vi.fn()}
+        onCompare={vi.fn()}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /save as collection/i }));
+
+    expect(onSaveCurrentFilteredAsCollection).toHaveBeenCalled();
+    expect(screen.getByText('18')).toBeTruthy();
+  });
+});

--- a/__tests__/GridToolbar.test.tsx
+++ b/__tests__/GridToolbar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import GridToolbar from '../components/GridToolbar';
 import { useImageStore } from '../store/useImageStore';
 
@@ -49,7 +49,7 @@ describe('GridToolbar', () => {
     } as any);
   });
 
-  it('opens collection actions from the toolbar and creates a new collection from filtered images', () => {
+  it('opens collection actions from the toolbar and creates a new collection from filtered images', async () => {
     const onCreateCollectionFromFiltered = vi.fn();
 
     render(
@@ -69,12 +69,12 @@ describe('GridToolbar', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Collection actions' }));
-    fireEvent.click(screen.getByText('Create new collection from filtered images'));
+    fireEvent.click(await screen.findByText('Create new collection from filtered images'));
 
     expect(onCreateCollectionFromFiltered).toHaveBeenCalled();
   });
 
-  it('adds filtered images to an existing collection from the toolbar menu', () => {
+  it('adds filtered images to an existing collection from the toolbar menu', async () => {
     const onAddCurrentFilteredToCollection = vi.fn();
 
     render(
@@ -94,9 +94,11 @@ describe('GridToolbar', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Collection actions' }));
-    fireEvent.mouseEnter(screen.getByText('Add filtered images to collection'));
-    fireEvent.click(screen.getByText('Carros'));
+    fireEvent.mouseEnter(await screen.findByText('Add filtered images to collection'));
+    fireEvent.click(await screen.findByText('Carros'));
 
-    expect(onAddCurrentFilteredToCollection).toHaveBeenCalledWith('collection-1');
+    await waitFor(() => {
+      expect(onAddCurrentFilteredToCollection).toHaveBeenCalledWith('collection-1');
+    });
   });
 });

--- a/__tests__/GridToolbar.test.tsx
+++ b/__tests__/GridToolbar.test.tsx
@@ -32,18 +32,34 @@ vi.mock('../components/TagManagerModal', () => ({
 describe('GridToolbar', () => {
   beforeEach(() => {
     useImageStore.getState().resetState();
+    useImageStore.setState({
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'manual',
+          name: 'Carros',
+          sortIndex: 0,
+          imageIds: [],
+          snapshotImageIds: [],
+          imageCount: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    } as any);
   });
 
-  it('renders the save-as-collection action in the toolbar', () => {
-    const onSaveCurrentFilteredAsCollection = vi.fn();
+  it('opens collection actions from the toolbar and creates a new collection from filtered images', () => {
+    const onCreateCollectionFromFiltered = vi.fn();
 
     render(
       <GridToolbar
         selectedImages={new Set()}
         images={[]}
         directories={[]}
-        onSaveCurrentFilteredAsCollection={onSaveCurrentFilteredAsCollection}
-        saveCurrentFilteredCount={18}
+        onCreateCollectionFromFiltered={onCreateCollectionFromFiltered}
+        onAddCurrentFilteredToCollection={vi.fn()}
+        filteredImageActionCount={18}
         onDeleteSelected={vi.fn()}
         onGenerateA1111={vi.fn()}
         onGenerateComfyUI={vi.fn()}
@@ -52,9 +68,35 @@ describe('GridToolbar', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /save as collection/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Collection actions' }));
+    fireEvent.click(screen.getByText('Create new collection from filtered images'));
 
-    expect(onSaveCurrentFilteredAsCollection).toHaveBeenCalled();
-    expect(screen.getByText('18')).toBeTruthy();
+    expect(onCreateCollectionFromFiltered).toHaveBeenCalled();
+  });
+
+  it('adds filtered images to an existing collection from the toolbar menu', () => {
+    const onAddCurrentFilteredToCollection = vi.fn();
+
+    render(
+      <GridToolbar
+        selectedImages={new Set()}
+        images={[]}
+        directories={[]}
+        onCreateCollectionFromFiltered={vi.fn()}
+        onAddCurrentFilteredToCollection={onAddCurrentFilteredToCollection}
+        filteredImageActionCount={18}
+        onDeleteSelected={vi.fn()}
+        onGenerateA1111={vi.fn()}
+        onGenerateComfyUI={vi.fn()}
+        onCompare={vi.fn()}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collection actions' }));
+    fireEvent.mouseEnter(screen.getByText('Add filtered images to collection'));
+    fireEvent.click(screen.getByText('Carros'));
+
+    expect(onAddCurrentFilteredToCollection).toHaveBeenCalledWith('collection-1');
   });
 });

--- a/__tests__/Header.launch-generator.test.tsx
+++ b/__tests__/Header.launch-generator.test.tsx
@@ -102,4 +102,22 @@ describe('Header launch generator', () => {
 
     expect(launchGenerator).not.toHaveBeenCalled();
   });
+
+  it('renders and switches to the collections tab', () => {
+    const onLibraryViewChange = vi.fn();
+
+    render(
+      <Header
+        onOpenSettings={() => {}}
+        onOpenAnalytics={() => {}}
+        onOpenLicense={() => {}}
+        libraryView="library"
+        onLibraryViewChange={onLibraryViewChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /collections/i }));
+
+    expect(onLibraryViewChange).toHaveBeenCalledWith('collections');
+  });
 });

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -7,12 +7,20 @@ import { useSettingsStore } from '../store/useSettingsStore';
 import type { IndexedImage } from '../types';
 
 const showContextMenuMock = vi.fn();
+const hideContextMenuMock = vi.fn();
+const contextMenuStateMock = {
+  visible: false,
+  x: 24,
+  y: 24,
+  image: undefined as IndexedImage | undefined,
+  directoryPath: 'D:/library',
+};
 
 vi.mock('../hooks/useContextMenu', () => ({
   useContextMenu: () => ({
-    contextMenu: { visible: false, x: 0, y: 0, image: undefined, directoryPath: undefined },
+    contextMenu: contextMenuStateMock,
     showContextMenu: showContextMenuMock,
-    hideContextMenu: vi.fn(),
+    hideContextMenu: hideContextMenuMock,
     copyPrompt: vi.fn(),
     copyNegativePrompt: vi.fn(),
     copySeed: vi.fn(),
@@ -140,6 +148,9 @@ const Harness = ({ images }: { images: IndexedImage[] }) => {
 describe('ImageGrid context menu', () => {
   beforeEach(() => {
     showContextMenuMock.mockReset();
+    hideContextMenuMock.mockReset();
+    contextMenuStateMock.visible = false;
+    contextMenuStateMock.image = undefined;
     useImageStore.getState().resetState();
     useSettingsStore.getState().resetState();
     useSettingsStore.setState({
@@ -183,5 +194,80 @@ describe('ImageGrid context menu', () => {
     expect(showContextMenuMock).toHaveBeenCalledTimes(1);
     expect(showContextMenuMock.mock.calls[0]?.[1]).toMatchObject({ id: 'img-1' });
     expect(showContextMenuMock.mock.calls[0]?.[2]).toBe('D:/library');
+  });
+
+  it('shows collection actions in the image context menu', () => {
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      collections: [],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection: vi.fn().mockResolvedValue(undefined),
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      bulkAddTag: vi.fn().mockResolvedValue(undefined),
+      bulkRemoveTag: vi.fn().mockResolvedValue(undefined),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<Harness images={[image]} />);
+
+    expect(screen.getByText('Collection')).toBeTruthy();
+    fireEvent.click(screen.getByText('Collection'));
+    expect(screen.getByText('Create New Collection')).toBeTruthy();
+  });
+
+  it('adds selected images to a manual collection from the context menu', () => {
+    const addImagesToCollection = vi.fn().mockResolvedValue(undefined);
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1']),
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'manual',
+          name: 'Motos',
+          sortIndex: 0,
+          imageCount: 0,
+          imageIds: [],
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection,
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      bulkAddTag: vi.fn().mockResolvedValue(undefined),
+      bulkRemoveTag: vi.fn().mockResolvedValue(undefined),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<Harness images={[image]} />);
+
+    fireEvent.click(screen.getByText('Collection'));
+    fireEvent.click(screen.getByText('Add to Collection'));
+    fireEvent.click(screen.getByText('Motos'));
+
+    expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
   });
 });

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -270,4 +270,49 @@ describe('ImageGrid context menu', () => {
 
     expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
   });
+
+  it('adds selected images explicitly even for collections with auto-add tags', () => {
+    const addImagesToCollection = vi.fn().mockResolvedValue(undefined);
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1']),
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'tag_rule',
+          name: 'Carros',
+          sortIndex: 0,
+          imageCount: 0,
+          imageIds: [],
+          sourceTag: 'carros',
+          autoUpdate: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection,
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<Harness images={[image]} />);
+
+    fireEvent.click(screen.getByText('Collection'));
+    fireEvent.click(screen.getByText('Add to Collection'));
+    fireEvent.click(screen.getByText('Carros'));
+
+    expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
+  });
 });

--- a/__tests__/ImageTable.contextMenu.test.tsx
+++ b/__tests__/ImageTable.contextMenu.test.tsx
@@ -133,4 +133,53 @@ describe('ImageTable context menu', () => {
     fireEvent.click(screen.getByText('Collection'));
     expect(screen.getByText('Create New Collection')).toBeTruthy();
   });
+
+  it('adds selected images explicitly to collections with auto-add enabled', () => {
+    const addImagesToCollection = vi.fn().mockResolvedValue(undefined);
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1']),
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'tag_rule',
+          name: 'Carros',
+          sortIndex: 0,
+          imageCount: 0,
+          imageIds: [],
+          sourceTag: 'carros',
+          autoUpdate: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection,
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      bulkSetImageRating: vi.fn(),
+      transferProgress: null,
+    } as any);
+
+    render(
+      <ImageTable
+        images={[image]}
+        onImageClick={vi.fn()}
+        selectedImages={new Set(['img-1'])}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Collection'));
+    fireEvent.click(screen.getByText('Add to Collection'));
+    fireEvent.click(screen.getByText('Carros'));
+
+    expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
+  });
 });

--- a/__tests__/ImageTable.contextMenu.test.tsx
+++ b/__tests__/ImageTable.contextMenu.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ImageTable from '../components/ImageTable';
+import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+import type { IndexedImage } from '../types';
+
+const showContextMenuMock = vi.fn();
+const hideContextMenuMock = vi.fn();
+const contextMenuStateMock = {
+  visible: false,
+  x: 24,
+  y: 24,
+  image: undefined as IndexedImage | undefined,
+  directoryPath: 'D:/library',
+};
+
+vi.mock('../hooks/useContextMenu', () => ({
+  useContextMenu: () => ({
+    contextMenu: contextMenuStateMock,
+    showContextMenu: showContextMenuMock,
+    hideContextMenu: hideContextMenuMock,
+    copyPrompt: vi.fn(),
+    copyNegativePrompt: vi.fn(),
+    copySeed: vi.fn(),
+    copyImage: vi.fn(),
+    copyModel: vi.fn(),
+    showInFolder: vi.fn(),
+    exportImage: vi.fn(),
+    copyRawMetadata: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useThumbnail', () => ({
+  useThumbnail: vi.fn(),
+}));
+
+vi.mock('../hooks/useResolvedThumbnail', () => ({
+  useResolvedThumbnail: () => ({
+    thumbnailStatus: 'ready',
+    thumbnailUrl: 'thumb://image',
+  }),
+}));
+
+vi.mock('../hooks/useFeatureAccess', () => ({
+  useFeatureAccess: () => ({
+    canUseFileManagement: true,
+    showProModal: vi.fn(),
+    initialized: true,
+    canUseDuringTrialOrPro: true,
+  }),
+}));
+
+vi.mock('../hooks/useReparseMetadata', () => ({
+  useReparseMetadata: () => ({
+    isReparsing: false,
+    reparseImages: vi.fn(),
+  }),
+}));
+
+vi.mock('../components/ProBadge', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/TransferImagesModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/CollectionFormModal', () => ({
+  default: ({ isOpen }: { isOpen: boolean }) => (isOpen ? <div>Create Collection Modal</div> : null),
+}));
+
+const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
+  id: overrides.id ?? 'dir-1::image.png',
+  name: overrides.name ?? 'image.png',
+  handle: overrides.handle ?? ({ name: overrides.name ?? 'image.png' } as FileSystemFileHandle),
+  metadata: overrides.metadata ?? ({} as any),
+  metadataString: overrides.metadataString ?? '',
+  lastModified: overrides.lastModified ?? 1,
+  directoryId: overrides.directoryId ?? 'dir-1',
+  models: overrides.models ?? [],
+  loras: overrides.loras ?? [],
+  scheduler: overrides.scheduler ?? '',
+  workflowNodes: overrides.workflowNodes ?? [],
+  ...overrides,
+});
+
+describe('ImageTable context menu', () => {
+  beforeEach(() => {
+    showContextMenuMock.mockReset();
+    hideContextMenuMock.mockReset();
+    contextMenuStateMock.visible = false;
+    contextMenuStateMock.image = undefined;
+    useImageStore.getState().resetState();
+    useSettingsStore.getState().resetState();
+    useSettingsStore.setState({
+      disableThumbnails: false,
+      showFullFilePath: false,
+    } as any);
+  });
+
+  it('shows collection actions in the image-table context menu', () => {
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      collections: [],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection: vi.fn().mockResolvedValue(undefined),
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      bulkAddTag: vi.fn().mockResolvedValue(undefined),
+      bulkRemoveTag: vi.fn().mockResolvedValue(undefined),
+      bulkSetImageRating: vi.fn(),
+      transferProgress: null,
+    } as any);
+
+    render(
+      <ImageTable
+        images={[image]}
+        onImageClick={vi.fn()}
+        selectedImages={new Set()}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Collection')).toBeTruthy();
+    fireEvent.click(screen.getByText('Collection'));
+    expect(screen.getByText('Create New Collection')).toBeTruthy();
+  });
+});

--- a/__tests__/Sidebar.layout.test.tsx
+++ b/__tests__/Sidebar.layout.test.tsx
@@ -33,7 +33,7 @@ describe('Sidebar layout', () => {
     cleanup();
   });
 
-  it('renders the left sidebar in three independently resizable panes', () => {
+  it('renders the left sidebar with the main scrollable filter content', () => {
     const FolderPane = (_props: Record<string, unknown>) => <div>Folder content</div>;
 
     render(
@@ -76,10 +76,8 @@ describe('Sidebar layout', () => {
       </Sidebar>,
     );
 
-    expect(screen.getByRole('region', { name: 'Folders pane' })).toBeTruthy();
-    expect(screen.getByRole('region', { name: 'Tags and favorites pane' })).toBeTruthy();
-    expect(screen.getByRole('region', { name: 'Filters pane' })).toBeTruthy();
-    expect(screen.getByRole('separator', { name: 'Resize Folders pane' })).toBeTruthy();
-    expect(screen.getByRole('separator', { name: 'Resize Tags and favorites pane' })).toBeTruthy();
+    expect(screen.getByText('Folder content')).toBeTruthy();
+    expect(screen.getByText('Ratings, Favorites & Tags')).toBeTruthy();
+    expect(screen.getByText('Sort Order')).toBeTruthy();
   });
 });

--- a/__tests__/Sidebar.layout.test.tsx
+++ b/__tests__/Sidebar.layout.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Sidebar from '../components/Sidebar';
+import { useImageStore } from '../store/useImageStore';
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  },
+}));
+
+describe('Sidebar layout', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      images: [],
+      filteredImages: [],
+      availableTags: [],
+      availableAutoTags: [],
+      selectedTags: [],
+      excludedTags: [],
+      selectedAutoTags: [],
+      excludedAutoTags: [],
+      selectedRatings: [],
+      favoriteFilterMode: 'neutral',
+    });
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the left sidebar in three independently resizable panes', () => {
+    const FolderPane = (_props: Record<string, unknown>) => <div>Folder content</div>;
+
+    render(
+      <Sidebar
+        searchQuery=""
+        onSearchChange={() => {}}
+        availableModels={[]}
+        availableLoras={[]}
+        availableSamplers={[]}
+        availableSchedulers={[]}
+        availableDimensions={[]}
+        selectedModels={[]}
+        selectedLoras={[]}
+        selectedSamplers={[]}
+        selectedSchedulers={[]}
+        onModelChange={() => {}}
+        onLoraChange={() => {}}
+        onSamplerChange={() => {}}
+        onSchedulerChange={() => {}}
+        onClearAllFilters={() => {}}
+        advancedFilters={{}}
+        onAdvancedFiltersChange={() => {}}
+        onClearAdvancedFilters={() => {}}
+        selectedRatings={[]}
+        onSelectedRatingsChange={() => {}}
+        isCollapsed={false}
+        onToggleCollapse={() => {}}
+        width={360}
+        isResizing={false}
+        onResizeStart={() => {}}
+        isIndexing={false}
+        scanSubfolders={true}
+        excludedFolders={new Set<string>()}
+        onExcludeFolder={() => {}}
+        onIncludeFolder={() => {}}
+        sortOrder="date-desc"
+        onSortOrderChange={() => {}}
+      >
+        <FolderPane />
+      </Sidebar>,
+    );
+
+    expect(screen.getByRole('region', { name: 'Folders pane' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Tags and favorites pane' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Filters pane' })).toBeTruthy();
+    expect(screen.getByRole('separator', { name: 'Resize Folders pane' })).toBeTruthy();
+    expect(screen.getByRole('separator', { name: 'Resize Tags and favorites pane' })).toBeTruthy();
+  });
+});

--- a/__tests__/TagInputCombobox.test.tsx
+++ b/__tests__/TagInputCombobox.test.tsx
@@ -70,6 +70,16 @@ describe('TagInputCombobox', () => {
     expect(escapeSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('delegates escape immediately when the current token has no matches', () => {
+    const { input, escapeSpy } = renderHarness();
+
+    fireEvent.change(input, { target: { value: 'zzz' } });
+    expect(screen.queryByRole('listbox')).toBeNull();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(escapeSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('applies mouse-selected suggestions without losing the action', () => {
     const { input, submitSpy } = renderHarness({ value: 'mac' });
 

--- a/__tests__/TagInputCombobox.test.tsx
+++ b/__tests__/TagInputCombobox.test.tsx
@@ -56,6 +56,27 @@ describe('TagInputCombobox', () => {
     expect(submitSpy).toHaveBeenCalledWith('landscape');
   });
 
+  it('submits the typed tag when suggestions are open without explicit selection', () => {
+    const { input, submitSpy } = renderHarness({ value: 'por' });
+
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeTruthy();
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(submitSpy).toHaveBeenCalledWith('por');
+  });
+
+  it('applies the first typed suggestion after arrow-key selection', () => {
+    const { input, submitSpy } = renderHarness({ value: 'por' });
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(submitSpy).toHaveBeenCalledWith('portrait');
+  });
+
   it('closes the open list on escape before delegating to the caller', () => {
     const { input, escapeSpy } = renderHarness({ value: 'por' });
 
@@ -91,7 +112,7 @@ describe('TagInputCombobox', () => {
     expect(submitSpy).toHaveBeenCalledWith('macro');
   });
 
-  it('replaces the last CSV token instead of submitting immediately in csv mode', async () => {
+  it('submits the typed CSV value when suggestions are open without explicit selection', async () => {
     const { input, submitSpy } = renderHarness({
       mode: 'csv',
     });
@@ -100,6 +121,21 @@ describe('TagInputCombobox', () => {
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeTruthy();
     });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(submitSpy).toHaveBeenCalledWith('macro, por');
+  });
+
+  it('still replaces the active CSV token after arrow-key selection', async () => {
+    const { input, submitSpy } = renderHarness({
+      mode: 'csv',
+    });
+
+    fireEvent.change(input, { target: { value: 'macro, por' } });
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeTruthy();
+    });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
     fireEvent.keyDown(input, { key: 'Enter' });
 
     await waitFor(() => {

--- a/__tests__/TagInputCombobox.test.tsx
+++ b/__tests__/TagInputCombobox.test.tsx
@@ -84,11 +84,9 @@ describe('TagInputCombobox', () => {
   it('replaces the last CSV token instead of submitting immediately in csv mode', async () => {
     const { input, submitSpy } = renderHarness({
       mode: 'csv',
-      value: 'macro, por',
     });
 
-    fireEvent.focus(input);
-    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.change(input, { target: { value: 'macro, por' } });
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeTruthy();
     });

--- a/__tests__/TagInputCombobox.test.tsx
+++ b/__tests__/TagInputCombobox.test.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import TagInputCombobox from '../components/TagInputCombobox';
+
+const renderHarness = (props: Partial<React.ComponentProps<typeof TagInputCombobox>> = {}) => {
+  const submitSpy = vi.fn();
+  const escapeSpy = vi.fn();
+  const { value: initialValue, ...restProps } = props;
+
+  const Harness = () => {
+    const [value, setValue] = useState(initialValue ?? '');
+
+    return (
+      <TagInputCombobox
+        value={value}
+        onValueChange={setValue}
+        onSubmit={(nextValue) => submitSpy(nextValue)}
+        onEscape={escapeSpy}
+        recentTags={['portrait', 'landscape', 'macro']}
+        availableTags={[
+          { name: 'portrait', count: 8 },
+          { name: 'landscape', count: 4 },
+          { name: 'macro', count: 2 },
+        ]}
+        suggestionLimit={10}
+        placeholder="Add tag..."
+        inputClassName="w-full"
+        {...restProps}
+      />
+    );
+  };
+
+  render(<Harness />);
+
+  return {
+    submitSpy,
+    escapeSpy,
+    input: screen.getByPlaceholderText('Add tag...'),
+  };
+};
+
+describe('TagInputCombobox', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('supports arrow-key navigation and enter-to-select', () => {
+    const { input, submitSpy } = renderHarness();
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(submitSpy).toHaveBeenCalledWith('landscape');
+  });
+
+  it('closes the open list on escape before delegating to the caller', () => {
+    const { input, escapeSpy } = renderHarness({ value: 'por' });
+
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeTruthy();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(escapeSpy).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(escapeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies mouse-selected suggestions without losing the action', () => {
+    const { input, submitSpy } = renderHarness({ value: 'mac' });
+
+    fireEvent.focus(input);
+    const option = screen.getByRole('option', { name: /macro/i });
+    fireEvent.pointerDown(option);
+    fireEvent.click(option);
+
+    expect(submitSpy).toHaveBeenCalledWith('macro');
+  });
+
+  it('replaces the last CSV token instead of submitting immediately in csv mode', async () => {
+    const { input, submitSpy } = renderHarness({
+      mode: 'csv',
+      value: 'macro, por',
+    });
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeTruthy();
+    });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect((input as HTMLInputElement).value).toBe('macro, portrait, ');
+    });
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/TagManagerModal.test.tsx
+++ b/__tests__/TagManagerModal.test.tsx
@@ -17,6 +17,7 @@ describe('TagManagerModal', () => {
     useImageStore.getState().resetState();
     useImageStore.setState({
       availableTags: [{ name: 'portrait', count: 2 }],
+      recentTags: ['portrait'],
       bulkAddTag,
       bulkRemoveTag,
       images: [

--- a/__tests__/TagsAndFavorites.test.tsx
+++ b/__tests__/TagsAndFavorites.test.tsx
@@ -193,7 +193,7 @@ describe('TagsAndFavorites manual tag browser', () => {
     render(<TagsAndFavorites />);
     openContextMenuForTag('carros');
     fireEvent.click(screen.getByText('Create Collection'));
-    fireEvent.click(screen.getByText('Create Collection'));
+    fireEvent.click(screen.getByRole('button', { name: 'Create Collection' }));
 
     expect(createCollection).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/__tests__/TagsAndFavorites.test.tsx
+++ b/__tests__/TagsAndFavorites.test.tsx
@@ -23,6 +23,7 @@ const seedSidebarState = (overrides: Record<string, unknown> = {}) => {
   const setExcludedAutoTags = vi.fn();
   const setSelectedRatings = vi.fn();
   const refreshAvailableAutoTags = vi.fn();
+  const createCollection = vi.fn().mockResolvedValue(undefined);
 
   useImageStore.getState().resetState();
   useImageStore.setState({
@@ -30,6 +31,7 @@ const seedSidebarState = (overrides: Record<string, unknown> = {}) => {
     availableAutoTags: [],
     images: [],
     filteredImages: [],
+    collections: [],
     selectedTags: [],
     excludedTags: [],
     selectedTagsMatchMode: 'any',
@@ -48,6 +50,7 @@ const seedSidebarState = (overrides: Record<string, unknown> = {}) => {
     setExcludedAutoTags,
     setSelectedRatings,
     refreshAvailableAutoTags,
+    createCollection,
     ...overrides,
   });
 
@@ -61,6 +64,7 @@ const seedSidebarState = (overrides: Record<string, unknown> = {}) => {
     setSelectedTagsMatchMode,
     setSelectedRatings,
     refreshAvailableAutoTags,
+    createCollection,
   };
 };
 
@@ -175,6 +179,30 @@ describe('TagsAndFavorites manual tag browser', () => {
     fireEvent.click(screen.getByText('Rename'));
 
     expect(renameTag).toHaveBeenCalledWith('ghost-tag', 'fixed-tag');
+  });
+
+  it('creates a tag-rule collection from the tag context menu', async () => {
+    const { createCollection } = seedSidebarState({
+      availableTags: [{ name: 'carros', count: 2 }],
+      images: [
+        { id: 'img-1', tags: ['carros'] } as any,
+        { id: 'img-2', tags: ['carros', 'motos'] } as any,
+      ],
+    });
+
+    render(<TagsAndFavorites />);
+    openContextMenuForTag('carros');
+    fireEvent.click(screen.getByText('Create Collection'));
+    fireEvent.click(screen.getByText('Create Collection'));
+
+    expect(createCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'tag_rule',
+        name: 'carros',
+        sourceTag: 'carros',
+        autoUpdate: true,
+      }),
+    );
   });
 
   it('hides delete-empty for used tags and keeps purge available', () => {

--- a/__tests__/VerticalSplitPanels.test.tsx
+++ b/__tests__/VerticalSplitPanels.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import VerticalSplitPanels from '../components/VerticalSplitPanels';
+
+describe('VerticalSplitPanels', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the configured panes and persists resized pane sizes', async () => {
+    const { getByTestId, rerender } = render(
+      <VerticalSplitPanels
+        storageKey="test-pane-sizes"
+        defaultSizes={[36, 34, 30]}
+        panes={[
+          { id: 'one', ariaLabel: 'Pane one', content: <div>One</div> },
+          { id: 'two', ariaLabel: 'Pane two', content: <div>Two</div> },
+          { id: 'three', ariaLabel: 'Pane three', content: <div>Three</div> },
+        ]}
+      />,
+    );
+
+    const layout = getByTestId('vertical-split-panels');
+    Object.defineProperty(layout, 'getBoundingClientRect', {
+      value: () => ({ width: 320, height: 600, top: 0, left: 0, right: 320, bottom: 600 }),
+    });
+
+    expect(screen.getByRole('region', { name: 'Pane one' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Pane two' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Pane three' })).toBeTruthy();
+
+    const firstHandle = screen.getByRole('separator', { name: 'Resize Pane one' });
+    fireEvent.pointerDown(firstHandle, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientY: -300 });
+    fireEvent.pointerUp(window);
+
+    await waitFor(() => {
+      const firstPane = screen.getByRole('region', { name: 'Pane one' }) as HTMLElement;
+      expect(parseFloat(firstPane.style.flexBasis)).toBe(20);
+    });
+
+    const stored = JSON.parse(window.localStorage.getItem('test-pane-sizes') ?? '[]') as number[];
+    expect(stored).toHaveLength(3);
+    expect(Math.round(stored[0])).toBe(20);
+
+    rerender(
+      <VerticalSplitPanels
+        storageKey="test-pane-sizes"
+        defaultSizes={[36, 34, 30]}
+        panes={[
+          { id: 'one', ariaLabel: 'Pane one', content: <div>One</div> },
+          { id: 'two', ariaLabel: 'Pane two', content: <div>Two</div> },
+          { id: 'three', ariaLabel: 'Pane three', content: <div>Three</div> },
+        ]}
+      />,
+    );
+
+    const reloadedFirstPane = screen.getByRole('region', { name: 'Pane one' }) as HTMLElement;
+    expect(Math.round(parseFloat(reloadedFirstPane.style.flexBasis))).toBe(20);
+  });
+});

--- a/__tests__/hotkeyManager.test.ts
+++ b/__tests__/hotkeyManager.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import hotkeyManager from '../services/hotkeyManager';
+
+const resetPauseState = () => {
+  for (let index = 0; index < 10; index += 1) {
+    hotkeyManager.resumeHotkeys();
+  }
+};
+
+describe('hotkeyManager pause state', () => {
+  beforeEach(() => {
+    resetPauseState();
+  });
+
+  it('keeps hotkeys paused until every pause request is resumed', () => {
+    expect(hotkeyManager.areHotkeysPaused()).toBe(false);
+
+    hotkeyManager.pauseHotkeys();
+    hotkeyManager.pauseHotkeys();
+
+    expect(hotkeyManager.areHotkeysPaused()).toBe(true);
+
+    hotkeyManager.resumeHotkeys();
+
+    expect(hotkeyManager.areHotkeysPaused()).toBe(true);
+
+    hotkeyManager.resumeHotkeys();
+
+    expect(hotkeyManager.areHotkeysPaused()).toBe(false);
+  });
+
+  it('ignores extra resume calls', () => {
+    hotkeyManager.resumeHotkeys();
+
+    expect(hotkeyManager.areHotkeysPaused()).toBe(false);
+  });
+});

--- a/__tests__/hotkeyManager.test.ts
+++ b/__tests__/hotkeyManager.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import hotkeyManager from '../services/hotkeyManager';
 
 const resetPauseState = () => {
@@ -9,6 +9,13 @@ const resetPauseState = () => {
 
 describe('hotkeyManager pause state', () => {
   beforeEach(() => {
+    resetPauseState();
+    hotkeyManager.clearActions();
+  });
+
+  afterEach(() => {
+    hotkeyManager.clearActions();
+    document.body.innerHTML = '';
     resetPauseState();
   });
 
@@ -33,5 +40,29 @@ describe('hotkeyManager pause state', () => {
     hotkeyManager.resumeHotkeys();
 
     expect(hotkeyManager.areHotkeysPaused()).toBe(false);
+  });
+
+  it('does not run app hotkeys while typing in an input', () => {
+    const quickSearch = vi.fn();
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    hotkeyManager.registerAction('quickSearch', quickSearch);
+    hotkeyManager.bindAllActions();
+
+    input.focus();
+
+    const slashEvent = new KeyboardEvent('keydown', {
+      key: '/',
+      code: 'Slash',
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(slashEvent, 'keyCode', { value: 191 });
+    Object.defineProperty(slashEvent, 'which', { value: 191 });
+
+    input.dispatchEvent(slashEvent);
+
+    expect(quickSearch).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type FakeStoreState = {
+  keyPath: string;
+  records: Map<string, any>;
+  indexes: Map<string, { keyPath: string | string[]; options?: IDBIndexParameters }>;
+};
+
+type FakeDbState = {
+  version: number;
+  stores: Map<string, FakeStoreState>;
+};
+
+const createDomStringList = (values: () => string[]): DOMStringList =>
+  ({
+    contains: (name: string) => values().includes(name),
+    item: (index: number) => values()[index] ?? null,
+    get length() {
+      return values().length;
+    },
+    [Symbol.iterator]: function* iterator() {
+      yield* values();
+    },
+  }) as unknown as DOMStringList;
+
+const cloneValue = <T,>(value: T): T =>
+  value == null ? value : JSON.parse(JSON.stringify(value));
+
+const createFakeIndexedDb = () => {
+  const databases = new Map<string, FakeDbState>();
+  let transaction: IDBTransaction;
+
+  const makeRequest = <T,>() =>
+    ({
+      result: undefined as T | undefined,
+      error: null as unknown,
+      onsuccess: null as ((event: Event) => void) | null,
+      onerror: null as ((event: Event) => void) | null,
+      onupgradeneeded: null as ((event: IDBVersionChangeEvent) => void) | null,
+      transaction: null as IDBTransaction | null,
+      readyState: 'pending' as IDBRequestReadyState,
+    }) as unknown as IDBOpenDBRequest & IDBRequest<T>;
+
+  const completeTransaction = (activeTransaction: any) => {
+    queueMicrotask(() => {
+      activeTransaction.oncomplete?.(new Event('complete'));
+    });
+  };
+
+  const makeStore = (dbState: FakeDbState, activeTransaction: any, storeName: string) => {
+    const storeState = dbState.stores.get(storeName);
+    if (!storeState) {
+      throw new Error(`Store ${storeName} not found`);
+    }
+
+    const makeStoreRequest = <T,>(executor: () => T) => {
+      const request = makeRequest<T>();
+      queueMicrotask(() => {
+        try {
+          request.result = executor();
+          request.readyState = 'done';
+          request.onsuccess?.(new Event('success'));
+          completeTransaction(activeTransaction);
+        } catch (error) {
+          request.error = error;
+          request.readyState = 'done';
+          request.onerror?.(new Event('error'));
+        }
+      });
+      return request;
+    };
+
+    const makeIndex = (indexName: string) => {
+      const definition = storeState.indexes.get(indexName);
+      if (!definition) {
+        throw new Error(`Index ${indexName} not found`);
+      }
+
+      return {
+        getAll: (query?: unknown) =>
+          makeStoreRequest(() => {
+            const results = Array.from(storeState.records.values()).filter((record) => {
+              const value = (record as Record<string, any>)[definition.keyPath as string];
+              if (definition.options?.multiEntry && Array.isArray(value)) {
+                return query === undefined || value.includes(query);
+              }
+              return query === undefined || value === query;
+            });
+
+            return cloneValue(results);
+          }),
+      } as unknown as IDBIndex;
+    };
+
+    return {
+      keyPath: storeState.keyPath,
+      indexNames: createDomStringList(() => Array.from(storeState.indexes.keys())),
+      createIndex: (name: string, keyPath: string | string[], options?: IDBIndexParameters) => {
+        storeState.indexes.set(name, { keyPath, options });
+        return makeIndex(name);
+      },
+      index: (name: string) => makeIndex(name),
+      get: (key: string) => makeStoreRequest(() => cloneValue(storeState.records.get(key))),
+      getAll: () => makeStoreRequest(() => cloneValue(Array.from(storeState.records.values()))),
+      put: (value: Record<string, any>) =>
+        makeStoreRequest(() => {
+          const key = String(value[storeState.keyPath]);
+          storeState.records.set(key, cloneValue(value));
+          return key;
+        }),
+      delete: (key: string) =>
+        makeStoreRequest(() => {
+          storeState.records.delete(String(key));
+          return undefined;
+        }),
+    } as unknown as IDBObjectStore;
+  };
+
+  const makeTransaction = (dbState: FakeDbState, storeNames: string | string[]) =>
+    ({
+      error: null,
+      oncomplete: null,
+      onabort: null,
+      onerror: null,
+      objectStore: (name: string) => {
+        const allowedStores = Array.isArray(storeNames) ? storeNames : [storeNames];
+        if (!allowedStores.includes(name)) {
+          throw new Error(`Store ${name} not in transaction scope`);
+        }
+        return makeStore(dbState, transaction, name);
+      },
+    } as unknown as IDBTransaction);
+
+  const makeDatabase = (dbState: FakeDbState) =>
+    ({
+      objectStoreNames: createDomStringList(() => Array.from(dbState.stores.keys())),
+      createObjectStore: (name: string, options?: IDBObjectStoreParameters) => {
+        const keyPath = typeof options?.keyPath === 'string' ? options.keyPath : 'id';
+        const storeState: FakeStoreState = {
+          keyPath,
+          records: new Map(),
+          indexes: new Map(),
+        };
+        dbState.stores.set(name, storeState);
+        return makeStore(dbState, { oncomplete: null, onabort: null, onerror: null }, name);
+      },
+      transaction: (storeNames: string | string[]) => {
+        transaction = makeTransaction(dbState, storeNames);
+        return transaction;
+      },
+      close: () => undefined,
+      onversionchange: null,
+      get version() {
+        return dbState.version;
+      },
+      get name() {
+        return 'image-metahub-preferences';
+      },
+    }) as unknown as IDBDatabase;
+
+  return {
+    open: (name: string, version?: number) => {
+      const request = makeRequest<IDBDatabase>();
+
+      queueMicrotask(() => {
+        const existing = databases.get(name) ?? { version: 0, stores: new Map<string, FakeStoreState>() };
+        const requestedVersion = version ?? existing.version ?? 1;
+
+        databases.set(name, existing);
+        const db = makeDatabase(existing);
+        request.result = db;
+
+        if (requestedVersion > existing.version) {
+          const oldVersion = existing.version;
+          existing.version = requestedVersion;
+          request.transaction = makeTransaction(existing, Array.from(existing.stores.keys()));
+          request.onupgradeneeded?.({ oldVersion } as IDBVersionChangeEvent);
+        }
+
+        request.readyState = 'done';
+        request.onsuccess?.(new Event('success'));
+      });
+
+      return request;
+    },
+    deleteDatabase: (name: string) => {
+      const request = makeRequest<undefined>();
+      queueMicrotask(() => {
+        databases.delete(name);
+        request.result = undefined;
+        request.readyState = 'done';
+        request.onsuccess?.(new Event('success'));
+      });
+      return request;
+    },
+  } as unknown as IDBFactory;
+};
+
+const installFakeIndexedDb = () => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: createFakeIndexedDb(),
+    configurable: true,
+    writable: true,
+  });
+};
+
+describe('smart collection storage', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    installFakeIndexedDb();
+  });
+
+  it('round-trips manual and tag_rule collections through IndexedDB', async () => {
+    const {
+      getAllSmartCollections,
+      getSmartCollection,
+      saveSmartCollection,
+    } = await import('../services/imageAnnotationsStorage');
+
+    await saveSmartCollection({
+      id: 'manual-1',
+      kind: 'manual',
+      name: 'Motos',
+      sortIndex: 1,
+      imageIds: ['img-1', 'img-2', 'img-2'],
+      imageCount: 2,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    await saveSmartCollection({
+      id: 'tag-1',
+      kind: 'tag_rule',
+      name: 'Carros',
+      sortIndex: 0,
+      sourceTag: 'carros',
+      autoUpdate: true,
+      snapshotImageIds: ['img-3'],
+      imageCount: 99,
+      createdAt: 2,
+      updatedAt: 2,
+    });
+
+    const collections = await getAllSmartCollections();
+    const tagRuleCollection = await getSmartCollection('tag-1');
+
+    expect(collections.map((collection) => collection.id)).toEqual(['tag-1', 'manual-1']);
+    expect(collections[1]?.imageIds).toEqual(['img-1', 'img-2']);
+    expect(tagRuleCollection).toMatchObject({
+      id: 'tag-1',
+      kind: 'tag_rule',
+      sourceTag: 'carros',
+      autoUpdate: true,
+    });
+  });
+
+  it('normalizes legacy smart-collection records with safe defaults', async () => {
+    const { normalizeSmartCollection } = await import('../services/imageAnnotationsStorage');
+
+    const normalized = normalizeSmartCollection({
+      id: 'legacy-1',
+      name: 'Legacy Collection',
+      type: 'custom',
+      query: { userTags: ['carros'] },
+      createdAt: 10,
+      updatedAt: 20,
+      imageCount: 0,
+    });
+
+    expect(normalized).toMatchObject({
+      id: 'legacy-1',
+      kind: 'manual',
+      sortIndex: 0,
+      imageIds: [],
+      snapshotImageIds: [],
+      query: { userTags: ['carros'] },
+      type: 'custom',
+    });
+  });
+
+  it('resolves live and frozen tag-rule memberships from the current image set', async () => {
+    const { resolveSmartCollectionImageIds } = await import('../services/imageAnnotationsStorage');
+
+    const images = [
+      { id: 'img-1', tags: ['carros'] },
+      { id: 'img-2', tags: ['carros', 'motos'] },
+      { id: 'img-3', tags: ['motos'] },
+    ] as any;
+
+    expect(
+      resolveSmartCollectionImageIds(
+        {
+          id: 'tag-live',
+          kind: 'tag_rule',
+          name: 'Carros',
+          sortIndex: 0,
+          sourceTag: 'carros',
+          autoUpdate: true,
+          imageCount: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        images,
+      ),
+    ).toEqual(['img-1', 'img-2']);
+
+    expect(
+      resolveSmartCollectionImageIds(
+        {
+          id: 'tag-frozen',
+          kind: 'tag_rule',
+          name: 'Carros',
+          sortIndex: 0,
+          sourceTag: 'carros',
+          autoUpdate: false,
+          snapshotImageIds: ['img-2'],
+          imageCount: 1,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        images,
+      ),
+    ).toEqual(['img-2']);
+  });
+});

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -392,4 +392,58 @@ describe('smart collection storage', () => {
     expect(readded.excludedImageIds).toEqual(['img-3']);
     expect(resolveSmartCollectionImageIds(readded, images)).toEqual(['img-2', 'img-1']);
   });
+
+  it('allocates new collection sort indexes after gaps in existing order', async () => {
+    const { useImageStore } = await import('../store/useImageStore');
+
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      images: [],
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'manual',
+          name: 'Alpha',
+          sortIndex: 0,
+          imageIds: [],
+          snapshotImageIds: [],
+          imageCount: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        {
+          id: 'collection-3',
+          kind: 'manual',
+          name: 'Charlie',
+          sortIndex: 2,
+          imageIds: [],
+          snapshotImageIds: [],
+          imageCount: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+
+    const created = await useImageStore.getState().createCollection({
+      id: 'collection-new',
+      kind: 'manual',
+      name: 'Bravo',
+      sortIndex: 2,
+      imageIds: [],
+      snapshotImageIds: [],
+      coverImageId: null,
+      autoUpdate: false,
+      sourceTag: null,
+      type: 'custom',
+      query: undefined,
+    });
+
+    expect(created.sortIndex).toBe(3);
+    expect(useImageStore.getState().collections.map((collection) => collection.id)).toEqual([
+      'collection-1',
+      'collection-3',
+      'collection-new',
+    ]);
+  });
 });

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -324,4 +324,29 @@ describe('smart collection storage', () => {
       ),
     ).toEqual(['img-1', 'img-2']);
   });
+
+  it('removes images from both manual and frozen snapshot membership sources', async () => {
+    const { removeImagesFromSmartCollection } = await import('../services/imageAnnotationsStorage');
+
+    const updated = await removeImagesFromSmartCollection(
+      {
+        id: 'tag-frozen',
+        kind: 'tag_rule',
+        name: 'Carros',
+        sortIndex: 0,
+        sourceTag: 'carros',
+        autoUpdate: false,
+        imageIds: ['img-1', 'img-2'],
+        snapshotImageIds: ['img-2', 'img-3'],
+        imageCount: 3,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      ['img-2', 'img-3'],
+    );
+
+    expect(updated.imageIds).toEqual(['img-1']);
+    expect(updated.snapshotImageIds).toEqual([]);
+    expect(updated.imageCount).toBe(1);
+  });
 });

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -297,7 +297,7 @@ describe('smart collection storage', () => {
           sortIndex: 0,
           sourceTag: 'carros',
           autoUpdate: true,
-          imageIds: ['img-3'],
+          imageIds: ['img-3', 'missing-manual'],
           excludedImageIds: ['img-2'],
           imageCount: 0,
           createdAt: 1,
@@ -316,8 +316,8 @@ describe('smart collection storage', () => {
           sortIndex: 0,
           sourceTag: 'carros',
           autoUpdate: false,
-          imageIds: ['img-1'],
-          snapshotImageIds: ['img-2'],
+          imageIds: ['img-1', 'missing-manual'],
+          snapshotImageIds: ['img-2', 'missing-snapshot'],
           imageCount: 1,
           createdAt: 1,
           updatedAt: 1,
@@ -325,6 +325,31 @@ describe('smart collection storage', () => {
         images,
       ),
     ).toEqual(['img-1', 'img-2']);
+  });
+
+  it('resolves manual collection membership from indexed images only', async () => {
+    const {
+      resolveSmartCollectionImageCount,
+      resolveSmartCollectionImageIds,
+    } = await import('../services/imageAnnotationsStorage');
+
+    const collection = {
+      id: 'manual',
+      kind: 'manual',
+      name: 'Manual',
+      sortIndex: 0,
+      imageIds: ['img-1', 'missing', 'img-3'],
+      imageCount: 3,
+      createdAt: 1,
+      updatedAt: 1,
+    } as any;
+    const images = [
+      { id: 'img-1' },
+      { id: 'img-3' },
+    ] as any;
+
+    expect(resolveSmartCollectionImageIds(collection, images)).toEqual(['img-1', 'img-3']);
+    expect(resolveSmartCollectionImageCount(collection, images)).toBe(2);
   });
 
   it('removes images from both manual and frozen snapshot membership sources', async () => {

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -273,6 +273,7 @@ describe('smart collection storage', () => {
       sortIndex: 0,
       imageIds: [],
       snapshotImageIds: [],
+      excludedImageIds: [],
       query: { userTags: ['carros'] },
       type: 'custom',
     });
@@ -297,13 +298,14 @@ describe('smart collection storage', () => {
           sourceTag: 'carros',
           autoUpdate: true,
           imageIds: ['img-3'],
+          excludedImageIds: ['img-2'],
           imageCount: 0,
           createdAt: 1,
           updatedAt: 1,
         },
         images,
       ),
-    ).toEqual(['img-3', 'img-1', 'img-2']);
+    ).toEqual(['img-3', 'img-1']);
 
     expect(
       resolveSmartCollectionImageIds(
@@ -348,5 +350,46 @@ describe('smart collection storage', () => {
     expect(updated.imageIds).toEqual(['img-1']);
     expect(updated.snapshotImageIds).toEqual([]);
     expect(updated.imageCount).toBe(1);
+  });
+
+  it('persists exclusions when removing matching images from live tag-rule collections', async () => {
+    const {
+      addImagesToSmartCollection,
+      removeImagesFromSmartCollection,
+      resolveSmartCollectionImageIds,
+    } = await import('../services/imageAnnotationsStorage');
+
+    const images = [
+      { id: 'img-1', tags: ['carros'] },
+      { id: 'img-2', tags: ['carros'] },
+      { id: 'img-3', tags: ['motos'] },
+    ] as any;
+
+    const removed = await removeImagesFromSmartCollection(
+      {
+        id: 'tag-live',
+        kind: 'tag_rule',
+        name: 'Carros',
+        sortIndex: 0,
+        sourceTag: 'carros',
+        autoUpdate: true,
+        imageIds: ['img-3'],
+        snapshotImageIds: [],
+        excludedImageIds: [],
+        imageCount: 3,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      ['img-2', 'img-3'],
+    );
+
+    expect(removed.imageIds).toEqual([]);
+    expect(removed.excludedImageIds).toEqual(['img-2', 'img-3']);
+    expect(resolveSmartCollectionImageIds(removed, images)).toEqual(['img-1']);
+
+    const readded = await addImagesToSmartCollection(removed, ['img-2']);
+
+    expect(readded.excludedImageIds).toEqual(['img-3']);
+    expect(resolveSmartCollectionImageIds(readded, images)).toEqual(['img-2', 'img-1']);
   });
 });

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -296,13 +296,14 @@ describe('smart collection storage', () => {
           sortIndex: 0,
           sourceTag: 'carros',
           autoUpdate: true,
+          imageIds: ['img-3'],
           imageCount: 0,
           createdAt: 1,
           updatedAt: 1,
         },
         images,
       ),
-    ).toEqual(['img-1', 'img-2']);
+    ).toEqual(['img-3', 'img-1', 'img-2']);
 
     expect(
       resolveSmartCollectionImageIds(
@@ -313,6 +314,7 @@ describe('smart collection storage', () => {
           sortIndex: 0,
           sourceTag: 'carros',
           autoUpdate: false,
+          imageIds: ['img-1'],
           snapshotImageIds: ['img-2'],
           imageCount: 1,
           createdAt: 1,
@@ -320,6 +322,6 @@ describe('smart collection storage', () => {
         },
         images,
       ),
-    ).toEqual(['img-2']);
+    ).toEqual(['img-1', 'img-2']);
   });
 });

--- a/__tests__/tagSuggestions.test.ts
+++ b/__tests__/tagSuggestions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getRecentTagChips, getTagSuggestions } from '../utils/tagSuggestions';
+
+describe('tagSuggestions utilities', () => {
+  it('orders prefix matches before substring matches and prioritizes recent tags within the same tier', () => {
+    const suggestions = getTagSuggestions({
+      query: 'art',
+      recentTags: ['smart-light', 'cinematic'],
+      availableTags: [
+        { name: 'transport', count: 2 },
+        { name: 'art', count: 5 },
+        { name: 'cartoon', count: 3 },
+        { name: 'smart-light', count: 8 },
+      ],
+      limit: 10,
+    });
+
+    expect(suggestions.map((entry) => entry.name)).toEqual([
+      'art',
+      'smart-light',
+      'cartoon',
+    ]);
+  });
+
+  it('dedupes, excludes already-applied tags, and respects the suggestion limit', () => {
+    const suggestions = getTagSuggestions({
+      query: '',
+      recentTags: ['portrait', 'portrait', 'landscape', 'macro', 'editorial', 'studio'],
+      availableTags: [
+        { name: 'portrait', count: 4 },
+        { name: 'landscape', count: 3 },
+        { name: 'macro', count: 2 },
+      ],
+      excludedTags: ['landscape'],
+      limit: 5,
+    });
+
+    expect(suggestions.map((entry) => entry.name)).toEqual(['portrait', 'macro', 'editorial', 'studio']);
+  });
+
+  it('limits recent tag chips independently from stored history', () => {
+    const chips = getRecentTagChips({
+      recentTags: ['portrait', 'macro', 'landscape', 'editorial', 'studio', 'warm'],
+      excludedTags: ['macro'],
+      limit: 5,
+    });
+
+    expect(chips).toEqual(['portrait', 'landscape', 'editorial', 'studio', 'warm']);
+  });
+});

--- a/__tests__/useSettingsStore.persistence.test.ts
+++ b/__tests__/useSettingsStore.persistence.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { mergeSettingsWithExisting, stripLicenseFromSettings } from '../store/useSettingsStore';
+
+describe('useSettingsStore persistence helpers', () => {
+  it('strips license data before hydrating the settings store', () => {
+    const next = stripLicenseFromSettings({
+      theme: 'dark',
+      autoUpdate: true,
+      license: {
+        licenseStatus: 'pro',
+        licenseEmail: 'pro@example.com',
+      },
+    });
+
+    expect(next).toEqual({
+      theme: 'dark',
+      autoUpdate: true,
+    });
+  });
+
+  it('preserves existing license data when saving general settings', () => {
+    const next = mergeSettingsWithExisting(
+      {
+        theme: 'system',
+        a1111LastConnectionStatus: 'unknown',
+        license: {
+          licenseStatus: 'pro',
+          licenseEmail: 'pro@example.com',
+          licenseKey: 'ABCD-EFGH-IJKL-MNOP',
+        },
+      },
+      {
+        theme: 'dark',
+        a1111LastConnectionStatus: 'connected',
+      },
+    );
+
+    expect(next).toEqual({
+      theme: 'dark',
+      a1111LastConnectionStatus: 'connected',
+      license: {
+        licenseStatus: 'pro',
+        licenseEmail: 'pro@example.com',
+        licenseKey: 'ABCD-EFGH-IJKL-MNOP',
+      },
+    });
+  });
+});

--- a/__tests__/useSettingsStore.tagging.test.ts
+++ b/__tests__/useSettingsStore.tagging.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSettingsStore } from '../store/useSettingsStore';
+import {
+  DEFAULT_RECENT_TAG_CHIP_LIMIT,
+  DEFAULT_TAG_SUGGESTION_LIMIT,
+  MAX_TAG_UI_LIMIT,
+  MIN_TAG_UI_LIMIT,
+} from '../utils/tagSuggestions';
+
+describe('useSettingsStore tagging preferences', () => {
+  beforeEach(() => {
+    useSettingsStore.getState().resetState();
+  });
+
+  it('starts with the expected tagging defaults', () => {
+    const state = useSettingsStore.getState();
+
+    expect(state.tagSuggestionLimit).toBe(DEFAULT_TAG_SUGGESTION_LIMIT);
+    expect(state.recentTagChipLimit).toBe(DEFAULT_RECENT_TAG_CHIP_LIMIT);
+  });
+
+  it('clamps tagging preference setters to the supported range', () => {
+    useSettingsStore.getState().setTagSuggestionLimit(MAX_TAG_UI_LIMIT + 100);
+    useSettingsStore.getState().setRecentTagChipLimit(MIN_TAG_UI_LIMIT - 10);
+
+    expect(useSettingsStore.getState().tagSuggestionLimit).toBe(MAX_TAG_UI_LIMIT);
+    expect(useSettingsStore.getState().recentTagChipLimit).toBe(MIN_TAG_UI_LIMIT);
+  });
+});

--- a/cli.ts
+++ b/cli.ts
@@ -12,7 +12,7 @@ const program = new Command();
 program
   .name('imagemetahub-cli')
   .description('Image MetaHub CLI - Parse AI-generated image metadata')
-  .version('0.14.0');
+  .version('0.14.1');
 
 type ParseOptions = { json: boolean; pretty: boolean; raw?: boolean; quiet?: boolean };
 type IndexOptions = { out: string; recursive: boolean; raw?: boolean; quiet?: boolean; concurrency?: string };

--- a/components/CollectionCard.tsx
+++ b/components/CollectionCard.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { FolderOpen, Sparkles } from 'lucide-react';
+import { IndexedImage, SmartCollection } from '../types';
+import { useThumbnail } from '../hooks/useThumbnail';
+import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+
+interface CollectionCardProps {
+  collection: SmartCollection;
+  images: IndexedImage[];
+  imageCount: number;
+  onClick: () => void;
+}
+
+const CollectionCard: React.FC<CollectionCardProps> = ({
+  collection,
+  images,
+  imageCount,
+  onClick,
+}) => {
+  const cardRef = useRef<HTMLButtonElement | null>(null);
+  const [previewIndex, setPreviewIndex] = useState(0);
+  const rafRef = useRef<number | null>(null);
+  const pendingIndexRef = useRef(0);
+
+  const previewImage = images[previewIndex] ?? images[0] ?? null;
+  const thumbnail = useResolvedThumbnail(previewImage);
+  useThumbnail(previewImage);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  const updatePreviewIndex = (nextIndex: number) => {
+    pendingIndexRef.current = nextIndex;
+    if (rafRef.current !== null) {
+      return;
+    }
+
+    rafRef.current = requestAnimationFrame(() => {
+      setPreviewIndex(pendingIndexRef.current);
+      rafRef.current = null;
+    });
+  };
+
+  const handlePointerMove = (event: React.PointerEvent) => {
+    if (!cardRef.current || images.length < 2) {
+      return;
+    }
+
+    const rect = cardRef.current.getBoundingClientRect();
+    const relativeX = Math.min(Math.max(event.clientX - rect.left, 0), rect.width);
+    const ratio = rect.width > 0 ? relativeX / rect.width : 0;
+    const index = Math.floor(ratio * (images.length - 1));
+    updatePreviewIndex(index);
+  };
+
+  const handlePointerLeave = () => {
+    updatePreviewIndex(0);
+  };
+
+  const coverUrl = thumbnail?.thumbnailUrl || '';
+  const description = collection.description?.trim() || null;
+  const autoAddLabel = collection.sourceTag
+    ? collection.autoUpdate !== false
+      ? `Auto-add: ${collection.sourceTag}`
+      : `Linked tag: ${collection.sourceTag}`
+    : null;
+
+  return (
+    <button
+      ref={cardRef}
+      type="button"
+      aria-label={`Open collection ${collection.name}`}
+      onClick={onClick}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={handlePointerLeave}
+      className="group overflow-hidden rounded-2xl border border-gray-800 bg-gray-900/60 text-left shadow-lg transition-all hover:border-blue-500/30 hover:shadow-xl hover:shadow-blue-500/20"
+    >
+      <div className="relative aspect-[4/5] overflow-hidden">
+        {coverUrl ? (
+          <img
+            src={coverUrl}
+            alt={collection.name}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-gray-800 via-gray-900 to-gray-800 text-gray-500">
+            <FolderOpen className="h-8 w-8 opacity-70" />
+          </div>
+        )}
+
+        <div className="absolute left-3 top-3 flex items-center gap-1.5 rounded-full bg-black/60 px-2.5 py-1 text-[11px] font-semibold text-gray-100">
+          <FolderOpen className="h-3.5 w-3.5" />
+          {imageCount}
+        </div>
+
+        {collection.sourceTag && (
+          <div className="absolute right-3 top-3 flex items-center gap-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/15 px-2.5 py-1 text-[11px] font-semibold text-emerald-100">
+            <Sparkles className="h-3.5 w-3.5" />
+            {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+          </div>
+        )}
+
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/80 to-transparent" />
+
+        {images.length > 1 && (
+          <div className="absolute bottom-3 left-3 right-3 z-10 h-1 overflow-hidden rounded-full bg-black/40">
+            <div
+              className="h-full bg-blue-400/80 transition-all duration-100"
+              style={{
+                width: images.length > 1 ? `${(previewIndex / (images.length - 1)) * 100}%` : '0%',
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="p-4">
+        <p className="truncate text-sm font-semibold text-gray-100" title={collection.name}>
+          {collection.name}
+        </p>
+        {description && (
+          <p className="mt-1 line-clamp-2 min-h-[2.5rem] text-xs text-gray-400">
+            {description}
+          </p>
+        )}
+        {!description && (
+          <p className="mt-1 min-h-[2.5rem] text-xs text-gray-500">
+            {imageCount} image{imageCount !== 1 ? 's' : ''}
+          </p>
+        )}
+        {autoAddLabel && (
+          <p className="mt-2 truncate text-[11px] uppercase tracking-wide text-gray-500">
+            {autoAddLabel}
+          </p>
+        )}
+      </div>
+    </button>
+  );
+};
+
+export default CollectionCard;

--- a/components/CollectionFormModal.tsx
+++ b/components/CollectionFormModal.tsx
@@ -121,15 +121,16 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
 
           {showSourceTag && (
             <label className="block">
-              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Auto-Add Tag</span>
+              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Auto-Add Tags</span>
               <input
                 type="text"
                 value={values.sourceTag}
                 disabled={disableSourceTag}
                 onChange={(event) => setValues((current) => ({ ...current, sourceTag: event.target.value }))}
                 className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-70"
-                placeholder="tag name"
+                placeholder="motos, carros, barcos"
               />
+              <span className="mt-1 block text-xs text-gray-500">Separate tags with commas.</span>
             </label>
           )}
 

--- a/components/CollectionFormModal.tsx
+++ b/components/CollectionFormModal.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { SmartCollection } from '../types';
 
 export interface CollectionFormValues {
   name: string;
@@ -16,12 +15,12 @@ interface CollectionFormModalProps {
   initialValues: CollectionFormValues;
   onClose: () => void;
   onSubmit: (values: CollectionFormValues) => Promise<void> | void;
+  subtitle?: string;
   showSourceTag?: boolean;
   disableSourceTag?: boolean;
   showAutoUpdate?: boolean;
   showIncludeTargetImages?: boolean;
   includeTargetImagesLabel?: string;
-  collectionKind?: SmartCollection['kind'];
 }
 
 const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
@@ -31,15 +30,16 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
   initialValues,
   onClose,
   onSubmit,
+  subtitle,
   showSourceTag = false,
   disableSourceTag = false,
   showAutoUpdate = false,
   showIncludeTargetImages = false,
   includeTargetImagesLabel = 'Add the current images now',
-  collectionKind = 'manual',
 }) => {
   const [values, setValues] = useState<CollectionFormValues>(initialValues);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const hasSourceTag = values.sourceTag.trim().length > 0;
 
   useEffect(() => {
     if (!isOpen) {
@@ -86,11 +86,7 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
       >
         <div className="mb-4">
           <h3 className="text-base font-semibold text-white">{title}</h3>
-          <p className="mt-1 text-xs text-gray-400">
-            {collectionKind === 'tag_rule'
-              ? 'Tag-based collections can stay in sync automatically or freeze the current membership.'
-              : 'Manual collections keep only the images you explicitly add.'}
-          </p>
+          {subtitle && <p className="mt-1 text-xs text-gray-400">{subtitle}</p>}
         </div>
 
         <div className="space-y-4">
@@ -125,7 +121,7 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
 
           {showSourceTag && (
             <label className="block">
-              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Source Tag</span>
+              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Auto-Add Tag</span>
               <input
                 type="text"
                 value={values.sourceTag}
@@ -141,14 +137,17 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
             <label className="flex items-start gap-3 rounded-xl border border-gray-700 bg-gray-800/50 px-3 py-3">
               <input
                 type="checkbox"
-                checked={values.autoUpdate}
+                checked={hasSourceTag ? values.autoUpdate : false}
+                disabled={!hasSourceTag}
                 onChange={(event) => setValues((current) => ({ ...current, autoUpdate: event.target.checked }))}
-                className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500"
+                className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
               />
               <span>
-                <span className="block text-sm font-medium text-gray-100">Auto-update from future tags</span>
+                <span className="block text-sm font-medium text-gray-100">Add matching tagged images automatically</span>
                 <span className="mt-1 block text-xs text-gray-400">
-                  Keep the collection synced with future images tagged with this source tag.
+                  {hasSourceTag
+                    ? 'New images with this tag will appear here automatically.'
+                    : 'Choose a tag above to enable this.'}
                 </span>
               </span>
             </label>
@@ -164,9 +163,6 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
               />
               <span>
                 <span className="block text-sm font-medium text-gray-100">{includeTargetImagesLabel}</span>
-                <span className="mt-1 block text-xs text-gray-400">
-                  The current context-menu target can be added immediately when the collection is created.
-                </span>
               </span>
             </label>
           )}

--- a/components/CollectionFormModal.tsx
+++ b/components/CollectionFormModal.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useState } from 'react';
+import { SmartCollection } from '../types';
+
+export interface CollectionFormValues {
+  name: string;
+  description: string;
+  sourceTag: string;
+  autoUpdate: boolean;
+  includeTargetImages: boolean;
+}
+
+interface CollectionFormModalProps {
+  isOpen: boolean;
+  title: string;
+  submitLabel: string;
+  initialValues: CollectionFormValues;
+  onClose: () => void;
+  onSubmit: (values: CollectionFormValues) => Promise<void> | void;
+  showSourceTag?: boolean;
+  disableSourceTag?: boolean;
+  showAutoUpdate?: boolean;
+  showIncludeTargetImages?: boolean;
+  includeTargetImagesLabel?: string;
+  collectionKind?: SmartCollection['kind'];
+}
+
+const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
+  isOpen,
+  title,
+  submitLabel,
+  initialValues,
+  onClose,
+  onSubmit,
+  showSourceTag = false,
+  disableSourceTag = false,
+  showAutoUpdate = false,
+  showIncludeTargetImages = false,
+  includeTargetImagesLabel = 'Add the current images now',
+  collectionKind = 'manual',
+}) => {
+  const [values, setValues] = useState<CollectionFormValues>(initialValues);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setValues(initialValues);
+    setIsSubmitting(false);
+  }, [initialValues, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = async () => {
+    if (!values.name.trim()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        ...values,
+        name: values.name.trim(),
+        description: values.description.trim(),
+        sourceTag: values.sourceTag.trim().toLowerCase(),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl border border-gray-700 bg-gray-900 p-5 shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mb-4">
+          <h3 className="text-base font-semibold text-white">{title}</h3>
+          <p className="mt-1 text-xs text-gray-400">
+            {collectionKind === 'tag_rule'
+              ? 'Tag-based collections can stay in sync automatically or freeze the current membership.'
+              : 'Manual collections keep only the images you explicitly add.'}
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Title</span>
+            <input
+              autoFocus
+              type="text"
+              value={values.name}
+              onChange={(event) => setValues((current) => ({ ...current, name: event.target.value }))}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  void handleSubmit();
+                }
+              }}
+              className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              placeholder="Collection name"
+            />
+          </label>
+
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Description</span>
+            <textarea
+              value={values.description}
+              onChange={(event) => setValues((current) => ({ ...current, description: event.target.value }))}
+              rows={3}
+              className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              placeholder="Optional notes about this collection"
+            />
+          </label>
+
+          {showSourceTag && (
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Source Tag</span>
+              <input
+                type="text"
+                value={values.sourceTag}
+                disabled={disableSourceTag}
+                onChange={(event) => setValues((current) => ({ ...current, sourceTag: event.target.value }))}
+                className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-70"
+                placeholder="tag name"
+              />
+            </label>
+          )}
+
+          {showAutoUpdate && (
+            <label className="flex items-start gap-3 rounded-xl border border-gray-700 bg-gray-800/50 px-3 py-3">
+              <input
+                type="checkbox"
+                checked={values.autoUpdate}
+                onChange={(event) => setValues((current) => ({ ...current, autoUpdate: event.target.checked }))}
+                className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500"
+              />
+              <span>
+                <span className="block text-sm font-medium text-gray-100">Auto-update from future tags</span>
+                <span className="mt-1 block text-xs text-gray-400">
+                  Keep the collection synced with future images tagged with this source tag.
+                </span>
+              </span>
+            </label>
+          )}
+
+          {showIncludeTargetImages && (
+            <label className="flex items-start gap-3 rounded-xl border border-gray-700 bg-gray-800/50 px-3 py-3">
+              <input
+                type="checkbox"
+                checked={values.includeTargetImages}
+                onChange={(event) => setValues((current) => ({ ...current, includeTargetImages: event.target.checked }))}
+                className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500"
+              />
+              <span>
+                <span className="block text-sm font-medium text-gray-100">{includeTargetImagesLabel}</span>
+                <span className="mt-1 block text-xs text-gray-400">
+                  The current context-menu target can be added immediately when the collection is created.
+                </span>
+              </span>
+            </label>
+          )}
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-700 px-3 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={isSubmitting || !values.name.trim()}
+            onClick={() => void handleSubmit()}
+            className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CollectionFormModal;

--- a/components/CollectionFormModal.tsx
+++ b/components/CollectionFormModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import hotkeyManager from '../services/hotkeyManager';
 
 export interface CollectionFormValues {
   name: string;
@@ -37,7 +38,21 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
   showIncludeTargetImages = false,
   includeTargetImagesLabel = 'Add the current images now',
 }) => {
-  const [values, setValues] = useState<CollectionFormValues>(initialValues);
+  const {
+    name: initialName,
+    description: initialDescription,
+    sourceTag: initialSourceTag,
+    autoUpdate: initialAutoUpdate,
+    includeTargetImages: initialIncludeTargetImages,
+  } = initialValues;
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const [values, setValues] = useState<CollectionFormValues>({
+    name: initialName,
+    description: initialDescription,
+    sourceTag: initialSourceTag,
+    autoUpdate: initialAutoUpdate,
+    includeTargetImages: initialIncludeTargetImages,
+  });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const hasSourceTag = values.sourceTag.trim().length > 0;
 
@@ -46,9 +61,57 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
       return;
     }
 
-    setValues(initialValues);
+    setValues({
+      name: initialName,
+      description: initialDescription,
+      sourceTag: initialSourceTag,
+      autoUpdate: initialAutoUpdate,
+      includeTargetImages: initialIncludeTargetImages,
+    });
     setIsSubmitting(false);
-  }, [initialValues, isOpen]);
+  }, [
+    initialAutoUpdate,
+    initialDescription,
+    initialIncludeTargetImages,
+    initialName,
+    initialSourceTag,
+    isOpen,
+  ]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    hotkeyManager.pauseHotkeys();
+
+    return () => {
+      hotkeyManager.resumeHotkeys();
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const focusTitleInput = () => {
+      titleInputRef.current?.focus({ preventScroll: true });
+    };
+
+    const animationFrameId =
+      typeof window.requestAnimationFrame === 'function'
+        ? window.requestAnimationFrame(focusTitleInput)
+        : null;
+    const timeoutId = window.setTimeout(focusTitleInput, 0);
+
+    return () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      window.clearTimeout(timeoutId);
+    };
+  }, [isOpen]);
 
   if (!isOpen) {
     return null;
@@ -76,6 +139,13 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
     <div
       className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm"
       onClick={onClose}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          event.stopPropagation();
+          onClose();
+        }
+      }}
     >
       <div
         className="w-full max-w-md rounded-2xl border border-gray-700 bg-gray-900 p-5 shadow-2xl"
@@ -93,6 +163,7 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
           <label className="block">
             <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400">Title</span>
             <input
+              ref={titleInputRef}
               autoFocus
               type="text"
               value={values.name}

--- a/components/CollectionFormModal.tsx
+++ b/components/CollectionFormModal.tsx
@@ -199,7 +199,7 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
                 disabled={disableSourceTag}
                 onChange={(event) => setValues((current) => ({ ...current, sourceTag: event.target.value }))}
                 className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-70"
-                placeholder="motos, carros, barcos"
+                placeholder=""
               />
               <span className="mt-1 block text-xs text-gray-500">Separate tags with commas.</span>
             </label>

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -14,6 +14,48 @@ interface CollectionsWorkspaceProps {
   children: React.ReactNode;
 }
 
+type CollectionSettingsUpdate = Partial<Omit<SmartCollection, 'id' | 'createdAt'>>;
+
+export const buildCollectionSettingsUpdate = ({
+  collection,
+  values,
+  images,
+  resolvedImageIds,
+}: {
+  collection: SmartCollection;
+  values: CollectionFormValues;
+  images: IndexedImage[];
+  resolvedImageIds: string[];
+}): CollectionSettingsUpdate => {
+  const normalizedSourceTags = normalizeCollectionTagNames(values.sourceTag);
+  const normalizedSourceTag = normalizedSourceTags.join(', ');
+  const hasAutoAddSettings = normalizedSourceTags.length > 0;
+  const snapshotImageIds =
+    hasAutoAddSettings && values.autoUpdate === false
+      ? images
+          .filter(
+            (image) =>
+              Array.isArray(image.tags) &&
+              normalizedSourceTags.some((sourceTag) => image.tags.includes(sourceTag)),
+          )
+          .map((image) => image.id)
+      : [];
+
+  return {
+    name: values.name,
+    description: values.description || undefined,
+    kind: hasAutoAddSettings ? 'tag_rule' : 'manual',
+    sourceTag: hasAutoAddSettings ? normalizedSourceTag : null,
+    autoUpdate: hasAutoAddSettings ? values.autoUpdate : false,
+    imageIds: hasAutoAddSettings ? collection.imageIds ?? [] : resolvedImageIds,
+    snapshotImageIds,
+    excludedImageIds:
+      hasAutoAddSettings && values.autoUpdate !== false
+        ? collection.excludedImageIds ?? []
+        : [],
+  };
+};
+
 const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
   filteredImages,
   totalImages,
@@ -110,28 +152,17 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
       return;
     }
 
-    const normalizedSourceTags = normalizeCollectionTagNames(values.sourceTag);
-    const normalizedSourceTag = normalizedSourceTags.join(', ');
-    const hasAutoAddSettings = normalizedSourceTags.length > 0;
-    const snapshotImageIds =
-      hasAutoAddSettings && values.autoUpdate === false
-        ? images
-            .filter(
-              (image) =>
-                Array.isArray(image.tags) &&
-                normalizedSourceTags.some((sourceTag) => image.tags.includes(sourceTag)),
-            )
-            .map((image) => image.id)
-        : [];
+    const resolvedImageIds = getResolvedCollectionImages(editingCollection.id).map((image) => image.id);
 
-    await updateCollection(editingCollection.id, {
-      name: values.name,
-      description: values.description || undefined,
-      kind: hasAutoAddSettings ? 'tag_rule' : 'manual',
-      sourceTag: hasAutoAddSettings ? normalizedSourceTag : null,
-      autoUpdate: hasAutoAddSettings ? values.autoUpdate : false,
-      snapshotImageIds,
-    });
+    await updateCollection(
+      editingCollection.id,
+      buildCollectionSettingsUpdate({
+        collection: editingCollection,
+        values,
+        images,
+        resolvedImageIds,
+      }),
+    );
     setEditingCollection(null);
   };
 

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useState } from 'react';
-import { ArrowDown, ArrowUp, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react';
 import { IndexedImage, SmartCollection } from '../types';
 import { useImageStore } from '../store/useImageStore';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
+import CollectionCard from './CollectionCard';
 
 interface CollectionsWorkspaceProps {
   filteredImages: IndexedImage[];
@@ -50,6 +51,22 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
 
     return getResolvedCollectionImages(selectedCollection.id);
   }, [getResolvedCollectionImages, selectedCollection]);
+
+  const collectionPreviewImages = useMemo(() => {
+    const imageById = new Map(images.map((image) => [image.id, image]));
+
+    return new Map(
+      collections.map((collection) => {
+        const resolvedImages = getResolvedCollectionImages(collection.id);
+        const explicitCover = collection.coverImageId ? imageById.get(collection.coverImageId) ?? null : null;
+        const orderedImages = explicitCover
+          ? [explicitCover, ...resolvedImages.filter((image) => image.id !== explicitCover.id)]
+          : resolvedImages;
+
+        return [collection.id, orderedImages];
+      }),
+    );
+  }, [collections, getResolvedCollectionImages, images]);
 
   const coverImage = useMemo(() => {
     if (!selectedCollection) {
@@ -166,38 +183,45 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
               return (
                 <div
                   key={collection.id}
-                  className={`rounded-xl border p-3 transition-colors ${
+                  role="button"
+                  aria-label={`Select collection ${collection.name}`}
+                  tabIndex={0}
+                  onClick={() => setActiveCollectionId(collection.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setActiveCollectionId(collection.id);
+                    }
+                  }}
+                  className={`cursor-pointer rounded-xl border p-3 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500/50 ${
                     isActive
                       ? 'border-blue-500/50 bg-blue-500/10'
                       : 'border-gray-800 bg-gray-900/60 hover:border-gray-700 hover:bg-gray-900'
                   }`}
                 >
-                  <button
-                    type="button"
-                    onClick={() => setActiveCollectionId(collection.id)}
-                    className="w-full text-left"
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-medium text-gray-100">{collection.name}</div>
-                        {collection.sourceTag && (
-                          <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
-                            {collection.autoUpdate !== false
-                              ? `Auto-add · ${collection.sourceTag}`
-                              : `Tag link · ${collection.sourceTag}`}
-                          </div>
-                        )}
-                      </div>
-                      <span className="rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[11px] text-gray-300">
-                        {collection.imageCount}
-                      </span>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-gray-100">{collection.name}</div>
+                      {collection.sourceTag && (
+                        <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
+                          {collection.autoUpdate !== false
+                            ? `Auto-add · ${collection.sourceTag}`
+                            : `Tag link · ${collection.sourceTag}`}
+                        </div>
+                      )}
                     </div>
-                  </button>
+                    <span className="rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[11px] text-gray-300">
+                      {collection.imageCount}
+                    </span>
+                  </div>
 
                   <div className="mt-3 flex items-center justify-end gap-1">
                     <button
                       type="button"
-                      onClick={() => void moveCollection(collection.id, -1)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void moveCollection(collection.id, -1);
+                      }}
                       disabled={index === 0}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
                       title="Move up"
@@ -206,7 +230,10 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                     </button>
                     <button
                       type="button"
-                      onClick={() => void moveCollection(collection.id, 1)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void moveCollection(collection.id, 1);
+                      }}
                       disabled={index === collections.length - 1}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
                       title="Move down"
@@ -215,7 +242,10 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                     </button>
                     <button
                       type="button"
-                      onClick={() => setEditingCollection(collection)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setEditingCollection(collection);
+                      }}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800"
                       title="Collection settings"
                     >
@@ -223,7 +253,10 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                     </button>
                     <button
                       type="button"
-                      onClick={() => void handleDeleteCollection(collection.id)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void handleDeleteCollection(collection.id);
+                      }}
                       className="rounded-md border border-red-900/40 p-1.5 text-red-300 transition-colors hover:bg-red-900/20"
                       title="Delete collection"
                     >
@@ -241,6 +274,17 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
         {selectedCollection ? (
           <>
             <div className="border-b border-gray-800 px-5 py-4">
+              <div className="mb-4 flex items-center justify-between gap-3">
+                <button
+                  type="button"
+                  onClick={() => setActiveCollectionId(null)}
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-900/70 px-3 py-2 text-sm text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-800 hover:text-white"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  All Collections
+                </button>
+              </div>
+
               <div className="flex items-start gap-4">
                 <div className="h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-gray-800 bg-gray-900">
                   {coverImage ? (
@@ -282,9 +326,36 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
             <div className="min-h-0 flex-1 p-4">{children}</div>
           </>
         ) : (
-          <div className="flex h-full flex-col items-center justify-center px-6 text-center text-gray-400">
-            <FolderOpen className="mb-4 h-10 w-10 text-gray-600" />
-            <h3 className="text-base font-semibold text-gray-200">Choose a collection</h3>
+          <div className="flex min-h-0 flex-1 flex-col p-5">
+            <div className="mb-5 flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold text-white">Collections</h2>
+              </div>
+              <div className="rounded-full border border-gray-700 bg-gray-900 px-3 py-1 text-xs text-gray-300">
+                {filteredCollections.length} visible
+              </div>
+            </div>
+
+            {filteredCollections.length === 0 ? (
+              <div className="flex flex-1 flex-col items-center justify-center px-6 text-center text-gray-400">
+                <FolderOpen className="mb-4 h-10 w-10 text-gray-600" />
+                <h3 className="text-base font-semibold text-gray-200">No collections found</h3>
+              </div>
+            ) : (
+              <div className="min-h-0 flex-1 overflow-auto pr-1">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+                  {filteredCollections.map((collection) => (
+                    <CollectionCard
+                      key={collection.id}
+                      collection={collection}
+                      images={collectionPreviewImages.get(collection.id) ?? []}
+                      imageCount={collection.imageCount}
+                      onClick={() => setActiveCollectionId(collection.id)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
       </section>

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -6,6 +6,7 @@ import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal
 import CollectionCard from './CollectionCard';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useThumbnail } from '../hooks/useThumbnail';
+import { normalizeCollectionTagNames } from '../services/imageAnnotationsStorage';
 
 interface CollectionsWorkspaceProps {
   filteredImages: IndexedImage[];
@@ -109,12 +110,17 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
       return;
     }
 
-    const normalizedSourceTag = values.sourceTag.trim().toLowerCase();
-    const hasAutoAddSettings = normalizedSourceTag.length > 0;
+    const normalizedSourceTags = normalizeCollectionTagNames(values.sourceTag);
+    const normalizedSourceTag = normalizedSourceTags.join(', ');
+    const hasAutoAddSettings = normalizedSourceTags.length > 0;
     const snapshotImageIds =
       hasAutoAddSettings && values.autoUpdate === false
         ? images
-            .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedSourceTag))
+            .filter(
+              (image) =>
+                Array.isArray(image.tags) &&
+                normalizedSourceTags.some((sourceTag) => image.tags.includes(sourceTag)),
+            )
             .map((image) => image.id)
         : [];
 

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -1,0 +1,333 @@
+import React, { useMemo, useState } from 'react';
+import { ArrowDown, ArrowUp, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react';
+import { IndexedImage, SmartCollection } from '../types';
+import { useImageStore } from '../store/useImageStore';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
+
+interface CollectionsWorkspaceProps {
+  filteredImages: IndexedImage[];
+  totalImages: IndexedImage[];
+  children: React.ReactNode;
+}
+
+const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
+  filteredImages,
+  totalImages,
+  children,
+}) => {
+  const images = useImageStore((state) => state.images);
+  const collections = useImageStore((state) => state.collections);
+  const activeCollectionId = useImageStore((state) => state.activeCollectionId);
+  const setActiveCollectionId = useImageStore((state) => state.setActiveCollectionId);
+  const createCollection = useImageStore((state) => state.createCollection);
+  const updateCollection = useImageStore((state) => state.updateCollection);
+  const deleteCollectionById = useImageStore((state) => state.deleteCollectionById);
+  const reorderCollections = useImageStore((state) => state.reorderCollections);
+  const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [editingCollection, setEditingCollection] = useState<SmartCollection | null>(null);
+
+  const selectedCollection = useMemo(
+    () => collections.find((collection) => collection.id === activeCollectionId) ?? null,
+    [activeCollectionId, collections],
+  );
+
+  const filteredCollections = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return collections;
+    }
+
+    return collections.filter((collection) => collection.name.toLowerCase().includes(normalizedQuery));
+  }, [collections, searchQuery]);
+
+  const selectedCollectionResolvedImages = useMemo(() => {
+    if (!selectedCollection) {
+      return [];
+    }
+
+    return getResolvedCollectionImages(selectedCollection.id);
+  }, [getResolvedCollectionImages, selectedCollection]);
+
+  const coverImage = useMemo(() => {
+    if (!selectedCollection) {
+      return null;
+    }
+
+    if (selectedCollection.coverImageId) {
+      return images.find((image) => image.id === selectedCollection.coverImageId) ?? null;
+    }
+
+    return selectedCollectionResolvedImages[0] ?? null;
+  }, [images, selectedCollection, selectedCollectionResolvedImages]);
+
+  const moveCollection = async (collectionId: string, direction: -1 | 1) => {
+    const currentIndex = collections.findIndex((collection) => collection.id === collectionId);
+    const nextIndex = currentIndex + direction;
+    if (currentIndex === -1 || nextIndex < 0 || nextIndex >= collections.length) {
+      return;
+    }
+
+    const ordered = [...collections];
+    const [movedCollection] = ordered.splice(currentIndex, 1);
+    ordered.splice(nextIndex, 0, movedCollection);
+    await reorderCollections(ordered.map((collection) => collection.id));
+  };
+
+  const handleCreateManualCollection = async (values: CollectionFormValues) => {
+    await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: collections.length,
+      imageIds: [],
+      snapshotImageIds: [],
+      coverImageId: null,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: undefined,
+      type: 'custom',
+      query: undefined,
+    });
+    setIsCreateModalOpen(false);
+  };
+
+  const handleSaveCollection = async (values: CollectionFormValues) => {
+    if (!editingCollection) {
+      return;
+    }
+
+    const normalizedSourceTag = values.sourceTag.trim().toLowerCase();
+    const snapshotImageIds =
+      editingCollection.kind === 'tag_rule' && values.autoUpdate === false
+        ? images
+            .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedSourceTag))
+            .map((image) => image.id)
+        : editingCollection.snapshotImageIds;
+
+    await updateCollection(editingCollection.id, {
+      name: values.name,
+      description: values.description || undefined,
+      sourceTag: editingCollection.kind === 'tag_rule' ? normalizedSourceTag : editingCollection.sourceTag,
+      autoUpdate: editingCollection.kind === 'tag_rule' ? values.autoUpdate : editingCollection.autoUpdate,
+      snapshotImageIds,
+    });
+    setEditingCollection(null);
+  };
+
+  const handleDeleteCollection = async (collectionId: string) => {
+    const confirmed = window.confirm('Delete this collection? This will not delete the underlying images.');
+    if (!confirmed) {
+      return;
+    }
+
+    await deleteCollectionById(collectionId);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 gap-4">
+      <aside className="flex w-[320px] flex-shrink-0 flex-col rounded-2xl border border-gray-800 bg-gray-950/40">
+        <div className="border-b border-gray-800 px-4 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-base font-semibold text-white">Collections</h2>
+              <p className="mt-1 text-xs text-gray-400">Group images by tag rules or manual curation.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsCreateModalOpen(true)}
+              className="inline-flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-blue-500"
+            >
+              <Plus className="h-4 w-4" />
+              New
+            </button>
+          </div>
+
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search collections..."
+            className="mt-3 w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        <div className="flex-1 space-y-2 overflow-y-auto px-3 py-3">
+          {filteredCollections.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-gray-700 bg-gray-900/50 px-4 py-5 text-center text-sm text-gray-500">
+              No collections yet.
+            </div>
+          ) : (
+            filteredCollections.map((collection, index) => {
+              const isActive = collection.id === selectedCollection?.id;
+              return (
+                <div
+                  key={collection.id}
+                  className={`rounded-xl border p-3 transition-colors ${
+                    isActive
+                      ? 'border-blue-500/50 bg-blue-500/10'
+                      : 'border-gray-800 bg-gray-900/60 hover:border-gray-700 hover:bg-gray-900'
+                  }`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setActiveCollectionId(collection.id)}
+                    className="w-full text-left"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-gray-100">{collection.name}</div>
+                        <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
+                          {collection.kind === 'tag_rule'
+                            ? collection.autoUpdate !== false
+                              ? `Tag rule · ${collection.sourceTag ?? 'no tag'}`
+                              : `Frozen tag rule · ${collection.sourceTag ?? 'no tag'}`
+                            : 'Manual'}
+                        </div>
+                      </div>
+                      <span className="rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[11px] text-gray-300">
+                        {collection.imageCount}
+                      </span>
+                    </div>
+                  </button>
+
+                  <div className="mt-3 flex items-center justify-end gap-1">
+                    <button
+                      type="button"
+                      onClick={() => void moveCollection(collection.id, -1)}
+                      disabled={index === 0}
+                      className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+                      title="Move up"
+                    >
+                      <ArrowUp className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void moveCollection(collection.id, 1)}
+                      disabled={index === collections.length - 1}
+                      className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+                      title="Move down"
+                    >
+                      <ArrowDown className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditingCollection(collection)}
+                      className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800"
+                      title="Manage collection"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void handleDeleteCollection(collection.id)}
+                      className="rounded-md border border-red-900/40 p-1.5 text-red-300 transition-colors hover:bg-red-900/20"
+                      title="Delete collection"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </aside>
+
+      <section className="flex min-w-0 flex-1 flex-col rounded-2xl border border-gray-800 bg-gray-950/20">
+        {selectedCollection ? (
+          <>
+            <div className="border-b border-gray-800 px-5 py-4">
+              <div className="flex items-start gap-4">
+                <div className="h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-gray-800 bg-gray-900">
+                  {coverImage ? (
+                    <img
+                      src={coverImage.thumbnailUrl}
+                      alt={selectedCollection.name}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-gray-600">
+                      <FolderOpen className="h-6 w-6" />
+                    </div>
+                  )}
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="text-lg font-semibold text-white">{selectedCollection.name}</h2>
+                    <span className="rounded-full border border-gray-700 bg-gray-900 px-2 py-0.5 text-[11px] uppercase tracking-wide text-gray-300">
+                      {selectedCollection.kind === 'tag_rule' ? 'Tag Rule' : 'Manual'}
+                    </span>
+                    {selectedCollection.kind === 'tag_rule' && selectedCollection.autoUpdate !== false && (
+                      <span className="rounded-full border border-emerald-600/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-emerald-300">
+                        Auto
+                      </span>
+                    )}
+                  </div>
+                  {selectedCollection.description && (
+                    <p className="mt-2 text-sm text-gray-300">{selectedCollection.description}</p>
+                  )}
+                  <div className="mt-3 flex flex-wrap gap-3 text-xs text-gray-400">
+                    <span>{totalImages.length} total in collection</span>
+                    <span>{filteredImages.length} after current filters</span>
+                    {selectedCollection.kind === 'tag_rule' && selectedCollection.sourceTag && (
+                      <span>Source tag: {selectedCollection.sourceTag}</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="min-h-0 flex-1 p-4">{children}</div>
+          </>
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center px-6 text-center text-gray-400">
+            <FolderOpen className="mb-4 h-10 w-10 text-gray-600" />
+            <h3 className="text-base font-semibold text-gray-200">Choose a collection</h3>
+            <p className="mt-2 max-w-md text-sm text-gray-500">
+              Create manual sets for hand-picked images or tag-rule collections that stay in sync automatically.
+            </p>
+          </div>
+        )}
+      </section>
+
+      <CollectionFormModal
+        isOpen={isCreateModalOpen}
+        title="Create Collection"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: '',
+          description: '',
+          sourceTag: '',
+          autoUpdate: false,
+          includeTargetImages: false,
+        }}
+        onClose={() => setIsCreateModalOpen(false)}
+        onSubmit={handleCreateManualCollection}
+      />
+
+      <CollectionFormModal
+        isOpen={editingCollection !== null}
+        title={editingCollection?.kind === 'tag_rule' ? 'Edit Tag Collection' : 'Edit Collection'}
+        submitLabel="Save Changes"
+        initialValues={{
+          name: editingCollection?.name ?? '',
+          description: editingCollection?.description ?? '',
+          sourceTag: editingCollection?.sourceTag ?? '',
+          autoUpdate: editingCollection?.autoUpdate ?? false,
+          includeTargetImages: false,
+        }}
+        onClose={() => setEditingCollection(null)}
+        onSubmit={handleSaveCollection}
+        collectionKind={editingCollection?.kind ?? 'manual'}
+        showSourceTag={editingCollection?.kind === 'tag_rule'}
+        showAutoUpdate={editingCollection?.kind === 'tag_rule'}
+      />
+    </div>
+  );
+};
+
+export default CollectionsWorkspace;

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -100,18 +100,20 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
     }
 
     const normalizedSourceTag = values.sourceTag.trim().toLowerCase();
+    const hasAutoAddSettings = normalizedSourceTag.length > 0;
     const snapshotImageIds =
-      editingCollection.kind === 'tag_rule' && values.autoUpdate === false
+      hasAutoAddSettings && values.autoUpdate === false
         ? images
             .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedSourceTag))
             .map((image) => image.id)
-        : editingCollection.snapshotImageIds;
+        : [];
 
     await updateCollection(editingCollection.id, {
       name: values.name,
       description: values.description || undefined,
-      sourceTag: editingCollection.kind === 'tag_rule' ? normalizedSourceTag : editingCollection.sourceTag,
-      autoUpdate: editingCollection.kind === 'tag_rule' ? values.autoUpdate : editingCollection.autoUpdate,
+      kind: hasAutoAddSettings ? 'tag_rule' : 'manual',
+      sourceTag: hasAutoAddSettings ? normalizedSourceTag : null,
+      autoUpdate: hasAutoAddSettings ? values.autoUpdate : false,
       snapshotImageIds,
     });
     setEditingCollection(null);
@@ -133,7 +135,6 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
           <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="text-base font-semibold text-white">Collections</h2>
-              <p className="mt-1 text-xs text-gray-400">Group images by tag rules or manual curation.</p>
             </div>
             <button
               type="button"
@@ -179,13 +180,13 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                     <div className="flex items-center justify-between gap-3">
                       <div className="min-w-0">
                         <div className="truncate text-sm font-medium text-gray-100">{collection.name}</div>
-                        <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
-                          {collection.kind === 'tag_rule'
-                            ? collection.autoUpdate !== false
-                              ? `Tag rule · ${collection.sourceTag ?? 'no tag'}`
-                              : `Frozen tag rule · ${collection.sourceTag ?? 'no tag'}`
-                            : 'Manual'}
-                        </div>
+                        {collection.sourceTag && (
+                          <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
+                            {collection.autoUpdate !== false
+                              ? `Auto-add · ${collection.sourceTag}`
+                              : `Tag link · ${collection.sourceTag}`}
+                          </div>
+                        )}
                       </div>
                       <span className="rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[11px] text-gray-300">
                         {collection.imageCount}
@@ -216,7 +217,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                       type="button"
                       onClick={() => setEditingCollection(collection)}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800"
-                      title="Manage collection"
+                      title="Collection settings"
                     >
                       <Pencil className="h-3.5 w-3.5" />
                     </button>
@@ -258,10 +259,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
                     <h2 className="text-lg font-semibold text-white">{selectedCollection.name}</h2>
-                    <span className="rounded-full border border-gray-700 bg-gray-900 px-2 py-0.5 text-[11px] uppercase tracking-wide text-gray-300">
-                      {selectedCollection.kind === 'tag_rule' ? 'Tag Rule' : 'Manual'}
-                    </span>
-                    {selectedCollection.kind === 'tag_rule' && selectedCollection.autoUpdate !== false && (
+                    {selectedCollection.sourceTag && selectedCollection.autoUpdate !== false && (
                       <span className="rounded-full border border-emerald-600/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-emerald-300">
                         Auto
                       </span>
@@ -273,8 +271,8 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                   <div className="mt-3 flex flex-wrap gap-3 text-xs text-gray-400">
                     <span>{totalImages.length} total in collection</span>
                     <span>{filteredImages.length} after current filters</span>
-                    {selectedCollection.kind === 'tag_rule' && selectedCollection.sourceTag && (
-                      <span>Source tag: {selectedCollection.sourceTag}</span>
+                    {selectedCollection.sourceTag && (
+                      <span>Auto-add tag: {selectedCollection.sourceTag}</span>
                     )}
                   </div>
                 </div>
@@ -287,9 +285,6 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
           <div className="flex h-full flex-col items-center justify-center px-6 text-center text-gray-400">
             <FolderOpen className="mb-4 h-10 w-10 text-gray-600" />
             <h3 className="text-base font-semibold text-gray-200">Choose a collection</h3>
-            <p className="mt-2 max-w-md text-sm text-gray-500">
-              Create manual sets for hand-picked images or tag-rule collections that stay in sync automatically.
-            </p>
           </div>
         )}
       </section>
@@ -311,7 +306,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
 
       <CollectionFormModal
         isOpen={editingCollection !== null}
-        title={editingCollection?.kind === 'tag_rule' ? 'Edit Tag Collection' : 'Edit Collection'}
+        title="Collection Settings"
         submitLabel="Save Changes"
         initialValues={{
           name: editingCollection?.name ?? '',
@@ -322,9 +317,8 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
         }}
         onClose={() => setEditingCollection(null)}
         onSubmit={handleSaveCollection}
-        collectionKind={editingCollection?.kind ?? 'manual'}
-        showSourceTag={editingCollection?.kind === 'tag_rule'}
-        showAutoUpdate={editingCollection?.kind === 'tag_rule'}
+        showSourceTag
+        showAutoUpdate
       />
     </div>
   );

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -6,7 +6,11 @@ import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal
 import CollectionCard from './CollectionCard';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useThumbnail } from '../hooks/useThumbnail';
-import { normalizeCollectionTagNames } from '../services/imageAnnotationsStorage';
+import {
+  normalizeCollectionTagNames,
+  resolveSmartCollectionImageIds,
+  resolveTagRuleMatchedImageIds,
+} from '../services/imageAnnotationsStorage';
 
 interface CollectionsWorkspaceProps {
   filteredImages: IndexedImage[];
@@ -20,25 +24,24 @@ export const buildCollectionSettingsUpdate = ({
   collection,
   values,
   images,
-  resolvedImageIds,
 }: {
   collection: SmartCollection;
   values: CollectionFormValues;
   images: IndexedImage[];
-  resolvedImageIds: string[];
 }): CollectionSettingsUpdate => {
   const normalizedSourceTags = normalizeCollectionTagNames(values.sourceTag);
   const normalizedSourceTag = normalizedSourceTags.join(', ');
+  const currentSourceTag = normalizeCollectionTagNames(collection.sourceTag).join(', ');
   const hasAutoAddSettings = normalizedSourceTags.length > 0;
+  const sourceTagChanged = normalizedSourceTag !== currentSourceTag;
+  const resolvedImageIds = resolveSmartCollectionImageIds(collection, images);
+  const frozenSnapshotImageIds =
+    sourceTagChanged
+      ? resolveTagRuleMatchedImageIds(normalizedSourceTag, images)
+      : resolvedImageIds;
   const snapshotImageIds =
     hasAutoAddSettings && values.autoUpdate === false
-      ? images
-          .filter(
-            (image) =>
-              Array.isArray(image.tags) &&
-              normalizedSourceTags.some((sourceTag) => image.tags.includes(sourceTag)),
-          )
-          .map((image) => image.id)
+      ? frozenSnapshotImageIds
       : [];
 
   return {
@@ -49,10 +52,7 @@ export const buildCollectionSettingsUpdate = ({
     autoUpdate: hasAutoAddSettings ? values.autoUpdate : false,
     imageIds: hasAutoAddSettings ? collection.imageIds ?? [] : resolvedImageIds,
     snapshotImageIds,
-    excludedImageIds:
-      hasAutoAddSettings && values.autoUpdate !== false
-        ? collection.excludedImageIds ?? []
-        : [],
+    excludedImageIds: hasAutoAddSettings && !sourceTagChanged ? collection.excludedImageIds ?? [] : [],
   };
 };
 
@@ -152,15 +152,12 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
       return;
     }
 
-    const resolvedImageIds = getResolvedCollectionImages(editingCollection.id).map((image) => image.id);
-
     await updateCollection(
       editingCollection.id,
       buildCollectionSettingsUpdate({
         collection: editingCollection,
         values,
         images,
-        resolvedImageIds,
       }),
     );
     setEditingCollection(null);

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -4,6 +4,8 @@ import { IndexedImage, SmartCollection } from '../types';
 import { useImageStore } from '../store/useImageStore';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 import CollectionCard from './CollectionCard';
+import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+import { useThumbnail } from '../hooks/useThumbnail';
 
 interface CollectionsWorkspaceProps {
   filteredImages: IndexedImage[];
@@ -44,14 +46,6 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
     return collections.filter((collection) => collection.name.toLowerCase().includes(normalizedQuery));
   }, [collections, searchQuery]);
 
-  const selectedCollectionResolvedImages = useMemo(() => {
-    if (!selectedCollection) {
-      return [];
-    }
-
-    return getResolvedCollectionImages(selectedCollection.id);
-  }, [getResolvedCollectionImages, selectedCollection]);
-
   const collectionPreviewImages = useMemo(() => {
     const imageById = new Map(images.map((image) => [image.id, image]));
 
@@ -73,12 +67,11 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
       return null;
     }
 
-    if (selectedCollection.coverImageId) {
-      return images.find((image) => image.id === selectedCollection.coverImageId) ?? null;
-    }
-
-    return selectedCollectionResolvedImages[0] ?? null;
-  }, [images, selectedCollection, selectedCollectionResolvedImages]);
+    const previewImages = collectionPreviewImages.get(selectedCollection.id) ?? [];
+    return previewImages[0] ?? null;
+  }, [collectionPreviewImages, selectedCollection]);
+  const coverThumbnail = useResolvedThumbnail(coverImage);
+  useThumbnail(coverImage);
 
   const moveCollection = async (collectionId: string, direction: -1 | 1) => {
     const currentIndex = collections.findIndex((collection) => collection.id === collectionId);
@@ -287,9 +280,9 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
 
               <div className="flex items-start gap-4">
                 <div className="h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-gray-800 bg-gray-900">
-                  {coverImage ? (
+                  {coverImage && coverThumbnail?.thumbnailUrl ? (
                     <img
-                      src={coverImage.thumbnailUrl}
+                      src={coverThumbnail.thumbnailUrl}
                       alt={selectedCollection.name}
                       className="h-full w-full object-cover"
                     />

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -177,8 +177,9 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
               No collections yet.
             </div>
           ) : (
-            filteredCollections.map((collection, index) => {
+            filteredCollections.map((collection) => {
               const isActive = collection.id === selectedCollection?.id;
+              const globalIndex = collections.findIndex((entry) => entry.id === collection.id);
               return (
                 <div
                   key={collection.id}
@@ -221,7 +222,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                         event.stopPropagation();
                         void moveCollection(collection.id, -1);
                       }}
-                      disabled={index === 0}
+                      disabled={globalIndex <= 0}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
                       title="Move up"
                     >
@@ -233,7 +234,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                         event.stopPropagation();
                         void moveCollection(collection.id, 1);
                       }}
-                      disabled={index === collections.length - 1}
+                      disabled={globalIndex === -1 || globalIndex >= collections.length - 1}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
                       title="Move down"
                     >

--- a/components/FolderSelector.tsx
+++ b/components/FolderSelector.tsx
@@ -18,7 +18,7 @@ const FolderSelector: React.FC<FolderSelectorProps> = ({ onSelectFolder }) => {
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center p-8 border-2 border-dashed border-gray-700 rounded-xl bg-gray-800/50">
       <img src="logo1.png" alt="Image MetaHub Logo" className="h-64 w-64 mb-4 rounded-lg shadow-lg" />
   <h2 className="text-2xl font-semibold mb-2 text-gray-100">Welcome to Image MetaHub v0.14</h2>
-  <p className="text-xs text-gray-500 mb-4">v0.14.0</p>
+  <p className="text-xs text-gray-500 mb-4">v0.14.1</p>
       <p className="text-gray-400 max-w-md mb-6">
         Select a folder to get started. The app will automatically scan <strong className="text-gray-200">all subfolders</strong> and display images from the entire directory tree.
       </p>

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -449,7 +449,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                             </button>
 
                             {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
-                              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
+                              <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
                                 {collections.length === 0 ? (
                                   <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
                                 ) : (

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useMemo } from 'react';
 import {
   Copy,
   Folder,
+  FolderPlus,
   Download,
   Heart,
   GitCompare,
@@ -25,6 +26,8 @@ interface GridToolbarProps {
   selectedImages: Set<string>;
   images: IndexedImage[];
   directories: { id: string; path: string }[];
+  onSaveCurrentFilteredAsCollection?: () => void;
+  saveCurrentFilteredCount?: number;
   onDeleteSelected: () => void;
   onGenerateA1111: (image: IndexedImage) => void;
   onGenerateComfyUI: (image: IndexedImage) => void;
@@ -48,6 +51,8 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   selectedImages,
   images,
   directories,
+  onSaveCurrentFilteredAsCollection,
+  saveCurrentFilteredCount = 0,
   onDeleteSelected,
   onGenerateA1111,
   onGenerateComfyUI,
@@ -223,6 +228,8 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   const selectedRatings = useImageStore((state) => state.selectedRatings);
 
   const advancedFilters = useImageStore((state) => state.advancedFilters);
+  const canSaveCurrentFilteredAsCollection =
+    Boolean(onSaveCurrentFilteredAsCollection) && saveCurrentFilteredCount > 0;
 
   const hasActiveFilters = 
       selectedModels.length > 0 ||
@@ -246,7 +253,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters) {
+  if (selectedCount === 0 && !hasActiveFilters && !canSaveCurrentFilteredAsCollection) {
     return null;
   }
 
@@ -385,6 +392,24 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                 </button>
                 
                 {/* Divider between selection tools and filters if both exist */}
+                {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
+              </>
+            )}
+
+            {canSaveCurrentFilteredAsCollection && (
+              <>
+                <button
+                  onClick={onSaveCurrentFilteredAsCollection}
+                  className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition-all duration-200 hover:border-amber-400/60 hover:bg-amber-500/20"
+                  title={`Save ${saveCurrentFilteredCount} filtered image${saveCurrentFilteredCount === 1 ? '' : 's'} as a collection`}
+                >
+                  <FolderPlus className="h-4 w-4" />
+                  <span>Save as Collection</span>
+                  <span className="rounded-full bg-black/20 px-1.5 py-0.5 text-[10px]">
+                    {saveCurrentFilteredCount}
+                  </span>
+                </button>
+
                 {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
               </>
             )}

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect, useMemo } from 'react';
 import {
   Copy,
   Folder,
-  FolderPlus,
   Download,
   Heart,
   GitCompare,
@@ -10,12 +9,13 @@ import {
   Trash2,
   ChevronDown,
   Tag,
-  RefreshCw
+  RefreshCw,
+  Plus
 } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
-import { type IndexedImage } from '../types';
+import { SmartCollection, type IndexedImage } from '../types';
 
 import ActiveFilters from './ActiveFilters';
 import TagManagerModal from './TagManagerModal';
@@ -26,8 +26,9 @@ interface GridToolbarProps {
   selectedImages: Set<string>;
   images: IndexedImage[];
   directories: { id: string; path: string }[];
-  onSaveCurrentFilteredAsCollection?: () => void;
-  saveCurrentFilteredCount?: number;
+  onCreateCollectionFromFiltered?: () => void;
+  onAddCurrentFilteredToCollection?: (collectionId: string) => Promise<void> | void;
+  filteredImageActionCount?: number;
   onDeleteSelected: () => void;
   onGenerateA1111: (image: IndexedImage) => void;
   onGenerateComfyUI: (image: IndexedImage) => void;
@@ -51,8 +52,9 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   selectedImages,
   images,
   directories,
-  onSaveCurrentFilteredAsCollection,
-  saveCurrentFilteredCount = 0,
+  onCreateCollectionFromFiltered,
+  onAddCurrentFilteredToCollection,
+  filteredImageActionCount = 0,
   onDeleteSelected,
   onGenerateA1111,
   onGenerateComfyUI,
@@ -60,9 +62,13 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   onBatchExport,
 }) => {
   const [generateDropdownOpen, setGenerateDropdownOpen] = useState(false);
+  const [isCollectionActionsOpen, setIsCollectionActionsOpen] = useState(false);
+  const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
   const [isTagModalOpen, setIsTagModalOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const collectionActionsRef = useRef<HTMLDivElement>(null);
   const toggleFavorite = useImageStore((state) => state.toggleFavorite);
+  const collections = useImageStore((state) => state.collections);
   const { canUseComparison, canUseA1111, canUseComfyUI, showProModal, canUseBulkTagging } = useFeatureAccess();
   const { isReparsing, reparseImages } = useReparseMetadata();
 
@@ -91,6 +97,10 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setGenerateDropdownOpen(false);
+      }
+      if (collectionActionsRef.current && !collectionActionsRef.current.contains(event.target as Node)) {
+        setIsCollectionActionsOpen(false);
+        setIsAddToCollectionSubmenuOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
@@ -228,8 +238,9 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   const selectedRatings = useImageStore((state) => state.selectedRatings);
 
   const advancedFilters = useImageStore((state) => state.advancedFilters);
-  const canSaveCurrentFilteredAsCollection =
-    Boolean(onSaveCurrentFilteredAsCollection) && saveCurrentFilteredCount > 0;
+  const canUseFilteredCollectionActions =
+    filteredImageActionCount > 0 &&
+    (Boolean(onCreateCollectionFromFiltered) || Boolean(onAddCurrentFilteredToCollection));
 
   const hasActiveFilters = 
       selectedModels.length > 0 ||
@@ -253,9 +264,25 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters && !canSaveCurrentFilteredAsCollection) {
+  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions) {
     return null;
   }
+
+  const handleAddToCollection = async (collection: SmartCollection) => {
+    if (!onAddCurrentFilteredToCollection) {
+      return;
+    }
+
+    await onAddCurrentFilteredToCollection(collection.id);
+    setIsCollectionActionsOpen(false);
+    setIsAddToCollectionSubmenuOpen(false);
+  };
+
+  const handleCreateCollectionFromFiltered = () => {
+    onCreateCollectionFromFiltered?.();
+    setIsCollectionActionsOpen(false);
+    setIsAddToCollectionSubmenuOpen(false);
+  };
 
   return (
     <>
@@ -396,19 +423,68 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
               </>
             )}
 
-            {canSaveCurrentFilteredAsCollection && (
+            {canUseFilteredCollectionActions && (
               <>
-                <button
-                  onClick={onSaveCurrentFilteredAsCollection}
-                  className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition-all duration-200 hover:border-amber-400/60 hover:bg-amber-500/20"
-                  title={`Save ${saveCurrentFilteredCount} filtered image${saveCurrentFilteredCount === 1 ? '' : 's'} as a collection`}
-                >
-                  <FolderPlus className="h-4 w-4" />
-                  <span>Save as Collection</span>
-                  <span className="rounded-full bg-black/20 px-1.5 py-0.5 text-[10px]">
-                    {saveCurrentFilteredCount}
-                  </span>
-                </button>
+                <div className="relative" ref={collectionActionsRef}>
+                  <button
+                    onClick={() => setIsCollectionActionsOpen((open) => !open)}
+                    className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
+                    title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
+                    aria-label="Collection actions"
+                  >
+                    <Plus className="w-4 h-4" />
+                  </button>
+
+                  {isCollectionActionsOpen && (
+                    <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
+                      <div
+                        className="relative"
+                        onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                        onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                      >
+                        <button
+                          onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                          disabled={!onAddCurrentFilteredToCollection}
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                        >
+                          <span>Add filtered images to collection</span>
+                          <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
+                        </button>
+
+                        {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
+                          <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
+                            {collections.length === 0 ? (
+                              <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
+                            ) : (
+                              collections.map((collection) => (
+                                <button
+                                  key={collection.id}
+                                  onClick={() => void handleAddToCollection(collection)}
+                                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                                >
+                                  <span className="truncate">{collection.name}</span>
+                                  {collection.sourceTag && (
+                                    <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                      {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                                    </span>
+                                  )}
+                                </button>
+                              ))
+                            )}
+                          </div>
+                        )}
+                      </div>
+
+                      <button
+                        onClick={handleCreateCollectionFromFiltered}
+                        disabled={!onCreateCollectionFromFiltered}
+                        className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                      >
+                        Create new collection from filtered images
+                      </button>
+                    </div>
+                  )}
+                </div>
 
                 {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
               </>

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -239,6 +239,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
 
   const advancedFilters = useImageStore((state) => state.advancedFilters);
   const canUseFilteredCollectionActions =
+    selectedCount > 0 &&
     filteredImageActionCount > 0 &&
     (Boolean(onCreateCollectionFromFiltered) || Boolean(onAddCurrentFilteredToCollection));
 
@@ -264,7 +265,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions) {
+  if (selectedCount === 0 && !hasActiveFilters) {
     return null;
   }
 
@@ -288,7 +289,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
     <>
       <div className="flex items-center justify-between gap-2 mb-1 px-5 min-h-[36px]">
         {/* Selection Context Toolbar - Centered or justified as needed */}
-        <div className="flex items-center gap-1 flex-1 overflow-hidden">
+        <div className="flex items-center gap-1 flex-1 min-w-0">
             {selectedCount > 0 && (
               <>
                 <span className="text-[11px] text-gray-400 mr-2 whitespace-nowrap">{selectedCount} selected</span>
@@ -419,79 +420,78 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                 </button>
                 
                 {/* Divider between selection tools and filters if both exist */}
-                {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
-              </>
-            )}
-
-            {canUseFilteredCollectionActions && (
-              <>
-                <div className="relative" ref={collectionActionsRef}>
-                  <button
-                    onClick={() => setIsCollectionActionsOpen((open) => !open)}
-                    className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
-                    title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
-                    aria-label="Collection actions"
-                  >
-                    <Plus className="w-4 h-4" />
-                  </button>
-
-                  {isCollectionActionsOpen && (
-                    <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
-                      <div
-                        className="relative"
-                        onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
-                        onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                {canUseFilteredCollectionActions && (
+                  <>
+                    <div className="relative" ref={collectionActionsRef}>
+                      <button
+                        onClick={() => setIsCollectionActionsOpen((open) => !open)}
+                        className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
+                        title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
+                        aria-label="Collection actions"
                       >
-                        <button
-                          onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
-                          disabled={!onAddCurrentFilteredToCollection}
-                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
-                        >
-                          <span>Add filtered images to collection</span>
-                          <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
-                        </button>
+                        <Plus className="w-4 h-4" />
+                      </button>
 
-                        {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
-                          <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
-                            {collections.length === 0 ? (
-                              <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
-                            ) : (
-                              collections.map((collection) => (
-                                <button
-                                  key={collection.id}
-                                  onClick={() => void handleAddToCollection(collection)}
-                                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
-                                >
-                                  <span className="truncate">{collection.name}</span>
-                                  {collection.sourceTag && (
-                                    <span className="text-[10px] uppercase tracking-wide text-gray-500">
-                                      {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
-                                    </span>
-                                  )}
-                                </button>
-                              ))
+                      {isCollectionActionsOpen && (
+                        <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
+                          <div
+                            className="relative"
+                            onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                            onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                          >
+                            <button
+                              onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                              disabled={!onAddCurrentFilteredToCollection}
+                              className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                            >
+                              <span>Add filtered images to collection</span>
+                              <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
+                            </button>
+
+                            {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
+                              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
+                                {collections.length === 0 ? (
+                                  <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
+                                ) : (
+                                  collections.map((collection) => (
+                                    <button
+                                      key={collection.id}
+                                      onClick={() => void handleAddToCollection(collection)}
+                                      className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                                    >
+                                      <span className="truncate">{collection.name}</span>
+                                      {collection.sourceTag && (
+                                        <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                          {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                                        </span>
+                                      )}
+                                    </button>
+                                  ))
+                                )}
+                              </div>
                             )}
                           </div>
-                        )}
-                      </div>
 
-                      <button
-                        onClick={handleCreateCollectionFromFiltered}
-                        disabled={!onCreateCollectionFromFiltered}
-                        className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
-                      >
-                        Create new collection from filtered images
-                      </button>
+                          <button
+                            onClick={handleCreateCollectionFromFiltered}
+                            disabled={!onCreateCollectionFromFiltered}
+                            className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                          >
+                            Create new collection from filtered images
+                          </button>
+                        </div>
+                      )}
                     </div>
-                  )}
-                </div>
+
+                  </>
+                )}
 
                 {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
               </>
             )}
 
             {/* Active Filters */}
-            <div className="flex-1 min-w-0">
+            <div className="flex-1 min-w-0 overflow-hidden">
                <ActiveFilters />
             </div>
         </div>

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -239,7 +239,6 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
 
   const advancedFilters = useImageStore((state) => state.advancedFilters);
   const canUseFilteredCollectionActions =
-    selectedCount > 0 &&
     filteredImageActionCount > 0 &&
     (Boolean(onCreateCollectionFromFiltered) || Boolean(onAddCurrentFilteredToCollection));
 
@@ -265,7 +264,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters) {
+  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions) {
     return null;
   }
 
@@ -419,73 +418,73 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                   <Trash2 className="w-4 h-4" />
                 </button>
                 
-                {/* Divider between selection tools and filters if both exist */}
-                {canUseFilteredCollectionActions && (
-                  <>
-                    <div className="relative" ref={collectionActionsRef}>
-                      <button
-                        onClick={() => setIsCollectionActionsOpen((open) => !open)}
-                        className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
-                        title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
-                        aria-label="Collection actions"
+                {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
+              </>
+            )}
+
+            {canUseFilteredCollectionActions && (
+              <>
+                {selectedCount > 0 && <div className="w-px h-4 bg-gray-700 mx-1" />}
+                <div className="relative" ref={collectionActionsRef}>
+                  <button
+                    onClick={() => setIsCollectionActionsOpen((open) => !open)}
+                    className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
+                    title={`Collection actions for ${filteredImageActionCount} filtered image${filteredImageActionCount === 1 ? '' : 's'}`}
+                    aria-label="Collection actions"
+                  >
+                    <Plus className="w-4 h-4" />
+                  </button>
+
+                  {isCollectionActionsOpen && (
+                    <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
+                      <div
+                        className="relative"
+                        onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                        onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
                       >
-                        <Plus className="w-4 h-4" />
-                      </button>
+                        <button
+                          onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                          disabled={!onAddCurrentFilteredToCollection}
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                        >
+                          <span>Add filtered images to collection</span>
+                          <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
+                        </button>
 
-                      {isCollectionActionsOpen && (
-                        <div className="absolute left-0 top-full mt-1 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl z-50">
-                          <div
-                            className="relative"
-                            onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
-                            onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
-                          >
-                            <button
-                              onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
-                              disabled={!onAddCurrentFilteredToCollection}
-                              className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
-                            >
-                              <span>Add filtered images to collection</span>
-                              <ChevronDown className={`h-4 w-4 transition-transform ${isAddToCollectionSubmenuOpen ? '-rotate-90' : 'rotate-[-90deg]'}`} />
-                            </button>
-
-                            {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
-                              <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
-                                {collections.length === 0 ? (
-                                  <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
-                                ) : (
-                                  collections.map((collection) => (
-                                    <button
-                                      key={collection.id}
-                                      onClick={() => void handleAddToCollection(collection)}
-                                      className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
-                                    >
-                                      <span className="truncate">{collection.name}</span>
-                                      {collection.sourceTag && (
-                                        <span className="text-[10px] uppercase tracking-wide text-gray-500">
-                                          {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
-                                        </span>
-                                      )}
-                                    </button>
-                                  ))
-                                )}
-                              </div>
+                        {isAddToCollectionSubmenuOpen && onAddCurrentFilteredToCollection && (
+                          <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl">
+                            {collections.length === 0 ? (
+                              <div className="px-3 py-2 text-sm text-gray-500">No collections yet</div>
+                            ) : (
+                              collections.map((collection) => (
+                                <button
+                                  key={collection.id}
+                                  onClick={() => void handleAddToCollection(collection)}
+                                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                                >
+                                  <span className="truncate">{collection.name}</span>
+                                  {collection.sourceTag && (
+                                    <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                      {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                                    </span>
+                                  )}
+                                </button>
+                              ))
                             )}
                           </div>
+                        )}
+                      </div>
 
-                          <button
-                            onClick={handleCreateCollectionFromFiltered}
-                            disabled={!onCreateCollectionFromFiltered}
-                            className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
-                          >
-                            Create new collection from filtered images
-                          </button>
-                        </div>
-                      )}
+                      <button
+                        onClick={handleCreateCollectionFromFiltered}
+                        disabled={!onCreateCollectionFromFiltered}
+                        className="w-full px-3 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:text-gray-500"
+                      >
+                        Create new collection from filtered images
+                      </button>
                     </div>
-
-                  </>
-                )}
-
+                  )}
+                </div>
                 {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
               </>
             )}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Settings, Bug, BarChart3, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft, Boxes } from 'lucide-react';
+import { Settings, Bug, BarChart3, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft } from 'lucide-react';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
@@ -7,13 +7,15 @@ import { A1111ApiClient } from '../services/a1111ApiClient';
 import { ComfyUIApiClient } from '../services/comfyUIApiClient';
 import { detectGeneratorFromLaunchCommand } from '../utils/detectGeneratorLaunch';
 
+type LibraryView = 'library' | 'smart' | 'model' | 'node' | 'collections';
+
 interface HeaderProps {
     onOpenSettings: () => void;
     onOpenAnalytics: () => void;
     onOpenLicense: () => void;
     onGeneratorSetupNeeded?: () => void;
-    libraryView?: 'library' | 'smart' | 'model' | 'node' | 'collections';
-    onLibraryViewChange?: (view: 'library' | 'smart' | 'model' | 'node' | 'collections') => void;
+    libraryView?: LibraryView;
+    onLibraryViewChange?: (view: LibraryView) => void;
 }
 
 const Header: React.FC<HeaderProps> = ({ 
@@ -251,18 +253,17 @@ const Header: React.FC<HeaderProps> = ({
 
   const generatorButtonClassName = useMemo(() => {
     if (isLaunchingGenerator) {
-      return 'bg-amber-600 border-amber-500/60 shadow-amber-900/20 cursor-wait';
+      return 'border-accent/40 bg-accent/15 text-accent cursor-wait hover:border-accent/40 hover:bg-accent/20 hover:text-accent';
     }
 
-    if (relevantConnectionStatus === 'connected' && hasRelevantServerUrl) {
-      return 'hover:bg-emerald-500 bg-emerald-600 shadow-emerald-900/20 border-emerald-500/50';
+    if (
+      (relevantConnectionStatus === 'connected' && hasRelevantServerUrl) ||
+      hasLaunchCommand
+    ) {
+      return 'border-accent/60 bg-accent text-white hover:border-accent/60 hover:bg-accent/90 hover:text-white';
     }
 
-    if (hasLaunchCommand) {
-      return 'hover:bg-blue-500 bg-blue-600 shadow-blue-900/20 border-blue-500/50';
-    }
-
-    return 'bg-gray-700 border-gray-600 text-gray-200 hover:bg-gray-600';
+    return 'text-gray-200';
   }, [hasLaunchCommand, hasRelevantServerUrl, isLaunchingGenerator, relevantConnectionStatus]);
 
   const generatorButtonTitle = useMemo(() => {
@@ -288,235 +289,178 @@ const Header: React.FC<HeaderProps> = ({
   const statusConfig = (() => {
     if (!initialized) {
       return {
-        label: 'Status: Checking license…',
-        classes: 'text-gray-300 bg-gray-800/70 border-gray-700',
+        label: 'Checking license',
+        classes: 'text-gray-300',
       };
     }
     if (isPro) {
       return {
-        label: 'Status: Pro License',
-        classes: 'text-green-300 bg-green-900/30 border-green-600/50',
+        label: 'Pro',
+        classes: 'text-gray-100',
       };
     }
     if (isTrialActive) {
       const daysLabel = `${trialDaysRemaining} ${trialDaysRemaining === 1 ? 'day' : 'days'} left`;
       return {
-        label: `Status: Pro Trial (${daysLabel})`,
-        classes: 'text-amber-400 bg-amber-900/30 border-amber-500/50',
+        label: `Trial • ${daysLabel}`,
+        classes: 'border-amber-500/40 bg-amber-500/15 text-amber-200 hover:border-amber-400/50 hover:bg-amber-500/20 hover:text-amber-100',
       };
     }
     if (isExpired) {
       return {
-        label: 'Status: Trial expired',
-        classes: 'text-red-300 bg-red-900/30 border-red-600/50',
+        label: 'Trial expired',
+        classes: 'border-amber-600/30 bg-amber-500/10 text-amber-200 hover:border-amber-500/40 hover:bg-amber-500/15 hover:text-amber-100',
       };
     }
     return {
-      label: 'Status: Free Version',
-      classes: 'text-gray-300 bg-gray-800/60 border-gray-700',
+      label: 'Free',
+      classes: 'border-amber-700/30 bg-amber-500/10 text-amber-200 hover:border-amber-600/40 hover:bg-amber-500/15 hover:text-amber-100',
     };
   })();
 
-  const analyticsBadgeClass = isPro
-    ? 'text-green-300'
-    : isTrialActive
-    ? 'text-amber-400'
-    : 'text-purple-400';
+  const analyticsBadgeClass = canUseAnalytics ? 'text-gray-500' : 'text-amber-400';
+  const viewTabs = useMemo(
+    () => [
+      { id: 'library' as const, label: 'Library' },
+      { id: 'smart' as const, label: 'Smart Library', count: clustersCount > 0 ? clustersCount : null },
+      { id: 'model' as const, label: 'Model View' },
+      { id: 'node' as const, label: 'Node View' },
+      { id: 'collections' as const, label: 'Collections' },
+    ],
+    [clustersCount]
+  );
+  const utilityButtonClassName = 'app-top-icon-button';
 
   return (
-    <header className="bg-gray-900/80 backdrop-blur-md sticky top-0 z-50 px-4 py-2 border-b border-gray-800/60 shadow-lg transition-all duration-300">
-      <div className="container mx-auto flex items-center justify-between gap-4">
-        
-        {/* Left Side - Status Indicator */}
-        <div className="flex items-center gap-4">
-            <button
-              onClick={onOpenLicense}
-              className={`inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded-full border transition-all duration-300 hover:scale-105 ${statusConfig.classes}`}
-              title={isFree ? 'Start trial or activate license' : 'Manage license and status'}
-            >
-              <Crown className="w-3 h-3" />
-              {statusConfig.label.replace('Status: ', '')}
-            </button>
+    <header className="sticky top-0 z-50 border-b border-gray-800/70 bg-gray-900/85 px-4 py-2.5 backdrop-blur-md shadow-lg shadow-black/20 transition-all duration-300">
+      <div className="container mx-auto flex items-center gap-4">
+        <div className="shrink-0">
+          <button
+            onClick={onOpenLicense}
+            className={`app-top-pill text-[10px] uppercase tracking-[0.18em] ${statusConfig.classes}`}
+            title={isFree ? 'Start trial or activate license' : 'Manage license and status'}
+          >
+            <Crown className="h-3 w-3" />
+            <span>{statusConfig.label}</span>
+          </button>
         </div>
 
-        {/* Center Side - View Controls (Only visible if libraryView is provided) */}
+        <div className="flex min-w-0 flex-1 justify-center">
         {libraryView && onLibraryViewChange && (
-            <div className="flex items-center gap-3">
-                <div className="flex items-center bg-gray-800/50 rounded-full p-1 border border-gray-700/50">
-                    <button
-                        onClick={() => onLibraryViewChange('library')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 ${
-                            libraryView === 'library' 
-                            ? 'bg-blue-600 text-white shadow-md shadow-blue-900/20' 
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        Library
-                    </button>
-                    <button
-                        onClick={() => onLibraryViewChange('smart')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
-                            libraryView === 'smart' 
-                            ? 'bg-purple-600 text-white shadow-md shadow-purple-900/20' 
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        Smart Library
-                        {clustersCount > 0 && (
-                            <span className="bg-black/20 px-1.5 rounded-full text-[10px]">{clustersCount}</span>
-                        )}
-                    </button>
-                    <button
-                        onClick={() => onLibraryViewChange('model')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
-                            libraryView === 'model' 
-                            ? 'bg-emerald-600 text-white shadow-md shadow-emerald-900/20' 
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        Model View
-                    </button>
-                    <button
-                        onClick={() => onLibraryViewChange('node')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
-                            libraryView === 'node'
-                            ? 'bg-cyan-600 text-white shadow-md shadow-cyan-900/20'
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        <Boxes className="h-3.5 w-3.5" />
-                        Node View
-                    </button>
-                    <button
-                        onClick={() => onLibraryViewChange('collections')}
-                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
-                            libraryView === 'collections'
-                            ? 'bg-amber-600 text-white shadow-md shadow-amber-900/20'
-                            : 'text-gray-400 hover:text-white hover:bg-white/5'
-                        }`}
-                    >
-                        Collections
-                    </button>
-                </div>
-
-            </div>
+          <div className="app-top-segmented max-w-full">
+            {viewTabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => onLibraryViewChange(tab.id)}
+                className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
+              >
+                <span>{tab.label}</span>
+                {tab.count ? (
+                  <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${
+                    libraryView === tab.id
+                      ? 'border-white/20 bg-black/20 text-white/90'
+                      : 'border-gray-700/80 bg-gray-950/80 text-gray-500'
+                  }`}>
+                    {tab.count}
+                  </span>
+                ) : null}
+              </button>
+            ))}
+          </div>
         )}
+        </div>
 
+        <div className="flex shrink-0 items-center gap-2">
+          {(libraryView === 'library' || libraryView === 'node') && (
+            <>
+              <button
+                onClick={() => setStackingEnabled(!isStackingEnabled)}
+                className={`${utilityButtonClassName} ${isStackingEnabled ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : ''}`}
+                title={isStackingEnabled ? 'Disable stacking' : 'Stack items by identical prompt'}
+              >
+                {isStackingEnabled ? <Layers2 size={16} /> : <Layers size={16} />}
+              </button>
 
-        {/* Right Side - Actions */}
-        <div className="flex items-center gap-3">
-            
-                   {/* Stacking Toggle - Only relevant for Library view */}
-                   {(libraryView === 'library' || libraryView === 'node') && (
-                     <>
-                        <button
-                          onClick={() => setStackingEnabled(!isStackingEnabled)}
-                          className={`p-1.5 rounded-lg transition-all duration-200 ${
-                              isStackingEnabled 
-                              ? 'text-blue-400 bg-blue-500/10' 
-                              : 'text-gray-500 hover:text-gray-300 hover:bg-white/5'
-                          }`}
-                          title={isStackingEnabled ? "Disable stacking" : "Stack items by identical prompt"}
-                        >
-                          {isStackingEnabled ? <Layers2 size={16} /> : <Layers size={16} />}
-                        </button>
-                        
-                         {/* Back from Stack Button */}
-                        {viewingStackPrompt && (
-                            <button
-                                onClick={() => {
-                                setSearchQuery('');
-                                setStackingEnabled(true);
-                                setViewingStackPrompt(null);
-                                }}
-                                className="flex items-center gap-1 px-2 py-1 bg-blue-500/10 text-blue-400 rounded-md hover:bg-blue-500/20 transition-colors text-xs font-medium"
-                            >
-                                <ArrowLeft size={12} />
-                                Back
-                            </button>
-                        )}
-                        <div className="w-px h-4 bg-gray-700/50 mx-1"></div>
-                     </>
-                   )}
-
-                   {/* Safe Mode Toggle */}
-                   <button
-                     onClick={() => setEnableSafeMode(!enableSafeMode)}
-                     className={`p-1.5 rounded-lg transition-all duration-200 ${
-                         enableSafeMode
-                         ? 'text-gray-400 hover:text-white'
-                         : 'text-gray-600 hover:text-gray-400'
-                     }`}
-                     title={enableSafeMode ? 'Safe Mode on' : 'Safe Mode off'}
-                   >
-                     {enableSafeMode ? <Eye size={16} /> : <EyeOff size={16} />}
-                   </button>
-           
-          {/* Smart Library Actions (Contextual) */}
-          {libraryView === 'smart' && (
-             <div className="flex items-center gap-2 mr-2 animate-in fade-in duration-300">
+              {viewingStackPrompt && (
                 <button
-                    onClick={handleGenerateClusters}
-                    disabled={!hasDirectories || isClustering}
-                    className={`inline-flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-xs font-semibold transition-all ${
-                        isClustering ? 'text-blue-400/50 cursor-wait' : 'text-blue-400 hover:bg-blue-500/10 hover:text-blue-300'
-                    }`}
-                    title="Generate Clusters"
+                  onClick={() => {
+                    setSearchQuery('');
+                    setStackingEnabled(true);
+                    setViewingStackPrompt(null);
+                  }}
+                  className="app-top-pill px-2.5 text-gray-300"
+                  title="Return to the stacked results"
                 >
-                    <Layers size={14} className={isClustering ? 'animate-pulse' : ''}/>
-                    <span className="hidden xl:inline">Cluster</span>
+                  <ArrowLeft size={12} />
+                  <span>Back</span>
                 </button>
-                <button
-                    onClick={handleGenerateAutoTags}
-                    disabled={!hasDirectories || isAutoTagging}
-                    className={`inline-flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-xs font-semibold transition-all ${
-                        isAutoTagging ? 'text-purple-400/50 cursor-wait' : 'text-purple-400 hover:bg-purple-500/10 hover:text-purple-300'
-                    }`}
-                    title="Generate Auto-Tags"
-                >
-                    <Sparkles size={14} className={isAutoTagging ? 'animate-pulse' : ''}/>
-                    <span className="hidden xl:inline">Auto-Tag</span>
-                </button>
-                 <div className="w-px h-5 bg-gray-700/50 mx-1"></div>
-             </div>
+              )}
+            </>
           )}
 
-          <a
-            href="https://github.com/LuqP2/Image-MetaHub/issues/new"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="px-2 py-1.5 rounded-lg transition-all duration-200 text-xs font-medium text-gray-400 hover:bg-white/5 hover:text-white flex items-center gap-2 group"
-            title="Report a bug or provide feedback"
-          >
-            <Bug size={14} className="group-hover:text-red-400 transition-colors" />
-            <span className="hidden sm:inline">Feedback</span>
-          </a>
-          
-          <div className="w-px h-5 bg-gray-700/50 mx-1"></div>
+          {libraryView === 'smart' && (
+            <div className="app-top-segmented animate-in fade-in duration-300">
+              <button
+                onClick={handleGenerateClusters}
+                disabled={!hasDirectories || isClustering}
+                className={`app-top-segment ${isClustering ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
+                title="Generate clusters"
+              >
+                <Layers size={14} className={isClustering ? 'animate-pulse' : ''} />
+                <span>Cluster</span>
+              </button>
+              <button
+                onClick={handleGenerateAutoTags}
+                disabled={!hasDirectories || isAutoTagging}
+                className={`app-top-segment ${isAutoTagging ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
+                title="Generate auto-tags"
+              >
+                <Sparkles size={14} className={isAutoTagging ? 'animate-pulse' : ''} />
+                <span>Auto-Tag</span>
+              </button>
+            </div>
+          )}
+
+          <span className="app-top-divider" />
 
           <button
             onClick={handleLaunchGenerator}
             disabled={isLaunchingGenerator}
-            className={`px-3 py-1.5 rounded-lg transition-all duration-300 text-xs font-bold text-white shadow-md border flex items-center gap-2 ${generatorButtonClassName}`}
+            className={`app-top-pill h-10 px-4 text-sm font-semibold shadow-sm ${generatorButtonClassName}`}
             title={generatorButtonTitle}
           >
-            <Sparkles size={14} className={`text-white/90 transition-colors ${isLaunchingGenerator ? 'animate-pulse' : ''}`} />
+            <Sparkles size={14} className={isLaunchingGenerator ? 'animate-pulse' : ''} />
             {generatorButtonLabel}
           </button>
-          
-          {/* Discreet Get Pro link - Unified Amber Theme */}
+
           {!isPro && (
             <a
               href="https://imagemetahub.com/getpro"
               target="_blank"
               rel="noopener noreferrer"
-              className="hidden lg:inline-flex text-[10px] font-bold uppercase tracking-wider text-amber-400 hover:text-amber-300 transition-colors px-3 py-1.5 rounded-full bg-amber-900/20 border border-amber-600/30 hover:bg-amber-900/40 hover:border-amber-500/50"
+              className="app-top-pill hidden border-amber-700/30 bg-amber-500/10 text-[10px] uppercase tracking-[0.18em] text-amber-200 hover:border-amber-600/40 hover:bg-amber-500/15 hover:text-amber-100 lg:inline-flex"
             >
               Get Pro
             </a>
           )}
-          
-          <div className="flex items-center bg-gray-800/50 rounded-full p-0.5 border border-gray-700/50">
+
+          <div className="app-top-segmented">
+            <button
+              onClick={() => setEnableSafeMode(!enableSafeMode)}
+              className={`${utilityButtonClassName} h-8 w-8 border-transparent bg-transparent ${enableSafeMode ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : 'text-gray-500 hover:text-gray-200'}`}
+              title={enableSafeMode ? 'Safe Mode on' : 'Safe Mode off'}
+            >
+              {enableSafeMode ? <Eye size={16} /> : <EyeOff size={16} />}
+            </button>
+            <a
+              href="https://github.com/LuqP2/Image-MetaHub/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${utilityButtonClassName} h-8 w-8 border-transparent bg-transparent`}
+              title="Report a bug or provide feedback"
+            >
+              <Bug size={16} />
+            </a>
             <button
               onClick={() => {
                 if (canUseAnalytics) {
@@ -525,17 +469,17 @@ const Header: React.FC<HeaderProps> = ({
                   showProModal('analytics');
                 }
               }}
-              className="p-1.5 rounded-full hover:bg-gray-700/80 text-gray-400 hover:text-white transition-all hover:shadow-lg relative group"
+              className={`${utilityButtonClassName} relative h-8 w-8 border-transparent bg-transparent`}
               title={canUseAnalytics ? 'Analytics (Pro)' : 'Analytics (Pro Feature) - start trial'}
             >
               <BarChart3 size={16} />
-              <div className="absolute -top-0.5 -right-0.5 transition-transform group-hover:scale-110">
+              <div className="absolute -right-0.5 -top-0.5">
                 <Crown className={`w-2.5 h-2.5 ${analyticsBadgeClass}`} />
               </div>
             </button>
             <button
               onClick={onOpenSettings}
-              className="p-1.5 rounded-full hover:bg-gray-700/80 text-gray-400 hover:text-white transition-all hover:rotate-45"
+              className={`${utilityButtonClassName} h-8 w-8 border-transparent bg-transparent`}
               title="Open Settings"
             >
               <Settings size={16} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,8 +12,8 @@ interface HeaderProps {
     onOpenAnalytics: () => void;
     onOpenLicense: () => void;
     onGeneratorSetupNeeded?: () => void;
-    libraryView?: 'library' | 'smart' | 'model' | 'node';
-    onLibraryViewChange?: (view: 'library' | 'smart' | 'model' | 'node') => void;
+    libraryView?: 'library' | 'smart' | 'model' | 'node' | 'collections';
+    onLibraryViewChange?: (view: 'library' | 'smart' | 'model' | 'node' | 'collections') => void;
 }
 
 const Header: React.FC<HeaderProps> = ({ 
@@ -386,6 +386,16 @@ const Header: React.FC<HeaderProps> = ({
                     >
                         <Boxes className="h-3.5 w-3.5" />
                         Node View
+                    </button>
+                    <button
+                        onClick={() => onLibraryViewChange('collections')}
+                        className={`px-3 py-1 text-xs font-semibold rounded-full transition-all duration-200 flex items-center gap-1.5 ${
+                            libraryView === 'collections'
+                            ? 'bg-amber-600 text-white shadow-md shadow-amber-900/20'
+                            : 'text-gray-400 hover:text-white hover:bg-white/5'
+                        }`}
+                    >
+                        Collections
                     </button>
                 </div>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -253,14 +253,14 @@ const Header: React.FC<HeaderProps> = ({
 
   const generatorButtonClassName = useMemo(() => {
     if (isLaunchingGenerator) {
-      return 'border-accent/40 bg-accent/15 text-accent cursor-wait hover:border-accent/40 hover:bg-accent/20 hover:text-accent';
+      return 'border-accent/45 bg-accent/15 text-accent cursor-wait hover:border-accent/45 hover:bg-accent/20 hover:text-accent';
     }
 
     if (
       (relevantConnectionStatus === 'connected' && hasRelevantServerUrl) ||
       hasLaunchCommand
     ) {
-      return 'border-accent/60 bg-accent text-white hover:border-accent/60 hover:bg-accent/90 hover:text-white';
+      return 'border-accent/45 bg-accent/12 text-accent hover:border-accent/55 hover:bg-accent/18 hover:text-accent';
     }
 
     return 'text-gray-200';
@@ -333,49 +333,48 @@ const Header: React.FC<HeaderProps> = ({
 
   return (
     <header className="sticky top-0 z-50 border-b border-gray-800/70 bg-gray-900/85 px-4 py-2.5 backdrop-blur-md shadow-lg shadow-black/20 transition-all duration-300">
-      <div className="container mx-auto flex items-center gap-4">
-        <div className="shrink-0">
+      <div className="container mx-auto flex items-center justify-between gap-4">
+        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
           <button
             onClick={onOpenLicense}
-            className={`app-top-pill text-[10px] uppercase tracking-[0.18em] ${statusConfig.classes}`}
+            className={`app-top-pill shrink-0 text-[10px] uppercase tracking-[0.18em] ${statusConfig.classes}`}
             title={isFree ? 'Start trial or activate license' : 'Manage license and status'}
           >
             <Crown className="h-3 w-3" />
             <span>{statusConfig.label}</span>
           </button>
-        </div>
 
-        <div className="flex min-w-0 flex-1 justify-center">
-        {libraryView && onLibraryViewChange && (
-          <div className="app-top-segmented max-w-full">
-            {viewTabs.map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => onLibraryViewChange(tab.id)}
-                className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
-              >
-                <span>{tab.label}</span>
-                {tab.count ? (
-                  <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${
-                    libraryView === tab.id
-                      ? 'border-white/20 bg-black/20 text-white/90'
-                      : 'border-gray-700/80 bg-gray-950/80 text-gray-500'
-                  }`}>
-                    {tab.count}
-                  </span>
-                ) : null}
-              </button>
-            ))}
-          </div>
-        )}
-        </div>
+          {libraryView && onLibraryViewChange && (
+            <div className="min-w-0 max-w-full overflow-x-auto scrollbar-thin">
+              <div className="app-top-segmented w-max">
+                {viewTabs.map((tab) => (
+                  <button
+                    key={tab.id}
+                    onClick={() => onLibraryViewChange(tab.id)}
+                    className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
+                  >
+                    <span>{tab.label}</span>
+                    {tab.count ? (
+                      <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${
+                        libraryView === tab.id
+                          ? 'border-white/20 bg-black/20 text-white/90'
+                          : 'border-gray-700/80 bg-gray-950/80 text-gray-500'
+                      }`}>
+                        {tab.count}
+                      </span>
+                    ) : null}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
-        <div className="flex shrink-0 items-center gap-2">
           {(libraryView === 'library' || libraryView === 'node') && (
             <>
+              <span className="app-top-divider shrink-0" />
               <button
                 onClick={() => setStackingEnabled(!isStackingEnabled)}
-                className={`${utilityButtonClassName} ${isStackingEnabled ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : ''}`}
+                className={`${utilityButtonClassName} shrink-0 ${isStackingEnabled ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : ''}`}
                 title={isStackingEnabled ? 'Disable stacking' : 'Stack items by identical prompt'}
               >
                 {isStackingEnabled ? <Layers2 size={16} /> : <Layers size={16} />}
@@ -388,7 +387,7 @@ const Header: React.FC<HeaderProps> = ({
                     setStackingEnabled(true);
                     setViewingStackPrompt(null);
                   }}
-                  className="app-top-pill px-2.5 text-gray-300"
+                  className="app-top-pill shrink-0 px-2.5 text-gray-300"
                   title="Return to the stacked results"
                 >
                   <ArrowLeft size={12} />
@@ -399,34 +398,39 @@ const Header: React.FC<HeaderProps> = ({
           )}
 
           {libraryView === 'smart' && (
-            <div className="app-top-segmented animate-in fade-in duration-300">
-              <button
-                onClick={handleGenerateClusters}
-                disabled={!hasDirectories || isClustering}
-                className={`app-top-segment ${isClustering ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
-                title="Generate clusters"
-              >
-                <Layers size={14} className={isClustering ? 'animate-pulse' : ''} />
-                <span>Cluster</span>
-              </button>
-              <button
-                onClick={handleGenerateAutoTags}
-                disabled={!hasDirectories || isAutoTagging}
-                className={`app-top-segment ${isAutoTagging ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
-                title="Generate auto-tags"
-              >
-                <Sparkles size={14} className={isAutoTagging ? 'animate-pulse' : ''} />
-                <span>Auto-Tag</span>
-              </button>
-            </div>
+            <>
+              <span className="app-top-divider shrink-0" />
+              <div className="app-top-segmented animate-in fade-in shrink-0 duration-300">
+                <button
+                  onClick={handleGenerateClusters}
+                  disabled={!hasDirectories || isClustering}
+                  className={`app-top-segment ${isClustering ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
+                  title="Generate clusters"
+                >
+                  <Layers size={14} className={isClustering ? 'animate-pulse' : ''} />
+                  <span>Cluster</span>
+                </button>
+                <button
+                  onClick={handleGenerateAutoTags}
+                  disabled={!hasDirectories || isAutoTagging}
+                  className={`app-top-segment ${isAutoTagging ? 'text-accent cursor-wait hover:text-accent' : ''} ${!hasDirectories ? 'cursor-not-allowed opacity-50' : ''}`}
+                  title="Generate auto-tags"
+                >
+                  <Sparkles size={14} className={isAutoTagging ? 'animate-pulse' : ''} />
+                  <span>Auto-Tag</span>
+                </button>
+              </div>
+            </>
           )}
+        </div>
 
+        <div className="flex shrink-0 items-center gap-2">
           <span className="app-top-divider" />
 
           <button
             onClick={handleLaunchGenerator}
             disabled={isLaunchingGenerator}
-            className={`app-top-pill h-10 px-4 text-sm font-semibold shadow-sm ${generatorButtonClassName}`}
+            className={`app-top-pill h-9 px-3 text-xs font-semibold shadow-sm ${generatorButtonClassName}`}
             title={generatorButtonTitle}
           >
             <Sparkles size={14} className={isLaunchingGenerator ? 'animate-pulse' : ''} />
@@ -438,7 +442,7 @@ const Header: React.FC<HeaderProps> = ({
               href="https://imagemetahub.com/getpro"
               target="_blank"
               rel="noopener noreferrer"
-              className="app-top-pill hidden border-amber-700/30 bg-amber-500/10 text-[10px] uppercase tracking-[0.18em] text-amber-200 hover:border-amber-600/40 hover:bg-amber-500/15 hover:text-amber-100 lg:inline-flex"
+              className="app-top-pill hidden h-9 border-amber-700/30 bg-amber-500/10 px-3 text-xs font-semibold text-amber-200 hover:border-amber-600/40 hover:bg-amber-500/15 hover:text-amber-100 lg:inline-flex"
             >
               Get Pro
             </a>

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -2,7 +2,7 @@ import { FixedSizeGrid as Grid, GridChildComponentProps, areEqual } from 'react-
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { type IndexedImage, type BaseMetadata, type Directory, ImageStack } from '../types';
+import { type IndexedImage, type BaseMetadata, type Directory, ImageStack, SmartCollection } from '../types';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
 import { useContextMenu } from '../hooks/useContextMenu';
@@ -33,6 +33,7 @@ import ProBadge from './ProBadge';
 import { useImageStacking } from '../hooks/useImageStacking';
 import TagManagerModal from './TagManagerModal';
 import TransferImagesModal from './TransferImagesModal';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 import { transferIndexedImages } from '../services/fileTransferService';
 import { thumbnailManager } from '../services/thumbnailManager';
 import { getContextMenuRatingTargetIds } from '../utils/ratingSelection';
@@ -673,6 +674,8 @@ interface ImageGridProps {
   totalPages: number;
   onPageChange: (page: number) => void;
   onBatchExport: () => void;
+  activeCollection?: SmartCollection | null;
+  isCollectionsView?: boolean;
   // Deduplication support (optional)
   markedBestIds?: Set<string>;      // IDs of images marked as best
   markedArchivedIds?: Set<string>;  // IDs of images marked for archive
@@ -683,7 +686,19 @@ const InnerGridElement = React.forwardRef<HTMLDivElement, React.HTMLAttributes<H
   <div ref={ref} {...props} data-grid-background="true" />
 ));
 
-const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedImages, currentPage, totalPages, onPageChange, onBatchExport, markedBestIds, markedArchivedIds }) => {
+const ImageGrid: React.FC<ImageGridProps> = ({
+  images,
+  onImageClick,
+  selectedImages,
+  currentPage,
+  totalPages,
+  onPageChange,
+  onBatchExport,
+  activeCollection = null,
+  isCollectionsView = false,
+  markedBestIds,
+  markedArchivedIds,
+}) => {
   const imageSize = useSettingsStore((state) => state.imageSize);
   const itemsPerPage = useSettingsStore((state) => state.itemsPerPage);
   const showFilenames = useSettingsStore((state) => state.showFilenames);
@@ -737,7 +752,17 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isTransferring, setIsTransferring] = useState(false);
   const [isCopySubmenuOpen, setIsCopySubmenuOpen] = useState(false);
+  const [isCollectionSubmenuOpen, setIsCollectionSubmenuOpen] = useState(false);
+  const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
+  const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
   const [transferStatusText, setTransferStatusText] = useState<string>('');
+  const collections = useImageStore((state) => state.collections);
+  const createCollection = useImageStore((state) => state.createCollection);
+  const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
+  const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
+  const updateCollection = useImageStore((state) => state.updateCollection);
+  const bulkAddTag = useImageStore((state) => state.bulkAddTag);
+  const bulkRemoveTag = useImageStore((state) => state.bulkRemoveTag);
   const { canUseComparison, showProModal, canUseA1111, canUseComfyUI, canUseBatchExport, canUseBulkTagging, canUseFileManagement, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
   const selectedCount = selectedImages.size;
   const sensitiveTagSet = useMemo(() => {
@@ -780,7 +805,13 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
     if (!contextMenu.visible && isCopySubmenuOpen) {
       setIsCopySubmenuOpen(false);
     }
-  }, [contextMenu.visible, isCopySubmenuOpen]);
+    if (!contextMenu.visible && isCollectionSubmenuOpen) {
+      setIsCollectionSubmenuOpen(false);
+    }
+    if (!contextMenu.visible && isAddToCollectionSubmenuOpen) {
+      setIsAddToCollectionSubmenuOpen(false);
+    }
+  }, [contextMenu.visible, isAddToCollectionSubmenuOpen, isCollectionSubmenuOpen, isCopySubmenuOpen]);
 
   const queuedComparisonFirstImageId = queuedComparisonImages[0]?.id;
 
@@ -866,6 +897,98 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
 
     return [contextMenu.image];
   }, [contextMenu.image, images, selectedImages]);
+
+  const handleAddToExistingCollection = useCallback(async (collection: SmartCollection) => {
+    const targetImages = getContextTargetImages();
+    if (targetImages.length === 0) {
+      hideContextMenu();
+      return;
+    }
+
+    if (collection.kind === 'tag_rule') {
+      if (!collection.sourceTag) {
+        hideContextMenu();
+        return;
+      }
+
+      await bulkAddTag(targetImages.map((image) => image.id), collection.sourceTag);
+    } else {
+      await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
+    }
+
+    hideContextMenu();
+  }, [addImagesToCollection, bulkAddTag, getContextTargetImages, hideContextMenu]);
+
+  const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
+    const targetImages = getContextTargetImages();
+    const targetImageIds = values.includeTargetImages ? targetImages.map((image) => image.id) : [];
+    const coverImageId = targetImageIds.length > 0 ? targetImageIds[0] : null;
+
+    await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: collections.length,
+      imageIds: targetImageIds,
+      snapshotImageIds: [],
+      coverImageId,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: coverImageId ?? undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setIsCollectionModalOpen(false);
+    hideContextMenu();
+  }, [collections.length, createCollection, getContextTargetImages, hideContextMenu]);
+
+  const handleSetCollectionCover = useCallback(async () => {
+    if (!activeCollection || !contextMenu.image) {
+      hideContextMenu();
+      return;
+    }
+
+    await updateCollection(activeCollection.id, {
+      coverImageId: contextMenu.image.id,
+      thumbnailId: contextMenu.image.id,
+    });
+    hideContextMenu();
+  }, [activeCollection, contextMenu.image, hideContextMenu, updateCollection]);
+
+  const handleRemoveFromCurrentCollection = useCallback(async () => {
+    if (!activeCollection) {
+      hideContextMenu();
+      return;
+    }
+
+    const targetImages = getContextTargetImages();
+    if (targetImages.length === 0) {
+      hideContextMenu();
+      return;
+    }
+
+    if (activeCollection.kind === 'tag_rule') {
+      const sourceTag = activeCollection.sourceTag;
+      if (!sourceTag) {
+        hideContextMenu();
+        return;
+      }
+
+      const confirmed = window.confirm(
+        `Remove the "${sourceTag}" tag from ${targetImages.length} image(s) in this collection?`,
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      await bulkRemoveTag(targetImages.map((image) => image.id), sourceTag);
+    } else {
+      await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
+    }
+
+    hideContextMenu();
+  }, [activeCollection, bulkRemoveTag, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
 
   const handleSetRating = useCallback((rating: 1 | 2 | 3 | 4 | 5 | null) => {
     const targetImageIds = getContextMenuRatingTargetIds(selectedImages, contextMenu.image?.id);
@@ -1311,6 +1434,93 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
             {!canUseBulkTagging && selectedCount > 1 && initialized && !canUseDuringTrialOrPro && <ProBadge size="sm" />}
           </button>
 
+          <div
+            className="relative"
+            onMouseEnter={() => setIsCollectionSubmenuOpen(true)}
+            onMouseLeave={() => {
+              setIsCollectionSubmenuOpen(false);
+              setIsAddToCollectionSubmenuOpen(false);
+            }}
+          >
+            <button
+              onClick={() => setIsCollectionSubmenuOpen((open) => !open)}
+              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+            >
+              <Folder className="w-4 h-4" />
+              <span className="flex-1">Collection</span>
+              <ChevronRight className="w-4 h-4 text-gray-400" />
+            </button>
+
+            {isCollectionSubmenuOpen && (
+              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                <div
+                  className="relative"
+                  onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                  onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                >
+                  <button
+                    onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                    className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                  >
+                    <span className="flex-1">Add to Collection</span>
+                    <ChevronRight className="h-4 w-4 text-gray-400" />
+                  </button>
+
+                  {isAddToCollectionSubmenuOpen && (
+                    <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                      {collections.length === 0 ? (
+                        <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
+                      ) : (
+                        collections.map((collection) => (
+                          <button
+                            key={collection.id}
+                            onClick={() => void handleAddToExistingCollection(collection)}
+                            className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                          >
+                            <span className="truncate">{collection.name}</span>
+                            <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                              {collection.kind === 'tag_rule' ? 'Tag' : 'Manual'}
+                            </span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <button
+                  onClick={() => {
+                    setIsCollectionModalOpen(true);
+                    hideContextMenu();
+                  }}
+                  className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                >
+                  Create New Collection
+                </button>
+              </div>
+            )}
+          </div>
+
+          {isCollectionsView && activeCollection && (
+            <>
+              <button
+                onClick={() => void handleSetCollectionCover()}
+                className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+              >
+                <Folder className="w-4 h-4" />
+                Set as Cover
+              </button>
+
+              <button
+                onClick={() => void handleRemoveFromCurrentCollection()}
+                className="w-full text-left px-4 py-2 text-sm text-amber-200 hover:bg-amber-900/20 hover:text-amber-100 transition-colors flex items-center gap-2"
+              >
+                <Folder className="w-4 h-4" />
+                <span className="flex-1">Remove from Current Collection</span>
+              </button>
+            </>
+          )}
+
           <div className="px-4 py-2">
             <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-500">Set Rating</div>
             <div className="flex flex-wrap gap-1.5">
@@ -1507,6 +1717,22 @@ const ImageGrid: React.FC<ImageGridProps> = ({ images, onImageClick, selectedIma
 
   const modalsContent = (
     <>
+      <CollectionFormModal
+        isOpen={isCollectionModalOpen}
+        title="Create Collection"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: '',
+          description: '',
+          sourceTag: '',
+          autoUpdate: false,
+          includeTargetImages: getContextTargetImages().length > 0,
+        }}
+        onClose={() => setIsCollectionModalOpen(false)}
+        onSubmit={handleCreateCollectionFromContext}
+        showIncludeTargetImages={getContextTargetImages().length > 0}
+      />
+
       <TagManagerModal
         isOpen={isTagManagerOpen}
         onClose={() => setIsTagManagerOpen(false)}

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -761,8 +761,6 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
   const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
   const updateCollection = useImageStore((state) => state.updateCollection);
-  const bulkAddTag = useImageStore((state) => state.bulkAddTag);
-  const bulkRemoveTag = useImageStore((state) => state.bulkRemoveTag);
   const { canUseComparison, showProModal, canUseA1111, canUseComfyUI, canUseBatchExport, canUseBulkTagging, canUseFileManagement, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
   const selectedCount = selectedImages.size;
   const sensitiveTagSet = useMemo(() => {
@@ -905,19 +903,10 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       return;
     }
 
-    if (collection.kind === 'tag_rule') {
-      if (!collection.sourceTag) {
-        hideContextMenu();
-        return;
-      }
-
-      await bulkAddTag(targetImages.map((image) => image.id), collection.sourceTag);
-    } else {
-      await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
-    }
+    await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
 
     hideContextMenu();
-  }, [addImagesToCollection, bulkAddTag, getContextTargetImages, hideContextMenu]);
+  }, [addImagesToCollection, getContextTargetImages, hideContextMenu]);
 
   const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
     const targetImages = getContextTargetImages();
@@ -968,27 +957,10 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       return;
     }
 
-    if (activeCollection.kind === 'tag_rule') {
-      const sourceTag = activeCollection.sourceTag;
-      if (!sourceTag) {
-        hideContextMenu();
-        return;
-      }
-
-      const confirmed = window.confirm(
-        `Remove the "${sourceTag}" tag from ${targetImages.length} image(s) in this collection?`,
-      );
-      if (!confirmed) {
-        return;
-      }
-
-      await bulkRemoveTag(targetImages.map((image) => image.id), sourceTag);
-    } else {
-      await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
-    }
+    await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
 
     hideContextMenu();
-  }, [activeCollection, bulkRemoveTag, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
+  }, [activeCollection, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
 
   const handleSetRating = useCallback((rating: 1 | 2 | 3 | 4 | 5 | null) => {
     const targetImageIds = getContextMenuRatingTargetIds(selectedImages, contextMenu.image?.id);
@@ -1478,9 +1450,11 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                             className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
                           >
                             <span className="truncate">{collection.name}</span>
-                            <span className="text-[10px] uppercase tracking-wide text-gray-500">
-                              {collection.kind === 'tag_rule' ? 'Tag' : 'Manual'}
-                            </span>
+                            {collection.sourceTag && (
+                              <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                              </span>
+                            )}
                           </button>
                         ))
                       )}

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1216,7 +1216,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
 
   // Adjust focusedImageIndex when changing pages via arrow keys
   useEffect(() => {
-    if (focusedImageIndex === -1 && images.length > 0) {
+    if (focusedImageIndex === -1 && images.length > 0 && gridKeyboardActiveRef.current) {
       // Quando volta de página, vai para última imagem
       setFocusedImageIndex(images.length - 1);
       setPreviewImage(images[images.length - 1]);

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1424,7 +1424,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             </button>
 
             {isCollectionSubmenuOpen && (
-              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+              <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                 <div
                   className="relative"
                   onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
@@ -1439,7 +1439,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                   </button>
 
                   {isAddToCollectionSubmenuOpen && (
-                    <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                    <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                       {collections.length === 0 ? (
                         <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
                       ) : (
@@ -1535,7 +1535,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             </button>
 
             {isCopySubmenuOpen && (
-              <div className="absolute left-full top-0 ml-1 min-w-[190px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+              <div className="absolute left-full top-0 min-w-[190px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                 <button
                   onClick={copyPrompt}
                   className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, FC, useCallback, useMemo, useRef } from 'react';
-import { type IndexedImage, type BaseMetadata, type LoRAInfo } from '../types';
+import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollection } from '../types';
 import { FileOperations } from '../services/fileOperations';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
 import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2 } from 'lucide-react';
@@ -27,6 +27,7 @@ import { MetadataEditorModal } from './MetadataEditorModal';
 import ImageLineageSection from './ImageLineageSection';
 import { getGenerationTypeLabel } from '../utils/imageLineage';
 import RatingStars from './RatingStars';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 
 
 const TAG_SUGGESTION_LIMIT = 5;
@@ -531,6 +532,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
     kind: 'media',
     selectionText: '',
   });
+  const [isCollectionSubmenuOpen, setIsCollectionSubmenuOpen] = useState(false);
+  const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
+  const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
   const [showDetails, setShowDetails] = useState(true);
   const [showPerformance, setShowPerformance] = useState(true);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
@@ -589,6 +593,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const recentTags = useImageStore((state) => state.recentTags);
   const setSelectedImage = useImageStore((state) => state.setSelectedImage);
   const setPreviewImage = useImageStore((state) => state.setPreviewImage);
+  const collections = useImageStore((state) => state.collections);
+  const createCollection = useImageStore((state) => state.createCollection);
+  const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
 
   // Shadow Metadata Hook
   const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata, deleteMetadata: deleteShadowMetadata } = useShadowMetadata(image.id);
@@ -633,6 +640,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
     ? `${directoryPath}${/[\\/]$/.test(directoryPath) ? '' : '\\'}${image.name}`
     : image.name;
   const mediaOverlayVisibilityClass = isMediaOverlayVisible ? 'opacity-100' : 'opacity-0 pointer-events-none';
+
+  useEffect(() => {
+    if (contextMenu.visible) {
+      return;
+    }
+
+    setIsCollectionSubmenuOpen(false);
+    setIsAddToCollectionSubmenuOpen(false);
+  }, [contextMenu.visible]);
 
   const applyModalWindowStyles = useCallback((windowState: ModalWindowState) => {
     if (isFullscreen || !modalShellRef.current) {
@@ -1086,6 +1102,34 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const hideContextMenu = () => {
     setContextMenu({ x: 0, y: 0, visible: false, kind: 'media', selectionText: '' });
   };
+
+  const handleAddToExistingCollection = useCallback(async (collection: SmartCollection) => {
+    await addImagesToCollection(collection.id, [image.id]);
+    hideContextMenu();
+  }, [addImagesToCollection, image.id]);
+
+  const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
+    const targetImageIds = values.includeTargetImages ? [image.id] : [];
+    const coverImageId = targetImageIds.length > 0 ? targetImageIds[0] : null;
+
+    await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: collections.length,
+      imageIds: targetImageIds,
+      snapshotImageIds: [],
+      coverImageId,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: coverImageId ?? undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setIsCollectionModalOpen(false);
+    hideContextMenu();
+  }, [collections.length, createCollection, image.id]);
 
   const copyPrompt = () => {
     copyToClipboardElectron(nMeta?.prompt || '', 'Prompt');
@@ -2689,6 +2733,22 @@ const ImageModal: React.FC<ImageModalProps> = ({
         imageId={image.id}
       />
 
+      <CollectionFormModal
+        isOpen={isCollectionModalOpen}
+        title="Create Collection"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: '',
+          description: '',
+          sourceTag: '',
+          autoUpdate: false,
+          includeTargetImages: true,
+        }}
+        onClose={() => setIsCollectionModalOpen(false)}
+        onSubmit={handleCreateCollectionFromContext}
+        showIncludeTargetImages
+      />
+
       {/* Context Menu */}
       {contextMenu.visible && (
         <div
@@ -2723,6 +2783,75 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 <Copy className="w-4 h-4" />
                 Copy to Clipboard
               </button>
+
+              <div
+                className="relative"
+                onMouseEnter={() => setIsCollectionSubmenuOpen(true)}
+                onMouseLeave={() => {
+                  setIsCollectionSubmenuOpen(false);
+                  setIsAddToCollectionSubmenuOpen(false);
+                }}
+              >
+                <button
+                  onClick={() => setIsCollectionSubmenuOpen((open) => !open)}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+                >
+                  <Folder className="w-4 h-4" />
+                  <span className="flex-1">Collection</span>
+                  <ChevronRight className="w-4 h-4 text-gray-400" />
+                </button>
+
+                {isCollectionSubmenuOpen && (
+                  <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                    <div
+                      className="relative"
+                      onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                      onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                    >
+                      <button
+                        onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                        className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                      >
+                        <span className="flex-1">Add to Collection</span>
+                        <ChevronRight className="h-4 w-4 text-gray-400" />
+                      </button>
+
+                      {isAddToCollectionSubmenuOpen && (
+                        <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                          {collections.length === 0 ? (
+                            <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
+                          ) : (
+                            collections.map((collection) => (
+                              <button
+                                key={collection.id}
+                                onClick={() => void handleAddToExistingCollection(collection)}
+                                className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                              >
+                                <span className="truncate">{collection.name}</span>
+                                {collection.sourceTag && (
+                                  <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                    {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                                  </span>
+                                )}
+                              </button>
+                            ))
+                          )}
+                        </div>
+                      )}
+                    </div>
+
+                    <button
+                      onClick={() => {
+                        setIsCollectionModalOpen(true);
+                        hideContextMenu();
+                      }}
+                      className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                    >
+                      Create New Collection
+                    </button>
+                  </div>
+                )}
+              </div>
 
               <div className="border-t border-gray-600 my-1"></div>
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2806,7 +2806,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 </button>
 
                 {isCollectionSubmenuOpen && (
-                  <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                  <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                     <div
                       className="relative"
                       onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
@@ -2821,7 +2821,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                       </button>
 
                       {isAddToCollectionSubmenuOpen && (
-                        <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                        <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                           {collections.length === 0 ? (
                             <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
                           ) : (

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2014,9 +2014,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
           <div className="p-6 space-y-4 overflow-y-auto flex-1">
           {/* Annotations Section */}
           <div className="bg-gray-900/50 p-3 rounded-lg border border-gray-700/50 space-y-2">
-            {/* Favorite and Tags Row */}
-            <div className="flex items-start gap-3">
-              <div className="flex items-center gap-2 rounded-lg border border-gray-700/60 bg-gray-950/30 px-2 py-1.5">
+            {/* Favorite, Rating, and Tags */}
+            <div className="space-y-3">
+              <div className="flex w-fit items-center gap-2 rounded-lg border border-gray-700/60 bg-gray-950/30 px-2 py-1.5">
                 <button
                   onClick={handleToggleFavorite}
                   className={`p-1 rounded transition-all ${
@@ -2033,7 +2033,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
               </div>
 
               {/* Tags Pills */}
-              <div className="flex-1 space-y-2">
+              <div className="space-y-2">
                 {/* Add Tag Input */}
                 <TagInputCombobox
                   ref={tagInputRef}

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -28,6 +28,8 @@ import { MetadataEditorModal } from './MetadataEditorModal';
 import ImageLineageSection from './ImageLineageSection';
 import { getGenerationTypeLabel } from '../utils/imageLineage';
 import RatingStars from './RatingStars';
+import TagInputCombobox from './TagInputCombobox';
+import { getRecentTagChips } from '../utils/tagSuggestions';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 
 
@@ -622,6 +624,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const currentAutoTags = liveImage.autoTags || [];
   const currentIsFavorite = liveImage.isFavorite ?? false;
   const currentRating = liveImage.rating ?? null;
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
+  const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
   const preferredThumbnailUrl = thumbnail?.thumbnailUrl ?? null;
   const recentTagSuggestions = useMemo(() => getRecentTagChips({
     recentTags,

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -28,37 +28,8 @@ import { MetadataEditorModal } from './MetadataEditorModal';
 import ImageLineageSection from './ImageLineageSection';
 import { getGenerationTypeLabel } from '../utils/imageLineage';
 import RatingStars from './RatingStars';
-
-
-const TAG_SUGGESTION_LIMIT = 5;
-
-const buildTagSuggestions = (
-  recentTags: string[],
-  availableTags: { name: string }[],
-  currentTags: string[],
-): string[] => {
-  const suggestions: string[] = [];
-
-  for (const tag of recentTags) {
-    if (!currentTags.includes(tag) && !suggestions.includes(tag)) {
-      suggestions.push(tag);
-      if (suggestions.length >= TAG_SUGGESTION_LIMIT) {
-        return suggestions;
-      }
-    }
-  }
-
-  for (const tag of availableTags) {
-    if (!currentTags.includes(tag.name) && !suggestions.includes(tag.name)) {
-      suggestions.push(tag.name);
-      if (suggestions.length >= TAG_SUGGESTION_LIMIT) {
-        break;
-      }
-    }
-  }
-
-  return suggestions;
-};
+import TagInputCombobox from './TagInputCombobox';
+import { getRecentTagChips } from '../utils/tagSuggestions';
 
 interface ImageModalProps {
   image: IndexedImage;
@@ -591,6 +562,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const recentTags = useImageStore((state) => state.recentTags);
   const setSelectedImage = useImageStore((state) => state.setSelectedImage);
   const setPreviewImage = useImageStore((state) => state.setPreviewImage);
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
+  const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
 
   // Shadow Metadata Hook
   const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata, deleteMetadata: deleteShadowMetadata } = useShadowMetadata(image.id);
@@ -616,12 +589,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const currentIsFavorite = liveImage.isFavorite ?? false;
   const currentRating = liveImage.rating ?? null;
   const preferredThumbnailUrl = thumbnail?.thumbnailUrl ?? null;
-  const tagSuggestions = buildTagSuggestions(recentTags, availableTags, currentTags);
+  const recentTagSuggestions = useMemo(() => getRecentTagChips({
+    recentTags,
+    excludedTags: currentTags,
+    limit: recentTagChipLimit,
+  }), [currentTags, recentTagChipLimit, recentTags]);
   const createdAtLabel = useMemo(() => new Date(image.lastModified).toLocaleString(), [image.lastModified]);
 
   // State for tag input
   const [tagInput, setTagInput] = useState('');
-  const [showTagAutocomplete, setShowTagAutocomplete] = useState(false);
   const [isMediaOverlayVisible, setIsMediaOverlayVisible] = useState(false);
   const tagInputRef = useRef<HTMLInputElement>(null);
   const imageContainerRef = useRef<HTMLDivElement>(null);
@@ -1378,7 +1354,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
     const focusInput = () => {
       tagInputRef.current?.focus();
       tagInputRef.current?.select();
-      setShowTagAutocomplete((tagInputRef.current?.value ?? '').trim().length > 0);
     };
 
     if (isFullscreen) {
@@ -1603,11 +1578,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
   };
 
   // Tag management handlers
-  const handleAddTag = () => {
-    if (!tagInput.trim()) return;
-    addTagToImage(image.id, tagInput);
+  const handleAddTag = (value = tagInput) => {
+    if (!value.trim()) return;
+    addTagToImage(image.id, value);
     setTagInput('');
-    setShowTagAutocomplete(false);
   };
 
   const handleRemoveTag = (tag: string) => {
@@ -1623,16 +1597,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
     await addTagToImage(image.id, tag);
     removeAutoTagFromImage(image.id, tag);
   };
-
-  // Filter autocomplete tags
-  const autocompleteOptions = tagInput
-    ? availableTags
-        .filter(tag =>
-          tag.name.includes(tagInput.toLowerCase()) &&
-          !currentTags.includes(tag.name)
-        )
-        .slice(0, 5)
-    : [];
 
   if (isMinimized) {
     return null;
@@ -1996,51 +1960,26 @@ const ImageModal: React.FC<ImageModalProps> = ({
               {/* Tags Pills */}
               <div className="flex-1 space-y-2">
                 {/* Add Tag Input */}
-                <div className="relative">
-                  <input
-                    ref={tagInputRef}
-                    type="text"
-                    placeholder="Add tag..."
-                    value={tagInput}
-                    onChange={(e) => {
-                      setTagInput(e.target.value);
-                      setShowTagAutocomplete(e.target.value.length > 0);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault();
-                        handleAddTag();
-                      }
-                      if (e.key === 'Escape') {
-                        setTagInput('');
-                        setShowTagAutocomplete(false);
-                      }
-                    }}
-                    onFocus={() => tagInput && setShowTagAutocomplete(true)}
-                    onBlur={() => setTimeout(() => setShowTagAutocomplete(false), 200)}
-                    className="w-full bg-gray-700/50 text-gray-200 border border-gray-600 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-500"
-                  />
-
-                  {/* Autocomplete Dropdown */}
-                  {showTagAutocomplete && autocompleteOptions.length > 0 && (
-                    <div className="absolute z-10 w-full mt-1 bg-gray-800 border border-gray-600 rounded-lg shadow-lg max-h-32 overflow-y-auto">
-                      {autocompleteOptions.map(tag => (
-                        <button
-                          key={tag.name}
-                          onClick={() => {
-                            addTagToImage(image.id, tag.name);
-                            setTagInput('');
-                            setShowTagAutocomplete(false);
-                          }}
-                          className="w-full text-left px-2 py-1.5 text-xs text-gray-200 hover:bg-gray-700 flex justify-between items-center"
-                        >
-                          <span>{tag.name}</span>
-                          <span className="text-xs text-gray-500">({tag.count})</span>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                <TagInputCombobox
+                  ref={tagInputRef}
+                  value={tagInput}
+                  onValueChange={setTagInput}
+                  onSubmit={handleAddTag}
+                  recentTags={recentTags}
+                  availableTags={availableTags}
+                  excludedTags={currentTags}
+                  suggestionLimit={tagSuggestionLimit}
+                  placeholder="Add tag..."
+                  inputClassName="w-full bg-gray-700/50 text-gray-200 border border-gray-600 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-500"
+                  dropdownClassName="absolute z-10 mt-1 max-h-32 w-full overflow-y-auto rounded-lg border border-gray-600 bg-gray-800 shadow-lg"
+                  optionClassName="w-full text-left px-2 py-1.5 text-xs text-gray-200 hover:bg-gray-700 flex justify-between items-center"
+                  activeOptionClassName="bg-gray-700 text-white"
+                  metaClassName="text-xs text-gray-500"
+                  onEscape={() => {
+                    setTagInput('');
+                    tagInputRef.current?.focus();
+                  }}
+                />
 
                 {/* Current Tags */}
                 {currentTags && currentTags.length > 0 && (
@@ -2060,9 +1999,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 )}
 
                 {/* Tag Suggestions */}
-                {tagInput.trim().length === 0 && tagSuggestions.length > 0 && (
+                {tagInput.trim().length === 0 && recentTagSuggestions.length > 0 && (
                   <div className="flex flex-wrap gap-1">
-                    {tagSuggestions.map(tag => (
+                    {recentTagSuggestions.map(tag => (
                       <button
                         key={tag}
                         onClick={() => addTagToImage(image.id, tag)}

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2725,34 +2725,38 @@ const ImageModal: React.FC<ImageModalProps> = ({
       </div>
 
       {/* Metadata Editor Modal */}
-      <MetadataEditorModal
-        isOpen={isMetadataEditorOpen}
-        onClose={() => setIsMetadataEditorOpen(false)}
-        initialMetadata={shadowMetadata}
-        onSave={async (m) => { await saveShadowMetadata(m); }}
-        imageId={image.id}
-      />
+      <div className="pointer-events-auto">
+        <MetadataEditorModal
+          isOpen={isMetadataEditorOpen}
+          onClose={() => setIsMetadataEditorOpen(false)}
+          initialMetadata={shadowMetadata}
+          onSave={async (m) => { await saveShadowMetadata(m); }}
+          imageId={image.id}
+        />
+      </div>
 
-      <CollectionFormModal
-        isOpen={isCollectionModalOpen}
-        title="Create Collection"
-        submitLabel="Create Collection"
-        initialValues={{
-          name: '',
-          description: '',
-          sourceTag: '',
-          autoUpdate: false,
-          includeTargetImages: true,
-        }}
-        onClose={() => setIsCollectionModalOpen(false)}
-        onSubmit={handleCreateCollectionFromContext}
-        showIncludeTargetImages
-      />
+      <div className="pointer-events-auto">
+        <CollectionFormModal
+          isOpen={isCollectionModalOpen}
+          title="Create Collection"
+          submitLabel="Create Collection"
+          initialValues={{
+            name: '',
+            description: '',
+            sourceTag: '',
+            autoUpdate: false,
+            includeTargetImages: true,
+          }}
+          onClose={() => setIsCollectionModalOpen(false)}
+          onSubmit={handleCreateCollectionFromContext}
+          showIncludeTargetImages
+        />
+      </div>
 
       {/* Context Menu */}
       {contextMenu.visible && (
         <div
-          className="fixed z-[60] bg-gray-800 border border-gray-600 rounded-lg shadow-xl py-1 min-w-[160px]"
+          className="pointer-events-auto fixed z-[60] bg-gray-800 border border-gray-600 rounded-lg shadow-xl py-1 min-w-[160px]"
           style={{ left: contextMenu.x, top: contextMenu.y }}
           onClick={(e) => e.stopPropagation()}
         >

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useState, FC, useCallback, useMemo, useRef } from 're
 import { type IndexedImage, type BaseMetadata, type LoRAInfo } from '../types';
 import { FileOperations } from '../services/fileOperations';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
-import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2 } from 'lucide-react';
+import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw } from 'lucide-react';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
 import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
 import { comparisonWillAutoOpen, useImageComparison } from '../hooks/useImageComparison';
+import { useReparseMetadata } from '../hooks/useReparseMetadata';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useGenerationProviderAvailability } from '../hooks/useGenerationProviderAvailability';
 import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } from './A1111GenerateModal';
@@ -573,6 +574,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   // Image comparison hook
   const { addImage, comparisonCount } = useImageComparison();
+  const { isReparsing, reparseImages } = useReparseMetadata();
 
   // Feature access (license/trial gating)
   const { canUseA1111, canUseComfyUI, canUseComparison, showProModal, initialized } = useFeatureAccess();
@@ -1147,6 +1149,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }
     // The showInExplorer utility can handle the full path directly
     showInExplorer(`${directoryPath}/${image.name}`);
+  };
+
+  const handleReparseMetadata = async () => {
+    hideContextMenu();
+    await reparseImages([liveImage]);
   };
 
   const exportImage = async () => {
@@ -2757,6 +2764,17 @@ const ImageModal: React.FC<ImageModalProps> = ({
               >
                 <Copy className="w-4 h-4" />
                 Copy Model
+              </button>
+
+              <div className="border-t border-gray-600 my-1"></div>
+
+              <button
+                onClick={handleReparseMetadata}
+                className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={isReparsing}
+              >
+                <RefreshCw className={`w-4 h-4 ${isReparsing ? 'animate-spin' : ''}`} />
+                Reparse Metadata
               </button>
 
               <div className="border-t border-gray-600 my-1"></div>

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, FC } from 'react';
+import React, { useEffect, useMemo, useRef, useState, FC } from 'react';
 import { Clipboard, Sparkles, ChevronDown, ChevronRight, Heart, X, Zap, CheckCircle, ArrowUp, Copy, Search } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { type BaseMetadata, type LoRAInfo } from '../types';
@@ -17,36 +17,9 @@ import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import ImageLineageSection from './ImageLineageSection';
 import { getGenerationTypeLabel } from '../utils/imageLineage';
 import RatingStars from './RatingStars';
-
-const TAG_SUGGESTION_LIMIT = 5;
-
-const buildTagSuggestions = (
-  recentTags: string[],
-  availableTags: { name: string }[],
-  currentTags: string[],
-): string[] => {
-  const suggestions: string[] = [];
-
-  for (const tag of recentTags) {
-    if (!currentTags.includes(tag) && !suggestions.includes(tag)) {
-      suggestions.push(tag);
-      if (suggestions.length >= TAG_SUGGESTION_LIMIT) {
-        return suggestions;
-      }
-    }
-  }
-
-  for (const tag of availableTags) {
-    if (!currentTags.includes(tag.name) && !suggestions.includes(tag.name)) {
-      suggestions.push(tag.name);
-      if (suggestions.length >= TAG_SUGGESTION_LIMIT) {
-        break;
-      }
-    }
-  }
-
-  return suggestions;
-};
+import TagInputCombobox from './TagInputCombobox';
+import { useSettingsStore } from '../store/useSettingsStore';
+import { getRecentTagChips } from '../utils/tagSuggestions';
 
 // Helper function to format LoRA with weight
 const formatLoRA = (lora: string | LoRAInfo): string => {
@@ -190,7 +163,6 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
   const [tagInput, setTagInput] = useState('');
-  const [showTagAutocomplete, setShowTagAutocomplete] = useState(false);
   const [showPerformance, setShowPerformance] = useState(true);
   const [showRawMetadata, setShowRawMetadata] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
@@ -199,6 +171,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     visible: false,
     selectionText: '',
   });
+  const tagInputRef = useRef<HTMLInputElement>(null);
 
   const { copyToA1111, isCopying, copyStatus } = useCopyToA1111();
   const { generateWithA1111, isGenerating, generateStatus } = useGenerateWithA1111();
@@ -218,7 +191,13 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const a1111GenerateLabel = singleVisibleProvider?.id === 'a1111' ? 'Generate' : 'Generate with A1111';
   const comfyGenerateLabel = singleVisibleProvider?.id === 'comfyui' ? 'Generate' : 'Generate with ComfyUI';
   const preferredThumbnailUrl = thumbnail?.thumbnailUrl ?? null;
-  const tagSuggestions = buildTagSuggestions(recentTags, availableTags, activeImage?.tags ?? []);
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
+  const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
+  const recentTagSuggestions = useMemo(() => getRecentTagChips({
+    recentTags,
+    excludedTags: activeImage?.tags ?? [],
+    limit: recentTagChipLimit,
+  }), [activeImage?.tags, recentTagChipLimit, recentTags]);
 
   useEffect(() => {
     let isMounted = true;
@@ -340,11 +319,10 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   };
 
   // Tag management handlers
-  const handleAddTag = () => {
-    if (!tagInput.trim() || !activeImage) return;
-    addTagToImage(activeImage.id, tagInput);
+  const handleAddTag = (value = tagInput) => {
+    if (!value.trim() || !activeImage) return;
+    addTagToImage(activeImage.id, value);
     setTagInput('');
-    setShowTagAutocomplete(false);
   };
 
   const handleRemoveTag = (tag: string) => {
@@ -373,16 +351,6 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     if (!activeImage) return;
     setImageRating(activeImage.id, rating);
   };
-
-  // Filter autocomplete tags
-  const autocompleteOptions = tagInput && activeImage
-    ? availableTags
-        .filter(tag =>
-          tag.name.includes(tagInput.toLowerCase()) &&
-          !(activeImage.tags || []).includes(tag.name)
-        )
-        .slice(0, 5)
-    : [];
 
   return (
     <div
@@ -478,50 +446,26 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
             {/* Tags Pills */}
             <div className="flex-1 space-y-2">
               {/* Add Tag Input */}
-              <div className="relative">
-                <input
-                  type="text"
-                  placeholder="Add tag..."
-                  value={tagInput}
-                  onChange={(e) => {
-                    setTagInput(e.target.value);
-                    setShowTagAutocomplete(e.target.value.length > 0);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      handleAddTag();
-                    }
-                    if (e.key === 'Escape') {
-                      setTagInput('');
-                      setShowTagAutocomplete(false);
-                    }
-                  }}
-                  onFocus={() => tagInput && setShowTagAutocomplete(true)}
-                  onBlur={() => setTimeout(() => setShowTagAutocomplete(false), 200)}
-                  className="w-full bg-white dark:bg-gray-700/50 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-400 dark:placeholder-gray-500"
-                />
-
-                {/* Autocomplete Dropdown */}
-                {showTagAutocomplete && autocompleteOptions.length > 0 && (
-                  <div className="absolute z-10 w-full mt-1 bg-gray-800 border border-gray-600 rounded-lg shadow-lg max-h-32 overflow-y-auto">
-                    {autocompleteOptions.map(tag => (
-                      <button
-                        key={tag.name}
-                        onClick={() => {
-                          addTagToImage(activeImage.id, tag.name);
-                          setTagInput('');
-                          setShowTagAutocomplete(false);
-                        }}
-                        className="w-full text-left px-2 py-1.5 text-xs text-gray-200 hover:bg-gray-700 flex justify-between items-center"
-                      >
-                        <span>{tag.name}</span>
-                        <span className="text-xs text-gray-500">({tag.count})</span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+              <TagInputCombobox
+                ref={tagInputRef}
+                value={tagInput}
+                onValueChange={setTagInput}
+                onSubmit={handleAddTag}
+                recentTags={recentTags}
+                availableTags={availableTags}
+                excludedTags={activeImage.tags ?? []}
+                suggestionLimit={tagSuggestionLimit}
+                placeholder="Add tag..."
+                inputClassName="w-full bg-white dark:bg-gray-700/50 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-400 dark:placeholder-gray-500"
+                dropdownClassName="absolute z-10 mt-1 max-h-32 w-full overflow-y-auto rounded-lg border border-gray-600 bg-gray-800 shadow-lg"
+                optionClassName="w-full text-left px-2 py-1.5 text-xs text-gray-200 hover:bg-gray-700 flex justify-between items-center"
+                activeOptionClassName="bg-gray-700 text-white"
+                metaClassName="text-xs text-gray-500"
+                onEscape={() => {
+                  setTagInput('');
+                  tagInputRef.current?.focus();
+                }}
+              />
 
               {/* Current Tags */}
               {activeImage.tags && activeImage.tags.length > 0 && (
@@ -541,9 +485,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
               )}
 
               {/* Tag Suggestions */}
-              {tagInput.trim().length === 0 && tagSuggestions.length > 0 && (
+              {tagInput.trim().length === 0 && recentTagSuggestions.length > 0 && (
                 <div className="flex flex-wrap gap-1">
-                  {tagSuggestions.map(tag => (
+                  {recentTagSuggestions.map(tag => (
                     <button
                       key={tag}
                       onClick={() => addTagToImage(activeImage.id, tag)}

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -425,9 +425,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
 
         {/* Annotations Section */}
         <div className="bg-gray-50 dark:bg-gray-900/50 p-3 rounded-lg border border-gray-200 dark:border-gray-700/50 space-y-2">
-          {/* Favorite and Tags Row */}
-          <div className="flex items-start gap-3">
-            <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white/70 px-2 py-1.5 dark:border-gray-700/60 dark:bg-gray-950/30">
+          {/* Favorite, Rating, and Tags */}
+          <div className="space-y-3">
+            <div className="flex w-fit items-center gap-2 rounded-lg border border-gray-200 bg-white/70 px-2 py-1.5 dark:border-gray-700/60 dark:bg-gray-950/30">
               <button
                 onClick={handleToggleFavorite}
                 className={`p-1 rounded transition-all ${
@@ -444,7 +444,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
             </div>
 
             {/* Tags Pills */}
-            <div className="flex-1 space-y-2">
+            <div className="space-y-2">
               {/* Add Tag Input */}
               <TagInputCombobox
                 ref={tagInputRef}

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -504,7 +504,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
             </button>
 
             {isCollectionSubmenuOpen && (
-              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+              <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                 <div
                   className="relative"
                   onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
@@ -519,7 +519,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
                   </button>
 
                   {isAddToCollectionSubmenuOpen && (
-                    <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                    <div className="absolute left-full top-0 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                       {collections.length === 0 ? (
                         <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
                       ) : (
@@ -590,7 +590,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
             </button>
 
             {isCopySubmenuOpen && (
-              <div className="absolute left-full top-0 ml-1 min-w-[190px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+              <div className="absolute left-full top-0 min-w-[190px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
                 <button
                   onClick={copyPrompt}
                   className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { FixedSizeList as List } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { type IndexedImage, type Directory } from '../types';
+import { type IndexedImage, type Directory, SmartCollection } from '../types';
 import { useContextMenu } from '../hooks/useContextMenu';
 import { useImageStore } from '../store/useImageStore';
 import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, RefreshCw, Star } from 'lucide-react';
@@ -15,12 +15,15 @@ import { transferIndexedImages } from '../services/fileTransferService';
 import { RATING_VALUES, RatingValueIcons, getRatingBadgeClasses, getRatingChipClasses, getRatingLabel } from './RatingStars';
 import { getContextMenuRatingTargetIds } from '../utils/ratingSelection';
 import { useReparseMetadata } from '../hooks/useReparseMetadata';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 
 interface ImageTableProps {
   images: IndexedImage[];
   onImageClick: (image: IndexedImage, event: React.MouseEvent) => void;
   selectedImages: Set<string>;
   onBatchExport: () => void;
+  activeCollection?: SmartCollection | null;
+  isCollectionsView?: boolean;
 }
 
 type SortField = 'filename' | 'model' | 'steps' | 'cfg' | 'size' | 'seed';
@@ -56,7 +59,14 @@ const joinDisplayPath = (basePath: string, relativePath: string): string => {
   return `${normalizedBase}/${normalizedRelative}`;
 };
 
-const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedImages, onBatchExport }) => {
+const ImageTable: React.FC<ImageTableProps> = ({
+  images,
+  onImageClick,
+  selectedImages,
+  onBatchExport,
+  activeCollection = null,
+  isCollectionsView = false,
+}) => {
   const directories = useImageStore((state) => state.directories);
   const transferProgress = useImageStore((state) => state.transferProgress);
   const [sortField, setSortField] = useState<SortField | null>(null);
@@ -66,8 +76,18 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isTransferring, setIsTransferring] = useState(false);
   const [isCopySubmenuOpen, setIsCopySubmenuOpen] = useState(false);
+  const [isCollectionSubmenuOpen, setIsCollectionSubmenuOpen] = useState(false);
+  const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
+  const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
   const [transferStatusText, setTransferStatusText] = useState<string>('');
   const bulkSetImageRating = useImageStore((state) => state.bulkSetImageRating);
+  const collections = useImageStore((state) => state.collections);
+  const createCollection = useImageStore((state) => state.createCollection);
+  const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
+  const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
+  const updateCollection = useImageStore((state) => state.updateCollection);
+  const bulkAddTag = useImageStore((state) => state.bulkAddTag);
+  const bulkRemoveTag = useImageStore((state) => state.bulkRemoveTag);
   const { canUseFileManagement, showProModal, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
   const { isReparsing, reparseImages } = useReparseMetadata();
 
@@ -89,7 +109,13 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
     if (!contextMenu.visible && isCopySubmenuOpen) {
       setIsCopySubmenuOpen(false);
     }
-  }, [contextMenu.visible, isCopySubmenuOpen]);
+    if (!contextMenu.visible && isCollectionSubmenuOpen) {
+      setIsCollectionSubmenuOpen(false);
+    }
+    if (!contextMenu.visible && isAddToCollectionSubmenuOpen) {
+      setIsAddToCollectionSubmenuOpen(false);
+    }
+  }, [contextMenu.visible, isAddToCollectionSubmenuOpen, isCollectionSubmenuOpen, isCopySubmenuOpen]);
 
   const selectedCount = selectedImages.size;
 
@@ -125,6 +151,98 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
     bulkSetImageRating(targetImageIds, rating);
     hideContextMenu();
   }, [bulkSetImageRating, contextMenu.image?.id, hideContextMenu, selectedImages]);
+
+  const handleAddToExistingCollection = useCallback(async (collection: SmartCollection) => {
+    const targetImages = getContextTargetImages();
+    if (!targetImages.length) {
+      hideContextMenu();
+      return;
+    }
+
+    if (collection.kind === 'tag_rule') {
+      if (!collection.sourceTag) {
+        hideContextMenu();
+        return;
+      }
+
+      await bulkAddTag(targetImages.map((image) => image.id), collection.sourceTag);
+    } else {
+      await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
+    }
+
+    hideContextMenu();
+  }, [addImagesToCollection, bulkAddTag, getContextTargetImages, hideContextMenu]);
+
+  const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
+    const targetImages = getContextTargetImages();
+    const targetImageIds = values.includeTargetImages ? targetImages.map((image) => image.id) : [];
+    const coverImageId = targetImageIds.length > 0 ? targetImageIds[0] : null;
+
+    await createCollection({
+      kind: 'manual',
+      name: values.name,
+      description: values.description || undefined,
+      sortIndex: collections.length,
+      imageIds: targetImageIds,
+      snapshotImageIds: [],
+      coverImageId,
+      autoUpdate: false,
+      sourceTag: null,
+      thumbnailId: coverImageId ?? undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setIsCollectionModalOpen(false);
+    hideContextMenu();
+  }, [collections.length, createCollection, getContextTargetImages, hideContextMenu]);
+
+  const handleSetCollectionCover = useCallback(async () => {
+    if (!activeCollection || !contextMenu.image) {
+      hideContextMenu();
+      return;
+    }
+
+    await updateCollection(activeCollection.id, {
+      coverImageId: contextMenu.image.id,
+      thumbnailId: contextMenu.image.id,
+    });
+    hideContextMenu();
+  }, [activeCollection, contextMenu.image, hideContextMenu, updateCollection]);
+
+  const handleRemoveFromCurrentCollection = useCallback(async () => {
+    if (!activeCollection) {
+      hideContextMenu();
+      return;
+    }
+
+    const targetImages = getContextTargetImages();
+    if (!targetImages.length) {
+      hideContextMenu();
+      return;
+    }
+
+    if (activeCollection.kind === 'tag_rule') {
+      const sourceTag = activeCollection.sourceTag;
+      if (!sourceTag) {
+        hideContextMenu();
+        return;
+      }
+
+      const confirmed = window.confirm(
+        `Remove the "${sourceTag}" tag from ${targetImages.length} image(s) in this collection?`,
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      await bulkRemoveTag(targetImages.map((image) => image.id), sourceTag);
+    } else {
+      await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
+    }
+
+    hideContextMenu();
+  }, [activeCollection, bulkRemoveTag, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
 
   const handleReparseMetadata = useCallback(async () => {
     const targetImages = getContextTargetImages();
@@ -398,6 +516,93 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
 
           <div
             className="relative"
+            onMouseEnter={() => setIsCollectionSubmenuOpen(true)}
+            onMouseLeave={() => {
+              setIsCollectionSubmenuOpen(false);
+              setIsAddToCollectionSubmenuOpen(false);
+            }}
+          >
+            <button
+              onClick={() => setIsCollectionSubmenuOpen((open) => !open)}
+              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+            >
+              <Folder className="w-4 h-4" />
+              <span className="flex-1">Collection</span>
+              <ChevronRight className="w-4 h-4 text-gray-400" />
+            </button>
+
+            {isCollectionSubmenuOpen && (
+              <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                <div
+                  className="relative"
+                  onMouseEnter={() => setIsAddToCollectionSubmenuOpen(true)}
+                  onMouseLeave={() => setIsAddToCollectionSubmenuOpen(false)}
+                >
+                  <button
+                    onClick={() => setIsAddToCollectionSubmenuOpen((open) => !open)}
+                    className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                  >
+                    <span className="flex-1">Add to Collection</span>
+                    <ChevronRight className="h-4 w-4 text-gray-400" />
+                  </button>
+
+                  {isAddToCollectionSubmenuOpen && (
+                    <div className="absolute left-full top-0 ml-1 min-w-[220px] rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl">
+                      {collections.length === 0 ? (
+                        <div className="px-4 py-2 text-sm text-gray-500">No collections yet</div>
+                      ) : (
+                        collections.map((collection) => (
+                          <button
+                            key={collection.id}
+                            onClick={() => void handleAddToExistingCollection(collection)}
+                            className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                          >
+                            <span className="truncate">{collection.name}</span>
+                            <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                              {collection.kind === 'tag_rule' ? 'Tag' : 'Manual'}
+                            </span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <button
+                  onClick={() => {
+                    setIsCollectionModalOpen(true);
+                    hideContextMenu();
+                  }}
+                  className="w-full px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                >
+                  Create New Collection
+                </button>
+              </div>
+            )}
+          </div>
+
+          {isCollectionsView && activeCollection && (
+            <>
+              <button
+                onClick={() => void handleSetCollectionCover()}
+                className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+              >
+                <Folder className="w-4 h-4" />
+                Set as Cover
+              </button>
+
+              <button
+                onClick={() => void handleRemoveFromCurrentCollection()}
+                className="w-full text-left px-4 py-2 text-sm text-amber-200 hover:bg-amber-900/20 hover:text-amber-100 transition-colors flex items-center gap-2"
+              >
+                <Folder className="w-4 h-4" />
+                <span className="flex-1">Remove from Current Collection</span>
+              </button>
+            </>
+          )}
+
+          <div
+            className="relative"
             onMouseEnter={() => setIsCopySubmenuOpen(true)}
             onMouseLeave={() => setIsCopySubmenuOpen(false)}
           >
@@ -537,6 +742,22 @@ const ImageTable: React.FC<ImageTableProps> = ({ images, onImageClick, selectedI
             )}
           </div>
         )}
+
+      <CollectionFormModal
+        isOpen={isCollectionModalOpen}
+        title="Create Collection"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: '',
+          description: '',
+          sourceTag: '',
+          autoUpdate: false,
+          includeTargetImages: getContextTargetImages().length > 0,
+        }}
+        onClose={() => setIsCollectionModalOpen(false)}
+        onSubmit={handleCreateCollectionFromContext}
+        showIncludeTargetImages={getContextTargetImages().length > 0}
+      />
 
       <TransferImagesModal
         isOpen={isTransferModalOpen && !!transferMode}

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -86,8 +86,6 @@ const ImageTable: React.FC<ImageTableProps> = ({
   const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
   const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
   const updateCollection = useImageStore((state) => state.updateCollection);
-  const bulkAddTag = useImageStore((state) => state.bulkAddTag);
-  const bulkRemoveTag = useImageStore((state) => state.bulkRemoveTag);
   const { canUseFileManagement, showProModal, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
   const { isReparsing, reparseImages } = useReparseMetadata();
 
@@ -159,19 +157,10 @@ const ImageTable: React.FC<ImageTableProps> = ({
       return;
     }
 
-    if (collection.kind === 'tag_rule') {
-      if (!collection.sourceTag) {
-        hideContextMenu();
-        return;
-      }
-
-      await bulkAddTag(targetImages.map((image) => image.id), collection.sourceTag);
-    } else {
-      await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
-    }
+    await addImagesToCollection(collection.id, targetImages.map((image) => image.id));
 
     hideContextMenu();
-  }, [addImagesToCollection, bulkAddTag, getContextTargetImages, hideContextMenu]);
+  }, [addImagesToCollection, getContextTargetImages, hideContextMenu]);
 
   const handleCreateCollectionFromContext = useCallback(async (values: CollectionFormValues) => {
     const targetImages = getContextTargetImages();
@@ -222,27 +211,10 @@ const ImageTable: React.FC<ImageTableProps> = ({
       return;
     }
 
-    if (activeCollection.kind === 'tag_rule') {
-      const sourceTag = activeCollection.sourceTag;
-      if (!sourceTag) {
-        hideContextMenu();
-        return;
-      }
-
-      const confirmed = window.confirm(
-        `Remove the "${sourceTag}" tag from ${targetImages.length} image(s) in this collection?`,
-      );
-      if (!confirmed) {
-        return;
-      }
-
-      await bulkRemoveTag(targetImages.map((image) => image.id), sourceTag);
-    } else {
-      await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
-    }
+    await removeImagesFromCollection(activeCollection.id, targetImages.map((image) => image.id));
 
     hideContextMenu();
-  }, [activeCollection, bulkRemoveTag, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
+  }, [activeCollection, getContextTargetImages, hideContextMenu, removeImagesFromCollection]);
 
   const handleReparseMetadata = useCallback(async () => {
     const targetImages = getContextTargetImages();
@@ -558,9 +530,11 @@ const ImageTable: React.FC<ImageTableProps> = ({
                             className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
                           >
                             <span className="truncate">{collection.name}</span>
-                            <span className="text-[10px] uppercase tracking-wide text-gray-500">
-                              {collection.kind === 'tag_rule' ? 'Tag' : 'Manual'}
-                            </span>
+                            {collection.sourceTag && (
+                              <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                                {collection.autoUpdate !== false ? 'Auto' : 'Linked'}
+                              </span>
+                            )}
                           </button>
                         ))
                       )}

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -84,11 +84,14 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 md:p-6"
+      className="fixed inset-0 z-50 overflow-y-auto bg-black/60 p-3 md:p-6"
       onClick={onClose}
     >
       <div
-        className="flex h-[92vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-800 text-gray-100 shadow-2xl"
+        className="mx-auto my-3 flex min-h-0 w-full max-w-6xl max-h-[calc(100vh-1.5rem)] flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-800 text-gray-100 shadow-2xl md:my-6 md:max-h-[calc(100vh-3rem)]"
+        style={{
+          minHeight: 'min(720px, calc(100vh - 1.5rem))',
+        }}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-gray-700/80 px-4 py-4 md:px-6">

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,12 +6,8 @@ import AdvancedFilters from './AdvancedFilters';
 import TagsAndFavorites from './TagsAndFavorites';
 import ActiveFilters from './ActiveFilters';
 import FacetFilterSection from './FacetFilterSection';
-import VerticalSplitPanels from './VerticalSplitPanels';
 import { useImageStore } from '../store/useImageStore';
 import type { AdvancedFilters as AdvancedFilterState, ImageRating } from '../types';
-
-const SIDEBAR_PANE_SIZES_STORAGE_KEY = 'image-metahub-sidebar-pane-sizes';
-const DEFAULT_SIDEBAR_PANE_SIZES = [36, 34, 30];
 
 const toFacetLabel = (value: unknown): string | null => {
   if (typeof value === 'string') {
@@ -279,57 +275,6 @@ const Sidebar: React.FC<SidebarProps> = ({
     favoriteFilterMode !== 'neutral' ||
     selectedRatings.length > 0 ||
     Object.keys(advancedFilters || {}).length > 0;
-  const directoryPaneContent = children && React.isValidElement(children)
-    ? React.cloneElement(children as React.ReactElement<any>, {
-        isIndexing,
-        scanSubfolders,
-        excludedFolders,
-        onExcludeFolder,
-        onIncludeFolder
-      })
-    : children;
-  const secondaryFiltersPane = (
-    <div className="space-y-4 pb-4">
-      {generationFacets.length > 0 && (
-        <section className="border-b border-gray-800/80 bg-gray-950/20">
-          <button
-            type="button"
-            onClick={() => setIsGenerationParametersExpanded((prev) => !prev)}
-            className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors hover:bg-gray-800/40"
-          >
-            <h3 className="text-base font-medium text-gray-200">Generation Parameters</h3>
-            <ChevronDown
-              className={`h-4 w-4 text-gray-500 transition-transform ${isGenerationParametersExpanded ? 'rotate-180' : ''}`}
-            />
-          </button>
-          {isGenerationParametersExpanded && (
-            <div className="space-y-3 px-4 pb-4">
-              {generationFacets.map((facet) => (
-                <FacetFilterSection
-                  key={facet.title}
-                  title={facet.title}
-                  items={facet.items}
-                  counts={facet.counts}
-                  selectedValues={facet.selectedValues}
-                  excludedValues={facet.excludedValues}
-                  onIncludeToggle={facet.onIncludeToggle}
-                  onExcludeToggle={facet.onExcludeToggle}
-                  onClear={facet.onClear}
-                />
-              ))}
-            </div>
-          )}
-        </section>
-      )}
-
-      <AdvancedFilters
-        advancedFilters={advancedFilters}
-        onAdvancedFiltersChange={onAdvancedFiltersChange}
-        onClearAdvancedFilters={onClearAdvancedFilters}
-        availableDimensions={availableDimensions}
-      />
-    </div>
-  );
 
   if (isCollapsed) {
     return (
@@ -418,76 +363,107 @@ const Sidebar: React.FC<SidebarProps> = ({
         />
       </div>
 
-      <div className="border-b border-gray-800/80">
-        <ActiveFilters />
-      </div>
+      <div className="flex-1 overflow-y-auto scrollbar-sidebar">
+        <div className="border-b border-gray-800/80">
+          <ActiveFilters />
+        </div>
 
-      <div className="px-4 py-3 border-b border-gray-700">
-        <label htmlFor="sidebar-sort" className="block text-gray-400 text-xs font-medium mb-2">Sort Order</label>
-        <div className="flex items-center">
-        <select
-          id="sidebar-sort"
-          value={sortOrder}
-          onChange={(e) => onSortOrderChange(e.target.value)}
-          className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <option value="date-desc">Newest First</option>
-          <option value="date-asc">Oldest First</option>
-          <option value="asc">A-Z</option>
-          <option value="desc">Z-A</option>
-          <option value="random">Random</option>
-        </select>
-        {sortOrder === 'random' && onReshuffle && (
-          <button
-              onClick={onReshuffle}
-              className="ml-2 p-2 text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-md border border-gray-600 transition-colors"
-              title="Reshuffle Random Order"
+        <div className="px-4 py-3 border-b border-gray-700">
+          <label htmlFor="sidebar-sort" className="block text-gray-400 text-xs font-medium mb-2">Sort Order</label>
+          <div className="flex items-center">
+          <select
+            id="sidebar-sort"
+            value={sortOrder}
+            onChange={(e) => onSortOrderChange(e.target.value)}
+            className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-              <RefreshCw className="h-5 w-5" />
-          </button>
+            <option value="date-desc">Newest First</option>
+            <option value="date-asc">Oldest First</option>
+            <option value="asc">A-Z</option>
+            <option value="desc">Z-A</option>
+            <option value="random">Random</option>
+          </select>
+          {sortOrder === 'random' && onReshuffle && (
+            <button
+                onClick={onReshuffle}
+                className="ml-2 p-2 text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-md border border-gray-600 transition-colors"
+                title="Reshuffle Random Order"
+            >
+                <RefreshCw className="h-5 w-5" />
+            </button>
+          )}
+          </div>
+        </div>
+
+        {onAddFolder && (
+          <div className="px-3 py-2 border-b border-gray-700">
+            <button
+              onClick={onAddFolder}
+              disabled={isIndexing}
+              className={`w-full flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
+                isIndexing
+                  ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
+                  : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
+              }`}
+              title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
+            >
+              <Plus size={14} />
+              <span>Add Folder</span>
+            </button>
+          </div>
         )}
-        </div>
-      </div>
 
-      {onAddFolder && (
-        <div className="px-3 py-2 border-b border-gray-700">
-          <button
-            onClick={onAddFolder}
-            disabled={isIndexing}
-            className={`w-full flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
-              isIndexing
-                ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
-                : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
-            }`}
-            title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
-          >
-            <Plus size={14} />
-            <span>Add Folder</span>
-          </button>
-        </div>
-      )}
+        {children && React.isValidElement(children) ? (
+          React.cloneElement(children as React.ReactElement<any>, {
+            isIndexing,
+            scanSubfolders,
+            excludedFolders,
+            onExcludeFolder,
+            onIncludeFolder
+          })
+        ) : (
+          children
+        )}
 
-      <div className="min-h-0 flex-1 px-3 py-3">
-        <VerticalSplitPanels
-          storageKey={SIDEBAR_PANE_SIZES_STORAGE_KEY}
-          defaultSizes={DEFAULT_SIDEBAR_PANE_SIZES}
-          panes={[
-            {
-              id: 'directories',
-              ariaLabel: 'Folders pane',
-              content: directoryPaneContent,
-            },
-            {
-              id: 'tags',
-              ariaLabel: 'Tags and favorites pane',
-              content: <TagsAndFavorites />,
-            },
-            {
-              id: 'filters',
-              ariaLabel: 'Filters pane',
-              content: secondaryFiltersPane,
-            },
-          ]}
+        <TagsAndFavorites />
+
+        {generationFacets.length > 0 && (
+          <section className="border-y border-gray-800/80 bg-gray-950/20">
+            <button
+              type="button"
+              onClick={() => setIsGenerationParametersExpanded((prev) => !prev)}
+              className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors hover:bg-gray-800/40"
+            >
+              <h3 className="text-base font-medium text-gray-200">Generation Parameters</h3>
+              <ChevronDown
+                className={`h-4 w-4 text-gray-500 transition-transform ${isGenerationParametersExpanded ? 'rotate-180' : ''}`}
+              />
+            </button>
+            {isGenerationParametersExpanded && (
+              <div className="space-y-3 px-4 pb-4">
+                {generationFacets.map((facet) => (
+                  <FacetFilterSection
+                    key={facet.title}
+                    title={facet.title}
+                    items={facet.items}
+                    counts={facet.counts}
+                    selectedValues={facet.selectedValues}
+                    excludedValues={facet.excludedValues}
+                    onIncludeToggle={facet.onIncludeToggle}
+                    onExcludeToggle={facet.onExcludeToggle}
+                    onClear={facet.onClear}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        <AdvancedFilters
+          advancedFilters={advancedFilters}
+          onAdvancedFiltersChange={onAdvancedFiltersChange}
+          onClearAdvancedFilters={onClearAdvancedFilters}
+          availableDimensions={availableDimensions}
         />
       </div>
 

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -284,10 +284,10 @@ const Sidebar: React.FC<SidebarProps> = ({
         className="fixed left-0 top-0 z-40 flex h-full w-16 flex-col items-center border-r border-gray-800/70 bg-gray-900/90 py-6 backdrop-blur-md shadow-lg shadow-black/20 transition-all duration-300 ease-in-out">
         <button
           onClick={onToggleCollapse}
-          className="app-top-icon-button mt-4 mb-6 h-10 w-10 overflow-hidden p-0"
+          className="mt-4 mb-6 rounded-xl p-0 text-gray-400 transition-colors duration-200 hover:bg-gray-800/50 hover:text-gray-100"
           title="Expand sidebar"
         >
-           <img src="logo1.png" alt="Expand" className="h-9 w-9 rounded-lg object-cover" />
+           <img src="logo1.png" alt="Expand" className="h-10 w-10 rounded-xl object-contain" />
         </button>
         <div className="flex flex-col space-y-3">
           {(selectedModels.length > 0 ||
@@ -336,9 +336,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       {/* Header with collapse button */}
       <div className="flex flex-col border-b border-gray-800/70 bg-gray-900/55">
         <div className="flex items-center gap-3 px-4 py-3">
-          <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl border border-gray-800/80 bg-gray-950/70 p-1">
-            <img src="logo1.png" alt="Image MetaHub" className="h-9 w-9 rounded-lg object-cover" />
-          </div>
+          <img src="logo1.png" alt="Image MetaHub" className="h-11 w-11 flex-shrink-0 rounded-xl object-contain" />
           <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
             <h1 className="truncate text-lg font-semibold tracking-tight text-white">Image MetaHub</h1>
             <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.14.0</span>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,8 +6,12 @@ import AdvancedFilters from './AdvancedFilters';
 import TagsAndFavorites from './TagsAndFavorites';
 import ActiveFilters from './ActiveFilters';
 import FacetFilterSection from './FacetFilterSection';
+import VerticalSplitPanels from './VerticalSplitPanels';
 import { useImageStore } from '../store/useImageStore';
 import type { AdvancedFilters as AdvancedFilterState, ImageRating } from '../types';
+
+const SIDEBAR_PANE_SIZES_STORAGE_KEY = 'image-metahub-sidebar-pane-sizes';
+const DEFAULT_SIDEBAR_PANE_SIZES = [36, 34, 30];
 
 const toFacetLabel = (value: unknown): string | null => {
   if (typeof value === 'string') {
@@ -275,6 +279,57 @@ const Sidebar: React.FC<SidebarProps> = ({
     favoriteFilterMode !== 'neutral' ||
     selectedRatings.length > 0 ||
     Object.keys(advancedFilters || {}).length > 0;
+  const directoryPaneContent = children && React.isValidElement(children)
+    ? React.cloneElement(children as React.ReactElement<any>, {
+        isIndexing,
+        scanSubfolders,
+        excludedFolders,
+        onExcludeFolder,
+        onIncludeFolder
+      })
+    : children;
+  const secondaryFiltersPane = (
+    <div className="space-y-4 pb-4">
+      {generationFacets.length > 0 && (
+        <section className="border-b border-gray-800/80 bg-gray-950/20">
+          <button
+            type="button"
+            onClick={() => setIsGenerationParametersExpanded((prev) => !prev)}
+            className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors hover:bg-gray-800/40"
+          >
+            <h3 className="text-base font-medium text-gray-200">Generation Parameters</h3>
+            <ChevronDown
+              className={`h-4 w-4 text-gray-500 transition-transform ${isGenerationParametersExpanded ? 'rotate-180' : ''}`}
+            />
+          </button>
+          {isGenerationParametersExpanded && (
+            <div className="space-y-3 px-4 pb-4">
+              {generationFacets.map((facet) => (
+                <FacetFilterSection
+                  key={facet.title}
+                  title={facet.title}
+                  items={facet.items}
+                  counts={facet.counts}
+                  selectedValues={facet.selectedValues}
+                  excludedValues={facet.excludedValues}
+                  onIncludeToggle={facet.onIncludeToggle}
+                  onExcludeToggle={facet.onExcludeToggle}
+                  onClear={facet.onClear}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      <AdvancedFilters
+        advancedFilters={advancedFilters}
+        onAdvancedFiltersChange={onAdvancedFiltersChange}
+        onClearAdvancedFilters={onClearAdvancedFilters}
+        availableDimensions={availableDimensions}
+      />
+    </div>
+  );
 
   if (isCollapsed) {
     return (
@@ -363,111 +418,76 @@ const Sidebar: React.FC<SidebarProps> = ({
         />
       </div>
 
-      {/* Scrollable Content - includes DirectoryList AND Filters */}
-      <div className="flex-1 overflow-y-auto scrollbar-sidebar">
-        <div className="border-b border-gray-800/80">
-          <ActiveFilters />
-        </div>
+      <div className="border-b border-gray-800/80">
+        <ActiveFilters />
+      </div>
 
-        <div className="px-4 py-3 border-b border-gray-700">
-          <label htmlFor="sidebar-sort" className="block text-gray-400 text-xs font-medium mb-2">Sort Order</label>
-          <div className="flex items-center">
-          <select
-            id="sidebar-sort"
-            value={sortOrder}
-            onChange={(e) => onSortOrderChange(e.target.value)}
-            className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+      <div className="px-4 py-3 border-b border-gray-700">
+        <label htmlFor="sidebar-sort" className="block text-gray-400 text-xs font-medium mb-2">Sort Order</label>
+        <div className="flex items-center">
+        <select
+          id="sidebar-sort"
+          value={sortOrder}
+          onChange={(e) => onSortOrderChange(e.target.value)}
+          className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="date-desc">Newest First</option>
+          <option value="date-asc">Oldest First</option>
+          <option value="asc">A-Z</option>
+          <option value="desc">Z-A</option>
+          <option value="random">Random</option>
+        </select>
+        {sortOrder === 'random' && onReshuffle && (
+          <button
+              onClick={onReshuffle}
+              className="ml-2 p-2 text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-md border border-gray-600 transition-colors"
+              title="Reshuffle Random Order"
           >
-            <option value="date-desc">Newest First</option>
-            <option value="date-asc">Oldest First</option>
-            <option value="asc">A-Z</option>
-            <option value="desc">Z-A</option>
-            <option value="random">Random</option>
-          </select>
-          {sortOrder === 'random' && onReshuffle && (
-            <button
-                onClick={onReshuffle}
-                className="ml-2 p-2 text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-md border border-gray-600 transition-colors"
-                title="Reshuffle Random Order"
-            >
-                <RefreshCw className="h-5 w-5" />
-            </button>
-          )}
-          </div>
+              <RefreshCw className="h-5 w-5" />
+          </button>
+        )}
         </div>
+      </div>
 
-        {/* Add Folder Button - Subtle and discrete */}
-        {onAddFolder && (
-          <div className="px-3 py-2 border-b border-gray-700">
-            <button
-              onClick={onAddFolder}
-              disabled={isIndexing}
-              className={`w-full flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
-                isIndexing
-                  ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
-                  : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
-              }`}
-              title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
-            >
-              <Plus size={14} />
-              <span>Add Folder</span>
-            </button>
-          </div>
-        )}
+      {onAddFolder && (
+        <div className="px-3 py-2 border-b border-gray-700">
+          <button
+            onClick={onAddFolder}
+            disabled={isIndexing}
+            className={`w-full flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
+              isIndexing
+                ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
+                : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
+            }`}
+            title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
+          >
+            <Plus size={14} />
+            <span>Add Folder</span>
+          </button>
+        </div>
+      )}
 
-        {/* Render children, which will be the DirectoryList */}
-        {children && React.isValidElement(children) ? (
-          React.cloneElement(children as React.ReactElement<any>, {
-            isIndexing,
-            scanSubfolders,
-            excludedFolders,
-            onExcludeFolder,
-            onIncludeFolder
-          })
-        ) : (
-          children
-        )}
-
-        {/* Tags and Favorites Section */}
-        <TagsAndFavorites />
-
-        {generationFacets.length > 0 && (
-          <section className="border-y border-gray-800/80 bg-gray-950/20">
-            <button
-              type="button"
-              onClick={() => setIsGenerationParametersExpanded((prev) => !prev)}
-              className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors hover:bg-gray-800/40"
-            >
-              <h3 className="text-base font-medium text-gray-200">Generation Parameters</h3>
-              <ChevronDown
-                className={`h-4 w-4 text-gray-500 transition-transform ${isGenerationParametersExpanded ? 'rotate-180' : ''}`}
-              />
-            </button>
-            {isGenerationParametersExpanded && (
-              <div className="space-y-3 px-4 pb-4">
-                {generationFacets.map((facet) => (
-                  <FacetFilterSection
-                    key={facet.title}
-                    title={facet.title}
-                    items={facet.items}
-                    counts={facet.counts}
-                    selectedValues={facet.selectedValues}
-                    excludedValues={facet.excludedValues}
-                    onIncludeToggle={facet.onIncludeToggle}
-                    onExcludeToggle={facet.onExcludeToggle}
-                    onClear={facet.onClear}
-                  />
-                ))}
-              </div>
-            )}
-          </section>
-        )}
-
-        <AdvancedFilters
-          advancedFilters={advancedFilters}
-          onAdvancedFiltersChange={onAdvancedFiltersChange}
-          onClearAdvancedFilters={onClearAdvancedFilters}
-          availableDimensions={availableDimensions}
+      <div className="min-h-0 flex-1 px-3 py-3">
+        <VerticalSplitPanels
+          storageKey={SIDEBAR_PANE_SIZES_STORAGE_KEY}
+          defaultSizes={DEFAULT_SIDEBAR_PANE_SIZES}
+          panes={[
+            {
+              id: 'directories',
+              ariaLabel: 'Folders pane',
+              content: directoryPaneContent,
+            },
+            {
+              id: 'tags',
+              ariaLabel: 'Tags and favorites pane',
+              content: <TagsAndFavorites />,
+            },
+            {
+              id: 'filters',
+              ariaLabel: 'Filters pane',
+              content: secondaryFiltersPane,
+            },
+          ]}
         />
       </div>
 

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -339,7 +339,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           <img src="logo1.png" alt="Image MetaHub" className="h-11 w-11 flex-shrink-0 rounded-xl object-contain" />
           <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
             <h1 className="truncate text-lg font-semibold tracking-tight text-white">Image MetaHub</h1>
-            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.14.0</span>
+            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.14.1</span>
           </div>
           <button
             onClick={onToggleCollapse}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -281,14 +281,13 @@ const Sidebar: React.FC<SidebarProps> = ({
       <div
         data-area="sidebar"
         tabIndex={-1}
-        className="fixed left-0 top-0 h-full w-16 bg-gray-900/90 backdrop-blur-md border-r border-gray-800/60 z-40 flex flex-col items-center py-6 transition-all duration-300 ease-in-out shadow-lg shadow-black/20">
+        className="fixed left-0 top-0 z-40 flex h-full w-16 flex-col items-center border-r border-gray-800/70 bg-gray-900/90 py-6 backdrop-blur-md shadow-lg shadow-black/20 transition-all duration-300 ease-in-out">
         <button
           onClick={onToggleCollapse}
-          className="mt-4 mb-6 relative group"
+          className="app-top-icon-button mt-4 mb-6 h-10 w-10 overflow-hidden p-0"
           title="Expand sidebar"
         >
-           <div className="absolute inset-0 bg-blue-500/20 blur-md rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-           <img src="logo1.png" alt="Expand" className="h-10 w-10 rounded-xl shadow-lg relative z-10 transition-transform duration-200 group-hover:scale-105" />
+           <img src="logo1.png" alt="Expand" className="h-9 w-9 rounded-lg object-cover" />
         </button>
         <div className="flex flex-col space-y-3">
           {(selectedModels.length > 0 ||
@@ -323,7 +322,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       data-area="sidebar"
       tabIndex={-1}
       style={{ width }}
-      className={`fixed left-0 top-0 h-full bg-gray-900/90 backdrop-blur-md border-r border-gray-800/60 z-40 flex flex-col shadow-2xl shadow-black/40 ${isResizing ? 'transition-none' : 'transition-[width] duration-300 ease-in-out'}`}>
+      className={`fixed left-0 top-0 z-40 flex h-full flex-col border-r border-gray-800/70 bg-gray-900/90 backdrop-blur-md shadow-2xl shadow-black/40 ${isResizing ? 'transition-none' : 'transition-[width] duration-300 ease-in-out'}`}>
       <div
         role="separator"
         aria-label="Resize filters sidebar"
@@ -335,19 +334,18 @@ const Sidebar: React.FC<SidebarProps> = ({
         <div className={`h-16 w-1 rounded-full transition-colors duration-150 ${isResizing ? 'bg-blue-400/90 shadow-[0_0_16px_rgba(96,165,250,0.55)]' : 'bg-gray-600/70 hover:bg-blue-400/80'}`} />
       </div>
       {/* Header with collapse button */}
-      <div className="flex flex-col border-b border-gray-800/60 bg-gray-900/40">
-        <div className="flex items-center gap-3.5 px-4 pt-2.5 pb-2">
-          <div className="relative flex-shrink-0">
-            <div className="absolute inset-0 rounded-full bg-blue-500/20 blur-xl opacity-50" />
-            <img src="logo1.png" alt="Image MetaHub" className="relative z-10 h-12 w-12 rounded-xl shadow-2xl" />
+      <div className="flex flex-col border-b border-gray-800/70 bg-gray-900/55">
+        <div className="flex items-center gap-3 px-4 py-3">
+          <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl border border-gray-800/80 bg-gray-950/70 p-1">
+            <img src="logo1.png" alt="Image MetaHub" className="h-9 w-9 rounded-lg object-cover" />
           </div>
           <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
-            <h1 className="truncate text-xl font-bold tracking-tight text-white">Image MetaHub</h1>
-            <span className="text-xs font-mono font-normal text-gray-500">v0.14.0</span>
+            <h1 className="truncate text-lg font-semibold tracking-tight text-white">Image MetaHub</h1>
+            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.14.0</span>
           </div>
           <button
             onClick={onToggleCollapse}
-            className="ml-auto rounded-lg border border-gray-700 bg-gray-800/40 p-1.5 text-gray-400 transition-colors hover:bg-gray-700/60 hover:text-white hover:shadow-lg hover:shadow-blue-500/20"
+            className="app-top-icon-button ml-auto h-8 w-8"
             title="Collapse sidebar"
           >
             <ChevronLeft className="w-4 h-4" />

--- a/components/StatusBar.tsx
+++ b/components/StatusBar.tsx
@@ -21,7 +21,7 @@ const StatusBar: React.FC<StatusBarProps> = ({
         <span>
           Displaying <span className="font-semibold text-gray-100">{filteredCount}</span> of <span className="font-semibold text-gray-100">{totalCount}</span> images across <span className="font-semibold text-gray-100">{directoryCount}</span> {folderText}
         </span>
-        <span className="text-xs text-gray-500">v0.14.0</span>
+        <span className="text-xs text-gray-500">v0.14.1</span>
       </div>
 
       {/* Metadata Enrichment Progress Bar */}

--- a/components/TagInputCombobox.tsx
+++ b/components/TagInputCombobox.tsx
@@ -48,6 +48,7 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
 }, ref) => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [isSuggestionSelectionActive, setIsSuggestionSelectionActive] = useState(false);
   const listboxId = useId();
   const searchToken = getTagSearchToken(value, mode);
   const suggestions = useMemo(
@@ -71,6 +72,7 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
   const closeSuggestions = () => {
     setIsOpen(false);
     setActiveIndex(0);
+    setIsSuggestionSelectionActive(false);
   };
 
   const openSuggestions = (nextIndex = 0) => {
@@ -121,6 +123,7 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
           if (nextSearchToken && nextSuggestions.length > 0) {
             setIsOpen(true);
             setActiveIndex(0);
+            setIsSuggestionSelectionActive(false);
           } else {
             closeSuggestions();
           }
@@ -128,6 +131,7 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
         onFocus={() => {
           if (searchToken && suggestions.length > 0) {
             openSuggestions(0);
+            setIsSuggestionSelectionActive(false);
           }
         }}
         onBlur={() => {
@@ -136,7 +140,8 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
         onKeyDown={(event) => {
           if (event.key === 'ArrowDown') {
             event.preventDefault();
-            if (!isOpen) {
+            setIsSuggestionSelectionActive(true);
+            if (!isOpen || !isSuggestionSelectionActive) {
               openSuggestions(0);
               return;
             }
@@ -147,7 +152,13 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
 
           if (event.key === 'ArrowUp') {
             event.preventDefault();
+            setIsSuggestionSelectionActive(true);
             if (!isOpen) {
+              openSuggestions(suggestions.length - 1);
+              return;
+            }
+
+            if (!isSuggestionSelectionActive) {
               openSuggestions(suggestions.length - 1);
               return;
             }
@@ -157,7 +168,7 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
           }
 
           if (event.key === 'Enter') {
-            if (isOpen && suggestions[activeIndex]) {
+            if (isOpen && isSuggestionSelectionActive && suggestions[activeIndex]) {
               event.preventDefault();
               applySuggestion(suggestions[activeIndex].name);
               return;

--- a/components/TagInputCombobox.tsx
+++ b/components/TagInputCombobox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useId, useMemo, useState } from 'react';
+import React, { forwardRef, useEffect, useId, useMemo, useState } from 'react';
 import type { TagInfo } from '../types';
 import { getTagSearchToken, getTagSuggestions, replaceLastCsvToken, type TagInputMode } from '../utils/tagSuggestions';
 
@@ -61,6 +61,13 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
     [availableTags, excludedTags, recentTags, searchToken, suggestionLimit],
   );
 
+  useEffect(() => {
+    if (isOpen && suggestions.length === 0) {
+      setIsOpen(false);
+      setActiveIndex(0);
+    }
+  }, [isOpen, suggestions.length]);
+
   const closeSuggestions = () => {
     setIsOpen(false);
     setActiveIndex(0);
@@ -101,8 +108,17 @@ const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
         aria-controls={isOpen ? listboxId : undefined}
         onChange={(event) => {
           const nextValue = event.target.value;
+          const nextSearchToken = getTagSearchToken(nextValue, mode);
+          const nextSuggestions = getTagSuggestions({
+            query: nextSearchToken,
+            recentTags,
+            availableTags,
+            excludedTags,
+            limit: suggestionLimit,
+          });
+
           onValueChange(nextValue);
-          if (getTagSearchToken(nextValue, mode)) {
+          if (nextSearchToken && nextSuggestions.length > 0) {
             setIsOpen(true);
             setActiveIndex(0);
           } else {

--- a/components/TagInputCombobox.tsx
+++ b/components/TagInputCombobox.tsx
@@ -1,0 +1,201 @@
+import React, { forwardRef, useId, useMemo, useState } from 'react';
+import type { TagInfo } from '../types';
+import { getTagSearchToken, getTagSuggestions, replaceLastCsvToken, type TagInputMode } from '../utils/tagSuggestions';
+
+interface TagInputComboboxProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  onSubmit: (value: string) => void | Promise<void>;
+  recentTags: string[];
+  availableTags: TagInfo[];
+  excludedTags?: string[];
+  suggestionLimit: number;
+  mode?: TagInputMode;
+  placeholder?: string;
+  disabled?: boolean;
+  wrapperClassName?: string;
+  inputClassName?: string;
+  dropdownClassName?: string;
+  optionClassName?: string;
+  activeOptionClassName?: string;
+  metaClassName?: string;
+  trailingContent?: React.ReactNode;
+  onEscape?: () => void;
+}
+
+const defaultOptionClassName =
+  'w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white flex justify-between items-center';
+
+const TagInputCombobox = forwardRef<HTMLInputElement, TagInputComboboxProps>(({
+  value,
+  onValueChange,
+  onSubmit,
+  recentTags,
+  availableTags,
+  excludedTags = [],
+  suggestionLimit,
+  mode = 'single',
+  placeholder = 'Add tag...',
+  disabled = false,
+  wrapperClassName = 'relative',
+  inputClassName = '',
+  dropdownClassName = 'absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-gray-700 bg-gray-800 shadow-xl',
+  optionClassName = defaultOptionClassName,
+  activeOptionClassName = 'bg-gray-700 text-white',
+  metaClassName = 'text-xs text-gray-500',
+  trailingContent,
+  onEscape,
+}, ref) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listboxId = useId();
+  const searchToken = getTagSearchToken(value, mode);
+  const suggestions = useMemo(
+    () => getTagSuggestions({
+      query: searchToken,
+      recentTags,
+      availableTags,
+      excludedTags,
+      limit: suggestionLimit,
+    }),
+    [availableTags, excludedTags, recentTags, searchToken, suggestionLimit],
+  );
+
+  const closeSuggestions = () => {
+    setIsOpen(false);
+    setActiveIndex(0);
+  };
+
+  const openSuggestions = (nextIndex = 0) => {
+    if (suggestions.length === 0) {
+      closeSuggestions();
+      return;
+    }
+
+    setIsOpen(true);
+    setActiveIndex(Math.min(Math.max(nextIndex, 0), suggestions.length - 1));
+  };
+
+  const applySuggestion = (tagName: string) => {
+    if (mode === 'csv') {
+      onValueChange(replaceLastCsvToken(value, tagName));
+      closeSuggestions();
+      return;
+    }
+
+    void onSubmit(tagName);
+    closeSuggestions();
+  };
+
+  return (
+    <div className={wrapperClassName}>
+      <input
+        ref={ref}
+        type="text"
+        value={value}
+        disabled={disabled}
+        placeholder={placeholder}
+        autoComplete="off"
+        aria-autocomplete="list"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? listboxId : undefined}
+        onChange={(event) => {
+          const nextValue = event.target.value;
+          onValueChange(nextValue);
+          if (getTagSearchToken(nextValue, mode)) {
+            setIsOpen(true);
+            setActiveIndex(0);
+          } else {
+            closeSuggestions();
+          }
+        }}
+        onFocus={() => {
+          if (searchToken && suggestions.length > 0) {
+            openSuggestions(0);
+          }
+        }}
+        onBlur={() => {
+          closeSuggestions();
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            if (!isOpen) {
+              openSuggestions(0);
+              return;
+            }
+
+            openSuggestions(activeIndex + 1);
+            return;
+          }
+
+          if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            if (!isOpen) {
+              openSuggestions(suggestions.length - 1);
+              return;
+            }
+
+            openSuggestions(activeIndex - 1);
+            return;
+          }
+
+          if (event.key === 'Enter') {
+            if (isOpen && suggestions[activeIndex]) {
+              event.preventDefault();
+              applySuggestion(suggestions[activeIndex].name);
+              return;
+            }
+
+            if (value.trim()) {
+              event.preventDefault();
+              void onSubmit(value);
+            }
+            return;
+          }
+
+          if (event.key === 'Escape') {
+            if (isOpen) {
+              event.preventDefault();
+              closeSuggestions();
+              return;
+            }
+
+            onEscape?.();
+          }
+        }}
+        className={inputClassName}
+      />
+
+      {trailingContent}
+
+      {isOpen && suggestions.length > 0 && (
+        <div id={listboxId} role="listbox" className={dropdownClassName}>
+          {suggestions.map((suggestion, index) => {
+            const isActive = index === activeIndex;
+            return (
+              <button
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                key={suggestion.name}
+                onPointerDown={(event) => {
+                  event.preventDefault();
+                }}
+                onClick={() => applySuggestion(suggestion.name)}
+                className={`${optionClassName} ${isActive ? activeOptionClassName : ''}`.trim()}
+              >
+                <span>{suggestion.name}</span>
+                <span className={metaClassName}>{suggestion.count}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+});
+
+TagInputCombobox.displayName = 'TagInputCombobox';
+
+export default TagInputCombobox;

--- a/components/TagManagerModal.tsx
+++ b/components/TagManagerModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { X, Plus, Tag } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+import TagInputCombobox from './TagInputCombobox';
 
 interface TagManagerModalProps {
   isOpen: boolean;
@@ -14,6 +16,8 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
   selectedImageIds,
 }) => {
   const { availableTags, bulkAddTag, bulkRemoveTag, images } = useImageStore();
+  const recentTags = useImageStore((state) => state.recentTags);
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
   const [inputValue, setInputValue] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [pendingRemoveTag, setPendingRemoveTag] = useState<string | null>(null);
@@ -64,23 +68,6 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
       }));
   }, [existingTagsStats, selectedImages.length]);
 
-  // Filter suggestions based on input (last part after comma)
-  const suggestions = useMemo(() => {
-    if (!inputValue.trim()) return [];
-    
-    const parts = inputValue.split(',');
-    const currentSearch = parts[parts.length - 1].trim().toLowerCase();
-    
-    if (!currentSearch) return [];
-
-    return availableTags
-      .filter(tag => 
-        tag.name.toLowerCase().includes(currentSearch) && 
-        !existingTagsStats.has(tag.name)
-      )
-      .slice(0, 5);
-  }, [inputValue, availableTags, existingTagsStats]);
-
   const handleAddTag = async (input: string) => {
     if (!input.trim()) return;
     
@@ -104,16 +91,6 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
       setIsSubmitting(false);
       focusInput();
     }
-  };
-
-  const handleSuggestionClick = (tagName: string) => {
-    const parts = inputValue.split(',');
-    parts.pop(); // Remove the partial chunk
-    parts.push(tagName); // Add the selected tag
-    // Join with comma and space, and add a trailing comma space for convenience to type next
-    const newValue = parts.map(p => p.trim()).join(', ') + ', ';
-    setInputValue(newValue);
-    focusInput();
   };
 
   const handleRemoveTagRequest = (tag: string, e?: React.MouseEvent) => {
@@ -140,12 +117,7 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      if (inputValue.trim()) {
-        handleAddTag(inputValue);
-      }
-    } else if (e.key === 'Escape') {
+    if (e.key === 'Escape') {
       if (pendingRemoveTag) {
         setPendingRemoveTag(null);
         focusInput();
@@ -185,42 +157,43 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
           
           {/* Input Section */}
           <div className="relative">
-            <input
+            <TagInputCombobox
               ref={inputRef}
-              type="text"
               value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={handleKeyDown}
+              onValueChange={setInputValue}
+              onSubmit={handleAddTag}
+              recentTags={recentTags}
+              availableTags={availableTags}
+              excludedTags={Array.from(existingTagsStats.keys())}
+              suggestionLimit={tagSuggestionLimit}
+              mode="csv"
               placeholder="Type tags separated by commas..."
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg pl-3 pr-10 py-2.5 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none"
-              autoComplete="off"
-            />
-            <button
-              type="button"
-              onClick={() => handleAddTag(inputValue)}
-              disabled={!inputValue.trim() || isSubmitting}
-              className="absolute right-1.5 top-1.5 p-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              aria-label="Add tags"
-            >
-              <Plus size={16} />
-            </button>
+              onEscape={() => {
+                if (pendingRemoveTag) {
+                  setPendingRemoveTag(null);
+                  focusInput();
+                  return;
+                }
 
-            {/* Suggestions Dropdown */}
-            {suggestions.length > 0 && (
-              <div className="absolute z-10 w-full mt-1 bg-gray-800 border border-gray-700 rounded-lg shadow-xl overflow-hidden">
-                {suggestions.map(tag => (
-                  <button
-                    type="button"
-                    key={tag.name}
-                    onClick={() => handleSuggestionClick(tag.name)}
-                    className="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white flex justify-between items-center group"
-                  >
-                    <span>{tag.name}</span>
-                    <span className="text-xs text-gray-500 group-hover:text-gray-400">{tag.count}</span>
-                  </button>
-                ))}
-              </div>
-            )}
+                onClose();
+              }}
+              wrapperClassName="relative"
+              inputClassName="w-full bg-gray-800 border border-gray-700 rounded-lg pl-3 pr-10 py-2.5 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none"
+              dropdownClassName="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-gray-700 bg-gray-800 shadow-xl"
+              metaClassName="text-xs text-gray-500"
+              trailingContent={
+                <button
+                  type="button"
+                  onClick={() => handleAddTag(inputValue)}
+                  onKeyDown={handleKeyDown}
+                  disabled={!inputValue.trim() || isSubmitting}
+                  className="absolute right-1.5 top-1.5 p-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  aria-label="Add tags"
+                >
+                  <Plus size={16} />
+                </button>
+              }
+            />
           </div>
 
           {pendingRemoveTag && (

--- a/components/TagsAndFavorites.tsx
+++ b/components/TagsAndFavorites.tsx
@@ -775,7 +775,7 @@ const TagsAndFavorites: React.FC = () => {
 
       <CollectionFormModal
         isOpen={collectionSourceTag !== null}
-        title="Create Collection from Tag"
+        title="Create Collection"
         submitLabel="Create Collection"
         initialValues={{
           name: collectionSourceTag ?? '',
@@ -786,7 +786,6 @@ const TagsAndFavorites: React.FC = () => {
         }}
         onClose={() => setCollectionSourceTag(null)}
         onSubmit={handleCreateCollection}
-        collectionKind="tag_rule"
         showSourceTag
         disableSourceTag
         showAutoUpdate

--- a/components/TagsAndFavorites.tsx
+++ b/components/TagsAndFavorites.tsx
@@ -5,6 +5,7 @@ import { useImageStore } from '../store/useImageStore';
 import { InclusionFilterMode, TagInfo } from '../types';
 import TriStateToggle, { getFilterModeLabel, getNextFilterMode } from './TriStateToggle';
 import { getRatingChipClasses, getRatingLabel, RatingValueIcons } from './RatingStars';
+import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 
 type TagContextMenuState = {
   x: number;
@@ -43,6 +44,8 @@ const TagsAndFavorites: React.FC = () => {
   const filteredImages = useImageStore((state) => state.filteredImages);
   const images = useImageStore((state) => state.images);
   const indexingState = useImageStore((state) => state.indexingState);
+  const collections = useImageStore((state) => state.collections);
+  const createCollection = useImageStore((state) => state.createCollection);
 
   const [isExpanded, setIsExpanded] = useState(true);
   const [tagSearchQuery, setTagSearchQuery] = useState('');
@@ -53,6 +56,7 @@ const TagsAndFavorites: React.FC = () => {
     sourceTag: '',
     value: '',
   });
+  const [collectionSourceTag, setCollectionSourceTag] = useState<string | null>(null);
   const contextMenuRef = React.useRef<HTMLDivElement>(null);
   const renameInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -275,6 +279,45 @@ const TagsAndFavorites: React.FC = () => {
   const handleTagAction = async (action: () => Promise<void>) => {
     closeContextMenu();
     await action();
+  };
+
+  const openCreateCollectionDialog = () => {
+    if (!contextMenu) {
+      return;
+    }
+
+    setCollectionSourceTag(contextMenu.tag.name);
+    closeContextMenu();
+  };
+
+  const handleCreateCollection = async (values: CollectionFormValues) => {
+    if (!collectionSourceTag) {
+      return;
+    }
+
+    const normalizedTag = collectionSourceTag.trim().toLowerCase();
+    const snapshotImageIds = values.autoUpdate
+      ? []
+      : images
+          .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedTag))
+          .map((image) => image.id);
+
+    await createCollection({
+      kind: 'tag_rule',
+      name: values.name,
+      description: values.description || undefined,
+      sourceTag: normalizedTag,
+      autoUpdate: values.autoUpdate,
+      imageIds: [],
+      snapshotImageIds,
+      sortIndex: collections.length,
+      coverImageId: null,
+      thumbnailId: undefined,
+      type: 'custom',
+      query: undefined,
+    });
+
+    setCollectionSourceTag(null);
   };
 
   const handleClearFromMenu = async () => {
@@ -685,6 +728,13 @@ const TagsAndFavorites: React.FC = () => {
           >
             Rename Tag
           </button>
+          <button
+            type="button"
+            className="w-full px-4 py-2 text-left text-sm text-gray-300 transition-colors hover:bg-gray-700"
+            onClick={openCreateCollectionDialog}
+          >
+            Create Collection
+          </button>
           {contextMenu.tag.count > 0 && (
             <button
               type="button"
@@ -722,6 +772,25 @@ const TagsAndFavorites: React.FC = () => {
           )}
         </div>
       )}
+
+      <CollectionFormModal
+        isOpen={collectionSourceTag !== null}
+        title="Create Collection from Tag"
+        submitLabel="Create Collection"
+        initialValues={{
+          name: collectionSourceTag ?? '',
+          description: '',
+          sourceTag: collectionSourceTag ?? '',
+          autoUpdate: true,
+          includeTargetImages: false,
+        }}
+        onClose={() => setCollectionSourceTag(null)}
+        onSubmit={handleCreateCollection}
+        collectionKind="tag_rule"
+        showSourceTag
+        disableSourceTag
+        showAutoUpdate
+      />
 
       {renameDialog.isOpen && (
         <div

--- a/components/TagsAndFavorites.tsx
+++ b/components/TagsAndFavorites.tsx
@@ -6,6 +6,7 @@ import { InclusionFilterMode, TagInfo } from '../types';
 import TriStateToggle, { getFilterModeLabel, getNextFilterMode } from './TriStateToggle';
 import { getRatingChipClasses, getRatingLabel, RatingValueIcons } from './RatingStars';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
+import { normalizeCollectionTagNames } from '../services/imageAnnotationsStorage';
 
 type TagContextMenuState = {
   x: number;
@@ -295,11 +296,16 @@ const TagsAndFavorites: React.FC = () => {
       return;
     }
 
-    const normalizedTag = collectionSourceTag.trim().toLowerCase();
+    const normalizedTag = normalizeCollectionTagNames(collectionSourceTag).join(', ');
+    const normalizedTags = normalizeCollectionTagNames(collectionSourceTag);
     const snapshotImageIds = values.autoUpdate
       ? []
       : images
-          .filter((image) => Array.isArray(image.tags) && image.tags.includes(normalizedTag))
+          .filter(
+            (image) =>
+              Array.isArray(image.tags) &&
+              normalizedTags.some((tag) => image.tags.includes(tag)),
+          )
           .map((image) => image.id);
 
     await createCollection({

--- a/components/VerticalSplitPanels.tsx
+++ b/components/VerticalSplitPanels.tsx
@@ -130,7 +130,11 @@ const VerticalSplitPanels: React.FC<VerticalSplitPanelsProps> = ({
   })), [minPaneHeight, sizes]);
 
   return (
-    <div ref={containerRef} data-testid="vertical-split-panels" className={`flex min-h-0 flex-1 flex-col ${className}`.trim()}>
+    <div
+      ref={containerRef}
+      data-testid="vertical-split-panels"
+      className={`flex min-h-0 flex-1 flex-col ${className}`.trim()}
+    >
       {panes.map((pane, index) => (
         <React.Fragment key={pane.id}>
           <section

--- a/components/VerticalSplitPanels.tsx
+++ b/components/VerticalSplitPanels.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+export interface VerticalSplitPane {
+  id: string;
+  content: React.ReactNode;
+  ariaLabel: string;
+}
+
+interface VerticalSplitPanelsProps {
+  panes: VerticalSplitPane[];
+  storageKey: string;
+  defaultSizes: number[];
+  minPaneHeight?: number;
+  className?: string;
+}
+
+const normalizeSizes = (sizes: number[]): number[] => {
+  const total = sizes.reduce((sum, size) => sum + size, 0);
+  if (!Number.isFinite(total) || total <= 0) {
+    return sizes;
+  }
+
+  return sizes.map((size) => (size / total) * 100);
+};
+
+export const sanitizeStoredPaneSizes = (
+  rawSizes: unknown,
+  expectedLength: number,
+  fallbackSizes: number[],
+): number[] => {
+  if (!Array.isArray(rawSizes) || rawSizes.length !== expectedLength) {
+    return normalizeSizes(fallbackSizes);
+  }
+
+  const parsed = rawSizes.map((value) => Number(value));
+  if (parsed.some((value) => !Number.isFinite(value) || value <= 0)) {
+    return normalizeSizes(fallbackSizes);
+  }
+
+  return normalizeSizes(parsed);
+};
+
+const VerticalSplitPanels: React.FC<VerticalSplitPanelsProps> = ({
+  panes,
+  storageKey,
+  defaultSizes,
+  minPaneHeight = 120,
+  className = '',
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [sizes, setSizes] = useState<number[]>(() => {
+    if (typeof window === 'undefined') {
+      return normalizeSizes(defaultSizes);
+    }
+
+    try {
+      const storedSizes = JSON.parse(window.localStorage.getItem(storageKey) ?? 'null');
+      return sanitizeStoredPaneSizes(storedSizes, panes.length, defaultSizes);
+    } catch {
+      return normalizeSizes(defaultSizes);
+    }
+  });
+  const [dragState, setDragState] = useState<{
+    handleIndex: number;
+    startY: number;
+    startSizes: number[];
+  } | null>(null);
+
+  useEffect(() => {
+    setSizes((currentSizes) => sanitizeStoredPaneSizes(currentSizes, panes.length, defaultSizes));
+  }, [defaultSizes, panes.length]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(storageKey, JSON.stringify(sizes));
+  }, [sizes, storageKey]);
+
+  useEffect(() => {
+    if (!dragState || typeof window === 'undefined') {
+      return;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const containerHeight = containerRef.current?.getBoundingClientRect().height ?? 0;
+      if (containerHeight <= 0) {
+        return;
+      }
+
+      const pairStart = dragState.startSizes[dragState.handleIndex] + dragState.startSizes[dragState.handleIndex + 1];
+      const minPercent = Math.min((minPaneHeight / containerHeight) * 100, pairStart / 2);
+      const deltaPercent = ((event.clientY - dragState.startY) / containerHeight) * 100;
+      const proposedFirst = dragState.startSizes[dragState.handleIndex] + deltaPercent;
+      const clampedFirst = Math.min(Math.max(proposedFirst, minPercent), pairStart - minPercent);
+      const nextSizes = [...dragState.startSizes];
+
+      nextSizes[dragState.handleIndex] = clampedFirst;
+      nextSizes[dragState.handleIndex + 1] = pairStart - clampedFirst;
+      setSizes(nextSizes);
+    };
+
+    const handlePointerUp = () => {
+      setDragState(null);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerUp);
+    window.addEventListener('blur', handlePointerUp);
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handlePointerUp);
+      window.removeEventListener('blur', handlePointerUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [dragState, minPaneHeight]);
+
+  const paneStyles = useMemo(() => sizes.map((size) => ({
+    flexBasis: `${size}%`,
+    flexGrow: 0,
+    flexShrink: 0,
+    minHeight: `${minPaneHeight}px`,
+  })), [minPaneHeight, sizes]);
+
+  return (
+    <div ref={containerRef} data-testid="vertical-split-panels" className={`flex min-h-0 flex-1 flex-col ${className}`.trim()}>
+      {panes.map((pane, index) => (
+        <React.Fragment key={pane.id}>
+          <section
+            role="region"
+            aria-label={pane.ariaLabel}
+            className="min-h-0 overflow-y-auto scrollbar-sidebar"
+            style={paneStyles[index]}
+          >
+            {pane.content}
+          </section>
+
+          {index < panes.length - 1 && (
+            <div
+              role="separator"
+              aria-label={`Resize ${pane.ariaLabel}`}
+              aria-orientation="horizontal"
+              onPointerDown={(event) => {
+                event.preventDefault();
+                event.currentTarget.setPointerCapture?.(event.pointerId);
+                setDragState({
+                  handleIndex: index,
+                  startY: event.clientY,
+                  startSizes: sizes,
+                });
+              }}
+              className="group flex h-4 shrink-0 cursor-row-resize items-center justify-center touch-none"
+              title="Drag to resize pane"
+            >
+              <div className={`h-1 w-16 rounded-full transition-colors ${dragState?.handleIndex === index ? 'bg-blue-400/90 shadow-[0_0_16px_rgba(96,165,250,0.55)]' : 'bg-gray-700/80 group-hover:bg-blue-400/80'}`} />
+            </div>
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default VerticalSplitPanels;

--- a/components/settings/ViewerSettingsPanel.tsx
+++ b/components/settings/ViewerSettingsPanel.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 import { useSettingsStore } from '../../store/useSettingsStore';
+import {
+  DEFAULT_RECENT_TAG_CHIP_LIMIT,
+  DEFAULT_TAG_SUGGESTION_LIMIT,
+  MAX_TAG_UI_LIMIT,
+  MIN_TAG_UI_LIMIT,
+} from '../../utils/tagSuggestions';
 import { SettingRow } from './SettingRow';
 import { SettingsPanel } from './SettingsPanel';
 import { SettingsSectionCard } from './SettingsSectionCard';
@@ -12,6 +18,10 @@ export const ViewerSettingsPanel: React.FC = () => {
   const setShowFullFilePath = useSettingsStore((state) => state.setShowFullFilePath);
   const doubleClickToOpen = useSettingsStore((state) => state.doubleClickToOpen);
   const setDoubleClickToOpen = useSettingsStore((state) => state.setDoubleClickToOpen);
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
+  const setTagSuggestionLimit = useSettingsStore((state) => state.setTagSuggestionLimit);
+  const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
+  const setRecentTagChipLimit = useSettingsStore((state) => state.setRecentTagChipLimit);
 
   return (
     <SettingsPanel title="Viewer" description="Control what appears in the library and how images open.">
@@ -30,6 +40,37 @@ export const ViewerSettingsPanel: React.FC = () => {
           label="Double-click to open"
           description="Keep single click for selection and open details on double click."
           control={<SettingSwitch checked={doubleClickToOpen} onChange={setDoubleClickToOpen} />}
+        />
+      </SettingsSectionCard>
+
+      <SettingsSectionCard title="Tagging">
+        <SettingRow
+          label="Suggestion list size"
+          description={`How many tag suggestions to show while typing. Range ${MIN_TAG_UI_LIMIT}-${MAX_TAG_UI_LIMIT}.`}
+          control={
+            <input
+              type="number"
+              min={MIN_TAG_UI_LIMIT}
+              max={MAX_TAG_UI_LIMIT}
+              value={tagSuggestionLimit}
+              onChange={(event) => setTagSuggestionLimit(Number(event.target.value) || DEFAULT_TAG_SUGGESTION_LIMIT)}
+              className="w-24 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-right text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+            />
+          }
+        />
+        <SettingRow
+          label="Recent tag chips"
+          description={`How many recent tags to show as quick-add chips. Range ${MIN_TAG_UI_LIMIT}-${MAX_TAG_UI_LIMIT}.`}
+          control={
+            <input
+              type="number"
+              min={MIN_TAG_UI_LIMIT}
+              max={MAX_TAG_UI_LIMIT}
+              value={recentTagChipLimit}
+              onChange={(event) => setRecentTagChipLimit(Number(event.target.value) || DEFAULT_RECENT_TAG_CHIP_LIMIT)}
+              className="w-24 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-right text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+            />
+          }
         />
       </SettingsSectionCard>
     </SettingsPanel>

--- a/electron.mjs
+++ b/electron.mjs
@@ -915,7 +915,7 @@ async function createWindow(startupDirectory = null) {
     mainWindow.setTitle(`Image MetaHub v${appVersion}`);
   } catch (e) {
     // Fallback if app.getVersion is not available
-    mainWindow.setTitle('Image MetaHub v0.14.0');
+    mainWindow.setTitle('Image MetaHub v0.14.1');
   }
 
   // Load the app

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Image MetaHub v0.14.0</title>
+  <title>Image MetaHub v0.14.1</title>
   </head>
   <body class="bg-gray-900 text-gray-100">
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Image MetaHub",
   "author": "LuqP2 <github.com/LuqP2>",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "main": "electron.mjs",
   "homepage": "./",

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Manual Collection Counts**: Fixed manual collection membership and counts so deleted or unindexed images no longer remain in resolved collection results.
 - **Collection Sort Ordering**: Fixed new collection ordering after deleted collections so sort indexes are allocated from the current maximum instead of reusing stale positions.
 - **Filtered Collection Reordering**: Fixed collection move buttons while searching collections so they reflect the collection's global order instead of the filtered list position.
+- **Tag Input Enter Behavior**: Fixed tag combobox Enter handling so typed tags submit as entered unless the user explicitly navigates to a suggestion first.
 - **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.
 - **Preview Sidebar Opening Unexpectedly**: Fixed the Image Preview sidebar opening by itself after search/filter changes or view switches by limiting automatic preview restoration to active grid keyboard navigation.
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.1] - Unreleased
+## [0.14.1] - 2026-04-10
 
 ### Added
 
@@ -23,15 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
-- **Collection Form Focus and Draft Text**: Fixed collection creation dialogs sometimes losing focus or clearing typed text after background rerenders.
 - **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.
 - **Preview Sidebar Opening Unexpectedly**: Fixed the Image Preview sidebar opening by itself after search/filter changes or view switches by limiting automatic preview restoration to active grid keyboard navigation.
-- **Collection Membership Consistency**: Fixed collection removals and updates so explicit image IDs and snapshot image IDs stay in sync.
-- **Live Collection Filtering**: Fixed collection filter results so they update in real time as filters and collection contents change.
-- **Collection Thumbnail Resolution**: Fixed collection cover thumbnails to resolve consistently across collection cards and workspace views.
-- **Context Menu Reliability**: Fixed collection context menu submenu gaps and Image Modal pointer-event handling that could make menus or modal actions feel unreliable.
 
-## [0.14.0] - Unreleased
+## [0.14.0] - 2026-04-06
 
 ### Added
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
 - **Live Collection Removal**: Fixed removing images from auto-updating tag collections so removed images stay excluded unless explicitly added back.
 - **Collection Settings Conversion**: Fixed clearing Auto-Add Tags in Collection Settings so tag-rule collections keep their currently resolved images when converted to manual collections.
+- **Frozen Collection Membership**: Fixed disabling auto-update on tag-driven collections so the frozen snapshot preserves the resolved, curated membership instead of reintroducing previously removed tag matches.
+- **Manual Collection Counts**: Fixed manual collection membership and counts so deleted or unindexed images no longer remain in resolved collection results.
 - **Collection Sort Ordering**: Fixed new collection ordering after deleted collections so sort indexes are allocated from the current maximum instead of reusing stale positions.
 - **Filtered Collection Reordering**: Fixed collection move buttons while searching collections so they reflect the collection's global order instead of the filtered list position.
 - **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -9,11 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Collections View**: Added a dedicated `Collections` tab for building reusable image groups across indexed folders, with support for manual collections, tag-driven auto-updating collections, collection ordering, cover images, and collection management from the main workspace.
+- **Collections**: Added a dedicated `Collections` tab for reusable image groups, with manual and tag-driven collections, multi-tag rules, ordering, cover images, collection cards, in-place settings, and collection actions across the grid, table, Image Modal, and toolbar, including saving or adding the current filtered result set.
+
+### Improved
+
+- **Unified Tag Entry UX**: Manual tag entry in `ImageModal`, `ImagePreviewSidebar`, and `Tag Manager` now shares the same suggestion combobox, keyboard navigation, mouse selection behavior, and match ranking, making tag suggestions feel consistent everywhere.
+- **Tagging Controls in Settings**: Added viewer settings for tag suggestion count and visible recent-tag chips, while keeping a larger internal recent-tag history so quick picks stay useful without overwhelming the UI.
+- **Safer Bulk Tag Suggestions**: The Tag Manager's comma-separated input now applies autocomplete only to the active CSV token, making multi-tag edits faster and less error-prone.
+- **Viewer Annotation Layout**: Moved the star rating control above the tag editor in the full image view and preview sidebar so tags have more horizontal space.
+- **Header and Navigation Polish**: Refreshed the header layout, aligned view navigation more cleanly, added Collections to the main view switcher, and reduced overlay issues around Settings and other top-level controls.
+- **Stable Sidebar Layout**: Restored the single-scroll sidebar filter flow and tightened sidebar sizing so folder, tag, and filter browsing remains predictable.
 
 ### Fixed
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+- **Collection Form Focus and Draft Text**: Fixed collection creation dialogs sometimes losing focus or clearing typed text after background rerenders.
+- **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.
+- **Preview Sidebar Opening Unexpectedly**: Fixed the Image Preview sidebar opening by itself after search/filter changes or view switches by limiting automatic preview restoration to active grid keyboard navigation.
+- **Collection Membership Consistency**: Fixed collection removals and updates so explicit image IDs and snapshot image IDs stay in sync.
+- **Live Collection Filtering**: Fixed collection filter results so they update in real time as filters and collection contents change.
+- **Collection Thumbnail Resolution**: Fixed collection cover thumbnails to resolve consistently across collection cards and workspace views.
+- **Context Menu Reliability**: Fixed collection context menu submenu gaps and Image Modal pointer-event handling that could make menus or modal actions feel unreliable.
 
 ## [0.14.0] - Unreleased
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+- **Live Collection Removal**: Fixed removing images from auto-updating tag collections so removed images stay excluded unless explicitly added back.
+- **Filtered Collection Reordering**: Fixed collection move buttons while searching collections so they reflect the collection's global order instead of the filtered list position.
 - **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.
 - **Preview Sidebar Opening Unexpectedly**: Fixed the Image Preview sidebar opening by itself after search/filter changes or view switches by limiting automatic preview restoration to active grid keyboard navigation.
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
 - **Live Collection Removal**: Fixed removing images from auto-updating tag collections so removed images stay excluded unless explicitly added back.
+- **Collection Settings Conversion**: Fixed clearing Auto-Add Tags in Collection Settings so tag-rule collections keep their currently resolved images when converted to manual collections.
+- **Collection Sort Ordering**: Fixed new collection ordering after deleted collections so sort indexes are allocated from the current maximum instead of reusing stale positions.
 - **Filtered Collection Reordering**: Fixed collection move buttons while searching collections so they reflect the collection's global order instead of the filtered list position.
 - **Search Field Hotkeys**: Fixed global hotkeys firing while typing in text inputs, preventing search text from being interrupted by app actions.
 - **Preview Sidebar Opening Unexpectedly**: Fixed the Image Preview sidebar opening by itself after search/filter changes or view switches by limiting automatic preview restoration to active grid keyboard navigation.

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,50 +5,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.0] - 2026-04-06
+## [0.14.1] - Unreleased
 
 ### Added
 
-- **Visual ComfyUI Workflow Inspector**: Added a visual node-based editor inside both the ComfyUI generation modal and the Image Details Modal, with zoom/pan controls, editable node fields, embedded-layout support, and an advanced JSON fallback for debugging edge cases.
-- **ComfyUI Node View**: Added a dedicated `Node View` alongside Library, Smart Library, and Model View, with exact node-type catalogs, per-node result counts, search, and multi-select OR filtering for images containing embedded ComfyUI workflows.
-- **Image Lineage for Transformations**: Added explicit lineage support for `img2img`, `inpaint`, and `outpaint`, so transformed images are no longer treated as generic generations. The viewer now shows generation type, source/input image status, denoise strength when available, and direct navigation between source and result when the original image can be recovered confidently.
-- **Analytics Explorer**: Rebuilt analytics as an interactive explorer with `Overview`, `Resources`, `Time`, `Performance`, and `Curation` views, scope switching between current results and full library, cohort comparison tools, and one-click promotion of insights into live filters.
-- **Windowed Image Viewer**: Added support for multiple open image windows with drag, resize, minimize/maximize, and dockable or collapsible details for more flexible comparison and inspection.
-- **Image Ratings**: Added persistent 1-5 ratings for images, including viewer controls, library badges, bulk rating actions, and multi-select rating filters in the sidebar and advanced filters.
-- **Startup Verification Modes**: Added configurable startup verification modes for saved folders, allowing the app to open from cache only, reconcile in the background, or verify folders strictly before startup completes.
-- **Manual Tag Management**: Added a persistent manual tag catalog so empty tags remain visible in the sidebar, along with right-click tag actions for renaming, clearing tags from images, removing unused tags, and clearing or deleting used tags.
+- **Collections View**: Added a dedicated `Collections` tab for building reusable image groups across indexed folders, with support for manual collections, tag-driven auto-updating collections, collection ordering, cover images, and collection management from the main workspace.
+
+### Fixed
+
+- **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+
+## [0.14.0] - Unreleased
+
+### Added
+
+- **Visual ComfyUI Workflow Inspector**: Added a visual node-based editor inside the ComfyUI generation modal and Image Details Modal, with zoom/pan controls, editable node fields, embedded-layout support, and an advanced JSON fallback for debugging edge cases.
+- **ComfyUI Node View**: Added a dedicated `Node View` alongside Library, Smart Library, and Model View, with searchable exact node-type catalogs, per-node result counts, and multi-select OR filtering for images that contain embedded ComfyUI workflows.
+- **Image Lineage for Transformations**: Added explicit lineage support for `img2img`, `inpaint`, and `outpaint`, so transformed images are no longer treated as generic generations. The viewer now shows the generation type, source/input image status, denoise strength when available, and direct navigation between source and result when the original image can be recovered with confidence.
+- **Analytics Explorer**: Rebuilt analytics into an interactive explorer with `Overview`, `Resources`, `Time`, `Performance`, and `Curation` views, scope switching between the current results and full library, cohort comparison tools, and one-click promotion of analytics insights into live filters.
+- **Windowed Image Viewer**: Added support for multiple open image windows with drag, resize, minimize/maximize, and dockable or collapsible details so images can be compared and inspected more flexibly.
+- **Image Ratings**: Added persistent 1-5 ratings for images, including star controls in the viewer, badges in the library views, bulk rating actions, and multi-select rating filters in the sidebar and advanced filters.
+- **Startup Verification Modes**: Added configurable startup verification modes for saved folders, so the app can now open from cache only, reconcile in the background, or verify folders strictly before startup completes.
+- **Manual Tag Management**: Added a persistent manual tag catalog so empty tags remain visible in the sidebar, plus right-click tag actions for renaming, clearing tags from images, removing unused tags, and clearing/deleting used tags in one step.
 - **Metadata Type Filters**: Added checkbox filters for `txt2img` / `img2img` generation modes and `Images` / `Videos` file types in `Metadata & File Filters`.
-- **Manual Metadata Recovery**: Added `Reparse Metadata` actions for single images and multi-selection workflows, reprocessing only the chosen files without requiring a full folder refresh or cache clear.
+- **Manual Metadata Recovery**: Added `Reparse Metadata` actions for single images and multi-selection workflows, reprocessing only the chosen files and updating their cached metadata without requiring a full folder refresh or cache clear.
 - **Expanded Compare View**: Added support for comparing up to 4 images at once, with new `Side Strip` and `2x2 Grid` layouts for 3-4 image sets, plus improved Compare integration with the windowed viewer workflow.
 
 ### Improved
 
-- **Electron Privileged IPC Hardening**: Restricted renderer-driven write operations to app-internal paths or user-approved export destinations, tightened generator launch requests to match saved integration settings, and limited test-only update dialog exposure to development builds.
-- **Offline License Integrity**: Revalidated persisted Pro/Lifetime state on startup, removed the temporary "unlock during initialization" window for paid features, and limited the `IMH_DEV_LICENSE` shortcut to development builds.
+- **Electron Privileged IPC Hardening**: Restricted renderer-driven write operations to app-internal paths or user-approved export destinations, tightened generator launch requests so they must match the saved integration settings, and limited test-only update dialog exposure to development builds.
+- **Offline License Integrity**: Revalidated persisted Pro/Lifetime state on startup, removed the temporary "unlock during initialization" window for paid features, and limited the `IMH_DEV_LICENSE` shortcut to development builds only.
 - **Background Worker Guardrails**: Added validation and sane limits for clustering and auto-tagging worker payloads so malformed or extreme jobs fail fast instead of consuming excessive CPU or memory.
 - **ComfyUI Variation Controls**: Expanded the ComfyUI generation modal with workflow mode selection, model-family aware resource overrides, LoRA controls, source image policy for transform workflows, and better handling for original-graph assets.
-- **Favorites Icon Refresh**: Replaced favorite stars with heart icons to clearly distinguish favorites from ratings.
+- **Favorites Icon Refresh**: Updated favorite actions and indicators to use a heart icon instead of a star for clearer separation from the new rating system.
 - **Sidebar Faceted Filters**: Reworked the sidebar filter experience around dedicated facet sections for checkpoints, LoRAs, samplers, and schedulers, with per-value include/exclude actions, result counts, in-section search, and clearer active-filter chips.
-- **Tag Match Mode**: Added an `Any / All` toggle for included manual tag filters in the sidebar, allowing searches to match any selected tag or require all selected tags.
-- **Large Library Responsiveness**: Improved responsiveness on large libraries by moving lineage resolution out of the image modal hot path, reducing expensive modal navigation lookups, and cutting renderer churn during indexing and filtering.
+- **Tag Match Mode**: Added an `Any / All` toggle for included manual tag filters in the sidebar, allowing tag searches to match any selected tag or require all selected tags for narrower curation workflows.
+- **Large Library Responsiveness**: Significantly improved responsiveness for large libraries by moving lineage resolution out of the image modal hot path, reducing expensive modal navigation lookups, and cutting renderer churn during indexing and filtering.
 - **Cached Startup Stability**: Reduced reopen instability on large libraries and made startup verification less intrusive by default, improving launches from cache on heavy libraries.
-- **Sidebar Visual Cohesion**: Simplified sidebar styling into a more consistent, subdued visual system and made the `Generation Parameters` section collapsible like the other filter groups.
-- **Resizable Side Panels**: The left filter sidebar, Image Preview sidebar, generation queue, and Image Details Modal sidebar can now be resized by dragging their edges for a more adaptable workspace.
-- **Generation Queue Compatibility**: Updated the generation queue to persist and retry the new workflow-native ComfyUI parameters, including workflow mode, source image policy, advanced JSON overrides, and mask inputs.
+- **Sidebar Visual Cohesion**: Simplified the sidebar styling into a more consistent, subdued visual system and made the `Generation Parameters` section collapsible like the other filter groups.
+- **Resizable Side Panels**: The left filter sidebar, Image Preview sidebar, generation queue, and Image Details Modal sidebar can now be resized by dragging their edges, with widths preserved between sessions for a more adaptable workspace.
+- **Generation Queue Compatibility**: Updated the existing generation queue to persist and retry the new workflow-native ComfyUI parameters, including workflow mode, source image policy, advanced JSON overrides, and mask inputs.
 - **Cross-Generator Transformation Detection**: Improved metadata parsing for ComfyUI, Automatic1111, Forge, SD.Next, InvokeAI, and Draw Things to detect transformation workflows more reliably, preserve lineage references during indexing, and surface img2img-specific parameters in a normalized way.
-- **Sampler & Scheduler Faceting**: Added sampler-aware caching and filtering support so sampler and scheduler metadata can be browsed more accurately from the sidebar and advanced filters.
-- **Analytics Cohorts & Coverage**: Improved analytics summaries to account more accurately for favorites, ratings, GPU devices, telemetry presence, and bucketed performance ranges, making curation and performance comparisons more useful on mixed libraries.
+- **Generator Faceting**: Added sampler-aware caching and filtering support so sampler and scheduler metadata can be browsed more accurately from the sidebar and advanced filters.
+- **Analytics Cohorts & Coverage**: Analytics summaries now account for favorites, ratings, GPU devices, telemetry presence, and bucketed performance ranges more accurately, making curation and performance comparisons more useful on mixed libraries.
 - **Task-Based Settings Navigation**: Reorganized the Settings modal into focused Library, Viewer, Integrations, Appearance, Privacy, and Shortcuts panels with sidebar navigation and compatibility for legacy deep links.
-- **Lineage Fallback Clarity**: When a transformation is detected but the original image cannot be recovered confidently, the UI now says so explicitly instead of implying a weak match.
+- **Lineage Fallback Clarity**: When a transformation is detected but the original image cannot be recovered with confidence, the UI now states that clearly instead of implying a weak or uncertain match.
 - **Grid Filename Readability**: Thumbnail captions now support a two-line layout, making long filenames and full-path display more usable without requiring fullscreen zoom.
-- **Copy Submenu in Grid Context Menu**: Grouped grid copy actions under a `Copy` submenu, including prompt, negative prompt, seed, and checkpoint.
+- **Copy Submenu in Grid Context Menu**: Grouped copy actions under a `Copy` submenu in the image grid, including prompt, negative prompt, seed, and checkpoint.
 - **Cross-Platform Path Handling**: Replaced hardcoded Windows path joins in Electron viewer utilities with platform-aware path resolution to keep desktop-only actions working more reliably on macOS and Linux.
 
 ### Fixed
 
-- **ComfyUI Payload Parsing Safety**: Added size limits around base64 decode, regex fallback scanning, and zlib inflate paths to prevent oversized metadata payloads from causing memory or responsiveness spikes during parsing and indexing.
+- **ComfyUI Payload Parsing Safety**: Added size limits around base64 decode, regex fallback scanning, and zlib inflate paths to avoid oversized metadata payloads causing memory or responsiveness spikes during parsing and indexing.
 - **Watcher Lifecycle IPC**: File watcher notifications now guard against destroyed renderer windows before sending events, avoiding shutdown-time errors and stray IPC churn.
-- **Deduplication Helper Feedback**: Applying or clearing deduplication suggestions now surfaces visible success or error feedback instead of failing silently in the UI.
+- **Deduplication Helper Feedback**: Applying or clearing deduplication suggestions now surfaces visible success/error feedback instead of failing silently in the UI.
 - **Electron Window Restore**: The desktop window now reopens on the last monitor with the previous size and position when that display is still available, while safely falling back to a visible screen when monitor layouts change.
 - **Startup Folder Reconciliation**: Cached folders are now silently reconciled against disk on launch, so files created while the app was closed are indexed automatically instead of requiring a manual folder refresh.
 - **Open-Ended Advanced Ranges**: Step and CFG filters now preserve min-only or max-only searches instead of dropping partially filled ranges.

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,50 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.0] - 2026-04-06
+## [0.14.1] - Unreleased
+
+### Fixed
+
+- **License Persistence on Restart**: Fixed an Electron settings persistence regression where saving general app settings could overwrite the stored license block, causing Pro users to fall back to Free Mode after restart.
+
+## [0.14.0] - Unreleased
 
 ### Added
 
-- **Visual ComfyUI Workflow Inspector**: Added a visual node-based editor inside both the ComfyUI generation modal and the Image Details Modal, with zoom/pan controls, editable node fields, embedded-layout support, and an advanced JSON fallback for debugging edge cases.
-- **ComfyUI Node View**: Added a dedicated `Node View` alongside Library, Smart Library, and Model View, with exact node-type catalogs, per-node result counts, search, and multi-select OR filtering for images containing embedded ComfyUI workflows.
-- **Image Lineage for Transformations**: Added explicit lineage support for `img2img`, `inpaint`, and `outpaint`, so transformed images are no longer treated as generic generations. The viewer now shows generation type, source/input image status, denoise strength when available, and direct navigation between source and result when the original image can be recovered confidently.
-- **Analytics Explorer**: Rebuilt analytics as an interactive explorer with `Overview`, `Resources`, `Time`, `Performance`, and `Curation` views, scope switching between current results and full library, cohort comparison tools, and one-click promotion of insights into live filters.
-- **Windowed Image Viewer**: Added support for multiple open image windows with drag, resize, minimize/maximize, and dockable or collapsible details for more flexible comparison and inspection.
-- **Image Ratings**: Added persistent 1-5 ratings for images, including viewer controls, library badges, bulk rating actions, and multi-select rating filters in the sidebar and advanced filters.
-- **Startup Verification Modes**: Added configurable startup verification modes for saved folders, allowing the app to open from cache only, reconcile in the background, or verify folders strictly before startup completes.
-- **Manual Tag Management**: Added a persistent manual tag catalog so empty tags remain visible in the sidebar, along with right-click tag actions for renaming, clearing tags from images, removing unused tags, and clearing or deleting used tags.
+- **Visual ComfyUI Workflow Inspector**: Added a visual node-based editor inside the ComfyUI generation modal and Image Details Modal, with zoom/pan controls, editable node fields, embedded-layout support, and an advanced JSON fallback for debugging edge cases.
+- **ComfyUI Node View**: Added a dedicated `Node View` alongside Library, Smart Library, and Model View, with searchable exact node-type catalogs, per-node result counts, and multi-select OR filtering for images that contain embedded ComfyUI workflows.
+- **Image Lineage for Transformations**: Added explicit lineage support for `img2img`, `inpaint`, and `outpaint`, so transformed images are no longer treated as generic generations. The viewer now shows the generation type, source/input image status, denoise strength when available, and direct navigation between source and result when the original image can be recovered with confidence.
+- **Analytics Explorer**: Rebuilt analytics into an interactive explorer with `Overview`, `Resources`, `Time`, `Performance`, and `Curation` views, scope switching between the current results and full library, cohort comparison tools, and one-click promotion of analytics insights into live filters.
+- **Windowed Image Viewer**: Added support for multiple open image windows with drag, resize, minimize/maximize, and dockable or collapsible details so images can be compared and inspected more flexibly.
+- **Image Ratings**: Added persistent 1-5 ratings for images, including star controls in the viewer, badges in the library views, bulk rating actions, and multi-select rating filters in the sidebar and advanced filters.
+- **Startup Verification Modes**: Added configurable startup verification modes for saved folders, so the app can now open from cache only, reconcile in the background, or verify folders strictly before startup completes.
+- **Manual Tag Management**: Added a persistent manual tag catalog so empty tags remain visible in the sidebar, plus right-click tag actions for renaming, clearing tags from images, removing unused tags, and clearing/deleting used tags in one step.
 - **Metadata Type Filters**: Added checkbox filters for `txt2img` / `img2img` generation modes and `Images` / `Videos` file types in `Metadata & File Filters`.
-- **Manual Metadata Recovery**: Added `Reparse Metadata` actions for single images and multi-selection workflows, reprocessing only the chosen files without requiring a full folder refresh or cache clear.
+- **Manual Metadata Recovery**: Added `Reparse Metadata` actions for single images and multi-selection workflows, reprocessing only the chosen files and updating their cached metadata without requiring a full folder refresh or cache clear.
 - **Expanded Compare View**: Added support for comparing up to 4 images at once, with new `Side Strip` and `2x2 Grid` layouts for 3-4 image sets, plus improved Compare integration with the windowed viewer workflow.
 
 ### Improved
 
-- **Electron Privileged IPC Hardening**: Restricted renderer-driven write operations to app-internal paths or user-approved export destinations, tightened generator launch requests to match saved integration settings, and limited test-only update dialog exposure to development builds.
-- **Offline License Integrity**: Revalidated persisted Pro/Lifetime state on startup, removed the temporary "unlock during initialization" window for paid features, and limited the `IMH_DEV_LICENSE` shortcut to development builds.
+- **Electron Privileged IPC Hardening**: Restricted renderer-driven write operations to app-internal paths or user-approved export destinations, tightened generator launch requests so they must match the saved integration settings, and limited test-only update dialog exposure to development builds.
+- **Offline License Integrity**: Revalidated persisted Pro/Lifetime state on startup, removed the temporary "unlock during initialization" window for paid features, and limited the `IMH_DEV_LICENSE` shortcut to development builds only.
 - **Background Worker Guardrails**: Added validation and sane limits for clustering and auto-tagging worker payloads so malformed or extreme jobs fail fast instead of consuming excessive CPU or memory.
 - **ComfyUI Variation Controls**: Expanded the ComfyUI generation modal with workflow mode selection, model-family aware resource overrides, LoRA controls, source image policy for transform workflows, and better handling for original-graph assets.
-- **Favorites Icon Refresh**: Replaced favorite stars with heart icons to clearly distinguish favorites from ratings.
+- **Favorites Icon Refresh**: Updated favorite actions and indicators to use a heart icon instead of a star for clearer separation from the new rating system.
 - **Sidebar Faceted Filters**: Reworked the sidebar filter experience around dedicated facet sections for checkpoints, LoRAs, samplers, and schedulers, with per-value include/exclude actions, result counts, in-section search, and clearer active-filter chips.
-- **Tag Match Mode**: Added an `Any / All` toggle for included manual tag filters in the sidebar, allowing searches to match any selected tag or require all selected tags.
-- **Large Library Responsiveness**: Improved responsiveness on large libraries by moving lineage resolution out of the image modal hot path, reducing expensive modal navigation lookups, and cutting renderer churn during indexing and filtering.
+- **Tag Match Mode**: Added an `Any / All` toggle for included manual tag filters in the sidebar, allowing tag searches to match any selected tag or require all selected tags for narrower curation workflows.
+- **Large Library Responsiveness**: Significantly improved responsiveness for large libraries by moving lineage resolution out of the image modal hot path, reducing expensive modal navigation lookups, and cutting renderer churn during indexing and filtering.
 - **Cached Startup Stability**: Reduced reopen instability on large libraries and made startup verification less intrusive by default, improving launches from cache on heavy libraries.
-- **Sidebar Visual Cohesion**: Simplified sidebar styling into a more consistent, subdued visual system and made the `Generation Parameters` section collapsible like the other filter groups.
-- **Resizable Side Panels**: The left filter sidebar, Image Preview sidebar, generation queue, and Image Details Modal sidebar can now be resized by dragging their edges for a more adaptable workspace.
-- **Generation Queue Compatibility**: Updated the generation queue to persist and retry the new workflow-native ComfyUI parameters, including workflow mode, source image policy, advanced JSON overrides, and mask inputs.
+- **Sidebar Visual Cohesion**: Simplified the sidebar styling into a more consistent, subdued visual system and made the `Generation Parameters` section collapsible like the other filter groups.
+- **Resizable Side Panels**: The left filter sidebar, Image Preview sidebar, generation queue, and Image Details Modal sidebar can now be resized by dragging their edges, with widths preserved between sessions for a more adaptable workspace.
+- **Generation Queue Compatibility**: Updated the existing generation queue to persist and retry the new workflow-native ComfyUI parameters, including workflow mode, source image policy, advanced JSON overrides, and mask inputs.
 - **Cross-Generator Transformation Detection**: Improved metadata parsing for ComfyUI, Automatic1111, Forge, SD.Next, InvokeAI, and Draw Things to detect transformation workflows more reliably, preserve lineage references during indexing, and surface img2img-specific parameters in a normalized way.
-- **Sampler & Scheduler Faceting**: Added sampler-aware caching and filtering support so sampler and scheduler metadata can be browsed more accurately from the sidebar and advanced filters.
-- **Analytics Cohorts & Coverage**: Improved analytics summaries to account more accurately for favorites, ratings, GPU devices, telemetry presence, and bucketed performance ranges, making curation and performance comparisons more useful on mixed libraries.
+- **Generator Faceting**: Added sampler-aware caching and filtering support so sampler and scheduler metadata can be browsed more accurately from the sidebar and advanced filters.
+- **Analytics Cohorts & Coverage**: Analytics summaries now account for favorites, ratings, GPU devices, telemetry presence, and bucketed performance ranges more accurately, making curation and performance comparisons more useful on mixed libraries.
 - **Task-Based Settings Navigation**: Reorganized the Settings modal into focused Library, Viewer, Integrations, Appearance, Privacy, and Shortcuts panels with sidebar navigation and compatibility for legacy deep links.
-- **Lineage Fallback Clarity**: When a transformation is detected but the original image cannot be recovered confidently, the UI now says so explicitly instead of implying a weak match.
+- **Lineage Fallback Clarity**: When a transformation is detected but the original image cannot be recovered with confidence, the UI now states that clearly instead of implying a weak or uncertain match.
 - **Grid Filename Readability**: Thumbnail captions now support a two-line layout, making long filenames and full-path display more usable without requiring fullscreen zoom.
-- **Copy Submenu in Grid Context Menu**: Grouped grid copy actions under a `Copy` submenu, including prompt, negative prompt, seed, and checkpoint.
+- **Copy Submenu in Grid Context Menu**: Grouped copy actions under a `Copy` submenu in the image grid, including prompt, negative prompt, seed, and checkpoint.
 - **Cross-Platform Path Handling**: Replaced hardcoded Windows path joins in Electron viewer utilities with platform-aware path resolution to keep desktop-only actions working more reliably on macOS and Linux.
 
 ### Fixed
 
-- **ComfyUI Payload Parsing Safety**: Added size limits around base64 decode, regex fallback scanning, and zlib inflate paths to prevent oversized metadata payloads from causing memory or responsiveness spikes during parsing and indexing.
+- **ComfyUI Payload Parsing Safety**: Added size limits around base64 decode, regex fallback scanning, and zlib inflate paths to avoid oversized metadata payloads causing memory or responsiveness spikes during parsing and indexing.
 - **Watcher Lifecycle IPC**: File watcher notifications now guard against destroyed renderer windows before sending events, avoiding shutdown-time errors and stray IPC churn.
-- **Deduplication Helper Feedback**: Applying or clearing deduplication suggestions now surfaces visible success or error feedback instead of failing silently in the UI.
+- **Deduplication Helper Feedback**: Applying or clearing deduplication suggestions now surfaces visible success/error feedback instead of failing silently in the UI.
 - **Electron Window Restore**: The desktop window now reopens on the last monitor with the previous size and position when that display is still available, while safely falling back to a visible screen when monitor layouts change.
 - **Startup Folder Reconciliation**: Cached folders are now silently reconciled against disk on launch, so files created while the app was closed are indexed automatically instead of requiring a manual folder refresh.
 - **Open-Ended Advanced Ranges**: Step and CFG filters now preserve min-only or max-only searches instead of dropping partially filled ranges.

--- a/services/hotkeyManager.ts
+++ b/services/hotkeyManager.ts
@@ -22,8 +22,8 @@ hotkeys.filter = function(event) {
 // A map to store the actions that the application supports.
 const registeredActions = new Map<string, RegisteredAction>();
 
-// Track whether hotkeys are currently paused
-let hotkeysPaused = false;
+// Track nested pause requests so overlapping modals do not resume hotkeys too early.
+let hotkeysPauseCount = 0;
 
 /**
  * Unbinds all currently bound hotkeys from the hotkeys-js instance.
@@ -54,7 +54,7 @@ const bindAllActions = () => {
 
     hotkeys(keysToRegister, { scope: action.scope, keyup: false, keydown: true }, (event, handler) => {
       // If hotkeys are paused, don't execute any actions
-      if (hotkeysPaused) {
+      if (hotkeysPauseCount > 0) {
         return;
       }
 
@@ -124,14 +124,14 @@ const getRegisteredHotkeys = (): (HotkeyDefinition & { currentKey: string })[] =
  * Useful when modals or input-heavy components are open.
  */
 const pauseHotkeys = () => {
-  hotkeysPaused = true;
+  hotkeysPauseCount += 1;
 };
 
 /**
  * Resumes hotkey execution after being paused.
  */
 const resumeHotkeys = () => {
-  hotkeysPaused = false;
+  hotkeysPauseCount = Math.max(0, hotkeysPauseCount - 1);
 };
 
 /**
@@ -139,7 +139,7 @@ const resumeHotkeys = () => {
  * @returns True if hotkeys are paused, false otherwise.
  */
 const areHotkeysPaused = () => {
-  return hotkeysPaused;
+  return hotkeysPauseCount > 0;
 };
 
 const hotkeyManager = {

--- a/services/hotkeyManager.ts
+++ b/services/hotkeyManager.ts
@@ -21,6 +21,11 @@ hotkeys.filter = function(event) {
 
 // A map to store the actions that the application supports.
 const registeredActions = new Map<string, RegisteredAction>();
+const hotkeysAllowedInTypingContext = new Set([
+  'openCommandPalette',
+  'openQuickSettings',
+  'openKeyboardShortcuts',
+]);
 
 // Track nested pause requests so overlapping modals do not resume hotkeys too early.
 let hotkeysPauseCount = 0;
@@ -61,6 +66,10 @@ const bindAllActions = () => {
       // Don't block keys in text inputs for typing operations
       const target = event.target as HTMLElement;
       const isTypingContext = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+
+      if (isTypingContext && !hotkeysAllowedInTypingContext.has(action.id)) {
+        return;
+      }
 
       // For navigation/action keys, prevent default even in inputs
       const isActionKey = ['delete', 'enter', 'escape', 'f1'].some(k => key.includes(k));

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -955,6 +955,7 @@ export function normalizeSmartCollection(
 ): SmartCollection {
   const imageIds = uniqueImageIds(collection.imageIds);
   const snapshotImageIds = uniqueImageIds(collection.snapshotImageIds);
+  const excludedImageIds = uniqueImageIds(collection.excludedImageIds);
   const sourceTag = serializeCollectionTagNames(normalizeCollectionTagNames(collection.sourceTag));
   const kind = collection.kind === 'tag_rule' ? 'tag_rule' : 'manual';
   const autoUpdate = kind === 'tag_rule' ? collection.autoUpdate !== false : false;
@@ -981,6 +982,7 @@ export function normalizeSmartCollection(
     autoUpdate,
     imageIds,
     snapshotImageIds,
+    excludedImageIds,
     imageCount: normalizedCount,
     thumbnailId: coverImageId ?? undefined,
     createdAt: collection.createdAt,
@@ -999,8 +1001,9 @@ export function resolveSmartCollectionImageIds(collection: SmartCollection, imag
 
   if (collection.autoUpdate !== false) {
     const sourceTags = normalizeCollectionTagNames(collection.sourceTag);
+    const excludedImageIdSet = new Set(uniqueImageIds(collection.excludedImageIds));
     if (sourceTags.length === 0) {
-      return manualImageIds;
+      return manualImageIds.filter((imageId) => !excludedImageIdSet.has(imageId));
     }
 
     return uniqueImageIds([
@@ -1012,7 +1015,7 @@ export function resolveSmartCollectionImageIds(collection: SmartCollection, imag
             sourceTags.some((sourceTag) => image.tags.includes(sourceTag)),
         )
         .map((image) => image.id),
-    ]);
+    ]).filter((imageId) => !excludedImageIdSet.has(imageId));
   }
 
   return uniqueImageIds([...manualImageIds, ...uniqueImageIds(collection.snapshotImageIds)]);
@@ -1179,10 +1182,12 @@ export async function addImagesToSmartCollection(
   imageIds: string[],
 ): Promise<SmartCollection> {
   const targetIds = uniqueImageIds(imageIds);
+  const targetIdSet = new Set(targetIds);
   const nextCollection = normalizeSmartCollection(
     {
       ...collection,
       imageIds: [...uniqueImageIds(collection.imageIds), ...targetIds],
+      excludedImageIds: uniqueImageIds(collection.excludedImageIds).filter((imageId) => !targetIdSet.has(imageId)),
       imageCount: uniqueImageIds([...(collection.imageIds ?? []), ...targetIds]).length,
       updatedAt: Date.now(),
     },
@@ -1202,6 +1207,10 @@ export async function removeImagesFromSmartCollection(
   const nextSnapshotIds = uniqueImageIds(collection.snapshotImageIds).filter(
     (imageId) => !targetIdSet.has(imageId),
   );
+  const nextExcludedIds =
+    collection.kind === 'tag_rule' && collection.autoUpdate !== false
+      ? uniqueImageIds([...uniqueImageIds(collection.excludedImageIds), ...Array.from(targetIdSet)])
+      : uniqueImageIds(collection.excludedImageIds).filter((imageId) => !targetIdSet.has(imageId));
   const nextImageCount =
     collection.kind === 'tag_rule' && collection.autoUpdate === false
       ? uniqueImageIds([...nextIds, ...nextSnapshotIds]).length
@@ -1211,6 +1220,7 @@ export async function removeImagesFromSmartCollection(
       ...collection,
       imageIds: nextIds,
       snapshotImageIds: nextSnapshotIds,
+      excludedImageIds: nextExcludedIds,
       imageCount: nextImageCount,
       updatedAt: Date.now(),
     },

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -73,6 +73,32 @@ const uniqueImageIds = (imageIds: unknown): string[] => {
   );
 };
 
+const getExistingImageIdSet = (images: IndexedImage[]): Set<string> =>
+  new Set(images.map((image) => image.id));
+
+const filterExistingImageIds = (imageIds: string[], existingImageIdSet: Set<string>): string[] =>
+  imageIds.filter((imageId) => existingImageIdSet.has(imageId));
+
+export const resolveTagRuleMatchedImageIds = (
+  sourceTag: string | null | undefined,
+  images: IndexedImage[],
+): string[] => {
+  const sourceTags = normalizeCollectionTagNames(sourceTag);
+  if (sourceTags.length === 0) {
+    return [];
+  }
+
+  return uniqueImageIds(
+    images
+      .filter(
+        (image) =>
+          Array.isArray(image.tags) &&
+          sourceTags.some((tagName) => image.tags.includes(tagName)),
+      )
+      .map((image) => image.id),
+  );
+};
+
 async function openDatabase({ allowReset = true }: { allowReset?: boolean } = {}): Promise<IDBDatabase | null> {
   const db = await openPreferencesDatabase({
     context: 'image annotations storage',
@@ -993,32 +1019,29 @@ export function normalizeSmartCollection(
 }
 
 export function resolveSmartCollectionImageIds(collection: SmartCollection, images: IndexedImage[]): string[] {
-  const manualImageIds = uniqueImageIds(collection.imageIds);
+  const existingImageIdSet = getExistingImageIdSet(images);
+  const manualImageIds = filterExistingImageIds(uniqueImageIds(collection.imageIds), existingImageIdSet);
 
   if (collection.kind === 'manual') {
     return manualImageIds;
   }
 
   if (collection.autoUpdate !== false) {
-    const sourceTags = normalizeCollectionTagNames(collection.sourceTag);
     const excludedImageIdSet = new Set(uniqueImageIds(collection.excludedImageIds));
-    if (sourceTags.length === 0) {
+    const matchedImageIds = resolveTagRuleMatchedImageIds(collection.sourceTag, images);
+    if (matchedImageIds.length === 0) {
       return manualImageIds.filter((imageId) => !excludedImageIdSet.has(imageId));
     }
 
-    return uniqueImageIds([
-      ...manualImageIds,
-      ...images
-        .filter(
-          (image) =>
-            Array.isArray(image.tags) &&
-            sourceTags.some((sourceTag) => image.tags.includes(sourceTag)),
-        )
-        .map((image) => image.id),
-    ]).filter((imageId) => !excludedImageIdSet.has(imageId));
+    return uniqueImageIds([...manualImageIds, ...matchedImageIds]).filter(
+      (imageId) => !excludedImageIdSet.has(imageId),
+    );
   }
 
-  return uniqueImageIds([...manualImageIds, ...uniqueImageIds(collection.snapshotImageIds)]);
+  return uniqueImageIds([
+    ...manualImageIds,
+    ...filterExistingImageIds(uniqueImageIds(collection.snapshotImageIds), existingImageIdSet),
+  ]);
 }
 
 export function resolveSmartCollectionImages(collection: SmartCollection, images: IndexedImage[]): IndexedImage[] {

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -41,14 +41,23 @@ function normalizeManualTagName(tagName: string): string {
   return tagName.trim().toLowerCase();
 }
 
-const normalizeCollectionTagName = (tagName: string | null | undefined): string | null => {
-  if (typeof tagName !== 'string') {
-    return null;
+export const normalizeCollectionTagNames = (tagNames: string | null | undefined): string[] => {
+  if (typeof tagNames !== 'string') {
+    return [];
   }
 
-  const normalized = tagName.trim().toLowerCase();
-  return normalized.length > 0 ? normalized : null;
+  return Array.from(
+    new Set(
+      tagNames
+        .split(',')
+        .map((tagName) => tagName.trim().toLowerCase())
+        .filter((tagName) => tagName.length > 0),
+    ),
+  );
 };
+
+const serializeCollectionTagNames = (tagNames: string[]): string | null =>
+  tagNames.length > 0 ? tagNames.join(', ') : null;
 
 const uniqueImageIds = (imageIds: unknown): string[] => {
   if (!Array.isArray(imageIds)) {
@@ -946,7 +955,7 @@ export function normalizeSmartCollection(
 ): SmartCollection {
   const imageIds = uniqueImageIds(collection.imageIds);
   const snapshotImageIds = uniqueImageIds(collection.snapshotImageIds);
-  const sourceTag = normalizeCollectionTagName(collection.sourceTag);
+  const sourceTag = serializeCollectionTagNames(normalizeCollectionTagNames(collection.sourceTag));
   const kind = collection.kind === 'tag_rule' ? 'tag_rule' : 'manual';
   const autoUpdate = kind === 'tag_rule' ? collection.autoUpdate !== false : false;
   const coverImageId =
@@ -989,15 +998,19 @@ export function resolveSmartCollectionImageIds(collection: SmartCollection, imag
   }
 
   if (collection.autoUpdate !== false) {
-    const sourceTag = normalizeCollectionTagName(collection.sourceTag);
-    if (!sourceTag) {
+    const sourceTags = normalizeCollectionTagNames(collection.sourceTag);
+    if (sourceTags.length === 0) {
       return manualImageIds;
     }
 
     return uniqueImageIds([
       ...manualImageIds,
       ...images
-        .filter((image) => Array.isArray(image.tags) && image.tags.includes(sourceTag))
+        .filter(
+          (image) =>
+            Array.isArray(image.tags) &&
+            sourceTags.some((sourceTag) => image.tags.includes(sourceTag)),
+        )
         .map((image) => image.id),
     ]);
   }

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -1199,11 +1199,19 @@ export async function removeImagesFromSmartCollection(
 ): Promise<SmartCollection> {
   const targetIdSet = new Set(uniqueImageIds(imageIds));
   const nextIds = uniqueImageIds(collection.imageIds).filter((imageId) => !targetIdSet.has(imageId));
+  const nextSnapshotIds = uniqueImageIds(collection.snapshotImageIds).filter(
+    (imageId) => !targetIdSet.has(imageId),
+  );
+  const nextImageCount =
+    collection.kind === 'tag_rule' && collection.autoUpdate === false
+      ? uniqueImageIds([...nextIds, ...nextSnapshotIds]).length
+      : nextIds.length;
   const nextCollection = normalizeSmartCollection(
     {
       ...collection,
       imageIds: nextIds,
-      imageCount: nextIds.length,
+      snapshotImageIds: nextSnapshotIds,
+      imageCount: nextImageCount,
       updatedAt: Date.now(),
     },
     collection.sortIndex,

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -982,22 +982,27 @@ export function normalizeSmartCollection(
 }
 
 export function resolveSmartCollectionImageIds(collection: SmartCollection, images: IndexedImage[]): string[] {
+  const manualImageIds = uniqueImageIds(collection.imageIds);
+
   if (collection.kind === 'manual') {
-    return uniqueImageIds(collection.imageIds);
+    return manualImageIds;
   }
 
   if (collection.autoUpdate !== false) {
     const sourceTag = normalizeCollectionTagName(collection.sourceTag);
     if (!sourceTag) {
-      return [];
+      return manualImageIds;
     }
 
-    return images
-      .filter((image) => Array.isArray(image.tags) && image.tags.includes(sourceTag))
-      .map((image) => image.id);
+    return uniqueImageIds([
+      ...manualImageIds,
+      ...images
+        .filter((image) => Array.isArray(image.tags) && image.tags.includes(sourceTag))
+        .map((image) => image.id),
+    ]);
   }
 
-  return uniqueImageIds(collection.snapshotImageIds);
+  return uniqueImageIds([...manualImageIds, ...uniqueImageIds(collection.snapshotImageIds)]);
 }
 
 export function resolveSmartCollectionImages(collection: SmartCollection, images: IndexedImage[]): IndexedImage[] {

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom" />
 
-import type { ClusterPreference, ImageAnnotations, ShadowMetadata, SmartCollection, TagInfo } from '../types';
+import type { ClusterPreference, ImageAnnotations, IndexedImage, ShadowMetadata, SmartCollection, TagInfo } from '../types';
 import {
   getIndexedDbErrorName,
   openPreferencesDatabase,
@@ -40,6 +40,29 @@ function disablePersistence(error?: unknown) {
 function normalizeManualTagName(tagName: string): string {
   return tagName.trim().toLowerCase();
 }
+
+const normalizeCollectionTagName = (tagName: string | null | undefined): string | null => {
+  if (typeof tagName !== 'string') {
+    return null;
+  }
+
+  const normalized = tagName.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+};
+
+const uniqueImageIds = (imageIds: unknown): string[] => {
+  if (!Array.isArray(imageIds)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      imageIds
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+        .map((value) => value.trim()),
+    ),
+  );
+};
 
 async function openDatabase({ allowReset = true }: { allowReset?: boolean } = {}): Promise<IDBDatabase | null> {
   const db = await openPreferencesDatabase({
@@ -917,6 +940,77 @@ export async function markForArchive(clusterId: string, imageIds: string[]): Pro
 
 // ===== Smart Collections Functions (Phase 1) =====
 
+export function normalizeSmartCollection(
+  collection: Partial<SmartCollection> & Pick<SmartCollection, 'id' | 'name' | 'createdAt' | 'updatedAt'>,
+  fallbackSortIndex = 0,
+): SmartCollection {
+  const imageIds = uniqueImageIds(collection.imageIds);
+  const snapshotImageIds = uniqueImageIds(collection.snapshotImageIds);
+  const sourceTag = normalizeCollectionTagName(collection.sourceTag);
+  const kind = collection.kind === 'tag_rule' ? 'tag_rule' : 'manual';
+  const autoUpdate = kind === 'tag_rule' ? collection.autoUpdate !== false : false;
+  const coverImageId =
+    typeof collection.coverImageId === 'string'
+      ? collection.coverImageId
+      : typeof collection.thumbnailId === 'string'
+      ? collection.thumbnailId
+      : null;
+  const normalizedCount = Number.isFinite(collection.imageCount)
+    ? Math.max(0, Number(collection.imageCount))
+    : kind === 'tag_rule'
+    ? (autoUpdate ? 0 : snapshotImageIds.length)
+    : imageIds.length;
+
+  return {
+    id: collection.id,
+    kind,
+    name: collection.name.trim(),
+    description: collection.description?.trim() || undefined,
+    coverImageId,
+    sortIndex: Number.isFinite(collection.sortIndex) ? Number(collection.sortIndex) : fallbackSortIndex,
+    sourceTag,
+    autoUpdate,
+    imageIds,
+    snapshotImageIds,
+    imageCount: normalizedCount,
+    thumbnailId: coverImageId ?? undefined,
+    createdAt: collection.createdAt,
+    updatedAt: collection.updatedAt,
+    type: collection.type,
+    query: collection.query,
+  };
+}
+
+export function resolveSmartCollectionImageIds(collection: SmartCollection, images: IndexedImage[]): string[] {
+  if (collection.kind === 'manual') {
+    return uniqueImageIds(collection.imageIds);
+  }
+
+  if (collection.autoUpdate !== false) {
+    const sourceTag = normalizeCollectionTagName(collection.sourceTag);
+    if (!sourceTag) {
+      return [];
+    }
+
+    return images
+      .filter((image) => Array.isArray(image.tags) && image.tags.includes(sourceTag))
+      .map((image) => image.id);
+  }
+
+  return uniqueImageIds(collection.snapshotImageIds);
+}
+
+export function resolveSmartCollectionImages(collection: SmartCollection, images: IndexedImage[]): IndexedImage[] {
+  const imageLookup = new Map(images.map((image) => [image.id, image]));
+  return resolveSmartCollectionImageIds(collection, images)
+    .map((imageId) => imageLookup.get(imageId))
+    .filter((image): image is IndexedImage => Boolean(image));
+}
+
+export function resolveSmartCollectionImageCount(collection: SmartCollection, images: IndexedImage[]): number {
+  return resolveSmartCollectionImageIds(collection, images).length;
+}
+
 /**
  * Get smart collection by ID
  */
@@ -929,7 +1023,10 @@ export async function getSmartCollection(id: string): Promise<SmartCollection | 
     const store = transaction.objectStore(SMART_COLLECTIONS_STORE_NAME);
     const request = store.get(id);
 
-    request.onsuccess = () => resolve(request.result || null);
+    request.onsuccess = () => {
+      const result = request.result as SmartCollection | undefined;
+      resolve(result ? normalizeSmartCollection(result) : null);
+    };
     request.onerror = () => {
       console.error('Error getting smart collection:', request.error);
       resolve(null);
@@ -944,12 +1041,18 @@ export async function saveSmartCollection(collection: SmartCollection): Promise<
   const db = await openDatabase();
   if (!db) return;
 
-  collection.updatedAt = Date.now();
+  const normalizedCollection = normalizeSmartCollection(
+    {
+      ...collection,
+      updatedAt: Date.now(),
+    },
+    collection.sortIndex,
+  );
 
   return new Promise((resolve, reject) => {
     const transaction = db.transaction([SMART_COLLECTIONS_STORE_NAME], 'readwrite');
     const store = transaction.objectStore(SMART_COLLECTIONS_STORE_NAME);
-    const request = store.put(collection);
+    const request = store.put(normalizedCollection);
 
     request.onsuccess = () => resolve();
     request.onerror = () => {
@@ -991,7 +1094,19 @@ export async function getAllSmartCollections(): Promise<SmartCollection[]> {
     const store = transaction.objectStore(SMART_COLLECTIONS_STORE_NAME);
     const request = store.getAll();
 
-    request.onsuccess = () => resolve(request.result || []);
+    request.onsuccess = () => {
+      const collections = ((request.result || []) as SmartCollection[])
+        .map((collection, index) => normalizeSmartCollection(collection, index))
+        .sort((a, b) => {
+          const sortDelta = a.sortIndex - b.sortIndex;
+          if (sortDelta !== 0) {
+            return sortDelta;
+          }
+          return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+        });
+
+      resolve(collections);
+    };
     request.onerror = () => {
       console.error('Error getting all smart collections:', request.error);
       resolve([]);
@@ -1012,12 +1127,72 @@ export async function getSmartCollectionsByType(type: SmartCollection['type']): 
     const index = store.index('type');
     const request = index.getAll(type);
 
-    request.onsuccess = () => resolve(request.result || []);
+    request.onsuccess = () =>
+      resolve(
+        ((request.result || []) as SmartCollection[]).map((collection, index) =>
+          normalizeSmartCollection(collection, index),
+        ),
+      );
     request.onerror = () => {
       console.error('Error getting smart collections by type:', request.error);
       resolve([]);
     };
   });
+}
+
+export async function reorderSmartCollections(collections: SmartCollection[]): Promise<SmartCollection[]> {
+  const normalizedCollections = collections.map((collection, index) =>
+    normalizeSmartCollection(
+      {
+        ...collection,
+        sortIndex: index,
+        updatedAt: Date.now(),
+      },
+      index,
+    ),
+  );
+
+  await Promise.all(normalizedCollections.map((collection) => saveSmartCollection(collection)));
+  return normalizedCollections;
+}
+
+export async function addImagesToSmartCollection(
+  collection: SmartCollection,
+  imageIds: string[],
+): Promise<SmartCollection> {
+  const targetIds = uniqueImageIds(imageIds);
+  const nextCollection = normalizeSmartCollection(
+    {
+      ...collection,
+      imageIds: [...uniqueImageIds(collection.imageIds), ...targetIds],
+      imageCount: uniqueImageIds([...(collection.imageIds ?? []), ...targetIds]).length,
+      updatedAt: Date.now(),
+    },
+    collection.sortIndex,
+  );
+
+  await saveSmartCollection(nextCollection);
+  return nextCollection;
+}
+
+export async function removeImagesFromSmartCollection(
+  collection: SmartCollection,
+  imageIds: string[],
+): Promise<SmartCollection> {
+  const targetIdSet = new Set(uniqueImageIds(imageIds));
+  const nextIds = uniqueImageIds(collection.imageIds).filter((imageId) => !targetIdSet.has(imageId));
+  const nextCollection = normalizeSmartCollection(
+    {
+      ...collection,
+      imageIds: nextIds,
+      imageCount: nextIds.length,
+      updatedAt: Date.now(),
+    },
+    collection.sortIndex,
+  );
+
+  await saveSmartCollection(nextCollection);
+  return nextCollection;
 }
 
 // ===== Shadow Metadata Functions =====

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,32 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .app-top-segmented {
+    @apply inline-flex items-center gap-1 rounded-xl border border-gray-700/70 bg-gray-900/60 p-1;
+  }
+
+  .app-top-segment {
+    @apply inline-flex h-9 items-center gap-2 rounded-lg border border-transparent px-3 text-xs font-semibold text-gray-400 transition-colors duration-200 hover:bg-gray-800/80 hover:text-gray-100;
+  }
+
+  .app-top-segment-active {
+    @apply border-accent/40 bg-accent/15 text-gray-50 shadow-sm;
+  }
+
+  .app-top-pill {
+    @apply inline-flex h-9 items-center gap-2 rounded-lg border border-gray-700/70 bg-gray-900/60 px-3 text-xs font-semibold text-gray-300 transition-colors duration-200 hover:border-gray-600 hover:bg-gray-800/80 hover:text-gray-100;
+  }
+
+  .app-top-icon-button {
+    @apply inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-700/70 bg-gray-900/60 text-gray-400 transition-colors duration-200 hover:border-gray-600 hover:bg-gray-800/80 hover:text-gray-100;
+  }
+
+  .app-top-divider {
+    @apply h-5 w-px bg-gray-800/80;
+  }
+}
+
 .masonry-grid {
   display: -webkit-box;
   display: -ms-flexbox;

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -28,9 +28,10 @@ import {
     toLightweightLineageImage,
 } from '../services/lineageRegistry';
 import { loadLineageRegistrySnapshot, saveLineageRegistrySnapshot } from '../services/lineageRegistryCache';
+import { MAX_RECENT_TAG_HISTORY } from '../utils/tagSuggestions';
 
 const RECENT_TAGS_STORAGE_KEY = 'image-metahub-recent-tags';
-const MAX_RECENT_TAGS = 12;
+const MAX_RECENT_TAGS = MAX_RECENT_TAG_HISTORY;
 
 type ThumbnailEntryState = {
     lastModified: number;

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, AutoTag, IndexedImageTransferProgress, InclusionFilterMode, ImageRating, type AdvancedFilters, type FilterOptions, type SelectedFiltersUpdate, type TagMatchMode } from '../types';
+import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, AutoTag, IndexedImageTransferProgress, InclusionFilterMode, ImageRating, SmartCollection, type AdvancedFilters, type FilterOptions, type SelectedFiltersUpdate, type TagMatchMode } from '../types';
 import { loadSelectedFolders, saveSelectedFolders, loadExcludedFolders, saveExcludedFolders } from '../services/folderSelectionStorage';
 import {
   loadAllAnnotations,
@@ -9,6 +9,16 @@ import {
   ensureManualTagExists,
   renameManualTag,
   deleteManualTag,
+  addImagesToSmartCollection,
+  deleteSmartCollection,
+  getAllSmartCollections,
+  normalizeSmartCollection,
+  removeImagesFromSmartCollection,
+  reorderSmartCollections,
+  resolveSmartCollectionImageCount,
+  resolveSmartCollectionImageIds,
+  resolveSmartCollectionImages,
+  saveSmartCollection,
 } from '../services/imageAnnotationsStorage';
 import { normalizeFacetValue, sanitizeIndexedImageFacets } from '../utils/facetNormalization';
 import { parseLocalDateFilterEndExclusive, parseLocalDateFilterStart } from '../utils/dateFilterUtils';
@@ -217,6 +227,29 @@ const renameAnnotationTag = (tags: string[], sourceTag: string, targetTag: strin
     return Array.from(new Set(tags.map(tag => tag === normalizedSource ? normalizedTarget : tag)));
 };
 
+const sortCollections = (collections: SmartCollection[]): SmartCollection[] =>
+    [...collections].sort((a, b) => {
+        const sortDelta = a.sortIndex - b.sortIndex;
+        if (sortDelta !== 0) {
+            return sortDelta;
+        }
+
+        return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    });
+
+const syncCollectionCounts = (collections: SmartCollection[], images: IndexedImage[]): SmartCollection[] =>
+    sortCollections(
+        collections.map((collection, index) =>
+            normalizeSmartCollection(
+                {
+                    ...collection,
+                    imageCount: resolveSmartCollectionImageCount(collection, images),
+                },
+                Number.isFinite(collection.sortIndex) ? collection.sortIndex : index,
+            ),
+        ),
+    );
+
 const normalizePath = (path: string) => {
     if (!path) return '';
     return path.replace(/\\/g, '/').replace(/[\\/]+$/, '');
@@ -344,6 +377,8 @@ interface ImageState {
   selectedImage: IndexedImage | null;
   selectedImages: Set<string>;
   activeImageScope: IndexedImage[] | null;
+  collections: SmartCollection[];
+  activeCollectionId: string | null;
   previewImage: IndexedImage | null;
   focusedImageIndex: number | null;
   isStackingEnabled: boolean;
@@ -473,6 +508,18 @@ interface ImageState {
   setPreviewImage: (image: IndexedImage | null) => void;
   setSelectedImage: (image: IndexedImage | null) => void;
   setActiveImageScope: (images: IndexedImage[] | null) => void;
+  loadCollections: () => Promise<void>;
+  createCollection: (collection: Omit<SmartCollection, 'id' | 'imageCount' | 'createdAt' | 'updatedAt'> & { id?: string }) => Promise<SmartCollection>;
+  updateCollection: (collectionId: string, updates: Partial<Omit<SmartCollection, 'id' | 'createdAt'>>) => Promise<SmartCollection | null>;
+  deleteCollectionById: (collectionId: string) => Promise<void>;
+  setActiveCollectionId: (collectionId: string | null) => void;
+  reorderCollections: (orderedCollectionIds: string[]) => Promise<void>;
+  addImagesToCollection: (collectionId: string, imageIds: string[]) => Promise<SmartCollection | null>;
+  removeImagesFromCollection: (collectionId: string, imageIds: string[]) => Promise<SmartCollection | null>;
+  getCollectionById: (collectionId: string) => SmartCollection | null;
+  getResolvedCollectionImages: (collectionId: string) => IndexedImage[];
+  getResolvedFilteredCollectionImages: (collectionId: string) => IndexedImage[];
+  getCollectionImageCount: (collectionId: string) => number;
   toggleImageSelection: (imageId: string) => void;
   selectAllImages: () => void;
   clearImageSelection: () => void;
@@ -1173,11 +1220,17 @@ export const useImageStore = create<ImageState>((set, get) => {
 
         // Then, recalculate available filters based on the filtered images (after folder selection)
         const availableFilters = recalculateAvailableFilters(filteredResult.filteredImages);
+        const syncedCollections = syncCollectionCounts(combinedState.collections, imagesWithAnnotations);
+        const activeCollectionId = syncedCollections.some((collection) => collection.id === combinedState.activeCollectionId)
+            ? combinedState.activeCollectionId
+            : null;
 
         return {
             ...combinedState,
             ...filteredResult,
             ...availableFilters,
+            collections: syncedCollections,
+            activeCollectionId,
             ...(imagesWithAnnotations.length === 0
                 ? {
                     lineageResolvedByImageId: {},
@@ -1690,6 +1743,8 @@ export const useImageStore = create<ImageState>((set, get) => {
         previewImage: null,
         selectedImages: new Set(),
         activeImageScope: null,
+        collections: [],
+        activeCollectionId: null,
         focusedImageIndex: null,
         isStackingEnabled: false,
         searchQuery: '',
@@ -2469,6 +2524,176 @@ export const useImageStore = create<ImageState>((set, get) => {
             }
             return { activeImageScope: images };
         }),
+        loadCollections: async () => {
+            const persistedCollections = await getAllSmartCollections();
+            set((state) => {
+                const collections = syncCollectionCounts(persistedCollections, state.images);
+                const activeCollectionId = collections.some((collection) => collection.id === state.activeCollectionId)
+                    ? state.activeCollectionId
+                    : collections[0]?.id ?? null;
+
+                return {
+                    collections,
+                    activeCollectionId,
+                };
+            });
+        },
+        createCollection: async (collection) => {
+            const state = get();
+            const nextCollection = normalizeSmartCollection(
+                {
+                    ...collection,
+                    id: collection.id ?? crypto.randomUUID(),
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                    imageCount: collection.kind === 'tag_rule'
+                        ? resolveSmartCollectionImageCount(collection as SmartCollection, state.images)
+                        : (collection.imageIds?.length ?? 0),
+                    sortIndex: Number.isFinite(collection.sortIndex) ? collection.sortIndex : state.collections.length,
+                },
+                state.collections.length,
+            );
+
+            await saveSmartCollection(nextCollection);
+
+            set((currentState) => {
+                const collections = syncCollectionCounts([...currentState.collections, nextCollection], currentState.images);
+                return {
+                    collections,
+                    activeCollectionId: nextCollection.id,
+                };
+            });
+
+            return nextCollection;
+        },
+        updateCollection: async (collectionId, updates) => {
+            const currentCollection = get().collections.find((collection) => collection.id === collectionId);
+            if (!currentCollection) {
+                return null;
+            }
+
+            const nextCollection = normalizeSmartCollection(
+                {
+                    ...currentCollection,
+                    ...updates,
+                    updatedAt: Date.now(),
+                },
+                currentCollection.sortIndex,
+            );
+
+            await saveSmartCollection(nextCollection);
+
+            set((state) => ({
+                collections: syncCollectionCounts(
+                    state.collections.map((collection) => collection.id === collectionId ? nextCollection : collection),
+                    state.images,
+                ),
+            }));
+
+            return nextCollection;
+        },
+        deleteCollectionById: async (collectionId) => {
+            await deleteSmartCollection(collectionId);
+
+            set((state) => {
+                const remainingCollections = syncCollectionCounts(
+                    state.collections.filter((collection) => collection.id !== collectionId),
+                    state.images,
+                );
+                const activeCollectionId = state.activeCollectionId === collectionId
+                    ? remainingCollections[0]?.id ?? null
+                    : state.activeCollectionId;
+
+                return {
+                    collections: remainingCollections,
+                    activeCollectionId,
+                };
+            });
+        },
+        setActiveCollectionId: (collectionId) => set((state) => ({
+            activeCollectionId: collectionId && state.collections.some((collection) => collection.id === collectionId)
+                ? collectionId
+                : null,
+        })),
+        reorderCollections: async (orderedCollectionIds) => {
+            const state = get();
+            const orderMap = new Map(orderedCollectionIds.map((collectionId, index) => [collectionId, index]));
+            const reordered = sortCollections(
+                state.collections.map((collection, index) =>
+                    normalizeSmartCollection(
+                        {
+                            ...collection,
+                            sortIndex: orderMap.get(collection.id) ?? (orderedCollectionIds.length + index),
+                        },
+                        index,
+                    ),
+                ),
+            );
+
+            const persistedCollections = await reorderSmartCollections(reordered);
+            set((currentState) => ({
+                collections: syncCollectionCounts(persistedCollections, currentState.images),
+            }));
+        },
+        addImagesToCollection: async (collectionId, imageIds) => {
+            const collection = get().collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return null;
+            }
+
+            const nextCollection = await addImagesToSmartCollection(collection, imageIds);
+            set((state) => ({
+                collections: syncCollectionCounts(
+                    state.collections.map((entry) => entry.id === collectionId ? nextCollection : entry),
+                    state.images,
+                ),
+            }));
+            return nextCollection;
+        },
+        removeImagesFromCollection: async (collectionId, imageIds) => {
+            const collection = get().collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return null;
+            }
+
+            const nextCollection = await removeImagesFromSmartCollection(collection, imageIds);
+            set((state) => ({
+                collections: syncCollectionCounts(
+                    state.collections.map((entry) => entry.id === collectionId ? nextCollection : entry),
+                    state.images,
+                ),
+            }));
+            return nextCollection;
+        },
+        getCollectionById: (collectionId) => get().collections.find((collection) => collection.id === collectionId) ?? null,
+        getResolvedCollectionImages: (collectionId) => {
+            const state = get();
+            const collection = state.collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return [];
+            }
+
+            return resolveSmartCollectionImages(collection, state.images);
+        },
+        getResolvedFilteredCollectionImages: (collectionId) => {
+            const state = get();
+            const collection = state.collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return [];
+            }
+
+            const visibleIds = new Set(state.filteredImages.map((image) => image.id));
+            return resolveSmartCollectionImages(collection, state.images).filter((image) => visibleIds.has(image.id));
+        },
+        getCollectionImageCount: (collectionId) => {
+            const state = get();
+            const collection = state.collections.find((entry) => entry.id === collectionId);
+            if (!collection) {
+                return 0;
+            }
+
+            return resolveSmartCollectionImageIds(collection, state.images).length;
+        },
         setFocusedImageIndex: (index) => set({ focusedImageIndex: index }),
         setFullscreenMode: (isFullscreen) => set({ isFullscreenMode: isFullscreen }),
 
@@ -3182,8 +3407,20 @@ export const useImageStore = create<ImageState>((set, get) => {
                 return;
             }
 
-            const { annotations } = get();
+            const { annotations, collections } = get();
             const updatedAnnotations: ImageAnnotations[] = [];
+            const updatedCollections = collections
+                .filter((collection) => collection.kind === 'tag_rule' && collection.sourceTag === normalizedSource)
+                .map((collection) =>
+                    normalizeSmartCollection(
+                        {
+                            ...collection,
+                            sourceTag: normalizedTarget,
+                            updatedAt: Date.now(),
+                        },
+                        collection.sortIndex,
+                    ),
+                );
 
             for (const annotation of annotations.values()) {
                 if (!annotation.tags.includes(normalizedSource)) {
@@ -3212,11 +3449,16 @@ export const useImageStore = create<ImageState>((set, get) => {
 
                 const filteredState = transferManualTagFilters(state, normalizedSource, normalizedTarget);
                 const updatedImages = applyAnnotationsToImages(state.images, newAnnotations);
+                const collectionMap = new Map(updatedCollections.map((collection) => [collection.id, collection]));
                 const newState = {
                     ...state,
                     ...filteredState,
                     annotations: newAnnotations,
                     images: updatedImages,
+                    collections: syncCollectionCounts(
+                        state.collections.map((collection) => collectionMap.get(collection.id) ?? collection),
+                        updatedImages,
+                    ),
                     recentTags: nextRecentTags,
                 };
 
@@ -3228,6 +3470,7 @@ export const useImageStore = create<ImageState>((set, get) => {
             await Promise.all([
                 updatedAnnotations.length > 0 ? bulkSaveAnnotations(updatedAnnotations) : Promise.resolve(),
                 renameManualTag(normalizedSource, normalizedTarget),
+                ...updatedCollections.map((collection) => saveSmartCollection(collection)),
             ]).catch(error => {
                 console.error('Failed to rename tag:', error);
             });
@@ -3606,6 +3849,8 @@ export const useImageStore = create<ImageState>((set, get) => {
             selectedImage: null,
             selectedImages: new Set(),
             activeImageScope: null,
+            collections: [],
+            activeCollectionId: null,
             searchQuery: '',
             availableModels: [],
             availableLoras: [],

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -13,6 +13,7 @@ import {
   deleteSmartCollection,
   getAllSmartCollections,
   normalizeSmartCollection,
+  normalizeCollectionTagNames,
   removeImagesFromSmartCollection,
   reorderSmartCollections,
   resolveSmartCollectionImageCount,
@@ -3410,12 +3411,20 @@ export const useImageStore = create<ImageState>((set, get) => {
             const { annotations, collections } = get();
             const updatedAnnotations: ImageAnnotations[] = [];
             const updatedCollections = collections
-                .filter((collection) => collection.kind === 'tag_rule' && collection.sourceTag === normalizedSource)
+                .filter((collection) => {
+                    if (collection.kind !== 'tag_rule') {
+                        return false;
+                    }
+
+                    return normalizeCollectionTagNames(collection.sourceTag).includes(normalizedSource);
+                })
                 .map((collection) =>
                     normalizeSmartCollection(
                         {
                             ...collection,
-                            sourceTag: normalizedTarget,
+                            sourceTag: normalizeCollectionTagNames(collection.sourceTag)
+                                .map((tag) => tag === normalizedSource ? normalizedTarget : tag)
+                                .join(', '),
                             updatedAt: Date.now(),
                         },
                         collection.sortIndex,

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -2530,7 +2530,7 @@ export const useImageStore = create<ImageState>((set, get) => {
                 const collections = syncCollectionCounts(persistedCollections, state.images);
                 const activeCollectionId = collections.some((collection) => collection.id === state.activeCollectionId)
                     ? state.activeCollectionId
-                    : collections[0]?.id ?? null;
+                    : null;
 
                 return {
                     collections,
@@ -2601,7 +2601,7 @@ export const useImageStore = create<ImageState>((set, get) => {
                     state.images,
                 );
                 const activeCollectionId = state.activeCollectionId === collectionId
-                    ? remainingCollections[0]?.id ?? null
+                    ? null
                     : state.activeCollectionId;
 
                 return {

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -239,6 +239,16 @@ const sortCollections = (collections: SmartCollection[]): SmartCollection[] =>
         return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
     });
 
+const getNextCollectionSortIndex = (collections: SmartCollection[]): number =>
+    collections.reduce(
+        (maxSortIndex, collection) =>
+            Math.max(
+                maxSortIndex,
+                Number.isFinite(collection.sortIndex) ? Number(collection.sortIndex) : -1,
+            ),
+        -1,
+    ) + 1;
+
 const syncCollectionCounts = (collections: SmartCollection[], images: IndexedImage[]): SmartCollection[] =>
     sortCollections(
         collections.map((collection, index) =>
@@ -2542,6 +2552,7 @@ export const useImageStore = create<ImageState>((set, get) => {
         },
         createCollection: async (collection) => {
             const state = get();
+            const nextSortIndex = getNextCollectionSortIndex(state.collections);
             const nextCollection = normalizeSmartCollection(
                 {
                     ...collection,
@@ -2551,9 +2562,9 @@ export const useImageStore = create<ImageState>((set, get) => {
                     imageCount: collection.kind === 'tag_rule'
                         ? resolveSmartCollectionImageCount(collection as SmartCollection, state.images)
                         : (collection.imageIds?.length ?? 0),
-                    sortIndex: Number.isFinite(collection.sortIndex) ? collection.sortIndex : state.collections.length,
+                    sortIndex: nextSortIndex,
                 },
-                state.collections.length,
+                nextSortIndex,
             );
 
             await saveSmartCollection(nextCollection);

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage, StateStorage } from 'zustand/middleware';
+import {
+  DEFAULT_RECENT_TAG_CHIP_LIMIT,
+  DEFAULT_TAG_SUGGESTION_LIMIT,
+  sanitizeTagUiLimit,
+} from '../utils/tagSuggestions';
 
 export const stripLicenseFromSettings = <T extends Record<string, unknown>>(settings: T | null | undefined): Omit<T, 'license'> => {
   if (!settings) {
@@ -93,6 +98,8 @@ interface SettingsState {
   globalAutoWatch: boolean;
   startupVerificationMode: StartupVerificationMode;
   doubleClickToOpen: boolean;
+  tagSuggestionLimit: number;
+  recentTagChipLimit: number;
   sensitiveTags: string[];
   blurSensitiveImages: boolean;
   enableSafeMode: boolean;
@@ -129,6 +136,8 @@ interface SettingsState {
   toggleGlobalAutoWatch: () => void;
   setStartupVerificationMode: (value: StartupVerificationMode) => void;
   setDoubleClickToOpen: (value: boolean) => void;
+  setTagSuggestionLimit: (value: number) => void;
+  setRecentTagChipLimit: (value: number) => void;
   setSensitiveTags: (tags: string[]) => void;
   setBlurSensitiveImages: (value: boolean) => void;
   setEnableSafeMode: (value: boolean) => void;
@@ -170,6 +179,8 @@ export const useSettingsStore = create<SettingsState>()(
       globalAutoWatch: true,
       startupVerificationMode: 'off',
       doubleClickToOpen: false,
+      tagSuggestionLimit: DEFAULT_TAG_SUGGESTION_LIMIT,
+      recentTagChipLimit: DEFAULT_RECENT_TAG_CHIP_LIMIT,
       sensitiveTags: ['nsfw', 'private', 'hidden'],
       blurSensitiveImages: true,
       enableSafeMode: true,
@@ -213,6 +224,8 @@ export const useSettingsStore = create<SettingsState>()(
       toggleGlobalAutoWatch: () => set((state) => ({ globalAutoWatch: !state.globalAutoWatch })),
       setStartupVerificationMode: (value) => set({ startupVerificationMode: value }),
       setDoubleClickToOpen: (value) => set({ doubleClickToOpen: !!value }),
+      setTagSuggestionLimit: (value) => set({ tagSuggestionLimit: sanitizeTagUiLimit(value, DEFAULT_TAG_SUGGESTION_LIMIT) }),
+      setRecentTagChipLimit: (value) => set({ recentTagChipLimit: sanitizeTagUiLimit(value, DEFAULT_RECENT_TAG_CHIP_LIMIT) }),
       setSensitiveTags: (tags) => {
         const normalized = (Array.isArray(tags) ? tags : [])
           .map(tag => (typeof tag === 'string' ? tag.trim().toLowerCase() : ''))
@@ -264,6 +277,8 @@ export const useSettingsStore = create<SettingsState>()(
         globalAutoWatch: true,
         startupVerificationMode: 'off',
         doubleClickToOpen: false,
+        tagSuggestionLimit: DEFAULT_TAG_SUGGESTION_LIMIT,
+        recentTagChipLimit: DEFAULT_RECENT_TAG_CHIP_LIMIT,
         sensitiveTags: ['nsfw', 'private', 'hidden'],
         blurSensitiveImages: true,
         enableSafeMode: true,
@@ -309,6 +324,11 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.showFullFilePath !== 'boolean') {
           state.showFullFilePath = false;
+        }
+
+        if (state) {
+          state.tagSuggestionLimit = sanitizeTagUiLimit(state.tagSuggestionLimit, DEFAULT_TAG_SUGGESTION_LIMIT);
+          state.recentTagChipLimit = sanitizeTagUiLimit(state.recentTagChipLimit, DEFAULT_RECENT_TAG_CHIP_LIMIT);
         }
 
         if (

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -1,6 +1,27 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage, StateStorage } from 'zustand/middleware';
 
+export const stripLicenseFromSettings = <T extends Record<string, unknown>>(settings: T | null | undefined): Omit<T, 'license'> => {
+  if (!settings) {
+    return {} as Omit<T, 'license'>;
+  }
+
+  const { license: _license, ...appSettings } = settings;
+  return appSettings;
+};
+
+export const mergeSettingsWithExisting = <
+  TState extends Record<string, unknown>,
+  TSettings extends Record<string, unknown>,
+>(
+  currentSettings: TSettings | null | undefined,
+  nextState: TState,
+): TSettings & TState => ({
+  ...(currentSettings ?? {} as TSettings),
+  ...nextState,
+  ...(currentSettings && 'license' in currentSettings ? { license: currentSettings.license } : {}),
+});
+
 // --- Electron IPC-based storage for Zustand ---
 // This storage adapter will be used if the app is running in Electron.
 const electronStorage: StateStorage = {
@@ -15,14 +36,15 @@ const electronStorage: StateStorage = {
         return null;
       }
 
-      return JSON.stringify({ state: settings });
+      return JSON.stringify({ state: stripLicenseFromSettings(settings) });
     }
     return null;
   },
   setItem: async (name: string, value: string): Promise<void> => {
     if (window.electronAPI) {
       const { state } = JSON.parse(value);
-      const result = await window.electronAPI.saveSettings(state);
+      const currentSettings = await window.electronAPI.getSettings();
+      const result = await window.electronAPI.saveSettings(mergeSettingsWithExisting(currentSettings, state));
       if (!result?.success) {
         throw new Error(result?.error || 'Failed to persist application settings.');
       }

--- a/types.ts
+++ b/types.ts
@@ -917,6 +917,7 @@ export interface SmartCollection {
   autoUpdate?: boolean;            // Live tag membership toggle
   imageIds?: string[];             // Explicit membership for manual collections
   snapshotImageIds?: string[];     // Frozen membership for tag_rule collections
+  excludedImageIds?: string[];     // User-removed images from live tag_rule collections
   imageCount: number;              // Cached count for list rendering
   thumbnailId?: string;            // Legacy alias for cover image
   createdAt: number;

--- a/types.ts
+++ b/types.ts
@@ -887,22 +887,11 @@ export interface AutoTag {
   sourceType: 'prompt' | 'metadata';  // Origin of tag
 }
 
-/**
- * Smart collection - virtual folder based on filters
- */
-export interface SmartCollection {
-  id: string;                      // Unique collection ID
-  name: string;                    // Display name
-  type: 'model' | 'style' | 'subject' | 'custom';  // Collection category
-  query: SmartCollectionQuery;     // Filter criteria
-  imageCount: number;              // Cached count
-  thumbnailId?: string;            // Cover image ID
-  createdAt: number;
-  updatedAt: number;
-}
+export type LegacySmartCollectionType = 'model' | 'style' | 'subject' | 'custom';
 
 /**
- * Query criteria for smart collections
+ * Query criteria for legacy smart collections.
+ * Kept optional for backward-compatible loading of older records.
  */
 export interface SmartCollectionQuery {
   models?: string[];
@@ -910,6 +899,32 @@ export interface SmartCollectionQuery {
   userTags?: string[];
   clusters?: string[];
   dateRange?: { from: number; to: number };
+}
+
+export type CollectionKind = 'manual' | 'tag_rule';
+
+/**
+ * Persisted collection record used by the Collections view.
+ */
+export interface SmartCollection {
+  id: string;                      // Unique collection ID
+  kind: CollectionKind;            // Manual or tag-driven collection
+  name: string;                    // Display name
+  description?: string;
+  coverImageId?: string | null;    // Explicit cover image
+  sortIndex: number;               // Manual ordering in the sidebar
+  sourceTag?: string | null;       // Tag source for tag_rule collections
+  autoUpdate?: boolean;            // Live tag membership toggle
+  imageIds?: string[];             // Explicit membership for manual collections
+  snapshotImageIds?: string[];     // Frozen membership for tag_rule collections
+  imageCount: number;              // Cached count for list rendering
+  thumbnailId?: string;            // Legacy alias for cover image
+  createdAt: number;
+  updatedAt: number;
+
+  // Legacy fields kept optional for backward-compatible loading.
+  type?: LegacySmartCollectionType;
+  query?: SmartCollectionQuery;
 }
 
 /**

--- a/utils/tagSuggestions.ts
+++ b/utils/tagSuggestions.ts
@@ -1,0 +1,176 @@
+import type { TagInfo } from '../types';
+
+export const DEFAULT_TAG_SUGGESTION_LIMIT = 10;
+export const DEFAULT_RECENT_TAG_CHIP_LIMIT = 10;
+export const MIN_TAG_UI_LIMIT = 5;
+export const MAX_TAG_UI_LIMIT = 20;
+export const MAX_RECENT_TAG_HISTORY = 50;
+
+export type TagInputMode = 'single' | 'csv';
+
+export interface TagSuggestion {
+  name: string;
+  count: number;
+  isRecent: boolean;
+  recentIndex: number;
+}
+
+interface BuildTagSuggestionsOptions {
+  query: string;
+  recentTags: string[];
+  availableTags: Array<Pick<TagInfo, 'name' | 'count'>>;
+  excludedTags?: string[];
+  limit: number;
+}
+
+interface RecentTagChipOptions {
+  recentTags: string[];
+  excludedTags?: string[];
+  limit: number;
+}
+
+const normalizeTag = (tag: string) => tag.trim().toLowerCase();
+
+export const sanitizeTagUiLimit = (value: number | null | undefined, fallback: number): number => {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.min(MAX_TAG_UI_LIMIT, Math.max(MIN_TAG_UI_LIMIT, Math.round(value as number)));
+};
+
+export const getTagSearchToken = (value: string, mode: TagInputMode): string => {
+  if (mode === 'csv') {
+    const parts = value.split(',');
+    return normalizeTag(parts[parts.length - 1] ?? '');
+  }
+
+  return normalizeTag(value);
+};
+
+export const replaceLastCsvToken = (value: string, nextTag: string): string => {
+  const parts = value.split(',');
+  parts.pop();
+  const preservedParts = parts
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  return [...preservedParts, normalizeTag(nextTag)].join(', ') + ', ';
+};
+
+export const getRecentTagChips = ({
+  recentTags,
+  excludedTags = [],
+  limit,
+}: RecentTagChipOptions): string[] => {
+  const normalizedExcluded = new Set(excludedTags.map(normalizeTag).filter(Boolean));
+  const normalizedLimit = sanitizeTagUiLimit(limit, DEFAULT_RECENT_TAG_CHIP_LIMIT);
+  const suggestions: string[] = [];
+
+  for (const tag of recentTags) {
+    const normalizedTag = normalizeTag(tag);
+    if (!normalizedTag || normalizedExcluded.has(normalizedTag) || suggestions.includes(normalizedTag)) {
+      continue;
+    }
+
+    suggestions.push(normalizedTag);
+
+    if (suggestions.length >= normalizedLimit) {
+      break;
+    }
+  }
+
+  return suggestions;
+};
+
+export const getTagSuggestions = ({
+  query,
+  recentTags,
+  availableTags,
+  excludedTags = [],
+  limit,
+}: BuildTagSuggestionsOptions): TagSuggestion[] => {
+  const normalizedQuery = normalizeTag(query);
+  const normalizedExcluded = new Set(excludedTags.map(normalizeTag).filter(Boolean));
+  const normalizedLimit = sanitizeTagUiLimit(limit, DEFAULT_TAG_SUGGESTION_LIMIT);
+  const availableTagCounts = new Map<string, number>();
+
+  for (const tag of availableTags) {
+    const normalizedName = normalizeTag(tag.name);
+    if (!normalizedName) {
+      continue;
+    }
+
+    availableTagCounts.set(normalizedName, tag.count ?? 0);
+  }
+
+  const candidates = new Map<string, TagSuggestion>();
+
+  recentTags.forEach((tag, index) => {
+    const normalizedTag = normalizeTag(tag);
+    if (!normalizedTag || normalizedExcluded.has(normalizedTag) || candidates.has(normalizedTag)) {
+      return;
+    }
+
+    if (normalizedQuery && !normalizedTag.includes(normalizedQuery)) {
+      return;
+    }
+
+    candidates.set(normalizedTag, {
+      name: normalizedTag,
+      count: availableTagCounts.get(normalizedTag) ?? 0,
+      isRecent: true,
+      recentIndex: index,
+    });
+  });
+
+  if (normalizedQuery) {
+    for (const tag of availableTags) {
+      const normalizedName = normalizeTag(tag.name);
+      if (!normalizedName || normalizedExcluded.has(normalizedName) || !normalizedName.includes(normalizedQuery)) {
+        continue;
+      }
+
+      const existing = candidates.get(normalizedName);
+      if (existing) {
+        candidates.set(normalizedName, { ...existing, count: tag.count ?? existing.count });
+        continue;
+      }
+
+      candidates.set(normalizedName, {
+        name: normalizedName,
+        count: tag.count ?? 0,
+        isRecent: false,
+        recentIndex: Number.POSITIVE_INFINITY,
+      });
+    }
+  }
+
+  const suggestions = Array.from(candidates.values());
+
+  if (!normalizedQuery) {
+    return suggestions.slice(0, normalizedLimit);
+  }
+
+  suggestions.sort((left, right) => {
+    const leftPrefix = left.name.startsWith(normalizedQuery) ? 0 : 1;
+    const rightPrefix = right.name.startsWith(normalizedQuery) ? 0 : 1;
+    if (leftPrefix !== rightPrefix) {
+      return leftPrefix - rightPrefix;
+    }
+
+    const leftRecent = left.isRecent ? 0 : 1;
+    const rightRecent = right.isRecent ? 0 : 1;
+    if (leftRecent !== rightRecent) {
+      return leftRecent - rightRecent;
+    }
+
+    if (left.isRecent && right.isRecent && left.recentIndex !== right.recentIndex) {
+      return left.recentIndex - right.recentIndex;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+
+  return suggestions.slice(0, normalizedLimit);
+};


### PR DESCRIPTION
## Summary

- Adds the new Collections workspace, collection cards, storage/store primitives, and collection actions across the grid, table, Image Modal, and toolbar.
- Unifies manual tag entry around the shared tag suggestion combobox, including CSV-aware autocomplete and viewer tagging settings.
- Refreshes the header/navigation and restores a stable sidebar layout.
- Fixes license persistence, collection modal focus/reset behavior, global hotkeys firing while typing, and the Image Preview sidebar opening unexpectedly after search or view changes.
- Moves the viewer star rating control above the tag editor so tags keep the full row width.

## Why

This branch rounds out the 0.14.1 release work around collections, tagging ergonomics, and several UI regressions found during testing and Discord feedback.

## Validation

- `npm test -- hotkeyManager CollectionFormModal --run`
- `npm test -- ImageGrid --run`
- `npx tsc -b`

## Notes

The branch also updates `package.json`, `ARCHITECTURE.md`, `CHANGELOG.md`, and `public/CHANGELOG.md` for version 0.14.1.