### PR TITLE
Add automation rules for tags and collections

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -234,6 +234,7 @@ export default function App() {
   const initializeFolderSelection = useImageStore((state) => state.initializeFolderSelection);
   const loadAnnotations = useImageStore((state) => state.loadAnnotations);
   const loadCollections = useImageStore((state) => state.loadCollections);
+  const loadAutomationRules = useImageStore((state) => state.loadAutomationRules);
   const imageStoreSetSortOrder = useImageStore((state) => state.setSortOrder);
   const sortOrder = useImageStore((state) => state.sortOrder);
   const reshuffle = useImageStore((state) => state.reshuffle);
@@ -514,6 +515,10 @@ export default function App() {
   useEffect(() => {
     loadCollections();
   }, [loadCollections]);
+
+  useEffect(() => {
+    loadAutomationRules();
+  }, [loadAutomationRules]);
 
   // Initialize license and keep trial opt-in
   useEffect(() => {

--- a/__tests__/AutomationRulesModal.test.tsx
+++ b/__tests__/AutomationRulesModal.test.tsx
@@ -84,6 +84,34 @@ describe('AutomationRulesModal', () => {
     expect(rule.actions.addTags).toEqual(['animal']);
   });
 
+  it('clears imported tag group mode when the row changes field', async () => {
+    useImageStore.setState({
+      selectedModels: [],
+      excludedLoras: [],
+      selectedTags: ['bird'],
+      selectedTagsMatchMode: 'all',
+    });
+
+    render(<AutomationRulesModal isOpen onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /import current sidebar filters/i }));
+    fireEvent.change(screen.getByLabelText('Condition field'), { target: { value: 'model' } });
+    fireEvent.change(screen.getByLabelText('Checkpoint value'), { target: { value: 'CyberRealistic' } });
+    fireEvent.change(screen.getByPlaceholderText('Add tag...'), { target: { value: 'animal' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.click(screen.getByRole('button', { name: /save rule/i }));
+
+    await waitFor(() => {
+      expect(useImageStore.getState().automationRules).toHaveLength(1);
+    });
+    const row = useImageStore.getState().automationRules[0]?.criteria.conditionRows?.[0];
+    expect(row).toMatchObject({
+      field: 'model',
+      value: 'CyberRealistic',
+    });
+    expect(row?.groupMode).toBeUndefined();
+  });
+
   it('clears the editor after deleting the selected rule', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     useImageStore.setState({

--- a/__tests__/AutomationRulesModal.test.tsx
+++ b/__tests__/AutomationRulesModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import AutomationRulesModal from '../components/AutomationRulesModal';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -33,6 +33,7 @@ describe('AutomationRulesModal', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     cleanup();
   });
 
@@ -81,5 +82,41 @@ describe('AutomationRulesModal', () => {
     expect(rule.criteria.conditionRows?.[0]).toMatchObject({ field: 'prompt', operator: 'contains', value: 'cat' });
     expect(rule.criteria.textConditions[0]).toMatchObject({ field: 'prompt', operator: 'contains', value: 'cat' });
     expect(rule.actions.addTags).toEqual(['animal']);
+  });
+
+  it('clears the editor after deleting the selected rule', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    useImageStore.setState({
+      automationRules: [
+        {
+          id: 'rule-1',
+          name: 'Delete me',
+          enabled: true,
+          criteria: {
+            matchMode: 'all',
+            textConditions: [],
+            conditionRows: [{ id: 'row-1', field: 'prompt', operator: 'contains', value: 'cat' }],
+            filters: { tagMatchMode: 'any', favoriteFilterMode: 'neutral', advancedFilters: {} },
+          },
+          actions: { addTags: ['animal'], addToCollectionIds: [] },
+          runOnNewImages: true,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAppliedAt: null,
+          lastMatchCount: 0,
+          lastChangeCount: 0,
+        },
+      ],
+    });
+
+    render(<AutomationRulesModal isOpen onClose={() => {}} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /delete/i }).at(-1) as HTMLElement);
+
+    await waitFor(() => {
+      expect(useImageStore.getState().automationRules).toEqual([]);
+    });
+    expect(screen.getByRole('heading', { name: /new rule/i })).toBeTruthy();
+    expect(screen.getByText(/no conditions yet/i)).toBeTruthy();
   });
 });

--- a/__tests__/AutomationRulesModal.test.tsx
+++ b/__tests__/AutomationRulesModal.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import AutomationRulesModal from '../components/AutomationRulesModal';
+import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+
+describe('AutomationRulesModal', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+    useSettingsStore.setState({ tagSuggestionLimit: 5 });
+    useImageStore.setState({
+      images: [],
+      filteredImages: [],
+      availableTags: [],
+      recentTags: [],
+      automationRules: [],
+      collections: [],
+      selectedModels: ['CyberRealistic'],
+      excludedLoras: ['x'],
+      selectedTags: ['bird'],
+      selectedTagsMatchMode: 'all',
+      isAnnotationsLoaded: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('captures current sidebar filters into the draft rule', () => {
+    render(<AutomationRulesModal isOpen onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /use current filters/i }));
+
+    expect((screen.getByLabelText('Checkpoints') as HTMLInputElement).value).toBe('CyberRealistic');
+    expect((screen.getByLabelText('Exclude LoRAs') as HTMLInputElement).value).toBe('x');
+    expect((screen.getByLabelText('Manual tags') as HTMLInputElement).value).toBe('bird');
+  });
+
+  it('creates a new rule from the editor', async () => {
+    render(<AutomationRulesModal isOpen onClose={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText('cat, dog, CyberRealistic...'), {
+      target: { value: 'cat' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('animal, realistic...'), {
+      target: { value: 'animal' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.click(screen.getByRole('button', { name: /save rule/i }));
+
+    await waitFor(() => {
+      expect(useImageStore.getState().automationRules).toHaveLength(1);
+    });
+
+    const [rule] = useImageStore.getState().automationRules;
+    expect(rule.criteria.textConditions[0]).toMatchObject({ field: 'prompt', operator: 'contains', value: 'cat' });
+    expect(rule.actions.addTags).toEqual(['animal']);
+  });
+});

--- a/__tests__/AutomationRulesModal.test.tsx
+++ b/__tests__/AutomationRulesModal.test.tsx
@@ -12,8 +12,16 @@ describe('AutomationRulesModal', () => {
     useImageStore.setState({
       images: [],
       filteredImages: [],
-      availableTags: [],
-      recentTags: [],
+      availableModels: ['CyberRealistic'],
+      availableLoras: ['x'],
+      availableSamplers: ['Euler a'],
+      availableSchedulers: ['karras'],
+      availableGenerators: ['Automatic1111'],
+      availableGpuDevices: ['NVIDIA RTX'],
+      availableDimensions: ['512x768'],
+      availableTags: [{ name: 'animal', count: 1 }, { name: 'bird', count: 1 }],
+      availableAutoTags: [{ name: 'portrait', count: 1 }],
+      recentTags: ['animal'],
       automationRules: [],
       collections: [],
       selectedModels: ['CyberRealistic'],
@@ -28,25 +36,40 @@ describe('AutomationRulesModal', () => {
     cleanup();
   });
 
-  it('captures current sidebar filters into the draft rule', () => {
+  it('opens a clean guided editor for a new rule', () => {
     render(<AutomationRulesModal isOpen onClose={() => {}} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /use current filters/i }));
+    expect(screen.getByRole('heading', { name: /new rule/i })).toBeTruthy();
+    expect(screen.getByText(/no conditions yet/i)).toBeTruthy();
 
-    expect((screen.getByLabelText('Checkpoints') as HTMLInputElement).value).toBe('CyberRealistic');
-    expect((screen.getByLabelText('Exclude LoRAs') as HTMLInputElement).value).toBe('x');
-    expect((screen.getByLabelText('Manual tags') as HTMLInputElement).value).toBe('bird');
+    fireEvent.click(screen.getByRole('button', { name: /add your first condition/i }));
+
+    expect((screen.getByLabelText('Condition field') as HTMLSelectElement).value).toBe('prompt');
+    expect((screen.getByLabelText('Condition operator') as HTMLSelectElement).value).toBe('contains');
+    expect(screen.getByLabelText('Prompt value')).toBeTruthy();
   });
 
-  it('creates a new rule from the editor', async () => {
+  it('captures current sidebar filters into editable condition rows', () => {
     render(<AutomationRulesModal isOpen onClose={() => {}} />);
 
-    fireEvent.change(screen.getByPlaceholderText('cat, dog, CyberRealistic...'), {
-      target: { value: 'cat' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('animal, realistic...'), {
-      target: { value: 'animal' },
-    });
+    fireEvent.click(screen.getByRole('button', { name: /import current sidebar filters/i }));
+
+    const fields = screen.getAllByLabelText('Condition field') as HTMLSelectElement[];
+    const operators = screen.getAllByLabelText('Condition operator') as HTMLSelectElement[];
+
+    expect(fields.map((field) => field.value)).toEqual(['model', 'lora', 'tag']);
+    expect(operators.map((operator) => operator.value)).toEqual(['includes', 'not_includes', 'includes']);
+    expect((screen.getByLabelText('Checkpoint value') as HTMLSelectElement).value).toBe('CyberRealistic');
+    expect((screen.getByLabelText('LoRA value') as HTMLSelectElement).value).toBe('x');
+    expect((screen.getByLabelText('Manual Tag value') as HTMLSelectElement).value).toBe('bird');
+  });
+
+  it('creates a new rule from condition rows and guided actions', async () => {
+    render(<AutomationRulesModal isOpen onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add your first condition/i }));
+    fireEvent.change(screen.getByLabelText('Prompt value'), { target: { value: 'cat' } });
+    fireEvent.change(screen.getByPlaceholderText('Add tag...'), { target: { value: 'animal' } });
     fireEvent.click(screen.getByRole('button', { name: 'Add' }));
     fireEvent.click(screen.getByRole('button', { name: /save rule/i }));
 
@@ -55,6 +78,7 @@ describe('AutomationRulesModal', () => {
     });
 
     const [rule] = useImageStore.getState().automationRules;
+    expect(rule.criteria.conditionRows?.[0]).toMatchObject({ field: 'prompt', operator: 'contains', value: 'cat' });
     expect(rule.criteria.textConditions[0]).toMatchObject({ field: 'prompt', operator: 'contains', value: 'cat' });
     expect(rule.actions.addTags).toEqual(['animal']);
   });

--- a/__tests__/Sidebar.layout.test.tsx
+++ b/__tests__/Sidebar.layout.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Sidebar from '../components/Sidebar';
 import { useImageStore } from '../store/useImageStore';
@@ -77,7 +77,9 @@ describe('Sidebar layout', () => {
     );
 
     expect(screen.getByText('Folder content')).toBeTruthy();
-    expect(screen.getByText('Ratings, Favorites & Tags')).toBeTruthy();
     expect(screen.getByText('Sort Order')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /rules/i })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /rules/i }));
+    expect(screen.getByRole('dialog', { name: /automation rules/i })).toBeTruthy();
   });
 });

--- a/__tests__/automationRuleEngine.test.ts
+++ b/__tests__/automationRuleEngine.test.ts
@@ -162,6 +162,26 @@ describe('automation rule engine', () => {
     expect(imageMatchesAutomationRule(blockedImage, rule)).toBe(false);
   });
 
+  it('preserves all-tags semantics for grouped manual tag rows', () => {
+    const imageWithBothTags = createImage({ id: 'both', tags: ['animal', 'portrait'] });
+    const imageWithOneTag = createImage({ id: 'one', tags: ['animal'] });
+    const rule = createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [],
+        conditionRows: [
+          { id: 'tag-1', field: 'tag', operator: 'includes', value: 'animal', groupMode: 'all' },
+          { id: 'tag-2', field: 'tag', operator: 'includes', value: 'portrait', groupMode: 'all' },
+        ],
+        filters: {},
+      },
+      actions: { addTags: ['matched'], addToCollectionIds: [] },
+    });
+
+    expect(imageMatchesAutomationRule(imageWithBothTags, rule)).toBe(true);
+    expect(imageMatchesAutomationRule(imageWithOneTag, rule)).toBe(false);
+  });
+
   it('does not apply disabled rules', () => {
     const rule = createRule({
       enabled: false,

--- a/__tests__/automationRuleEngine.test.ts
+++ b/__tests__/automationRuleEngine.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import type { AutomationRule, ImageAnnotations, IndexedImage, SmartCollection } from '../types';
+import {
+  applyAutomationRuleToImages,
+  imageMatchesAutomationRule,
+  previewAutomationRule,
+} from '../services/automationRuleEngine';
+
+const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
+  id: overrides.id ?? `img-${overrides.name ?? 'image.png'}`,
+  name: overrides.name ?? 'image.png',
+  handle: {} as FileSystemFileHandle,
+  metadata: {} as any,
+  metadataString: '',
+  lastModified: 1,
+  models: [],
+  loras: [],
+  sampler: '',
+  scheduler: '',
+  directoryId: 'dir-1',
+  ...overrides,
+});
+
+const createRule = (overrides: Partial<AutomationRule>): AutomationRule => ({
+  id: overrides.id ?? 'rule-1',
+  name: overrides.name ?? 'Rule',
+  enabled: overrides.enabled ?? true,
+  criteria: overrides.criteria ?? {
+    matchMode: 'all',
+    textConditions: [],
+    filters: {},
+  },
+  actions: overrides.actions ?? {
+    addTags: [],
+    addToCollectionIds: [],
+  },
+  runOnNewImages: overrides.runOnNewImages ?? true,
+  createdAt: 1,
+  updatedAt: 1,
+  lastAppliedAt: null,
+  lastMatchCount: 0,
+  lastChangeCount: 0,
+});
+
+describe('automation rule engine', () => {
+  it('matches prompt text and previews tag additions', () => {
+    const images = [
+      createImage({ id: 'cat', prompt: 'small cat in the garden' }),
+      createImage({ id: 'dog', prompt: 'small dog in the garden' }),
+    ];
+    const rule = createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [{ id: 'c1', field: 'prompt', operator: 'contains', value: 'cat' }],
+        filters: {},
+      },
+      actions: { addTags: ['animal'], addToCollectionIds: [] },
+    });
+
+    expect(imageMatchesAutomationRule(images[0], rule)).toBe(true);
+    expect(imageMatchesAutomationRule(images[1], rule)).toBe(false);
+    expect(previewAutomationRule(rule, images, new Map(), [])).toMatchObject({
+      matchedImageIds: ['cat'],
+      matchCount: 1,
+      changeCount: 1,
+      tagChangeCount: 1,
+    });
+  });
+
+  it('matches prompt and checkpoint together', () => {
+    const image = createImage({
+      prompt: 'dog portrait',
+      models: ['CyberRealistic'],
+    });
+    const rule = createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [{ id: 'c1', field: 'prompt', operator: 'contains', value: 'dog' }],
+        filters: { models: ['CyberRealistic'] },
+      },
+      actions: { addTags: ['realistic'], addToCollectionIds: [] },
+    });
+
+    expect(imageMatchesAutomationRule(image, rule)).toBe(true);
+  });
+
+  it('matches prompt and excluded LoRA absence', () => {
+    const birdWithoutLora = createImage({ id: 'bird-1', prompt: 'bird flying', loras: [] });
+    const birdWithLora = createImage({ id: 'bird-2', prompt: 'bird flying', loras: ['x'] });
+    const rule = createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [{ id: 'c1', field: 'prompt', operator: 'contains', value: 'bird' }],
+        filters: { excludedLoras: ['x'] },
+      },
+      actions: { addTags: ['y'], addToCollectionIds: [] },
+    });
+
+    expect(imageMatchesAutomationRule(birdWithoutLora, rule)).toBe(true);
+    expect(imageMatchesAutomationRule(birdWithLora, rule)).toBe(false);
+  });
+
+  it('does not apply disabled rules', () => {
+    const rule = createRule({
+      enabled: false,
+      criteria: {
+        matchMode: 'all',
+        textConditions: [{ id: 'c1', field: 'prompt', operator: 'contains', value: 'cat' }],
+        filters: {},
+      },
+      actions: { addTags: ['animal'], addToCollectionIds: [] },
+    });
+
+    expect(previewAutomationRule(rule, [createImage({ prompt: 'cat' })], new Map(), [])).toMatchObject({
+      matchCount: 0,
+      changeCount: 0,
+    });
+  });
+
+  it('is idempotent for tags and collection image IDs', () => {
+    const annotations = new Map<string, ImageAnnotations>([
+      ['img-1', { imageId: 'img-1', isFavorite: false, tags: ['animal'], addedAt: 1, updatedAt: 1 }],
+    ]);
+    const collection: SmartCollection = {
+      id: 'collection-1',
+      kind: 'manual',
+      name: 'Animals',
+      sortIndex: 0,
+      imageIds: ['img-1'],
+      snapshotImageIds: [],
+      excludedImageIds: [],
+      imageCount: 1,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const rule = createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [{ id: 'c1', field: 'prompt', operator: 'contains', value: 'cat' }],
+        filters: {},
+      },
+      actions: { addTags: ['animal'], addToCollectionIds: ['collection-1'] },
+    });
+
+    const result = applyAutomationRuleToImages(
+      rule,
+      [createImage({ id: 'img-1', prompt: 'cat', tags: ['animal'] })],
+      annotations,
+      [collection],
+    );
+
+    expect(result.matchCount).toBe(1);
+    expect(result.changeCount).toBe(0);
+    expect(result.updatedAnnotations).toEqual([]);
+    expect(result.collectionImageAdds.size).toBe(0);
+  });
+});

--- a/__tests__/automationRuleEngine.test.ts
+++ b/__tests__/automationRuleEngine.test.ts
@@ -120,6 +120,48 @@ describe('automation rule engine', () => {
     expect(imageMatchesAutomationRule(birdWithLora, rule)).toBe(false);
   });
 
+  it('keeps OR semantics for multiple values from the same facet row group', () => {
+    const fluxImage = createImage({ id: 'flux', models: ['Flux'] });
+    const sdxlImage = createImage({ id: 'sdxl', models: ['SDXL'] });
+    const otherImage = createImage({ id: 'other', models: ['Other'] });
+    const rule = createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [],
+        conditionRows: [
+          { id: 'model-1', field: 'model', operator: 'includes', value: 'Flux' },
+          { id: 'model-2', field: 'model', operator: 'includes', value: 'SDXL' },
+        ],
+        filters: {},
+      },
+      actions: { addTags: ['matched'], addToCollectionIds: [] },
+    });
+
+    expect(imageMatchesAutomationRule(fluxImage, rule)).toBe(true);
+    expect(imageMatchesAutomationRule(sdxlImage, rule)).toBe(true);
+    expect(imageMatchesAutomationRule(otherImage, rule)).toBe(false);
+  });
+
+  it('requires all excluded values from the same facet row group to be absent', () => {
+    const cleanImage = createImage({ id: 'clean', loras: [] });
+    const blockedImage = createImage({ id: 'blocked', loras: ['x'] });
+    const rule = createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [],
+        conditionRows: [
+          { id: 'lora-1', field: 'lora', operator: 'not_includes', value: 'x' },
+          { id: 'lora-2', field: 'lora', operator: 'not_includes', value: 'y' },
+        ],
+        filters: {},
+      },
+      actions: { addTags: ['matched'], addToCollectionIds: [] },
+    });
+
+    expect(imageMatchesAutomationRule(cleanImage, rule)).toBe(true);
+    expect(imageMatchesAutomationRule(blockedImage, rule)).toBe(false);
+  });
+
   it('does not apply disabled rules', () => {
     const rule = createRule({
       enabled: false,

--- a/__tests__/automationRuleEngine.test.ts
+++ b/__tests__/automationRuleEngine.test.ts
@@ -182,6 +182,21 @@ describe('automation rule engine', () => {
     expect(imageMatchesAutomationRule(imageWithOneTag, rule)).toBe(false);
   });
 
+  it('matches imported global search rows across searchable image fields', () => {
+    const image = createImage({ id: 'cat', prompt: 'cat portrait', metadataString: '' });
+    const rule = createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [],
+        conditionRows: [{ id: 'search', field: 'search', operator: 'contains', value: 'cat' }],
+        filters: {},
+      },
+      actions: { addTags: ['matched'], addToCollectionIds: [] },
+    });
+
+    expect(imageMatchesAutomationRule(image, rule)).toBe(true);
+  });
+
   it('does not apply disabled rules', () => {
     const rule = createRule({
       enabled: false,

--- a/__tests__/automationRuleEngine.test.ts
+++ b/__tests__/automationRuleEngine.test.ts
@@ -100,6 +100,26 @@ describe('automation rule engine', () => {
     expect(imageMatchesAutomationRule(birdWithLora, rule)).toBe(false);
   });
 
+  it('matches the guided condition-row criteria directly', () => {
+    const birdWithoutLora = createImage({ id: 'bird-1', prompt: 'bright bird flying', loras: [] });
+    const birdWithLora = createImage({ id: 'bird-2', prompt: 'bright bird flying', loras: ['x'] });
+    const rule = createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [],
+        conditionRows: [
+          { id: 'prompt', field: 'prompt', operator: 'contains', value: 'bird' },
+          { id: 'lora', field: 'lora', operator: 'not_includes', value: 'x' },
+        ],
+        filters: {},
+      },
+      actions: { addTags: ['y'], addToCollectionIds: [] },
+    });
+
+    expect(imageMatchesAutomationRule(birdWithoutLora, rule)).toBe(true);
+    expect(imageMatchesAutomationRule(birdWithLora, rule)).toBe(false);
+  });
+
   it('does not apply disabled rules', () => {
     const rule = createRule({
       enabled: false,

--- a/__tests__/automationRuleRows.test.ts
+++ b/__tests__/automationRuleRows.test.ts
@@ -46,7 +46,7 @@ describe('automation rule condition rows', () => {
       expect.objectContaining({ field: 'prompt', operator: 'contains', value: 'dog' }),
       expect.objectContaining({ field: 'model', operator: 'includes', value: 'CyberRealistic' }),
       expect.objectContaining({ field: 'lora', operator: 'not_includes', value: 'x' }),
-      expect.objectContaining({ field: 'tag', operator: 'includes', value: 'bird' }),
+      expect.objectContaining({ field: 'tag', operator: 'includes', value: 'bird', groupMode: 'all' }),
       expect.objectContaining({ field: 'favorite', operator: 'is' }),
       expect.objectContaining({ field: 'rating', operator: 'equals', value: '5' }),
       expect.objectContaining({ field: 'steps', operator: 'between', value: '10', valueEnd: '20' }),
@@ -58,6 +58,8 @@ describe('automation rule condition rows', () => {
       { id: 'prompt', field: 'prompt', operator: 'contains', value: 'cat' },
       { id: 'model', field: 'model', operator: 'includes', value: 'CyberRealistic' },
       { id: 'lora', field: 'lora', operator: 'not_includes', value: 'x' },
+      { id: 'tag-all-1', field: 'tag', operator: 'includes', value: 'animal', groupMode: 'all' },
+      { id: 'tag-all-2', field: 'tag', operator: 'includes', value: 'portrait', groupMode: 'all' },
       { id: 'tag', field: 'tag', operator: 'not_includes', value: 'Hidden' },
       { id: 'steps', field: 'steps', operator: 'between', value: '10', valueEnd: '20' },
     ], 'all');
@@ -65,9 +67,11 @@ describe('automation rule condition rows', () => {
     expect(criteria.textConditions).toEqual([
       { id: 'prompt', field: 'prompt', operator: 'contains', value: 'cat' },
     ]);
-    expect(criteria.conditionRows).toHaveLength(5);
+    expect(criteria.conditionRows).toHaveLength(7);
     expect(criteria.filters.models).toEqual(['CyberRealistic']);
     expect(criteria.filters.excludedLoras).toEqual(['x']);
+    expect(criteria.filters.tags).toEqual(['animal', 'portrait']);
+    expect(criteria.filters.tagMatchMode).toBe('all');
     expect(criteria.filters.excludedTags).toEqual(['hidden']);
     expect(criteria.filters.advancedFilters?.steps).toEqual({ min: 10, max: 20 });
   });

--- a/__tests__/automationRuleRows.test.ts
+++ b/__tests__/automationRuleRows.test.ts
@@ -55,6 +55,7 @@ describe('automation rule condition rows', () => {
 
   it('converts rows back to compatible criteria without losing includes and excludes', () => {
     const criteria = conditionRowsToCriteria([
+      { id: 'search', field: 'search', operator: 'contains', value: 'garden' },
       { id: 'prompt', field: 'prompt', operator: 'contains', value: 'cat' },
       { id: 'model', field: 'model', operator: 'includes', value: 'CyberRealistic' },
       { id: 'lora', field: 'lora', operator: 'not_includes', value: 'x' },
@@ -67,7 +68,8 @@ describe('automation rule condition rows', () => {
     expect(criteria.textConditions).toEqual([
       { id: 'prompt', field: 'prompt', operator: 'contains', value: 'cat' },
     ]);
-    expect(criteria.conditionRows).toHaveLength(7);
+    expect(criteria.conditionRows).toHaveLength(8);
+    expect(criteria.filters.searchQuery).toBe('garden');
     expect(criteria.filters.models).toEqual(['CyberRealistic']);
     expect(criteria.filters.excludedLoras).toEqual(['x']);
     expect(criteria.filters.tags).toEqual(['animal', 'portrait']);
@@ -88,7 +90,7 @@ describe('automation rule condition rows', () => {
     });
 
     expect(rows).toEqual(expect.arrayContaining([
-      expect.objectContaining({ field: 'metadata', operator: 'contains', value: 'cat' }),
+      expect.objectContaining({ field: 'search', operator: 'contains', value: 'cat' }),
       expect.objectContaining({ field: 'model', operator: 'includes', value: 'CyberRealistic' }),
       expect.objectContaining({ field: 'lora', operator: 'not_includes', value: 'x' }),
       expect.objectContaining({ field: 'autoTag', operator: 'includes', value: 'portrait' }),

--- a/__tests__/automationRuleRows.test.ts
+++ b/__tests__/automationRuleRows.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { AutomationRule } from '../types';
+import {
+  conditionRowsToCriteria,
+  filterCriteriaToConditionRows,
+  ruleToConditionRows,
+} from '../utils/automationRuleRows';
+
+const createRule = (overrides: Partial<AutomationRule>): AutomationRule => ({
+  id: overrides.id ?? 'rule-1',
+  name: overrides.name ?? 'Rule',
+  enabled: overrides.enabled ?? true,
+  criteria: overrides.criteria ?? {
+    matchMode: 'all',
+    textConditions: [],
+    filters: { tagMatchMode: 'any', favoriteFilterMode: 'neutral', advancedFilters: {} },
+  },
+  actions: overrides.actions ?? { addTags: [], addToCollectionIds: [] },
+  runOnNewImages: overrides.runOnNewImages ?? true,
+  createdAt: 1,
+  updatedAt: 1,
+  lastAppliedAt: null,
+  lastMatchCount: 0,
+  lastChangeCount: 0,
+});
+
+describe('automation rule condition rows', () => {
+  it('converts older rule criteria into editable rows', () => {
+    const rows = ruleToConditionRows(createRule({
+      criteria: {
+        matchMode: 'all',
+        textConditions: [{ id: 'text-1', field: 'prompt', operator: 'contains', value: 'dog' }],
+        filters: {
+          models: ['CyberRealistic'],
+          excludedLoras: ['x'],
+          tags: ['bird'],
+          tagMatchMode: 'all',
+          favoriteFilterMode: 'include',
+          ratings: [5],
+          advancedFilters: { steps: { min: 10, max: 20 } },
+        },
+      },
+    }));
+
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ field: 'prompt', operator: 'contains', value: 'dog' }),
+      expect.objectContaining({ field: 'model', operator: 'includes', value: 'CyberRealistic' }),
+      expect.objectContaining({ field: 'lora', operator: 'not_includes', value: 'x' }),
+      expect.objectContaining({ field: 'tag', operator: 'includes', value: 'bird' }),
+      expect.objectContaining({ field: 'favorite', operator: 'is' }),
+      expect.objectContaining({ field: 'rating', operator: 'equals', value: '5' }),
+      expect.objectContaining({ field: 'steps', operator: 'between', value: '10', valueEnd: '20' }),
+    ]));
+  });
+
+  it('converts rows back to compatible criteria without losing includes and excludes', () => {
+    const criteria = conditionRowsToCriteria([
+      { id: 'prompt', field: 'prompt', operator: 'contains', value: 'cat' },
+      { id: 'model', field: 'model', operator: 'includes', value: 'CyberRealistic' },
+      { id: 'lora', field: 'lora', operator: 'not_includes', value: 'x' },
+      { id: 'tag', field: 'tag', operator: 'not_includes', value: 'Hidden' },
+      { id: 'steps', field: 'steps', operator: 'between', value: '10', valueEnd: '20' },
+    ], 'all');
+
+    expect(criteria.textConditions).toEqual([
+      { id: 'prompt', field: 'prompt', operator: 'contains', value: 'cat' },
+    ]);
+    expect(criteria.conditionRows).toHaveLength(5);
+    expect(criteria.filters.models).toEqual(['CyberRealistic']);
+    expect(criteria.filters.excludedLoras).toEqual(['x']);
+    expect(criteria.filters.excludedTags).toEqual(['hidden']);
+    expect(criteria.filters.advancedFilters?.steps).toEqual({ min: 10, max: 20 });
+  });
+
+  it('imports active sidebar filters as condition rows', () => {
+    const rows = filterCriteriaToConditionRows({
+      searchQuery: 'cat',
+      models: ['CyberRealistic'],
+      excludedLoras: ['x'],
+      autoTags: ['portrait'],
+      tagMatchMode: 'any',
+      favoriteFilterMode: 'exclude',
+      advancedFilters: { hasVerifiedTelemetry: true },
+    });
+
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ field: 'metadata', operator: 'contains', value: 'cat' }),
+      expect.objectContaining({ field: 'model', operator: 'includes', value: 'CyberRealistic' }),
+      expect.objectContaining({ field: 'lora', operator: 'not_includes', value: 'x' }),
+      expect.objectContaining({ field: 'autoTag', operator: 'includes', value: 'portrait' }),
+      expect.objectContaining({ field: 'favorite', operator: 'is_not' }),
+      expect.objectContaining({ field: 'verifiedTelemetry', operator: 'is' }),
+    ]));
+  });
+});

--- a/__tests__/automationRuleRows.test.ts
+++ b/__tests__/automationRuleRows.test.ts
@@ -89,7 +89,7 @@ describe('automation rule condition rows', () => {
       expect.objectContaining({ field: 'lora', operator: 'not_includes', value: 'x' }),
       expect.objectContaining({ field: 'autoTag', operator: 'includes', value: 'portrait' }),
       expect.objectContaining({ field: 'favorite', operator: 'is_not' }),
-      expect.objectContaining({ field: 'verifiedTelemetry', operator: 'is' }),
     ]));
+    expect(rows.some((row) => row.field === 'telemetry' || row.field === 'verifiedTelemetry')).toBe(false);
   });
 });

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -228,6 +228,7 @@ describe('smart collection storage', () => {
       criteria: {
         matchMode: 'all',
         textConditions: [{ id: 'c1', field: 'prompt', operator: 'contains', value: 'cat' }],
+        conditionRows: [{ id: 'row-1', field: 'model', operator: 'includes', value: 'CyberRealistic' }],
         filters: {},
       },
       actions: { addTags: ['Animal'], addToCollectionIds: ['collection-1'] },
@@ -239,6 +240,9 @@ describe('smart collection storage', () => {
     expect(await getAllAutomationRules()).toMatchObject([
       {
         id: 'rule-1',
+        criteria: {
+          conditionRows: [{ id: 'row-1', field: 'model', operator: 'includes', value: 'CyberRealistic' }],
+        },
         actions: { addTags: ['animal'], addToCollectionIds: ['collection-1'] },
       },
     ]);

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -210,6 +210,43 @@ describe('smart collection storage', () => {
     installFakeIndexedDb();
   });
 
+  it('round-trips automation rules through IndexedDB', async () => {
+    const {
+      deleteAutomationRule,
+      getAllAutomationRules,
+      saveAutomationRule,
+    } = await import('../services/automationRulesStorage');
+    const { PREFERENCES_DB_VERSION, PREFERENCES_STORE_NAMES } = await import('../services/preferencesDb');
+
+    expect(PREFERENCES_DB_VERSION).toBe(7);
+    expect(PREFERENCES_STORE_NAMES.automationRules).toBe('automationRules');
+
+    await saveAutomationRule({
+      id: 'rule-1',
+      name: 'Cats',
+      enabled: true,
+      criteria: {
+        matchMode: 'all',
+        textConditions: [{ id: 'c1', field: 'prompt', operator: 'contains', value: 'cat' }],
+        filters: {},
+      },
+      actions: { addTags: ['Animal'], addToCollectionIds: ['collection-1'] },
+      runOnNewImages: true,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    expect(await getAllAutomationRules()).toMatchObject([
+      {
+        id: 'rule-1',
+        actions: { addTags: ['animal'], addToCollectionIds: ['collection-1'] },
+      },
+    ]);
+
+    await deleteAutomationRule('rule-1');
+    expect(await getAllAutomationRules()).toEqual([]);
+  });
+
   it('round-trips manual and tag_rule collections through IndexedDB', async () => {
     const {
       getAllSmartCollections,

--- a/__tests__/useImageStore.filters.test.ts
+++ b/__tests__/useImageStore.filters.test.ts
@@ -523,4 +523,49 @@ describe('useImageStore tri-state filters', () => {
     expect(useImageStore.getState().collections[0]?.imageIds).toEqual([catImage.id]);
     expect(useImageStore.getState().collections[0]?.imageCount).toBe(1);
   });
+
+  it('loads automation rules before auto-applying them to new images', async () => {
+    const catImage = createImage({
+      id: 'dir-1::startup-cat.png',
+      name: 'startup-cat.png',
+      prompt: 'cat portrait',
+      tags: [],
+    });
+
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      directories: [directory],
+      images: [catImage],
+      filteredImages: [catImage],
+      annotations: new Map(),
+      isAnnotationsLoaded: true,
+      isAutomationRulesLoaded: true,
+    });
+
+    await useImageStore.getState().createAutomationRule({
+      id: 'startup-rule',
+      name: 'Startup Cats',
+      enabled: true,
+      criteria: {
+        matchMode: 'all',
+        textConditions: [{ id: 'c1', field: 'prompt', operator: 'contains', value: 'cat' }],
+        filters: {},
+      },
+      actions: { addTags: ['startup-animal'], addToCollectionIds: [] },
+      runOnNewImages: true,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    useImageStore.setState({
+      automationRules: [],
+      isAutomationRulesLoaded: false,
+    });
+
+    const result = await useImageStore.getState().applyEnabledAutomationRulesToImages([catImage]);
+
+    expect(result.some((preview) => preview.matchCount === 1 && preview.changeCount === 1)).toBe(true);
+    expect(useImageStore.getState().images[0]?.tags).toContain('startup-animal');
+    expect(useImageStore.getState().isAutomationRulesLoaded).toBe(true);
+  });
 });

--- a/__tests__/useImageStore.filters.test.ts
+++ b/__tests__/useImageStore.filters.test.ts
@@ -467,4 +467,60 @@ describe('useImageStore tri-state filters', () => {
 
     expect(useImageStore.getState().filteredImages.map((image) => image.name)).toContain('i.png');
   });
+
+  it('applies automation rules to annotations and collection membership', async () => {
+    const catImage = createImage({
+      id: 'dir-1::cat.png',
+      name: 'cat.png',
+      prompt: 'cat portrait',
+      tags: [],
+    });
+
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      directories: [directory],
+      images: [catImage],
+      filteredImages: [catImage],
+      annotations: new Map(),
+      isAnnotationsLoaded: true,
+      automationRules: [
+        {
+          id: 'rule-1',
+          name: 'Cats',
+          enabled: true,
+          criteria: {
+            matchMode: 'all',
+            textConditions: [{ id: 'c1', field: 'prompt', operator: 'contains', value: 'cat' }],
+            filters: {},
+          },
+          actions: { addTags: ['animal'], addToCollectionIds: ['collection-1'] },
+          runOnNewImages: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      collections: [
+        {
+          id: 'collection-1',
+          kind: 'manual',
+          name: 'Animals',
+          sortIndex: 0,
+          imageIds: [],
+          snapshotImageIds: [],
+          excludedImageIds: [],
+          imageCount: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+
+    const result = await useImageStore.getState().applyAutomationRuleNow('rule-1');
+
+    expect(result).toMatchObject({ matchCount: 1, changeCount: 2 });
+    expect(useImageStore.getState().images[0]?.tags).toEqual(['animal']);
+    expect(useImageStore.getState().annotations.get(catImage.id)?.tags).toEqual(['animal']);
+    expect(useImageStore.getState().collections[0]?.imageIds).toEqual([catImage.id]);
+    expect(useImageStore.getState().collections[0]?.imageCount).toBe(1);
+  });
 });

--- a/components/AutomationRulesModal.tsx
+++ b/components/AutomationRulesModal.tsx
@@ -545,13 +545,14 @@ interface ConditionRowEditorProps {
 const ConditionRowEditor: React.FC<ConditionRowEditorProps> = ({ row, valueSource, onUpdate, onRemove }) => {
   const fieldOptions = getConditionFieldOptions();
   const operatorOptions = getOperatorsForField(row.field);
-  const valueOptions = getConditionValueOptions(row.field, valueSource);
   const isText = TEXT_CONDITION_FIELDS.includes(row.field);
+  const valueOptions = isText ? [] : getConditionValueOptions(row.field, valueSource);
   const isBoolean = row.field === 'favorite' || row.field === 'telemetry' || row.field === 'verifiedTelemetry';
   const isBetween = row.operator === 'between';
+  const valueContainerClassName = `min-w-0 md:col-span-2 ${isBetween ? 'grid gap-2 sm:grid-cols-2' : ''}`.trim();
 
   return (
-    <div className="grid gap-2 rounded-lg border border-gray-800 bg-gray-900/50 p-2 md:grid-cols-[170px_170px_minmax(0,1fr)_40px]">
+    <div className="grid gap-2 rounded-lg border border-gray-800 bg-gray-900/50 p-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_40px]">
       <select
         aria-label="Condition field"
         value={row.field}
@@ -569,18 +570,22 @@ const ConditionRowEditor: React.FC<ConditionRowEditorProps> = ({ row, valueSourc
         {operatorOptions.map((operator) => <option key={operator} value={operator}>{OPERATOR_LABELS[operator]}</option>)}
       </select>
 
-      <div className={isBetween ? 'grid gap-2 sm:grid-cols-2' : ''}>
+      <button type="button" onClick={onRemove} className="h-9 rounded-lg border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-rose-300" title="Remove condition">
+        <X className="mx-auto h-4 w-4" />
+      </button>
+
+      <div className={valueContainerClassName}>
         {isBoolean ? (
-          <div className="flex h-9 items-center rounded-lg border border-gray-700 bg-gray-800 px-3 text-sm text-gray-300">
+          <div className="flex h-9 w-full items-center rounded-lg border border-gray-700 bg-gray-800 px-3 text-sm text-gray-300">
             {row.field === 'telemetry' ? 'present' : row.field === 'verifiedTelemetry' ? 'true' : 'favorite'}
           </div>
         ) : isText ? (
-          <SuggestInput
-            ariaLabel={`${CONDITION_FIELD_LABELS[row.field]} value`}
+          <input
+            aria-label={`${CONDITION_FIELD_LABELS[row.field]} value`}
             value={row.value}
-            options={valueOptions}
-            onChange={(value) => onUpdate({ value })}
-            placeholder="Type or choose..."
+            onChange={(event) => onUpdate({ value: event.target.value })}
+            className={compactInputClassName}
+            placeholder="Type here..."
           />
         ) : valueOptions.length > 0 && !['steps', 'cfg'].includes(row.field) ? (
           <select
@@ -614,63 +619,6 @@ const ConditionRowEditor: React.FC<ConditionRowEditorProps> = ({ row, valueSourc
           />
         )}
       </div>
-
-      <button type="button" onClick={onRemove} className="h-9 rounded-lg border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-rose-300" title="Remove condition">
-        <X className="mx-auto h-4 w-4" />
-      </button>
-    </div>
-  );
-};
-
-interface SuggestInputProps {
-  value: string;
-  options: string[];
-  onChange: (value: string) => void;
-  placeholder: string;
-  ariaLabel: string;
-}
-
-const SuggestInput: React.FC<SuggestInputProps> = ({ value, options, onChange, placeholder, ariaLabel }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const filteredOptions = useMemo(() => {
-    const query = value.trim().toLowerCase();
-    return options
-      .filter((option) => !query || option.toLowerCase().includes(query))
-      .slice(0, 8);
-  }, [options, value]);
-
-  return (
-    <div className="relative">
-      <input
-        aria-label={ariaLabel}
-        value={value}
-        onChange={(event) => {
-          onChange(event.target.value);
-          setIsOpen(true);
-        }}
-        onFocus={() => setIsOpen(true)}
-        onBlur={() => window.setTimeout(() => setIsOpen(false), 120)}
-        className={compactInputClassName}
-        placeholder={placeholder}
-      />
-      {isOpen && filteredOptions.length > 0 && (
-        <div className="absolute z-20 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-gray-700 bg-gray-800 shadow-xl">
-          {filteredOptions.map((option) => (
-            <button
-              key={option}
-              type="button"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={() => {
-                onChange(option);
-                setIsOpen(false);
-              }}
-              className="block w-full px-3 py-2 text-left text-sm text-gray-200 hover:bg-gray-700"
-            >
-              {option}
-            </button>
-          ))}
-        </div>
-      )}
     </div>
   );
 };

--- a/components/AutomationRulesModal.tsx
+++ b/components/AutomationRulesModal.tsx
@@ -1,73 +1,72 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Copy, Play, Plus, Power, SlidersHorizontal, Trash2, X } from 'lucide-react';
+import { Copy, Play, Plus, Power, Trash2, X } from 'lucide-react';
 import type {
-  AdvancedFilters,
+  AutomationConditionField,
+  AutomationConditionOperator,
+  AutomationConditionRow,
   AutomationRule,
-  AutomationRuleCriteria,
-  AutomationRuleFilterCriteria,
-  AutomationTextCondition,
-  AutomationTextField,
-  AutomationTextOperator,
-  ImageRating,
   SmartCollection,
   TagInfo,
 } from '../types';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import TagInputCombobox from './TagInputCombobox';
+import {
+  CONDITION_FIELD_LABELS,
+  OPERATOR_LABELS,
+  TEXT_CONDITION_FIELDS,
+  conditionRowsToCriteria,
+  createDefaultConditionRow,
+  filterCriteriaToConditionRows,
+  getConditionFieldOptions,
+  getConditionValueOptions,
+  getDefaultOperatorForField,
+  getOperatorsForField,
+  isConditionRowComplete,
+  normalizeConditionRow,
+  ruleToConditionRows,
+} from '../utils/automationRuleRows';
 
 interface AutomationRulesModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-const TEXT_FIELDS: Array<{ value: AutomationTextField; label: string }> = [
-  { value: 'prompt', label: 'Prompt' },
-  { value: 'negativePrompt', label: 'Negative prompt' },
-  { value: 'filename', label: 'Filename' },
-  { value: 'metadata', label: 'Metadata' },
-];
+type PreviewState = {
+  matchCount: number;
+  changeCount: number;
+  tagChangeCount: number;
+  collectionChangeCount: number;
+};
 
-const TEXT_OPERATORS: Array<{ value: AutomationTextOperator; label: string }> = [
-  { value: 'contains', label: 'contains' },
-  { value: 'not_contains', label: 'does not contain' },
-  { value: 'equals', label: 'equals' },
-  { value: 'not_equals', label: 'does not equal' },
-];
+const emptyPreview: PreviewState = {
+  matchCount: 0,
+  changeCount: 0,
+  tagChangeCount: 0,
+  collectionChangeCount: 0,
+};
 
 const createId = () =>
   typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
     ? crypto.randomUUID()
     : `rule-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
-const csvToList = (value: string, lower = false): string[] =>
-  Array.from(
-    new Set(
-      value
-        .split(',')
-        .map((item) => item.trim())
-        .filter(Boolean)
-        .map((item) => lower ? item.toLowerCase() : item),
-    ),
-  );
-
-const listToCsv = (value: string[] | undefined): string => (value ?? []).join(', ');
-
-const emptyCriteria = (): AutomationRuleCriteria => ({
-  matchMode: 'all',
-  textConditions: [{ id: createId(), field: 'prompt', operator: 'contains', value: '' }],
-  filters: {
-    tagMatchMode: 'any',
-    favoriteFilterMode: 'neutral',
-    advancedFilters: {},
-  },
-});
+const inputClassName =
+  'w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500';
+const compactInputClassName =
+  'h-9 w-full rounded-lg border border-gray-700 bg-gray-800 px-2.5 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500';
+const labelClassName = 'mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400';
 
 const createDraftRule = (): AutomationRule => ({
   id: createId(),
   name: 'New Rule',
   enabled: true,
-  criteria: emptyCriteria(),
+  criteria: {
+    matchMode: 'all',
+    textConditions: [],
+    conditionRows: [],
+    filters: { tagMatchMode: 'any', favoriteFilterMode: 'neutral', advancedFilters: {} },
+  },
   actions: { addTags: [], addToCollectionIds: [] },
   runOnNewImages: true,
   createdAt: Date.now(),
@@ -77,56 +76,47 @@ const createDraftRule = (): AutomationRule => ({
   lastChangeCount: 0,
 });
 
-const describeCriteria = (criteria: AutomationRuleCriteria): string => {
-  const parts: string[] = [];
-  const textCount = criteria.textConditions.filter((condition) => condition.value.trim()).length;
-  if (textCount > 0) parts.push(`${textCount} text`);
-
-  const filters = criteria.filters;
-  const filterCount = [
-    filters.searchQuery,
-    ...(filters.models ?? []),
-    ...(filters.excludedModels ?? []),
-    ...(filters.loras ?? []),
-    ...(filters.excludedLoras ?? []),
-    ...(filters.samplers ?? []),
-    ...(filters.excludedSamplers ?? []),
-    ...(filters.schedulers ?? []),
-    ...(filters.excludedSchedulers ?? []),
-    ...(filters.tags ?? []),
-    ...(filters.excludedTags ?? []),
-    ...(filters.autoTags ?? []),
-    ...(filters.excludedAutoTags ?? []),
-  ].filter(Boolean).length;
-  if (filterCount > 0) parts.push(`${filterCount} filters`);
-  if (filters.favoriteFilterMode && filters.favoriteFilterMode !== 'neutral') parts.push('favorite');
-  if (filters.ratings?.length) parts.push('rating');
-  if (filters.advancedFilters && Object.keys(filters.advancedFilters).length > 0) parts.push('advanced');
-
-  return parts.length > 0 ? parts.join(' + ') : 'No criteria yet';
+const describeCriteria = (rule: AutomationRule): string => {
+  const rows = ruleToConditionRows(rule);
+  if (rows.length === 0) return 'No conditions yet';
+  return `${rows.length} condition${rows.length === 1 ? '' : 's'} (${rule.criteria.matchMode})`;
 };
 
 const describeActions = (rule: AutomationRule, collectionNames: Map<string, string>): string => {
   const parts: string[] = [];
-  if (rule.actions.addTags.length > 0) {
-    parts.push(`tags: ${rule.actions.addTags.join(', ')}`);
-  }
+  if (rule.actions.addTags.length > 0) parts.push(`tags: ${rule.actions.addTags.join(', ')}`);
   if (rule.actions.addToCollectionIds.length > 0) {
     parts.push(`collections: ${rule.actions.addToCollectionIds.map((id) => collectionNames.get(id) ?? id).join(', ')}`);
   }
   return parts.length > 0 ? parts.join(' | ') : 'No actions yet';
 };
 
-const inputClassName =
-  'w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500';
-const labelClassName = 'mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400';
+const hasActions = (rule: AutomationRule): boolean =>
+  rule.actions.addTags.length > 0 || rule.actions.addToCollectionIds.length > 0;
 
-const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onClose }) => {
+const hasValidRows = (rows: AutomationConditionRow[]): boolean =>
+  rows.some((row) => isConditionRowComplete(normalizeConditionRow(row)));
+
+const buildRuleFromRows = (rule: AutomationRule, rows: AutomationConditionRow[]): AutomationRule => ({
+  ...rule,
+  criteria: conditionRowsToCriteria(rows, rule.criteria.matchMode),
+  updatedAt: Date.now(),
+});
+
+export default function AutomationRulesModal({ isOpen, onClose }: AutomationRulesModalProps) {
   const images = useImageStore((state) => state.images);
   const automationRules = useImageStore((state) => state.automationRules);
   const collections = useImageStore((state) => state.collections);
   const availableTags = useImageStore((state) => state.availableTags);
+  const availableAutoTags = useImageStore((state) => state.availableAutoTags);
   const recentTags = useImageStore((state) => state.recentTags);
+  const availableModels = useImageStore((state) => state.availableModels);
+  const availableLoras = useImageStore((state) => state.availableLoras);
+  const availableSamplers = useImageStore((state) => state.availableSamplers);
+  const availableSchedulers = useImageStore((state) => state.availableSchedulers);
+  const availableGenerators = useImageStore((state) => state.availableGenerators);
+  const availableGpuDevices = useImageStore((state) => state.availableGpuDevices);
+  const availableDimensions = useImageStore((state) => state.availableDimensions);
   const selectedModels = useImageStore((state) => state.selectedModels);
   const excludedModels = useImageStore((state) => state.excludedModels);
   const selectedLoras = useImageStore((state) => state.selectedLoras);
@@ -157,8 +147,9 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
 
   const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
   const [draft, setDraft] = useState<AutomationRule>(() => createDraftRule());
+  const [rows, setRows] = useState<AutomationConditionRow[]>([]);
   const [tagInput, setTagInput] = useState('');
-  const [preview, setPreview] = useState({ matchCount: 0, changeCount: 0, tagChangeCount: 0, collectionChangeCount: 0 });
+  const [preview, setPreview] = useState<PreviewState>(emptyPreview);
   const [isApplying, setIsApplying] = useState(false);
 
   const collectionNames = useMemo(
@@ -166,131 +157,133 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
     [collections],
   );
 
+  const valueSource = useMemo(() => ({
+    images,
+    availableModels,
+    availableLoras,
+    availableSamplers,
+    availableSchedulers,
+    availableGenerators,
+    availableGpuDevices,
+    availableDimensions,
+    availableTags,
+    availableAutoTags,
+  }), [
+    availableAutoTags,
+    availableDimensions,
+    availableGenerators,
+    availableGpuDevices,
+    availableLoras,
+    availableModels,
+    availableSamplers,
+    availableSchedulers,
+    availableTags,
+    images,
+  ]);
+
+  const loadRuleForEditing = (rule: AutomationRule | null) => {
+    const nextRule = rule ?? createDraftRule();
+    setEditingRuleId(rule?.id ?? null);
+    setDraft(nextRule);
+    setRows(rule ? ruleToConditionRows(rule) : []);
+    setTagInput('');
+  };
+
   useEffect(() => {
     if (!isOpen) return;
-    if (automationRules.length > 0) {
-      const first = automationRules[0];
-      setEditingRuleId(first.id);
-      setDraft({ ...first, criteria: { ...first.criteria, filters: { ...first.criteria.filters } } });
-      return;
-    }
-    setEditingRuleId(null);
-    setDraft(createDraftRule());
+    loadRuleForEditing(automationRules[0] ?? null);
   }, [automationRules, isOpen]);
+
+  const ruleForPreview = useMemo(() => buildRuleFromRows(draft, rows), [draft, rows]);
 
   useEffect(() => {
     if (!isOpen) return;
     const timeoutId = window.setTimeout(() => {
-      setPreview(previewAutomationRule(draft));
+      setPreview(previewAutomationRule(ruleForPreview));
     }, 250);
     return () => window.clearTimeout(timeoutId);
-  }, [draft, images, isOpen, previewAutomationRule]);
+  }, [isOpen, previewAutomationRule, ruleForPreview]);
 
-  if (!isOpen) {
-    return null;
-  }
+  if (!isOpen) return null;
 
   const isExistingRule = editingRuleId !== null && automationRules.some((rule) => rule.id === editingRuleId);
   const activeRuleCount = automationRules.filter((rule) => rule.enabled).length;
+  const canSave = draft.name.trim().length > 0 && hasValidRows(rows) && hasActions(draft);
 
   const updateDraft = (updates: Partial<AutomationRule>) => {
     setDraft((current) => ({ ...current, ...updates, updatedAt: Date.now() }));
   };
 
-  const updateCriteria = (updates: Partial<AutomationRuleCriteria>) => {
-    setDraft((current) => ({
-      ...current,
-      criteria: { ...current.criteria, ...updates },
-      updatedAt: Date.now(),
-    }));
+  const addConditionRow = () => {
+    setRows((current) => [...current, createDefaultConditionRow()]);
   };
 
-  const updateFilters = (updates: Partial<AutomationRuleFilterCriteria>) => {
-    setDraft((current) => ({
-      ...current,
-      criteria: {
-        ...current.criteria,
-        filters: { ...current.criteria.filters, ...updates },
-      },
-      updatedAt: Date.now(),
-    }));
+  const updateConditionRow = (rowId: string, updates: Partial<AutomationConditionRow>) => {
+    setRows((current) =>
+      current.map((row) => {
+        if (row.id !== rowId) return row;
+        const fieldChanged = updates.field && updates.field !== row.field;
+        const nextField = updates.field ?? row.field;
+        return normalizeConditionRow({
+          ...row,
+          ...updates,
+          operator: fieldChanged ? getDefaultOperatorForField(nextField) : updates.operator ?? row.operator,
+          value: fieldChanged ? '' : updates.value ?? row.value,
+          valueEnd: fieldChanged ? '' : updates.valueEnd ?? row.valueEnd,
+        });
+      }),
+    );
   };
 
-  const updateTextCondition = (conditionId: string, updates: Partial<AutomationTextCondition>) => {
-    updateCriteria({
-      textConditions: draft.criteria.textConditions.map((condition) =>
-        condition.id === conditionId ? { ...condition, ...updates } : condition,
-      ),
+  const removeConditionRow = (rowId: string) => {
+    setRows((current) => current.filter((row) => row.id !== rowId));
+  };
+
+  const importCurrentFilters = () => {
+    const importedRows = filterCriteriaToConditionRows({
+      searchQuery,
+      models: selectedModels,
+      excludedModels,
+      loras: selectedLoras,
+      excludedLoras,
+      samplers: selectedSamplers,
+      excludedSamplers,
+      schedulers: selectedSchedulers,
+      excludedSchedulers,
+      generators: selectedGenerators,
+      excludedGenerators,
+      gpuDevices: selectedGpuDevices,
+      excludedGpuDevices,
+      tags: selectedTags,
+      excludedTags,
+      tagMatchMode: selectedTagsMatchMode,
+      autoTags: selectedAutoTags,
+      excludedAutoTags,
+      favoriteFilterMode,
+      ratings: selectedRatings,
+      advancedFilters,
     });
-  };
-
-  const addTextCondition = () => {
-    updateCriteria({
-      textConditions: [
-        ...draft.criteria.textConditions,
-        { id: createId(), field: 'prompt', operator: 'contains', value: '' },
-      ],
-    });
-  };
-
-  const removeTextCondition = (conditionId: string) => {
-    updateCriteria({
-      textConditions: draft.criteria.textConditions.filter((condition) => condition.id !== conditionId),
-    });
-  };
-
-  const useCurrentFilters = () => {
-    updateCriteria({
-      filters: {
-        searchQuery,
-        models: selectedModels,
-        excludedModels,
-        loras: selectedLoras,
-        excludedLoras,
-        samplers: selectedSamplers,
-        excludedSamplers,
-        schedulers: selectedSchedulers,
-        excludedSchedulers,
-        generators: selectedGenerators,
-        excludedGenerators,
-        gpuDevices: selectedGpuDevices,
-        excludedGpuDevices,
-        tags: selectedTags,
-        excludedTags,
-        tagMatchMode: selectedTagsMatchMode,
-        autoTags: selectedAutoTags,
-        excludedAutoTags,
-        favoriteFilterMode,
-        ratings: selectedRatings,
-        advancedFilters,
-      },
-    });
+    setRows(importedRows.length > 0 ? importedRows : [createDefaultConditionRow()]);
   };
 
   const handleSave = async (): Promise<AutomationRule | null> => {
+    if (!canSave) return null;
     const preparedRule = {
-      ...draft,
-      name: draft.name.trim() || 'Untitled Rule',
-      criteria: {
-        ...draft.criteria,
-        textConditions: draft.criteria.textConditions.filter((condition) => condition.value.trim()),
-      },
+      ...buildRuleFromRows(draft, rows),
+      name: draft.name.trim(),
     };
     const savedRule = isExistingRule
       ? await updateAutomationRule(editingRuleId as string, preparedRule)
       : await createAutomationRule(preparedRule);
-    if (savedRule) {
-      setEditingRuleId(savedRule.id);
-      setDraft(savedRule);
-    }
+    if (savedRule) loadRuleForEditing(savedRule);
     return savedRule;
   };
 
   const handleApply = async () => {
     setIsApplying(true);
     try {
-      const savedRule = isExistingRule ? draft : await handleSave();
-      const ruleId = isExistingRule ? editingRuleId : savedRule?.id;
+      const savedRule = isExistingRule ? await handleSave() : await handleSave();
+      const ruleId = savedRule?.id ?? editingRuleId;
       if (!ruleId) return;
       const result = await applyAutomationRuleNow(ruleId);
       if (result) setPreview(result);
@@ -300,8 +293,7 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
   };
 
   const handleDuplicate = (rule: AutomationRule) => {
-    setEditingRuleId(null);
-    setDraft({
+    const copy = {
       ...rule,
       id: createId(),
       name: `${rule.name} Copy`,
@@ -310,7 +302,10 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
       lastAppliedAt: null,
       lastMatchCount: 0,
       lastChangeCount: 0,
-    });
+    };
+    setEditingRuleId(null);
+    setDraft(copy);
+    setRows(ruleToConditionRows(rule));
   };
 
   const handleDelete = async (ruleId: string) => {
@@ -320,7 +315,12 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
   };
 
   const addTagsFromInput = (value: string) => {
-    const tags = csvToList(value, true);
+    const tags = Array.from(new Set(
+      value
+        .split(',')
+        .map((tag) => tag.trim().toLowerCase())
+        .filter(Boolean),
+    ));
     if (tags.length === 0) return;
     updateDraft({
       actions: {
@@ -355,14 +355,11 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
               </div>
               <button
                 type="button"
-                onClick={() => {
-                  setEditingRuleId(null);
-                  setDraft(createDraftRule());
-                }}
+                onClick={() => loadRuleForEditing(null)}
                 className="inline-flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-blue-500"
               >
                 <Plus className="h-4 w-4" />
-                New
+                New Rule
               </button>
             </div>
           </div>
@@ -376,27 +373,21 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
               automationRules.map((rule) => {
                 const isActive = editingRuleId === rule.id;
                 return (
-                  <div
+                  <button
                     key={rule.id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => {
-                      setEditingRuleId(rule.id);
-                      setDraft({ ...rule, criteria: { ...rule.criteria, filters: { ...rule.criteria.filters } } });
-                    }}
-                    className={`rounded-lg border p-3 text-left transition-colors ${
+                    type="button"
+                    onClick={() => loadRuleForEditing(rule)}
+                    className={`w-full rounded-lg border p-3 text-left transition-colors ${
                       isActive ? 'border-blue-500/50 bg-blue-500/10' : 'border-gray-800 bg-gray-900/60 hover:border-gray-700'
                     }`}
                   >
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0">
                         <div className="truncate text-sm font-medium text-gray-100">{rule.name}</div>
-                        <div className="mt-1 text-xs text-gray-500">{describeCriteria(rule.criteria)}</div>
+                        <div className="mt-1 text-xs text-gray-500">{describeCriteria(rule)}</div>
                       </div>
                       <span className={`rounded-full border px-2 py-0.5 text-[11px] ${
-                        rule.enabled
-                          ? 'border-emerald-700/50 bg-emerald-950/50 text-emerald-300'
-                          : 'border-gray-700 bg-gray-950 text-gray-500'
+                        rule.enabled ? 'border-emerald-700/50 bg-emerald-950/50 text-emerald-300' : 'border-gray-700 bg-gray-950 text-gray-500'
                       }`}>
                         {rule.enabled ? 'On' : 'Off'}
                       </span>
@@ -404,11 +395,7 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
                     <div className="mt-2 truncate text-xs text-gray-400" title={describeActions(rule, collectionNames)}>
                       {describeActions(rule, collectionNames)}
                     </div>
-                    <div className="mt-3 flex items-center justify-between text-[11px] text-gray-500">
-                      <span>{rule.lastMatchCount ?? 0} matches</span>
-                      <span>{rule.lastChangeCount ?? 0} changes</span>
-                    </div>
-                  </div>
+                  </button>
                 );
               })
             )}
@@ -419,7 +406,7 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
           <div className="flex items-center justify-between gap-3 border-b border-gray-800 px-5 py-4">
             <div>
               <h2 className="text-lg font-semibold text-white">{isExistingRule ? 'Edit Rule' : 'New Rule'}</h2>
-              <p className="mt-1 text-xs text-gray-500">Rules add tags or collection membership without removing existing curation.</p>
+              <p className="mt-1 text-xs text-gray-500">Build rules from simple rows: field, operator, value.</p>
             </div>
             <button type="button" onClick={onClose} className="rounded-lg p-2 text-gray-400 hover:bg-gray-800 hover:text-white">
               <X className="h-5 w-5" />
@@ -429,21 +416,16 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
           <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
               <div className="space-y-5">
-                <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_160px_180px]">
+                <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_170px_180px]">
                   <label>
                     <span className={labelClassName}>Name</span>
-                    <input
-                      value={draft.name}
-                      onChange={(event) => updateDraft({ name: event.target.value })}
-                      className={inputClassName}
-                      placeholder="Rule name"
-                    />
+                    <input value={draft.name} onChange={(event) => updateDraft({ name: event.target.value })} className={inputClassName} placeholder="Rule name" />
                   </label>
                   <label>
                     <span className={labelClassName}>Match</span>
                     <select
                       value={draft.criteria.matchMode}
-                      onChange={(event) => updateCriteria({ matchMode: event.target.value === 'any' ? 'any' : 'all' })}
+                      onChange={(event) => updateDraft({ criteria: conditionRowsToCriteria(rows, event.target.value === 'any' ? 'any' : 'all') })}
                       className={inputClassName}
                     >
                       <option value="all">All conditions</option>
@@ -451,54 +433,21 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
                     </select>
                   </label>
                   <label className="flex items-end gap-2 rounded-lg border border-gray-800 bg-gray-950/30 px-3 py-2">
-                    <input
-                      type="checkbox"
-                      checked={draft.enabled}
-                      onChange={(event) => updateDraft({ enabled: event.target.checked })}
-                      className="mb-1 h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-500 focus:ring-blue-500"
-                    />
+                    <input type="checkbox" checked={draft.enabled} onChange={(event) => updateDraft({ enabled: event.target.checked })} className="mb-1 h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-500 focus:ring-blue-500" />
                     <span className="pb-0.5 text-sm text-gray-200">Enabled</span>
                   </label>
                 </div>
 
-                <div>
-                  <div className="mb-2 flex items-center justify-between gap-3">
-                    <h3 className="text-sm font-semibold text-gray-100">Text conditions</h3>
-                    <button type="button" onClick={addTextCondition} className="rounded-lg border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800">
-                      Add condition
-                    </button>
-                  </div>
-
-                  <div className="space-y-2">
-                    {draft.criteria.textConditions.map((condition) => (
-                      <div key={condition.id} className="grid gap-2 md:grid-cols-[160px_170px_minmax(0,1fr)_40px]">
-                        <select value={condition.field} onChange={(event) => updateTextCondition(condition.id, { field: event.target.value as AutomationTextField })} className={inputClassName}>
-                          {TEXT_FIELDS.map((field) => <option key={field.value} value={field.value}>{field.label}</option>)}
-                        </select>
-                        <select value={condition.operator} onChange={(event) => updateTextCondition(condition.id, { operator: event.target.value as AutomationTextOperator })} className={inputClassName}>
-                          {TEXT_OPERATORS.map((operator) => <option key={operator.value} value={operator.value}>{operator.label}</option>)}
-                        </select>
-                        <input
-                          value={condition.value}
-                          onChange={(event) => updateTextCondition(condition.id, { value: event.target.value })}
-                          className={inputClassName}
-                          placeholder="cat, dog, CyberRealistic..."
-                        />
-                        <button type="button" onClick={() => removeTextCondition(condition.id)} className="rounded-lg border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-rose-300" title="Remove condition">
-                          <X className="mx-auto h-4 w-4" />
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                <RuleFilterEditor
-                  draft={draft}
-                  updateFilters={updateFilters}
-                  useCurrentFilters={useCurrentFilters}
+                <WhenBuilder
+                  rows={rows}
+                  valueSource={valueSource}
+                  onAdd={addConditionRow}
+                  onImport={importCurrentFilters}
+                  onUpdate={updateConditionRow}
+                  onRemove={removeConditionRow}
                 />
 
-                <RuleActionsEditor
+                <ThenActions
                   draft={draft}
                   tagInput={tagInput}
                   setTagInput={setTagInput}
@@ -511,16 +460,17 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
                 />
               </div>
 
-              <RulePreviewPanel
+              <PreviewPanel
                 preview={preview}
+                canSave={canSave}
                 isExistingRule={isExistingRule}
                 isApplying={isApplying}
                 draft={draft}
                 editingRuleId={editingRuleId}
-                handleSave={handleSave}
-                handleApply={handleApply}
-                handleDuplicate={handleDuplicate}
-                handleDelete={handleDelete}
+                onSave={handleSave}
+                onApply={handleApply}
+                onDuplicate={handleDuplicate}
+                onDelete={handleDelete}
                 updateAutomationRule={updateAutomationRule}
                 setDraft={setDraft}
               />
@@ -530,102 +480,202 @@ const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onC
       </div>
     </div>
   );
-};
-
-interface RuleFilterEditorProps {
-  draft: AutomationRule;
-  updateFilters: (updates: Partial<AutomationRuleFilterCriteria>) => void;
-  useCurrentFilters: () => void;
 }
 
-const RuleFilterEditor: React.FC<RuleFilterEditorProps> = ({ draft, updateFilters, useCurrentFilters }) => {
-  const textFilters: Array<[string, keyof AutomationRuleFilterCriteria, boolean]> = [
-    ['Checkpoints', 'models', false],
-    ['Exclude checkpoints', 'excludedModels', false],
-    ['LoRAs', 'loras', false],
-    ['Exclude LoRAs', 'excludedLoras', false],
-    ['Manual tags', 'tags', true],
-    ['Exclude manual tags', 'excludedTags', true],
-    ['Auto-tags', 'autoTags', false],
-    ['Exclude auto-tags', 'excludedAutoTags', false],
-    ['Samplers', 'samplers', false],
-    ['Schedulers', 'schedulers', false],
-  ];
+interface WhenBuilderProps {
+  rows: AutomationConditionRow[];
+  valueSource: Parameters<typeof getConditionValueOptions>[1];
+  onAdd: () => void;
+  onImport: () => void;
+  onUpdate: (rowId: string, updates: Partial<AutomationConditionRow>) => void;
+  onRemove: (rowId: string) => void;
+}
 
-  return (
-    <div>
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <h3 className="text-sm font-semibold text-gray-100">Filter criteria</h3>
-        <button
-          type="button"
-          onClick={useCurrentFilters}
-          className="inline-flex items-center gap-2 rounded-lg border border-blue-700/50 bg-blue-950/30 px-3 py-1.5 text-xs text-blue-200 hover:bg-blue-900/40"
-        >
-          <SlidersHorizontal className="h-3.5 w-3.5" />
-          Use Current Filters
+const WhenBuilder: React.FC<WhenBuilderProps> = ({ rows, valueSource, onAdd, onImport, onUpdate, onRemove }) => (
+  <section className="rounded-xl border border-gray-800 bg-gray-950/30 p-4">
+    <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h3 className="text-sm font-semibold text-gray-100">When</h3>
+        <p className="mt-1 text-xs text-gray-500">Add one line per condition.</p>
+      </div>
+      <div className="flex items-center gap-2">
+        <button type="button" onClick={onImport} className="rounded-lg border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800">
+          Import current sidebar filters
+        </button>
+        <button type="button" onClick={onAdd} className="inline-flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-500">
+          <Plus className="h-3.5 w-3.5" />
+          Add condition
         </button>
       </div>
+    </div>
 
-      <div className="grid gap-3 md:grid-cols-2">
-        {textFilters.map(([label, key, lower]) => (
-          <label key={String(key)}>
-            <span className={labelClassName}>{label}</span>
-            <input
-              value={listToCsv(draft.criteria.filters[key] as string[])}
-              onChange={(event) => updateFilters({ [key]: csvToList(event.target.value, lower) })}
-              className={inputClassName}
-              placeholder="Comma separated"
-            />
-          </label>
+    {rows.length === 0 ? (
+      <button
+        type="button"
+        onClick={onAdd}
+        className="flex w-full flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/40 px-4 py-10 text-center text-gray-400 transition-colors hover:border-blue-600/50 hover:bg-blue-950/20 hover:text-blue-200"
+      >
+        <Plus className="mb-2 h-6 w-6" />
+        <span className="text-sm font-medium">No conditions yet</span>
+        <span className="mt-1 text-xs text-gray-500">Add your first condition</span>
+      </button>
+    ) : (
+      <div className="space-y-2">
+        {rows.map((row) => (
+          <ConditionRowEditor
+            key={row.id}
+            row={row}
+            valueSource={valueSource}
+            onUpdate={(updates) => onUpdate(row.id, updates)}
+            onRemove={() => onRemove(row.id)}
+          />
         ))}
       </div>
+    )}
+  </section>
+);
 
-      <div className="mt-3 grid gap-3 md:grid-cols-3">
-        <label>
-          <span className={labelClassName}>Search query</span>
-          <input
-            value={draft.criteria.filters.searchQuery ?? ''}
-            onChange={(event) => updateFilters({ searchQuery: event.target.value })}
-            className={inputClassName}
+interface ConditionRowEditorProps {
+  row: AutomationConditionRow;
+  valueSource: Parameters<typeof getConditionValueOptions>[1];
+  onUpdate: (updates: Partial<AutomationConditionRow>) => void;
+  onRemove: () => void;
+}
+
+const ConditionRowEditor: React.FC<ConditionRowEditorProps> = ({ row, valueSource, onUpdate, onRemove }) => {
+  const fieldOptions = getConditionFieldOptions();
+  const operatorOptions = getOperatorsForField(row.field);
+  const valueOptions = getConditionValueOptions(row.field, valueSource);
+  const isText = TEXT_CONDITION_FIELDS.includes(row.field);
+  const isBoolean = row.field === 'favorite' || row.field === 'telemetry' || row.field === 'verifiedTelemetry';
+  const isBetween = row.operator === 'between';
+
+  return (
+    <div className="grid gap-2 rounded-lg border border-gray-800 bg-gray-900/50 p-2 md:grid-cols-[170px_170px_minmax(0,1fr)_40px]">
+      <select
+        aria-label="Condition field"
+        value={row.field}
+        onChange={(event) => onUpdate({ field: event.target.value as AutomationConditionField })}
+        className={compactInputClassName}
+      >
+        {fieldOptions.map((field) => <option key={field.value} value={field.value}>{field.label}</option>)}
+      </select>
+      <select
+        aria-label="Condition operator"
+        value={row.operator}
+        onChange={(event) => onUpdate({ operator: event.target.value as AutomationConditionOperator })}
+        className={compactInputClassName}
+      >
+        {operatorOptions.map((operator) => <option key={operator} value={operator}>{OPERATOR_LABELS[operator]}</option>)}
+      </select>
+
+      <div className={isBetween ? 'grid gap-2 sm:grid-cols-2' : ''}>
+        {isBoolean ? (
+          <div className="flex h-9 items-center rounded-lg border border-gray-700 bg-gray-800 px-3 text-sm text-gray-300">
+            {row.field === 'telemetry' ? 'present' : row.field === 'verifiedTelemetry' ? 'true' : 'favorite'}
+          </div>
+        ) : isText ? (
+          <SuggestInput
+            ariaLabel={`${CONDITION_FIELD_LABELS[row.field]} value`}
+            value={row.value}
+            options={valueOptions}
+            onChange={(value) => onUpdate({ value })}
+            placeholder="Type or choose..."
           />
-        </label>
-        <label>
-          <span className={labelClassName}>Favorite</span>
+        ) : valueOptions.length > 0 && !['steps', 'cfg'].includes(row.field) ? (
           <select
-            value={draft.criteria.filters.favoriteFilterMode ?? 'neutral'}
-            onChange={(event) => updateFilters({ favoriteFilterMode: event.target.value as 'neutral' | 'include' | 'exclude' })}
-            className={inputClassName}
+            aria-label={`${CONDITION_FIELD_LABELS[row.field]} value`}
+            value={row.value}
+            onChange={(event) => onUpdate({ value: event.target.value })}
+            className={compactInputClassName}
           >
-            <option value="neutral">Ignore</option>
-            <option value="include">Only favorites</option>
-            <option value="exclude">Exclude favorites</option>
+            <option value="">Choose...</option>
+            {valueOptions.map((value) => <option key={value} value={value}>{value}</option>)}
           </select>
-        </label>
-        <label>
-          <span className={labelClassName}>Ratings</span>
+        ) : (
           <input
-            value={(draft.criteria.filters.ratings ?? []).join(', ')}
-            onChange={(event) => updateFilters({
-              ratings: csvToList(event.target.value)
-                .map((value) => Number(value))
-                .filter((value): value is ImageRating => [1, 2, 3, 4, 5].includes(value)),
-            })}
-            className={inputClassName}
-            placeholder="1, 2, 3..."
+            aria-label={`${CONDITION_FIELD_LABELS[row.field]} value`}
+            type="number"
+            value={row.value}
+            onChange={(event) => onUpdate({ value: event.target.value })}
+            className={compactInputClassName}
+            placeholder="Value"
           />
-        </label>
+        )}
+
+        {isBetween && (
+          <input
+            aria-label={`${CONDITION_FIELD_LABELS[row.field]} end value`}
+            type="number"
+            value={row.valueEnd ?? ''}
+            onChange={(event) => onUpdate({ valueEnd: event.target.value })}
+            className={compactInputClassName}
+            placeholder="To"
+          />
+        )}
       </div>
 
-      {draft.criteria.filters.advancedFilters && Object.keys(draft.criteria.filters.advancedFilters as AdvancedFilters).length > 0 && (
-        <p className="mt-3 rounded-lg border border-gray-800 bg-gray-950/40 px-3 py-2 text-xs text-gray-400">
-          Advanced filters captured from the sidebar: {Object.keys(draft.criteria.filters.advancedFilters).join(', ')}
-        </p>
+      <button type="button" onClick={onRemove} className="h-9 rounded-lg border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-rose-300" title="Remove condition">
+        <X className="mx-auto h-4 w-4" />
+      </button>
+    </div>
+  );
+};
+
+interface SuggestInputProps {
+  value: string;
+  options: string[];
+  onChange: (value: string) => void;
+  placeholder: string;
+  ariaLabel: string;
+}
+
+const SuggestInput: React.FC<SuggestInputProps> = ({ value, options, onChange, placeholder, ariaLabel }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const filteredOptions = useMemo(() => {
+    const query = value.trim().toLowerCase();
+    return options
+      .filter((option) => !query || option.toLowerCase().includes(query))
+      .slice(0, 8);
+  }, [options, value]);
+
+  return (
+    <div className="relative">
+      <input
+        aria-label={ariaLabel}
+        value={value}
+        onChange={(event) => {
+          onChange(event.target.value);
+          setIsOpen(true);
+        }}
+        onFocus={() => setIsOpen(true)}
+        onBlur={() => window.setTimeout(() => setIsOpen(false), 120)}
+        className={compactInputClassName}
+        placeholder={placeholder}
+      />
+      {isOpen && filteredOptions.length > 0 && (
+        <div className="absolute z-20 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-gray-700 bg-gray-800 shadow-xl">
+          {filteredOptions.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => {
+                onChange(option);
+                setIsOpen(false);
+              }}
+              className="block w-full px-3 py-2 text-left text-sm text-gray-200 hover:bg-gray-700"
+            >
+              {option}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   );
 };
 
-interface RuleActionsEditorProps {
+interface ThenActionsProps {
   draft: AutomationRule;
   tagInput: string;
   setTagInput: (value: string) => void;
@@ -637,7 +687,7 @@ interface RuleActionsEditorProps {
   tagSuggestionLimit: number;
 }
 
-const RuleActionsEditor: React.FC<RuleActionsEditorProps> = ({
+const ThenActions: React.FC<ThenActionsProps> = ({
   draft,
   tagInput,
   setTagInput,
@@ -648,11 +698,13 @@ const RuleActionsEditor: React.FC<RuleActionsEditorProps> = ({
   availableTags,
   tagSuggestionLimit,
 }) => (
-  <div>
-    <h3 className="mb-2 text-sm font-semibold text-gray-100">Actions</h3>
-    <div className="space-y-3">
+  <section className="rounded-xl border border-gray-800 bg-gray-950/30 p-4">
+    <h3 className="text-sm font-semibold text-gray-100">Then</h3>
+    <p className="mt-1 text-xs text-gray-500">Choose what this rule adds.</p>
+
+    <div className="mt-4 space-y-4">
       <div>
-        <span className={labelClassName}>Add tags</span>
+        <span className={labelClassName}>Add tag</span>
         <TagInputCombobox
           value={tagInput}
           onValueChange={setTagInput}
@@ -661,10 +713,10 @@ const RuleActionsEditor: React.FC<RuleActionsEditorProps> = ({
           availableTags={availableTags}
           excludedTags={draft.actions.addTags}
           suggestionLimit={tagSuggestionLimit}
-          mode="csv"
-          placeholder="animal, realistic..."
+          mode="single"
+          placeholder="Add tag..."
           wrapperClassName="relative"
-          inputClassName={inputClassName}
+          inputClassName={`${inputClassName} pr-14`}
           trailingContent={
             <button
               type="button"
@@ -697,7 +749,7 @@ const RuleActionsEditor: React.FC<RuleActionsEditorProps> = ({
       </div>
 
       <div>
-        <span className={labelClassName}>Add to collections</span>
+        <span className={labelClassName}>Add to collection</span>
         <div className="max-h-40 space-y-2 overflow-y-auto rounded-lg border border-gray-800 bg-gray-950/40 p-2">
           {collections.length === 0 ? (
             <div className="px-2 py-3 text-center text-xs text-gray-500">No collections yet.</div>
@@ -736,37 +788,39 @@ const RuleActionsEditor: React.FC<RuleActionsEditorProps> = ({
         />
         <span>
           <span className="block text-sm text-gray-200">Run on new or updated images</span>
-          <span className="mt-1 block text-xs text-gray-500">Manual apply is always available from this modal.</span>
+          <span className="mt-1 block text-xs text-gray-500">Manual apply is always available.</span>
         </span>
       </label>
     </div>
-  </div>
+  </section>
 );
 
-interface RulePreviewPanelProps {
-  preview: { matchCount: number; changeCount: number; tagChangeCount: number; collectionChangeCount: number };
+interface PreviewPanelProps {
+  preview: PreviewState;
+  canSave: boolean;
   isExistingRule: boolean;
   isApplying: boolean;
   draft: AutomationRule;
   editingRuleId: string | null;
-  handleSave: () => Promise<AutomationRule | null>;
-  handleApply: () => Promise<void>;
-  handleDuplicate: (rule: AutomationRule) => void;
-  handleDelete: (ruleId: string) => Promise<void>;
+  onSave: () => Promise<AutomationRule | null>;
+  onApply: () => Promise<void>;
+  onDuplicate: (rule: AutomationRule) => void;
+  onDelete: (ruleId: string) => Promise<void>;
   updateAutomationRule: (ruleId: string, updates: Partial<Omit<AutomationRule, 'id' | 'createdAt'>>) => Promise<AutomationRule | null>;
   setDraft: (rule: AutomationRule) => void;
 }
 
-const RulePreviewPanel: React.FC<RulePreviewPanelProps> = ({
+const PreviewPanel: React.FC<PreviewPanelProps> = ({
   preview,
+  canSave,
   isExistingRule,
   isApplying,
   draft,
   editingRuleId,
-  handleSave,
-  handleApply,
-  handleDuplicate,
-  handleDelete,
+  onSave,
+  onApply,
+  onDuplicate,
+  onDelete,
   updateAutomationRule,
   setDraft,
 }) => (
@@ -791,21 +845,22 @@ const RulePreviewPanel: React.FC<RulePreviewPanelProps> = ({
     <div className="space-y-2">
       <button
         type="button"
-        onClick={() => void handleSave()}
-        disabled={!draft.name.trim()}
+        onClick={() => void onSave()}
+        disabled={!canSave}
         className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
       >
         Save Rule
       </button>
       <button
         type="button"
-        onClick={() => void handleApply()}
-        disabled={isApplying || !draft.name.trim()}
+        onClick={() => void onApply()}
+        disabled={isApplying || !canSave}
         className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-emerald-700/50 bg-emerald-950/40 px-4 py-2 text-sm font-semibold text-emerald-200 transition-colors hover:bg-emerald-900/40 disabled:cursor-not-allowed disabled:opacity-50"
       >
         <Play className="h-4 w-4" />
         {isApplying ? 'Applying...' : 'Apply Now'}
       </button>
+
       {isExistingRule && editingRuleId && (
         <>
           <button
@@ -822,7 +877,7 @@ const RulePreviewPanel: React.FC<RulePreviewPanelProps> = ({
           </button>
           <button
             type="button"
-            onClick={() => handleDuplicate(draft)}
+            onClick={() => onDuplicate(draft)}
             className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-gray-700 px-4 py-2 text-sm text-gray-200 transition-colors hover:bg-gray-800"
           >
             <Copy className="h-4 w-4" />
@@ -830,7 +885,7 @@ const RulePreviewPanel: React.FC<RulePreviewPanelProps> = ({
           </button>
           <button
             type="button"
-            onClick={() => void handleDelete(editingRuleId)}
+            onClick={() => void onDelete(editingRuleId)}
             className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-rose-900/50 px-4 py-2 text-sm text-rose-200 transition-colors hover:bg-rose-950/40"
           >
             <Trash2 className="h-4 w-4" />
@@ -841,5 +896,3 @@ const RulePreviewPanel: React.FC<RulePreviewPanelProps> = ({
     </div>
   </aside>
 );
-
-export default AutomationRulesModal;

--- a/components/AutomationRulesModal.tsx
+++ b/components/AutomationRulesModal.tsx
@@ -335,6 +335,8 @@ export default function AutomationRulesModal({
     const confirmed = window.confirm('Delete this rule? Existing tags and collection membership will stay in place.');
     if (!confirmed) return;
     await deleteAutomationRuleById(ruleId);
+    const nextRule = automationRules.find((rule) => rule.id !== ruleId) ?? null;
+    loadRuleForEditing(nextRule);
   };
 
   const addTagsFromInput = (value: string) => {

--- a/components/AutomationRulesModal.tsx
+++ b/components/AutomationRulesModal.tsx
@@ -429,7 +429,6 @@ export default function AutomationRulesModal({
           <div className="flex items-center justify-between gap-3 border-b border-gray-800 px-5 py-4">
             <div>
               <h2 className="text-lg font-semibold text-white">{isExistingRule ? 'Edit Rule' : 'New Rule'}</h2>
-              <p className="mt-1 text-xs text-gray-500">Build rules from simple rows: field, operator, value.</p>
             </div>
             <button type="button" onClick={onClose} className="rounded-lg p-2 text-gray-400 hover:bg-gray-800 hover:text-white">
               <X className="h-5 w-5" />
@@ -519,7 +518,6 @@ const WhenBuilder: React.FC<WhenBuilderProps> = ({ rows, valueSource, onAdd, onI
     <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
       <div>
         <h3 className="text-sm font-semibold text-gray-100">When</h3>
-        <p className="mt-1 text-xs text-gray-500">Add one line per condition.</p>
       </div>
       <div className="flex items-center gap-2">
         <button type="button" onClick={onImport} className="rounded-lg border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800">
@@ -671,7 +669,6 @@ const ThenActions: React.FC<ThenActionsProps> = ({
 }) => (
   <section className="rounded-xl border border-gray-800 bg-gray-950/30 p-4">
     <h3 className="text-sm font-semibold text-gray-100">Then</h3>
-    <p className="mt-1 text-xs text-gray-500">Choose what this rule adds.</p>
 
     <div className="mt-4 space-y-4">
       <div>
@@ -759,7 +756,6 @@ const ThenActions: React.FC<ThenActionsProps> = ({
         />
         <span>
           <span className="block text-sm text-gray-200">Run on new or updated images</span>
-          <span className="mt-1 block text-xs text-gray-500">Manual apply is always available.</span>
         </span>
       </label>
     </div>

--- a/components/AutomationRulesModal.tsx
+++ b/components/AutomationRulesModal.tsx
@@ -1,0 +1,845 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Copy, Play, Plus, Power, SlidersHorizontal, Trash2, X } from 'lucide-react';
+import type {
+  AdvancedFilters,
+  AutomationRule,
+  AutomationRuleCriteria,
+  AutomationRuleFilterCriteria,
+  AutomationTextCondition,
+  AutomationTextField,
+  AutomationTextOperator,
+  ImageRating,
+  SmartCollection,
+  TagInfo,
+} from '../types';
+import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+import TagInputCombobox from './TagInputCombobox';
+
+interface AutomationRulesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const TEXT_FIELDS: Array<{ value: AutomationTextField; label: string }> = [
+  { value: 'prompt', label: 'Prompt' },
+  { value: 'negativePrompt', label: 'Negative prompt' },
+  { value: 'filename', label: 'Filename' },
+  { value: 'metadata', label: 'Metadata' },
+];
+
+const TEXT_OPERATORS: Array<{ value: AutomationTextOperator; label: string }> = [
+  { value: 'contains', label: 'contains' },
+  { value: 'not_contains', label: 'does not contain' },
+  { value: 'equals', label: 'equals' },
+  { value: 'not_equals', label: 'does not equal' },
+];
+
+const createId = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `rule-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const csvToList = (value: string, lower = false): string[] =>
+  Array.from(
+    new Set(
+      value
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .map((item) => lower ? item.toLowerCase() : item),
+    ),
+  );
+
+const listToCsv = (value: string[] | undefined): string => (value ?? []).join(', ');
+
+const emptyCriteria = (): AutomationRuleCriteria => ({
+  matchMode: 'all',
+  textConditions: [{ id: createId(), field: 'prompt', operator: 'contains', value: '' }],
+  filters: {
+    tagMatchMode: 'any',
+    favoriteFilterMode: 'neutral',
+    advancedFilters: {},
+  },
+});
+
+const createDraftRule = (): AutomationRule => ({
+  id: createId(),
+  name: 'New Rule',
+  enabled: true,
+  criteria: emptyCriteria(),
+  actions: { addTags: [], addToCollectionIds: [] },
+  runOnNewImages: true,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  lastAppliedAt: null,
+  lastMatchCount: 0,
+  lastChangeCount: 0,
+});
+
+const describeCriteria = (criteria: AutomationRuleCriteria): string => {
+  const parts: string[] = [];
+  const textCount = criteria.textConditions.filter((condition) => condition.value.trim()).length;
+  if (textCount > 0) parts.push(`${textCount} text`);
+
+  const filters = criteria.filters;
+  const filterCount = [
+    filters.searchQuery,
+    ...(filters.models ?? []),
+    ...(filters.excludedModels ?? []),
+    ...(filters.loras ?? []),
+    ...(filters.excludedLoras ?? []),
+    ...(filters.samplers ?? []),
+    ...(filters.excludedSamplers ?? []),
+    ...(filters.schedulers ?? []),
+    ...(filters.excludedSchedulers ?? []),
+    ...(filters.tags ?? []),
+    ...(filters.excludedTags ?? []),
+    ...(filters.autoTags ?? []),
+    ...(filters.excludedAutoTags ?? []),
+  ].filter(Boolean).length;
+  if (filterCount > 0) parts.push(`${filterCount} filters`);
+  if (filters.favoriteFilterMode && filters.favoriteFilterMode !== 'neutral') parts.push('favorite');
+  if (filters.ratings?.length) parts.push('rating');
+  if (filters.advancedFilters && Object.keys(filters.advancedFilters).length > 0) parts.push('advanced');
+
+  return parts.length > 0 ? parts.join(' + ') : 'No criteria yet';
+};
+
+const describeActions = (rule: AutomationRule, collectionNames: Map<string, string>): string => {
+  const parts: string[] = [];
+  if (rule.actions.addTags.length > 0) {
+    parts.push(`tags: ${rule.actions.addTags.join(', ')}`);
+  }
+  if (rule.actions.addToCollectionIds.length > 0) {
+    parts.push(`collections: ${rule.actions.addToCollectionIds.map((id) => collectionNames.get(id) ?? id).join(', ')}`);
+  }
+  return parts.length > 0 ? parts.join(' | ') : 'No actions yet';
+};
+
+const inputClassName =
+  'w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500';
+const labelClassName = 'mb-1 block text-xs font-medium uppercase tracking-wide text-gray-400';
+
+const AutomationRulesModal: React.FC<AutomationRulesModalProps> = ({ isOpen, onClose }) => {
+  const images = useImageStore((state) => state.images);
+  const automationRules = useImageStore((state) => state.automationRules);
+  const collections = useImageStore((state) => state.collections);
+  const availableTags = useImageStore((state) => state.availableTags);
+  const recentTags = useImageStore((state) => state.recentTags);
+  const selectedModels = useImageStore((state) => state.selectedModels);
+  const excludedModels = useImageStore((state) => state.excludedModels);
+  const selectedLoras = useImageStore((state) => state.selectedLoras);
+  const excludedLoras = useImageStore((state) => state.excludedLoras);
+  const selectedSamplers = useImageStore((state) => state.selectedSamplers);
+  const excludedSamplers = useImageStore((state) => state.excludedSamplers);
+  const selectedSchedulers = useImageStore((state) => state.selectedSchedulers);
+  const excludedSchedulers = useImageStore((state) => state.excludedSchedulers);
+  const selectedGenerators = useImageStore((state) => state.selectedGenerators);
+  const excludedGenerators = useImageStore((state) => state.excludedGenerators);
+  const selectedGpuDevices = useImageStore((state) => state.selectedGpuDevices);
+  const excludedGpuDevices = useImageStore((state) => state.excludedGpuDevices);
+  const selectedTags = useImageStore((state) => state.selectedTags);
+  const excludedTags = useImageStore((state) => state.excludedTags);
+  const selectedTagsMatchMode = useImageStore((state) => state.selectedTagsMatchMode);
+  const selectedAutoTags = useImageStore((state) => state.selectedAutoTags);
+  const excludedAutoTags = useImageStore((state) => state.excludedAutoTags);
+  const favoriteFilterMode = useImageStore((state) => state.favoriteFilterMode);
+  const selectedRatings = useImageStore((state) => state.selectedRatings);
+  const searchQuery = useImageStore((state) => state.searchQuery);
+  const advancedFilters = useImageStore((state) => state.advancedFilters);
+  const createAutomationRule = useImageStore((state) => state.createAutomationRule);
+  const updateAutomationRule = useImageStore((state) => state.updateAutomationRule);
+  const deleteAutomationRuleById = useImageStore((state) => state.deleteAutomationRuleById);
+  const previewAutomationRule = useImageStore((state) => state.previewAutomationRule);
+  const applyAutomationRuleNow = useImageStore((state) => state.applyAutomationRuleNow);
+  const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
+
+  const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<AutomationRule>(() => createDraftRule());
+  const [tagInput, setTagInput] = useState('');
+  const [preview, setPreview] = useState({ matchCount: 0, changeCount: 0, tagChangeCount: 0, collectionChangeCount: 0 });
+  const [isApplying, setIsApplying] = useState(false);
+
+  const collectionNames = useMemo(
+    () => new Map(collections.map((collection) => [collection.id, collection.name])),
+    [collections],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (automationRules.length > 0) {
+      const first = automationRules[0];
+      setEditingRuleId(first.id);
+      setDraft({ ...first, criteria: { ...first.criteria, filters: { ...first.criteria.filters } } });
+      return;
+    }
+    setEditingRuleId(null);
+    setDraft(createDraftRule());
+  }, [automationRules, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const timeoutId = window.setTimeout(() => {
+      setPreview(previewAutomationRule(draft));
+    }, 250);
+    return () => window.clearTimeout(timeoutId);
+  }, [draft, images, isOpen, previewAutomationRule]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const isExistingRule = editingRuleId !== null && automationRules.some((rule) => rule.id === editingRuleId);
+  const activeRuleCount = automationRules.filter((rule) => rule.enabled).length;
+
+  const updateDraft = (updates: Partial<AutomationRule>) => {
+    setDraft((current) => ({ ...current, ...updates, updatedAt: Date.now() }));
+  };
+
+  const updateCriteria = (updates: Partial<AutomationRuleCriteria>) => {
+    setDraft((current) => ({
+      ...current,
+      criteria: { ...current.criteria, ...updates },
+      updatedAt: Date.now(),
+    }));
+  };
+
+  const updateFilters = (updates: Partial<AutomationRuleFilterCriteria>) => {
+    setDraft((current) => ({
+      ...current,
+      criteria: {
+        ...current.criteria,
+        filters: { ...current.criteria.filters, ...updates },
+      },
+      updatedAt: Date.now(),
+    }));
+  };
+
+  const updateTextCondition = (conditionId: string, updates: Partial<AutomationTextCondition>) => {
+    updateCriteria({
+      textConditions: draft.criteria.textConditions.map((condition) =>
+        condition.id === conditionId ? { ...condition, ...updates } : condition,
+      ),
+    });
+  };
+
+  const addTextCondition = () => {
+    updateCriteria({
+      textConditions: [
+        ...draft.criteria.textConditions,
+        { id: createId(), field: 'prompt', operator: 'contains', value: '' },
+      ],
+    });
+  };
+
+  const removeTextCondition = (conditionId: string) => {
+    updateCriteria({
+      textConditions: draft.criteria.textConditions.filter((condition) => condition.id !== conditionId),
+    });
+  };
+
+  const useCurrentFilters = () => {
+    updateCriteria({
+      filters: {
+        searchQuery,
+        models: selectedModels,
+        excludedModels,
+        loras: selectedLoras,
+        excludedLoras,
+        samplers: selectedSamplers,
+        excludedSamplers,
+        schedulers: selectedSchedulers,
+        excludedSchedulers,
+        generators: selectedGenerators,
+        excludedGenerators,
+        gpuDevices: selectedGpuDevices,
+        excludedGpuDevices,
+        tags: selectedTags,
+        excludedTags,
+        tagMatchMode: selectedTagsMatchMode,
+        autoTags: selectedAutoTags,
+        excludedAutoTags,
+        favoriteFilterMode,
+        ratings: selectedRatings,
+        advancedFilters,
+      },
+    });
+  };
+
+  const handleSave = async (): Promise<AutomationRule | null> => {
+    const preparedRule = {
+      ...draft,
+      name: draft.name.trim() || 'Untitled Rule',
+      criteria: {
+        ...draft.criteria,
+        textConditions: draft.criteria.textConditions.filter((condition) => condition.value.trim()),
+      },
+    };
+    const savedRule = isExistingRule
+      ? await updateAutomationRule(editingRuleId as string, preparedRule)
+      : await createAutomationRule(preparedRule);
+    if (savedRule) {
+      setEditingRuleId(savedRule.id);
+      setDraft(savedRule);
+    }
+    return savedRule;
+  };
+
+  const handleApply = async () => {
+    setIsApplying(true);
+    try {
+      const savedRule = isExistingRule ? draft : await handleSave();
+      const ruleId = isExistingRule ? editingRuleId : savedRule?.id;
+      if (!ruleId) return;
+      const result = await applyAutomationRuleNow(ruleId);
+      if (result) setPreview(result);
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  const handleDuplicate = (rule: AutomationRule) => {
+    setEditingRuleId(null);
+    setDraft({
+      ...rule,
+      id: createId(),
+      name: `${rule.name} Copy`,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      lastAppliedAt: null,
+      lastMatchCount: 0,
+      lastChangeCount: 0,
+    });
+  };
+
+  const handleDelete = async (ruleId: string) => {
+    const confirmed = window.confirm('Delete this rule? Existing tags and collection membership will stay in place.');
+    if (!confirmed) return;
+    await deleteAutomationRuleById(ruleId);
+  };
+
+  const addTagsFromInput = (value: string) => {
+    const tags = csvToList(value, true);
+    if (tags.length === 0) return;
+    updateDraft({
+      actions: {
+        ...draft.actions,
+        addTags: Array.from(new Set([...draft.actions.addTags, ...tags])),
+      },
+    });
+    setTagInput('');
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/75 px-4 backdrop-blur-sm"
+      onClick={onClose}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Automation rules"
+        className="flex h-[86vh] w-full max-w-6xl overflow-hidden rounded-xl border border-gray-700 bg-gray-900 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <aside className="flex w-80 flex-shrink-0 flex-col border-r border-gray-800 bg-gray-950/50">
+          <div className="border-b border-gray-800 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold text-white">Rules</h2>
+                <p className="mt-1 text-xs text-gray-500">{activeRuleCount} active of {automationRules.length}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingRuleId(null);
+                  setDraft(createDraftRule());
+                }}
+                className="inline-flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-blue-500"
+              >
+                <Plus className="h-4 w-4" />
+                New
+              </button>
+            </div>
+          </div>
+
+          <div className="flex-1 space-y-2 overflow-y-auto p-3">
+            {automationRules.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-gray-700 px-3 py-8 text-center text-sm text-gray-500">
+                No rules yet.
+              </div>
+            ) : (
+              automationRules.map((rule) => {
+                const isActive = editingRuleId === rule.id;
+                return (
+                  <div
+                    key={rule.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => {
+                      setEditingRuleId(rule.id);
+                      setDraft({ ...rule, criteria: { ...rule.criteria, filters: { ...rule.criteria.filters } } });
+                    }}
+                    className={`rounded-lg border p-3 text-left transition-colors ${
+                      isActive ? 'border-blue-500/50 bg-blue-500/10' : 'border-gray-800 bg-gray-900/60 hover:border-gray-700'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-gray-100">{rule.name}</div>
+                        <div className="mt-1 text-xs text-gray-500">{describeCriteria(rule.criteria)}</div>
+                      </div>
+                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${
+                        rule.enabled
+                          ? 'border-emerald-700/50 bg-emerald-950/50 text-emerald-300'
+                          : 'border-gray-700 bg-gray-950 text-gray-500'
+                      }`}>
+                        {rule.enabled ? 'On' : 'Off'}
+                      </span>
+                    </div>
+                    <div className="mt-2 truncate text-xs text-gray-400" title={describeActions(rule, collectionNames)}>
+                      {describeActions(rule, collectionNames)}
+                    </div>
+                    <div className="mt-3 flex items-center justify-between text-[11px] text-gray-500">
+                      <span>{rule.lastMatchCount ?? 0} matches</span>
+                      <span>{rule.lastChangeCount ?? 0} changes</span>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </aside>
+
+        <section className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center justify-between gap-3 border-b border-gray-800 px-5 py-4">
+            <div>
+              <h2 className="text-lg font-semibold text-white">{isExistingRule ? 'Edit Rule' : 'New Rule'}</h2>
+              <p className="mt-1 text-xs text-gray-500">Rules add tags or collection membership without removing existing curation.</p>
+            </div>
+            <button type="button" onClick={onClose} className="rounded-lg p-2 text-gray-400 hover:bg-gray-800 hover:text-white">
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+              <div className="space-y-5">
+                <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_160px_180px]">
+                  <label>
+                    <span className={labelClassName}>Name</span>
+                    <input
+                      value={draft.name}
+                      onChange={(event) => updateDraft({ name: event.target.value })}
+                      className={inputClassName}
+                      placeholder="Rule name"
+                    />
+                  </label>
+                  <label>
+                    <span className={labelClassName}>Match</span>
+                    <select
+                      value={draft.criteria.matchMode}
+                      onChange={(event) => updateCriteria({ matchMode: event.target.value === 'any' ? 'any' : 'all' })}
+                      className={inputClassName}
+                    >
+                      <option value="all">All conditions</option>
+                      <option value="any">Any condition</option>
+                    </select>
+                  </label>
+                  <label className="flex items-end gap-2 rounded-lg border border-gray-800 bg-gray-950/30 px-3 py-2">
+                    <input
+                      type="checkbox"
+                      checked={draft.enabled}
+                      onChange={(event) => updateDraft({ enabled: event.target.checked })}
+                      className="mb-1 h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-500 focus:ring-blue-500"
+                    />
+                    <span className="pb-0.5 text-sm text-gray-200">Enabled</span>
+                  </label>
+                </div>
+
+                <div>
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <h3 className="text-sm font-semibold text-gray-100">Text conditions</h3>
+                    <button type="button" onClick={addTextCondition} className="rounded-lg border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800">
+                      Add condition
+                    </button>
+                  </div>
+
+                  <div className="space-y-2">
+                    {draft.criteria.textConditions.map((condition) => (
+                      <div key={condition.id} className="grid gap-2 md:grid-cols-[160px_170px_minmax(0,1fr)_40px]">
+                        <select value={condition.field} onChange={(event) => updateTextCondition(condition.id, { field: event.target.value as AutomationTextField })} className={inputClassName}>
+                          {TEXT_FIELDS.map((field) => <option key={field.value} value={field.value}>{field.label}</option>)}
+                        </select>
+                        <select value={condition.operator} onChange={(event) => updateTextCondition(condition.id, { operator: event.target.value as AutomationTextOperator })} className={inputClassName}>
+                          {TEXT_OPERATORS.map((operator) => <option key={operator.value} value={operator.value}>{operator.label}</option>)}
+                        </select>
+                        <input
+                          value={condition.value}
+                          onChange={(event) => updateTextCondition(condition.id, { value: event.target.value })}
+                          className={inputClassName}
+                          placeholder="cat, dog, CyberRealistic..."
+                        />
+                        <button type="button" onClick={() => removeTextCondition(condition.id)} className="rounded-lg border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-rose-300" title="Remove condition">
+                          <X className="mx-auto h-4 w-4" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <RuleFilterEditor
+                  draft={draft}
+                  updateFilters={updateFilters}
+                  useCurrentFilters={useCurrentFilters}
+                />
+
+                <RuleActionsEditor
+                  draft={draft}
+                  tagInput={tagInput}
+                  setTagInput={setTagInput}
+                  addTagsFromInput={addTagsFromInput}
+                  updateDraft={updateDraft}
+                  collections={collections}
+                  recentTags={recentTags}
+                  availableTags={availableTags}
+                  tagSuggestionLimit={tagSuggestionLimit}
+                />
+              </div>
+
+              <RulePreviewPanel
+                preview={preview}
+                isExistingRule={isExistingRule}
+                isApplying={isApplying}
+                draft={draft}
+                editingRuleId={editingRuleId}
+                handleSave={handleSave}
+                handleApply={handleApply}
+                handleDuplicate={handleDuplicate}
+                handleDelete={handleDelete}
+                updateAutomationRule={updateAutomationRule}
+                setDraft={setDraft}
+              />
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+interface RuleFilterEditorProps {
+  draft: AutomationRule;
+  updateFilters: (updates: Partial<AutomationRuleFilterCriteria>) => void;
+  useCurrentFilters: () => void;
+}
+
+const RuleFilterEditor: React.FC<RuleFilterEditorProps> = ({ draft, updateFilters, useCurrentFilters }) => {
+  const textFilters: Array<[string, keyof AutomationRuleFilterCriteria, boolean]> = [
+    ['Checkpoints', 'models', false],
+    ['Exclude checkpoints', 'excludedModels', false],
+    ['LoRAs', 'loras', false],
+    ['Exclude LoRAs', 'excludedLoras', false],
+    ['Manual tags', 'tags', true],
+    ['Exclude manual tags', 'excludedTags', true],
+    ['Auto-tags', 'autoTags', false],
+    ['Exclude auto-tags', 'excludedAutoTags', false],
+    ['Samplers', 'samplers', false],
+    ['Schedulers', 'schedulers', false],
+  ];
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-gray-100">Filter criteria</h3>
+        <button
+          type="button"
+          onClick={useCurrentFilters}
+          className="inline-flex items-center gap-2 rounded-lg border border-blue-700/50 bg-blue-950/30 px-3 py-1.5 text-xs text-blue-200 hover:bg-blue-900/40"
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          Use Current Filters
+        </button>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {textFilters.map(([label, key, lower]) => (
+          <label key={String(key)}>
+            <span className={labelClassName}>{label}</span>
+            <input
+              value={listToCsv(draft.criteria.filters[key] as string[])}
+              onChange={(event) => updateFilters({ [key]: csvToList(event.target.value, lower) })}
+              className={inputClassName}
+              placeholder="Comma separated"
+            />
+          </label>
+        ))}
+      </div>
+
+      <div className="mt-3 grid gap-3 md:grid-cols-3">
+        <label>
+          <span className={labelClassName}>Search query</span>
+          <input
+            value={draft.criteria.filters.searchQuery ?? ''}
+            onChange={(event) => updateFilters({ searchQuery: event.target.value })}
+            className={inputClassName}
+          />
+        </label>
+        <label>
+          <span className={labelClassName}>Favorite</span>
+          <select
+            value={draft.criteria.filters.favoriteFilterMode ?? 'neutral'}
+            onChange={(event) => updateFilters({ favoriteFilterMode: event.target.value as 'neutral' | 'include' | 'exclude' })}
+            className={inputClassName}
+          >
+            <option value="neutral">Ignore</option>
+            <option value="include">Only favorites</option>
+            <option value="exclude">Exclude favorites</option>
+          </select>
+        </label>
+        <label>
+          <span className={labelClassName}>Ratings</span>
+          <input
+            value={(draft.criteria.filters.ratings ?? []).join(', ')}
+            onChange={(event) => updateFilters({
+              ratings: csvToList(event.target.value)
+                .map((value) => Number(value))
+                .filter((value): value is ImageRating => [1, 2, 3, 4, 5].includes(value)),
+            })}
+            className={inputClassName}
+            placeholder="1, 2, 3..."
+          />
+        </label>
+      </div>
+
+      {draft.criteria.filters.advancedFilters && Object.keys(draft.criteria.filters.advancedFilters as AdvancedFilters).length > 0 && (
+        <p className="mt-3 rounded-lg border border-gray-800 bg-gray-950/40 px-3 py-2 text-xs text-gray-400">
+          Advanced filters captured from the sidebar: {Object.keys(draft.criteria.filters.advancedFilters).join(', ')}
+        </p>
+      )}
+    </div>
+  );
+};
+
+interface RuleActionsEditorProps {
+  draft: AutomationRule;
+  tagInput: string;
+  setTagInput: (value: string) => void;
+  addTagsFromInput: (value: string) => void;
+  updateDraft: (updates: Partial<AutomationRule>) => void;
+  collections: SmartCollection[];
+  recentTags: string[];
+  availableTags: TagInfo[];
+  tagSuggestionLimit: number;
+}
+
+const RuleActionsEditor: React.FC<RuleActionsEditorProps> = ({
+  draft,
+  tagInput,
+  setTagInput,
+  addTagsFromInput,
+  updateDraft,
+  collections,
+  recentTags,
+  availableTags,
+  tagSuggestionLimit,
+}) => (
+  <div>
+    <h3 className="mb-2 text-sm font-semibold text-gray-100">Actions</h3>
+    <div className="space-y-3">
+      <div>
+        <span className={labelClassName}>Add tags</span>
+        <TagInputCombobox
+          value={tagInput}
+          onValueChange={setTagInput}
+          onSubmit={addTagsFromInput}
+          recentTags={recentTags}
+          availableTags={availableTags}
+          excludedTags={draft.actions.addTags}
+          suggestionLimit={tagSuggestionLimit}
+          mode="csv"
+          placeholder="animal, realistic..."
+          wrapperClassName="relative"
+          inputClassName={inputClassName}
+          trailingContent={
+            <button
+              type="button"
+              onClick={() => addTagsFromInput(tagInput)}
+              className="absolute right-1.5 top-1.5 rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-500"
+            >
+              Add
+            </button>
+          }
+        />
+        {draft.actions.addTags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {draft.actions.addTags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => updateDraft({
+                  actions: {
+                    ...draft.actions,
+                    addTags: draft.actions.addTags.filter((value) => value !== tag),
+                  },
+                })}
+                className="rounded-full border border-blue-700/40 bg-blue-950/40 px-2 py-1 text-xs text-blue-200 hover:border-rose-500/50 hover:text-rose-200"
+              >
+                {tag} x
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <span className={labelClassName}>Add to collections</span>
+        <div className="max-h-40 space-y-2 overflow-y-auto rounded-lg border border-gray-800 bg-gray-950/40 p-2">
+          {collections.length === 0 ? (
+            <div className="px-2 py-3 text-center text-xs text-gray-500">No collections yet.</div>
+          ) : (
+            collections.map((collection) => {
+              const checked = draft.actions.addToCollectionIds.includes(collection.id);
+              return (
+                <label key={collection.id} className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 text-sm text-gray-200 hover:bg-gray-800/50">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(event) => updateDraft({
+                      actions: {
+                        ...draft.actions,
+                        addToCollectionIds: event.target.checked
+                          ? [...draft.actions.addToCollectionIds, collection.id]
+                          : draft.actions.addToCollectionIds.filter((id) => id !== collection.id),
+                      },
+                    })}
+                    className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-500 focus:ring-blue-500"
+                  />
+                  <span className="truncate">{collection.name}</span>
+                </label>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      <label className="flex items-start gap-3 rounded-lg border border-gray-800 bg-gray-950/40 px-3 py-3">
+        <input
+          type="checkbox"
+          checked={draft.runOnNewImages}
+          onChange={(event) => updateDraft({ runOnNewImages: event.target.checked })}
+          className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-500 focus:ring-blue-500"
+        />
+        <span>
+          <span className="block text-sm text-gray-200">Run on new or updated images</span>
+          <span className="mt-1 block text-xs text-gray-500">Manual apply is always available from this modal.</span>
+        </span>
+      </label>
+    </div>
+  </div>
+);
+
+interface RulePreviewPanelProps {
+  preview: { matchCount: number; changeCount: number; tagChangeCount: number; collectionChangeCount: number };
+  isExistingRule: boolean;
+  isApplying: boolean;
+  draft: AutomationRule;
+  editingRuleId: string | null;
+  handleSave: () => Promise<AutomationRule | null>;
+  handleApply: () => Promise<void>;
+  handleDuplicate: (rule: AutomationRule) => void;
+  handleDelete: (ruleId: string) => Promise<void>;
+  updateAutomationRule: (ruleId: string, updates: Partial<Omit<AutomationRule, 'id' | 'createdAt'>>) => Promise<AutomationRule | null>;
+  setDraft: (rule: AutomationRule) => void;
+}
+
+const RulePreviewPanel: React.FC<RulePreviewPanelProps> = ({
+  preview,
+  isExistingRule,
+  isApplying,
+  draft,
+  editingRuleId,
+  handleSave,
+  handleApply,
+  handleDuplicate,
+  handleDelete,
+  updateAutomationRule,
+  setDraft,
+}) => (
+  <aside className="space-y-3">
+    <div className="rounded-lg border border-gray-800 bg-gray-950/50 p-4">
+      <h3 className="text-sm font-semibold text-gray-100">Preview</h3>
+      <div className="mt-3 grid grid-cols-2 gap-2 text-center">
+        <div className="rounded-lg border border-gray-800 bg-gray-900 px-3 py-3">
+          <div className="text-lg font-semibold text-white">{preview.matchCount}</div>
+          <div className="text-[11px] uppercase tracking-wide text-gray-500">matches</div>
+        </div>
+        <div className="rounded-lg border border-gray-800 bg-gray-900 px-3 py-3">
+          <div className="text-lg font-semibold text-white">{preview.changeCount}</div>
+          <div className="text-[11px] uppercase tracking-wide text-gray-500">changes</div>
+        </div>
+      </div>
+      <p className="mt-3 text-xs text-gray-500">
+        {preview.tagChangeCount} tag additions, {preview.collectionChangeCount} collection additions.
+      </p>
+    </div>
+
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => void handleSave()}
+        disabled={!draft.name.trim()}
+        className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Save Rule
+      </button>
+      <button
+        type="button"
+        onClick={() => void handleApply()}
+        disabled={isApplying || !draft.name.trim()}
+        className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-emerald-700/50 bg-emerald-950/40 px-4 py-2 text-sm font-semibold text-emerald-200 transition-colors hover:bg-emerald-900/40 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Play className="h-4 w-4" />
+        {isApplying ? 'Applying...' : 'Apply Now'}
+      </button>
+      {isExistingRule && editingRuleId && (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              void updateAutomationRule(editingRuleId, { enabled: !draft.enabled }).then((rule) => {
+                if (rule) setDraft(rule);
+              });
+            }}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-gray-700 px-4 py-2 text-sm text-gray-200 transition-colors hover:bg-gray-800"
+          >
+            <Power className="h-4 w-4" />
+            {draft.enabled ? 'Disable Rule' : 'Enable Rule'}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleDuplicate(draft)}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-gray-700 px-4 py-2 text-sm text-gray-200 transition-colors hover:bg-gray-800"
+          >
+            <Copy className="h-4 w-4" />
+            Duplicate
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleDelete(editingRuleId)}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-rose-900/50 px-4 py-2 text-sm text-rose-200 transition-colors hover:bg-rose-950/40"
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete
+          </button>
+        </>
+      )}
+    </div>
+  </aside>
+);
+
+export default AutomationRulesModal;

--- a/components/AutomationRulesModal.tsx
+++ b/components/AutomationRulesModal.tsx
@@ -253,6 +253,7 @@ export default function AutomationRulesModal({
           operator: fieldChanged ? getDefaultOperatorForField(nextField) : updates.operator ?? row.operator,
           value: fieldChanged ? '' : updates.value ?? row.value,
           valueEnd: fieldChanged ? '' : updates.valueEnd ?? row.valueEnd,
+          groupMode: fieldChanged ? undefined : updates.groupMode ?? row.groupMode,
         });
       }),
     );

--- a/components/AutomationRulesModal.tsx
+++ b/components/AutomationRulesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Copy, Play, Plus, Power, Trash2, X } from 'lucide-react';
 import type {
   AutomationConditionField,
@@ -30,6 +30,8 @@ import {
 interface AutomationRulesModalProps {
   isOpen: boolean;
   onClose: () => void;
+  initialCollectionId?: string | null;
+  initialRuleName?: string;
 }
 
 type PreviewState = {
@@ -103,7 +105,12 @@ const buildRuleFromRows = (rule: AutomationRule, rows: AutomationConditionRow[])
   updatedAt: Date.now(),
 });
 
-export default function AutomationRulesModal({ isOpen, onClose }: AutomationRulesModalProps) {
+export default function AutomationRulesModal({
+  isOpen,
+  onClose,
+  initialCollectionId = null,
+  initialRuleName,
+}: AutomationRulesModalProps) {
   const images = useImageStore((state) => state.images);
   const automationRules = useImageStore((state) => state.automationRules);
   const collections = useImageStore((state) => state.collections);
@@ -151,6 +158,7 @@ export default function AutomationRulesModal({ isOpen, onClose }: AutomationRule
   const [tagInput, setTagInput] = useState('');
   const [preview, setPreview] = useState<PreviewState>(emptyPreview);
   const [isApplying, setIsApplying] = useState(false);
+  const didInitializeForOpenRef = useRef(false);
 
   const collectionNames = useMemo(
     () => new Map(collections.map((collection) => [collection.id, collection.name])),
@@ -190,9 +198,24 @@ export default function AutomationRulesModal({ isOpen, onClose }: AutomationRule
   };
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      didInitializeForOpenRef.current = false;
+      return;
+    }
+    if (didInitializeForOpenRef.current) return;
+    didInitializeForOpenRef.current = true;
+    if (initialCollectionId) {
+      const nextRule = createDraftRule();
+      nextRule.name = initialRuleName ?? 'New Collection Rule';
+      nextRule.actions.addToCollectionIds = [initialCollectionId];
+      setEditingRuleId(null);
+      setDraft(nextRule);
+      setRows([]);
+      setTagInput('');
+      return;
+    }
     loadRuleForEditing(automationRules[0] ?? null);
-  }, [automationRules, isOpen]);
+  }, [automationRules, initialCollectionId, initialRuleName, isOpen]);
 
   const ruleForPreview = useMemo(() => buildRuleFromRows(draft, rows), [draft, rows]);
 

--- a/components/CollectionFormModal.tsx
+++ b/components/CollectionFormModal.tsx
@@ -7,6 +7,7 @@ export interface CollectionFormValues {
   sourceTag: string;
   autoUpdate: boolean;
   includeTargetImages: boolean;
+  configureAutomationRules?: boolean;
 }
 
 interface CollectionFormModalProps {
@@ -22,6 +23,7 @@ interface CollectionFormModalProps {
   showAutoUpdate?: boolean;
   showIncludeTargetImages?: boolean;
   includeTargetImagesLabel?: string;
+  showAutomationRulesOption?: boolean;
 }
 
 const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
@@ -37,6 +39,7 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
   showAutoUpdate = false,
   showIncludeTargetImages = false,
   includeTargetImagesLabel = 'Add the current images now',
+  showAutomationRulesOption = false,
 }) => {
   const {
     name: initialName,
@@ -52,8 +55,10 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
     sourceTag: initialSourceTag,
     autoUpdate: initialAutoUpdate,
     includeTargetImages: initialIncludeTargetImages,
+    configureAutomationRules: initialValues.configureAutomationRules ?? false,
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
   const hasSourceTag = values.sourceTag.trim().length > 0;
 
   useEffect(() => {
@@ -67,14 +72,17 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
       sourceTag: initialSourceTag,
       autoUpdate: initialAutoUpdate,
       includeTargetImages: initialIncludeTargetImages,
+      configureAutomationRules: initialValues.configureAutomationRules ?? false,
     });
     setIsSubmitting(false);
+    setIsAdvancedOpen(false);
   }, [
     initialAutoUpdate,
     initialDescription,
     initialIncludeTargetImages,
     initialName,
     initialSourceTag,
+    initialValues.configureAutomationRules,
     isOpen,
   ]);
 
@@ -129,6 +137,7 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
         name: values.name.trim(),
         description: values.description.trim(),
         sourceTag: values.sourceTag.trim().toLowerCase(),
+        configureAutomationRules: values.configureAutomationRules ?? false,
       });
     } finally {
       setIsSubmitting(false);
@@ -237,6 +246,38 @@ const CollectionFormModal: React.FC<CollectionFormModalProps> = ({
                 <span className="block text-sm font-medium text-gray-100">{includeTargetImagesLabel}</span>
               </span>
             </label>
+          )}
+
+          {showAutomationRulesOption && (
+            <div className="rounded-xl border border-gray-700 bg-gray-800/40">
+              <button
+                type="button"
+                onClick={() => setIsAdvancedOpen((current) => !current)}
+                className="flex w-full items-center justify-between px-3 py-3 text-left text-sm text-gray-200 transition-colors hover:bg-gray-800/70"
+              >
+                <span className="font-medium">Advanced</span>
+                <span className="text-xs text-gray-500">{isAdvancedOpen ? 'Hide' : 'Show'}</span>
+              </button>
+              {isAdvancedOpen && (
+                <label className="flex items-start gap-3 border-t border-gray-700 px-3 py-3">
+                  <input
+                    type="checkbox"
+                    checked={values.configureAutomationRules ?? false}
+                    onChange={(event) => setValues((current) => ({
+                      ...current,
+                      configureAutomationRules: event.target.checked,
+                    }))}
+                    className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-gray-100">Set up rules after creating</span>
+                    <span className="mt-1 block text-xs text-gray-400">
+                      Create the collection first, then open Rules with this collection already selected.
+                    </span>
+                  </span>
+                </label>
+              )}
+            </div>
           )}
         </div>
 

--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -4,6 +4,7 @@ import { IndexedImage, SmartCollection } from '../types';
 import { useImageStore } from '../store/useImageStore';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 import CollectionCard from './CollectionCard';
+import AutomationRulesModal from './AutomationRulesModal';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useThumbnail } from '../hooks/useThumbnail';
 import {
@@ -74,6 +75,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editingCollection, setEditingCollection] = useState<SmartCollection | null>(null);
+  const [automationRuleCollection, setAutomationRuleCollection] = useState<SmartCollection | null>(null);
 
   const selectedCollection = useMemo(
     () => collections.find((collection) => collection.id === activeCollectionId) ?? null,
@@ -130,7 +132,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
   };
 
   const handleCreateManualCollection = async (values: CollectionFormValues) => {
-    await createCollection({
+    const collection = await createCollection({
       kind: 'manual',
       name: values.name,
       description: values.description || undefined,
@@ -145,6 +147,9 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
       query: undefined,
     });
     setIsCreateModalOpen(false);
+    if (values.configureAutomationRules) {
+      setAutomationRuleCollection(collection);
+    }
   };
 
   const handleSaveCollection = async (values: CollectionFormValues) => {
@@ -401,6 +406,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
         }}
         onClose={() => setIsCreateModalOpen(false)}
         onSubmit={handleCreateManualCollection}
+        showAutomationRulesOption
       />
 
       <CollectionFormModal
@@ -418,6 +424,13 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
         onSubmit={handleSaveCollection}
         showSourceTag
         showAutoUpdate
+      />
+
+      <AutomationRulesModal
+        isOpen={automationRuleCollection !== null}
+        onClose={() => setAutomationRuleCollection(null)}
+        initialCollectionId={automationRuleCollection?.id ?? null}
+        initialRuleName={automationRuleCollection ? `Add to ${automationRuleCollection.name}` : undefined}
       />
     </div>
   );

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -396,23 +396,39 @@ const Sidebar: React.FC<SidebarProps> = ({
           </div>
         </div>
 
-        {onAddFolder && (
-          <div className="px-3 py-2 border-b border-gray-700">
+        <div className="px-3 py-2 border-b border-gray-700">
+          <div className={`grid gap-2 ${onAddFolder ? 'grid-cols-2' : 'grid-cols-1'}`}>
+            {onAddFolder && (
+              <button
+                onClick={onAddFolder}
+                disabled={isIndexing}
+                className={`flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
+                  isIndexing
+                    ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
+                    : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
+                }`}
+                title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
+              >
+                <Plus size={14} />
+                <span>Add Folder</span>
+              </button>
+            )}
             <button
-              onClick={onAddFolder}
-              disabled={isIndexing}
-              className={`w-full flex items-center justify-center gap-1 py-1.5 px-2 rounded text-sm transition-all duration-200 ${
-                isIndexing
-                  ? 'bg-gray-700/50 text-gray-500 cursor-not-allowed'
-                  : 'bg-gray-700/40 text-gray-300 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20'
-              }`}
-              title={isIndexing ? "Cannot add folder during indexing" : "Add a new folder"}
+              type="button"
+              onClick={() => setIsAutomationRulesOpen(true)}
+              className="relative flex items-center justify-center gap-1 rounded bg-gray-700/40 px-2 py-1.5 text-sm text-gray-300 transition-all duration-200 hover:bg-gray-700/60 hover:text-gray-50 hover:shadow-md hover:shadow-accent/20"
+              title="Automation rules"
             >
-              <Plus size={14} />
-              <span>Add Folder</span>
+              <SlidersHorizontal size={14} />
+              <span>Rules</span>
+              {activeAutomationRuleCount > 0 && (
+                <span className="absolute -right-1 -top-1 rounded-full border border-blue-700/50 bg-blue-950 px-1.5 py-0.5 text-[10px] leading-none text-blue-200">
+                  {activeAutomationRuleCount}
+                </span>
+              )}
             </button>
           </div>
-        )}
+        </div>
 
         {children && React.isValidElement(children) ? (
           React.cloneElement(children as React.ReactElement<any>, {
@@ -425,24 +441,6 @@ const Sidebar: React.FC<SidebarProps> = ({
         ) : (
           children
         )}
-
-        <div className="border-b border-gray-800/80 px-3 py-2">
-          <button
-            type="button"
-            onClick={() => setIsAutomationRulesOpen(true)}
-            className="flex w-full items-center justify-between rounded-lg border border-gray-800 bg-gray-950/30 px-3 py-2 text-sm text-gray-300 transition-colors hover:border-gray-700 hover:bg-gray-800/50 hover:text-white"
-          >
-            <span className="inline-flex items-center gap-2">
-              <SlidersHorizontal className="h-4 w-4 text-blue-300" />
-              Rules
-            </span>
-            {activeAutomationRuleCount > 0 && (
-              <span className="rounded-full border border-blue-700/50 bg-blue-950/60 px-2 py-0.5 text-[11px] text-blue-200">
-                {activeAutomationRuleCount}
-              </span>
-            )}
-          </button>
-        </div>
 
         <TagsAndFavorites />
 

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,11 +1,12 @@
 
 import React, { useMemo, useState } from 'react';
-import { ChevronDown, ChevronLeft, Plus, RefreshCw } from 'lucide-react';
+import { ChevronDown, ChevronLeft, Plus, RefreshCw, SlidersHorizontal } from 'lucide-react';
 import SearchBar from './SearchBar';
 import AdvancedFilters from './AdvancedFilters';
 import TagsAndFavorites from './TagsAndFavorites';
 import ActiveFilters from './ActiveFilters';
 import FacetFilterSection from './FacetFilterSection';
+import AutomationRulesModal from './AutomationRulesModal';
 import { useImageStore } from '../store/useImageStore';
 import type { AdvancedFilters as AdvancedFilterState, ImageRating } from '../types';
 
@@ -96,6 +97,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   onReshuffle
 }) => {
   const [isGenerationParametersExpanded, setIsGenerationParametersExpanded] = useState(true);
+  const [isAutomationRulesOpen, setIsAutomationRulesOpen] = useState(false);
   const selectedTags = useImageStore((state) => state.selectedTags);
   const excludedTags = useImageStore((state) => state.excludedTags);
   const selectedAutoTags = useImageStore((state) => state.selectedAutoTags);
@@ -111,6 +113,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   const excludedGenerators = useImageStore((state) => state.excludedGenerators);
   const selectedGpuDevices = useImageStore((state) => state.selectedGpuDevices);
   const excludedGpuDevices = useImageStore((state) => state.excludedGpuDevices);
+  const automationRules = useImageStore((state) => state.automationRules);
   const setSelectedFilters = useImageStore((state) => state.setSelectedFilters);
   const countFacetValues = useMemo(() => {
     if (isIndexing) {
@@ -275,6 +278,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     favoriteFilterMode !== 'neutral' ||
     selectedRatings.length > 0 ||
     Object.keys(advancedFilters || {}).length > 0;
+  const activeAutomationRuleCount = automationRules.filter((rule) => rule.enabled).length;
 
   if (isCollapsed) {
     return (
@@ -318,6 +322,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   }
 
   return (
+    <>
     <div
       data-area="sidebar"
       tabIndex={-1}
@@ -421,6 +426,24 @@ const Sidebar: React.FC<SidebarProps> = ({
           children
         )}
 
+        <div className="border-b border-gray-800/80 px-3 py-2">
+          <button
+            type="button"
+            onClick={() => setIsAutomationRulesOpen(true)}
+            className="flex w-full items-center justify-between rounded-lg border border-gray-800 bg-gray-950/30 px-3 py-2 text-sm text-gray-300 transition-colors hover:border-gray-700 hover:bg-gray-800/50 hover:text-white"
+          >
+            <span className="inline-flex items-center gap-2">
+              <SlidersHorizontal className="h-4 w-4 text-blue-300" />
+              Rules
+            </span>
+            {activeAutomationRuleCount > 0 && (
+              <span className="rounded-full border border-blue-700/50 bg-blue-950/60 px-2 py-0.5 text-[11px] text-blue-200">
+                {activeAutomationRuleCount}
+              </span>
+            )}
+          </button>
+        </div>
+
         <TagsAndFavorites />
 
         {generationFacets.length > 0 && (
@@ -475,6 +498,8 @@ const Sidebar: React.FC<SidebarProps> = ({
         </div>
       )}
     </div>
+    <AutomationRulesModal isOpen={isAutomationRulesOpen} onClose={() => setIsAutomationRulesOpen(false)} />
+    </>
   );
 };
 

--- a/services/automationRuleEngine.ts
+++ b/services/automationRuleEngine.ts
@@ -1,5 +1,6 @@
 import type {
   AutomationRule,
+  AutomationConditionRow,
   AutomationRuleFilterCriteria,
   AutomationTextCondition,
   ImageAnnotations,
@@ -28,6 +29,8 @@ export interface AutomationRuleApplyResult extends AutomationRulePreview {
 
 const normalize = (value: unknown): string =>
   typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+const stripDimension = (value: string): string => value.replace(/\s+/g, '').toLowerCase();
 
 const normalizeList = (values: string[] | undefined): string[] =>
   Array.isArray(values)
@@ -86,6 +89,23 @@ const matchesTextCondition = (image: IndexedImage, condition: AutomationTextCond
   }
 
   switch (condition.operator) {
+    case 'not_contains':
+      return !haystack.includes(needle);
+    case 'equals':
+      return haystack === needle;
+    case 'not_equals':
+      return haystack !== needle;
+    case 'contains':
+    default:
+      return haystack.includes(needle);
+  }
+};
+
+const matchesTextOperator = (sourceValue: string, operator: string, targetValue: string): boolean => {
+  const haystack = normalize(sourceValue);
+  const needle = normalize(targetValue);
+  if (!needle) return true;
+  switch (operator) {
     case 'not_contains':
       return !haystack.includes(needle);
     case 'equals':
@@ -303,9 +323,113 @@ const matchesFilterCriteria = (image: IndexedImage, filters: AutomationRuleFilte
   return matchesAdvancedFilters(image, filters);
 };
 
+const getRowTextValue = (image: IndexedImage, field: AutomationConditionRow['field']): string => {
+  switch (field) {
+    case 'negativePrompt':
+      return image.negativePrompt ?? image.metadata?.normalizedMetadata?.negativePrompt ?? '';
+    case 'filename':
+      return image.name ?? '';
+    case 'metadata':
+      return image.metadataString ?? '';
+    case 'prompt':
+      return image.prompt ?? image.metadata?.normalizedMetadata?.prompt ?? '';
+    default:
+      return '';
+  }
+};
+
+const matchesNumberRow = (value: number | undefined, row: AutomationConditionRow): boolean => {
+  if (value === undefined || Number.isNaN(value)) return false;
+  const target = Number(row.value);
+  const targetEnd = Number(row.valueEnd);
+  if (!Number.isFinite(target)) return false;
+  switch (row.operator) {
+    case 'at_least':
+      return value >= target;
+    case 'at_most':
+      return value <= target;
+    case 'between':
+      return Number.isFinite(targetEnd) && value >= target && value <= targetEnd;
+    case 'not_equals':
+      return value !== target;
+    case 'equals':
+    default:
+      return value === target;
+  }
+};
+
+const matchesFacetRow = (values: Set<string>, row: AutomationConditionRow): boolean => {
+  const target = normalize(row.value);
+  if (!target) return true;
+  const hasValue = values.has(target);
+  return row.operator === 'not_includes' || row.operator === 'not_equals' ? !hasValue : hasValue;
+};
+
+const matchesConditionRow = (image: IndexedImage, row: AutomationConditionRow): boolean => {
+  switch (row.field) {
+    case 'prompt':
+    case 'negativePrompt':
+    case 'filename':
+    case 'metadata':
+      return matchesTextOperator(getRowTextValue(image, row.field), row.operator, row.value);
+    case 'model':
+      return matchesFacetRow(getImageModelSet(image), row);
+    case 'lora':
+      return matchesFacetRow(getImageLoraSet(image), row);
+    case 'sampler':
+      return matchesFacetRow(makeValueSet([image.sampler]), row);
+    case 'scheduler':
+      return matchesFacetRow(makeValueSet([image.scheduler]), row);
+    case 'generator':
+      return matchesFacetRow(makeValueSet([getImageGenerator(image)]), row);
+    case 'gpu':
+      return matchesFacetRow(makeValueSet([getImageGpuDevice(image) ?? undefined]), row);
+    case 'tag':
+      return matchesFacetRow(makeValueSet(image.tags ?? []), row);
+    case 'autoTag':
+      return matchesFacetRow(makeValueSet(image.autoTags ?? []), row);
+    case 'dimension': {
+      const imageDimension = stripDimension(image.dimensions ?? '');
+      const target = stripDimension(row.value);
+      const hasDimension = Boolean(target) && imageDimension === target;
+      return row.operator === 'not_includes' || row.operator === 'not_equals' ? !hasDimension : hasDimension;
+    }
+    case 'favorite': {
+      const isFavorite = image.isFavorite === true;
+      return row.operator === 'is_not' ? !isFavorite : isFavorite;
+    }
+    case 'rating':
+      return matchesNumberRow(image.rating, row);
+    case 'steps':
+      return matchesNumberRow(image.steps, row);
+    case 'cfg':
+      return matchesNumberRow(image.cfgScale, row);
+    case 'telemetry': {
+      const hasTelemetry = hasTelemetryData(image);
+      return row.operator === 'is_not' ? !hasTelemetry : hasTelemetry;
+    }
+    case 'verifiedTelemetry': {
+      const hasVerified = hasVerifiedTelemetry(image);
+      return row.operator === 'is_not' ? !hasVerified : hasVerified;
+    }
+    default:
+      return false;
+  }
+};
+
 export function imageMatchesAutomationRule(image: IndexedImage, rule: AutomationRule): boolean {
   if (!rule.enabled) {
     return false;
+  }
+
+  if (rule.criteria.conditionRows?.length) {
+    const rowChecks = rule.criteria.conditionRows
+      .filter((row) => row.value.trim() || row.field === 'favorite' || row.field === 'telemetry' || row.field === 'verifiedTelemetry')
+      .map((row) => matchesConditionRow(image, row));
+    if (rowChecks.length === 0) return false;
+    return rule.criteria.matchMode === 'any'
+      ? rowChecks.some(Boolean)
+      : rowChecks.every(Boolean);
   }
 
   const filters = rule.criteria.filters ?? {};

--- a/services/automationRuleEngine.ts
+++ b/services/automationRuleEngine.ts
@@ -69,6 +69,8 @@ const getImageLoraSet = (image: IndexedImage): Set<string> => {
 
 const getTextFieldValue = (image: IndexedImage, condition: AutomationTextCondition): string => {
   switch (condition.field) {
+    case 'search':
+      return getSearchText(image);
     case 'negativePrompt':
       return image.negativePrompt ?? image.metadata?.normalizedMetadata?.negativePrompt ?? '';
     case 'filename':
@@ -325,6 +327,8 @@ const matchesFilterCriteria = (image: IndexedImage, filters: AutomationRuleFilte
 
 const getRowTextValue = (image: IndexedImage, field: AutomationConditionRow['field']): string => {
   switch (field) {
+    case 'search':
+      return getSearchText(image);
     case 'negativePrompt':
       return image.negativePrompt ?? image.metadata?.normalizedMetadata?.negativePrompt ?? '';
     case 'filename':
@@ -401,6 +405,7 @@ const combineGroupedRowResults = (row: AutomationConditionRow, results: boolean[
 const matchesConditionRow = (image: IndexedImage, row: AutomationConditionRow): boolean => {
   switch (row.field) {
     case 'prompt':
+    case 'search':
     case 'negativePrompt':
     case 'filename':
     case 'metadata':

--- a/services/automationRuleEngine.ts
+++ b/services/automationRuleEngine.ts
@@ -365,6 +365,36 @@ const matchesFacetRow = (values: Set<string>, row: AutomationConditionRow): bool
   return row.operator === 'not_includes' || row.operator === 'not_equals' ? !hasValue : hasValue;
 };
 
+const GROUPABLE_ROW_FIELDS = new Set<AutomationConditionRow['field']>([
+  'model',
+  'lora',
+  'sampler',
+  'scheduler',
+  'generator',
+  'gpu',
+  'tag',
+  'autoTag',
+  'dimension',
+]);
+
+const getConditionRowGroupKey = (row: AutomationConditionRow): string | null => {
+  if (GROUPABLE_ROW_FIELDS.has(row.field)) {
+    return `${row.field}:${row.operator}`;
+  }
+  if (row.field === 'rating' && row.operator === 'equals') {
+    return `${row.field}:${row.operator}`;
+  }
+  return null;
+};
+
+const combineGroupedRowResults = (row: AutomationConditionRow, results: boolean[]): boolean => {
+  const exclusionOperator =
+    row.operator === 'not_includes' ||
+    row.operator === 'is_not' ||
+    row.operator === 'not_equals';
+  return exclusionOperator ? results.every(Boolean) : results.some(Boolean);
+};
+
 const matchesConditionRow = (image: IndexedImage, row: AutomationConditionRow): boolean => {
   switch (row.field) {
     case 'prompt':
@@ -423,9 +453,31 @@ export function imageMatchesAutomationRule(image: IndexedImage, rule: Automation
   }
 
   if (rule.criteria.conditionRows?.length) {
-    const rowChecks = rule.criteria.conditionRows
-      .filter((row) => row.value.trim() || row.field === 'favorite' || row.field === 'telemetry' || row.field === 'verifiedTelemetry')
-      .map((row) => matchesConditionRow(image, row));
+    const rowChecks: boolean[] = [];
+    const groupedChecks = new Map<string, { row: AutomationConditionRow; results: boolean[] }>();
+    const rows = rule.criteria.conditionRows.filter((row) =>
+      row.value.trim() ||
+      row.field === 'favorite' ||
+      row.field === 'telemetry' ||
+      row.field === 'verifiedTelemetry',
+    );
+
+    for (const row of rows) {
+      const groupKey = getConditionRowGroupKey(row);
+      const result = matchesConditionRow(image, row);
+      if (!groupKey) {
+        rowChecks.push(result);
+        continue;
+      }
+      const group = groupedChecks.get(groupKey) ?? { row, results: [] };
+      group.results.push(result);
+      groupedChecks.set(groupKey, group);
+    }
+
+    for (const group of groupedChecks.values()) {
+      rowChecks.push(combineGroupedRowResults(group.row, group.results));
+    }
+
     if (rowChecks.length === 0) return false;
     return rule.criteria.matchMode === 'any'
       ? rowChecks.some(Boolean)

--- a/services/automationRuleEngine.ts
+++ b/services/automationRuleEngine.ts
@@ -1,0 +1,426 @@
+import type {
+  AutomationRule,
+  AutomationRuleFilterCriteria,
+  AutomationTextCondition,
+  ImageAnnotations,
+  ImageRating,
+  IndexedImage,
+  LoRAInfo,
+  SmartCollection,
+} from '../types';
+import { getImageGenerator, getImageGpuDevice, hasTelemetryData } from '../utils/analyticsUtils';
+import { parseLocalDateFilterEndExclusive, parseLocalDateFilterStart } from '../utils/dateFilterUtils';
+import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
+import { resolveSmartCollectionImageIds } from './imageAnnotationsStorage';
+
+export interface AutomationRulePreview {
+  matchedImageIds: string[];
+  matchCount: number;
+  changeCount: number;
+  tagChangeCount: number;
+  collectionChangeCount: number;
+}
+
+export interface AutomationRuleApplyResult extends AutomationRulePreview {
+  updatedAnnotations: ImageAnnotations[];
+  collectionImageAdds: Map<string, string[]>;
+}
+
+const normalize = (value: unknown): string =>
+  typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+const normalizeList = (values: string[] | undefined): string[] =>
+  Array.isArray(values)
+    ? values.map(normalize).filter(Boolean)
+    : [];
+
+const hasValues = (values: string[] | undefined): boolean =>
+  Array.isArray(values) && values.some((value) => normalize(value));
+
+const getLoraName = (lora: string | LoRAInfo): string => {
+  if (typeof lora === 'string') {
+    return lora;
+  }
+  return lora?.name || lora?.model_name || '';
+};
+
+const makeValueSet = (values: Array<string | undefined | null>): Set<string> =>
+  new Set(values.map(normalize).filter(Boolean));
+
+const getImageModelSet = (image: IndexedImage): Set<string> =>
+  makeValueSet([
+    ...(image.models ?? []),
+    image.metadata?.normalizedMetadata?.model,
+    ...(image.metadata?.normalizedMetadata?.models ?? []),
+  ]);
+
+const getImageLoraSet = (image: IndexedImage): Set<string> => {
+  const values: string[] = [];
+  image.loras?.forEach((lora) => values.push(getLoraName(lora)));
+  const metadataLoras = image.metadata?.normalizedMetadata?.loras;
+  if (Array.isArray(metadataLoras)) {
+    metadataLoras.forEach((lora) => values.push(typeof lora === 'string' ? lora : lora?.name || lora?.model_name || ''));
+  }
+  return makeValueSet(values);
+};
+
+const getTextFieldValue = (image: IndexedImage, condition: AutomationTextCondition): string => {
+  switch (condition.field) {
+    case 'negativePrompt':
+      return image.negativePrompt ?? image.metadata?.normalizedMetadata?.negativePrompt ?? '';
+    case 'filename':
+      return image.name ?? '';
+    case 'metadata':
+      return image.metadataString ?? '';
+    case 'prompt':
+    default:
+      return image.prompt ?? image.metadata?.normalizedMetadata?.prompt ?? '';
+  }
+};
+
+const matchesTextCondition = (image: IndexedImage, condition: AutomationTextCondition): boolean => {
+  const haystack = normalize(getTextFieldValue(image, condition));
+  const needle = normalize(condition.value);
+  if (!needle) {
+    return true;
+  }
+
+  switch (condition.operator) {
+    case 'not_contains':
+      return !haystack.includes(needle);
+    case 'equals':
+      return haystack === needle;
+    case 'not_equals':
+      return haystack !== needle;
+    case 'contains':
+    default:
+      return haystack.includes(needle);
+  }
+};
+
+const intersects = (imageValues: Set<string>, requiredValues: string[] | undefined): boolean => {
+  const normalizedRequired = normalizeList(requiredValues);
+  return normalizedRequired.some((value) => imageValues.has(value));
+};
+
+const excludesAll = (imageValues: Set<string>, excludedValues: string[] | undefined): boolean => {
+  const normalizedExcluded = normalizeList(excludedValues);
+  return !normalizedExcluded.some((value) => imageValues.has(value));
+};
+
+const matchesRange = (
+  value: number | null | undefined,
+  range: { min?: number | null; max?: number | null; maxExclusive?: boolean } | undefined,
+): boolean => {
+  if (!range) {
+    return true;
+  }
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return false;
+  }
+
+  if (range.min !== null && range.min !== undefined && value < range.min) {
+    return false;
+  }
+  if (range.max !== null && range.max !== undefined) {
+    return range.maxExclusive === true ? value < range.max : value <= range.max;
+  }
+
+  return true;
+};
+
+const matchesAdvancedFilters = (image: IndexedImage, filters: AutomationRuleFilterCriteria): boolean => {
+  const advanced = filters.advancedFilters;
+  if (!advanced || Object.keys(advanced).length === 0) {
+    return true;
+  }
+
+  if (advanced.dimension) {
+    const imageDim = image.dimensions?.replace(/\s+/g, '');
+    const filterDim = advanced.dimension.replace(/\s+/g, '');
+    if (!imageDim || imageDim !== filterDim) {
+      return false;
+    }
+  }
+
+  if (!matchesRange(image.steps, advanced.steps)) {
+    return false;
+  }
+  if (!matchesRange(image.cfgScale, advanced.cfg)) {
+    return false;
+  }
+
+  if (advanced.date?.from || advanced.date?.to) {
+    if (advanced.date.from && image.lastModified < parseLocalDateFilterStart(advanced.date.from)) {
+      return false;
+    }
+    if (advanced.date.to && image.lastModified >= parseLocalDateFilterEndExclusive(advanced.date.to)) {
+      return false;
+    }
+  }
+
+  if (Array.isArray(advanced.generationModes) && advanced.generationModes.length > 0) {
+    const explicitGenerationType = image.metadata?.normalizedMetadata?.generationType;
+    const isVideo =
+      image.metadata?.normalizedMetadata?.media_type === 'video' ||
+      (image.fileType ?? '').startsWith('video/');
+    const resolvedGenerationMode =
+      explicitGenerationType === 'txt2img' || explicitGenerationType === 'img2img'
+        ? explicitGenerationType
+        : isVideo
+          ? null
+          : 'txt2img';
+
+    if (!resolvedGenerationMode || !advanced.generationModes.includes(resolvedGenerationMode)) {
+      return false;
+    }
+  }
+
+  if (Array.isArray(advanced.mediaTypes) && advanced.mediaTypes.length > 0) {
+    const resolvedMediaType =
+      image.metadata?.normalizedMetadata?.media_type === 'video' || (image.fileType ?? '').startsWith('video/')
+        ? 'video'
+        : 'image';
+    if (!advanced.mediaTypes.includes(resolvedMediaType)) {
+      return false;
+    }
+  }
+
+  if (advanced.telemetryState === 'present' && !hasTelemetryData(image)) {
+    return false;
+  }
+  if (advanced.telemetryState === 'missing' && hasTelemetryData(image)) {
+    return false;
+  }
+  if (advanced.hasVerifiedTelemetry === true && !hasVerifiedTelemetry(image)) {
+    return false;
+  }
+
+  const analytics =
+    image.metadata?.normalizedMetadata?.analytics ||
+    (image.metadata?.normalizedMetadata as { _analytics?: Record<string, number> } | undefined)?._analytics;
+
+  return (
+    matchesRange(analytics?.generation_time_ms, advanced.generationTimeMs) &&
+    matchesRange(analytics?.steps_per_second, advanced.stepsPerSecond) &&
+    matchesRange(analytics?.vram_peak_mb, advanced.vramPeakMb)
+  );
+};
+
+const getSearchText = (image: IndexedImage): string =>
+  normalize([
+    image.name,
+    image.prompt,
+    image.negativePrompt,
+    image.metadataString,
+    ...(image.models ?? []),
+    ...(image.loras ?? []).map(getLoraName),
+    image.sampler,
+    image.scheduler,
+  ].filter(Boolean).join(' '));
+
+const hasActiveFilters = (filters: AutomationRuleFilterCriteria): boolean =>
+  Boolean(
+    normalize(filters.searchQuery) ||
+    hasValues(filters.models) ||
+    hasValues(filters.excludedModels) ||
+    hasValues(filters.loras) ||
+    hasValues(filters.excludedLoras) ||
+    hasValues(filters.samplers) ||
+    hasValues(filters.excludedSamplers) ||
+    hasValues(filters.schedulers) ||
+    hasValues(filters.excludedSchedulers) ||
+    hasValues(filters.generators) ||
+    hasValues(filters.excludedGenerators) ||
+    hasValues(filters.gpuDevices) ||
+    hasValues(filters.excludedGpuDevices) ||
+    hasValues(filters.tags) ||
+    hasValues(filters.excludedTags) ||
+    hasValues(filters.autoTags) ||
+    hasValues(filters.excludedAutoTags) ||
+    filters.favoriteFilterMode === 'include' ||
+    filters.favoriteFilterMode === 'exclude' ||
+    (Array.isArray(filters.ratings) && filters.ratings.length > 0) ||
+    (filters.advancedFilters && Object.keys(filters.advancedFilters).length > 0),
+  );
+
+const matchesFilterCriteria = (image: IndexedImage, filters: AutomationRuleFilterCriteria): boolean => {
+  const modelSet = getImageModelSet(image);
+  const loraSet = getImageLoraSet(image);
+  const tagSet = makeValueSet(image.tags ?? []);
+  const autoTagSet = makeValueSet(image.autoTags ?? []);
+  const samplerSet = makeValueSet([image.sampler]);
+  const schedulerSet = makeValueSet([image.scheduler]);
+  const generatorSet = makeValueSet([getImageGenerator(image)]);
+  const gpuDevice = getImageGpuDevice(image);
+  const gpuSet = makeValueSet([gpuDevice ?? undefined]);
+
+  if (normalize(filters.searchQuery)) {
+    const terms = normalize(filters.searchQuery).split(/\s+/).filter(Boolean);
+    const text = getSearchText(image);
+    if (!terms.every((term) => text.includes(term))) {
+      return false;
+    }
+  }
+
+  if (hasValues(filters.models) && !intersects(modelSet, filters.models)) return false;
+  if (hasValues(filters.excludedModels) && !excludesAll(modelSet, filters.excludedModels)) return false;
+  if (hasValues(filters.loras) && !intersects(loraSet, filters.loras)) return false;
+  if (hasValues(filters.excludedLoras) && !excludesAll(loraSet, filters.excludedLoras)) return false;
+  if (hasValues(filters.samplers) && !intersects(samplerSet, filters.samplers)) return false;
+  if (hasValues(filters.excludedSamplers) && !excludesAll(samplerSet, filters.excludedSamplers)) return false;
+  if (hasValues(filters.schedulers) && !intersects(schedulerSet, filters.schedulers)) return false;
+  if (hasValues(filters.excludedSchedulers) && !excludesAll(schedulerSet, filters.excludedSchedulers)) return false;
+  if (hasValues(filters.generators) && !intersects(generatorSet, filters.generators)) return false;
+  if (hasValues(filters.excludedGenerators) && !excludesAll(generatorSet, filters.excludedGenerators)) return false;
+  if (hasValues(filters.gpuDevices) && !intersects(gpuSet, filters.gpuDevices)) return false;
+  if (hasValues(filters.excludedGpuDevices) && !excludesAll(gpuSet, filters.excludedGpuDevices)) return false;
+
+  if (hasValues(filters.tags)) {
+    const requiredTags = normalizeList(filters.tags);
+    const tagMatched =
+      filters.tagMatchMode === 'all'
+        ? requiredTags.every((tag) => tagSet.has(tag))
+        : requiredTags.some((tag) => tagSet.has(tag));
+    if (!tagMatched) {
+      return false;
+    }
+  }
+  if (hasValues(filters.excludedTags) && !excludesAll(tagSet, filters.excludedTags)) return false;
+  if (hasValues(filters.autoTags) && !intersects(autoTagSet, filters.autoTags)) return false;
+  if (hasValues(filters.excludedAutoTags) && !excludesAll(autoTagSet, filters.excludedAutoTags)) return false;
+
+  if (filters.favoriteFilterMode === 'include' && image.isFavorite !== true) return false;
+  if (filters.favoriteFilterMode === 'exclude' && image.isFavorite === true) return false;
+
+  if (Array.isArray(filters.ratings) && filters.ratings.length > 0) {
+    const ratings = new Set<ImageRating>(filters.ratings);
+    if (image.rating === undefined || !ratings.has(image.rating)) {
+      return false;
+    }
+  }
+
+  return matchesAdvancedFilters(image, filters);
+};
+
+export function imageMatchesAutomationRule(image: IndexedImage, rule: AutomationRule): boolean {
+  if (!rule.enabled) {
+    return false;
+  }
+
+  const filters = rule.criteria.filters ?? {};
+  const checks: boolean[] = [
+    ...(rule.criteria.textConditions ?? []).map((condition) => matchesTextCondition(image, condition)),
+  ];
+
+  if (hasActiveFilters(filters)) {
+    checks.push(matchesFilterCriteria(image, filters));
+  }
+
+  if (checks.length === 0) {
+    return false;
+  }
+
+  return rule.criteria.matchMode === 'any'
+    ? checks.some(Boolean)
+    : checks.every(Boolean);
+}
+
+const buildAnnotation = (
+  imageId: string,
+  currentAnnotation: ImageAnnotations | undefined,
+  tags: string[],
+): ImageAnnotations => ({
+  imageId,
+  isFavorite: currentAnnotation?.isFavorite ?? false,
+  tags,
+  rating: currentAnnotation?.rating,
+  addedAt: currentAnnotation?.addedAt ?? Date.now(),
+  updatedAt: Date.now(),
+});
+
+export function applyAutomationRuleToImages(
+  rule: AutomationRule,
+  images: IndexedImage[],
+  annotations: Map<string, ImageAnnotations>,
+  collections: SmartCollection[],
+): AutomationRuleApplyResult {
+  const matchedImageIds: string[] = [];
+  const updatedAnnotations: ImageAnnotations[] = [];
+  const collectionImageAdds = new Map<string, string[]>();
+  const normalizedActionTags = normalizeList(rule.actions.addTags).map((tag) => tag.toLowerCase());
+  const collectionIds = normalizeList(rule.actions.addToCollectionIds);
+  const collectionById = new Map(collections.map((collection) => [collection.id, collection]));
+  const resolvedCollectionIds = new Map<string, Set<string>>();
+  for (const collectionId of collectionIds) {
+    const collection = collectionById.get(collectionId);
+    if (collection) {
+      resolvedCollectionIds.set(collectionId, new Set(resolveSmartCollectionImageIds(collection, images)));
+    }
+  }
+  let tagChangeCount = 0;
+  let collectionChangeCount = 0;
+
+  for (const image of images) {
+    if (!imageMatchesAutomationRule(image, rule)) {
+      continue;
+    }
+
+    matchedImageIds.push(image.id);
+    const currentAnnotation = annotations.get(image.id);
+    const existingTags = new Set((currentAnnotation?.tags ?? image.tags ?? []).map((tag) => tag.toLowerCase()));
+    const nextTags = [...existingTags];
+
+    for (const tag of normalizedActionTags) {
+      if (!existingTags.has(tag)) {
+        existingTags.add(tag);
+        nextTags.push(tag);
+        tagChangeCount += 1;
+      }
+    }
+
+    if (nextTags.length !== (currentAnnotation?.tags ?? image.tags ?? []).length) {
+      updatedAnnotations.push(buildAnnotation(image.id, currentAnnotation, nextTags));
+    }
+
+    for (const collectionId of collectionIds) {
+      const collection = collectionById.get(collectionId);
+      const resolvedIds = collection ? resolvedCollectionIds.get(collectionId) : undefined;
+      if (!collection || !resolvedIds || resolvedIds.has(image.id)) {
+        continue;
+      }
+
+      const existingAdds = collectionImageAdds.get(collectionId) ?? [];
+      existingAdds.push(image.id);
+      collectionImageAdds.set(collectionId, existingAdds);
+      resolvedIds.add(image.id);
+      collectionChangeCount += 1;
+    }
+  }
+
+  return {
+    matchedImageIds,
+    matchCount: matchedImageIds.length,
+    changeCount: tagChangeCount + collectionChangeCount,
+    tagChangeCount,
+    collectionChangeCount,
+    updatedAnnotations,
+    collectionImageAdds,
+  };
+}
+
+export function previewAutomationRule(
+  rule: AutomationRule,
+  images: IndexedImage[],
+  annotations: Map<string, ImageAnnotations>,
+  collections: SmartCollection[],
+): AutomationRulePreview {
+  const result = applyAutomationRuleToImages(rule, images, annotations, collections);
+  return {
+    matchedImageIds: result.matchedImageIds,
+    matchCount: result.matchCount,
+    changeCount: result.changeCount,
+    tagChangeCount: result.tagChangeCount,
+    collectionChangeCount: result.collectionChangeCount,
+  };
+}

--- a/services/automationRuleEngine.ts
+++ b/services/automationRuleEngine.ts
@@ -392,6 +392,9 @@ const combineGroupedRowResults = (row: AutomationConditionRow, results: boolean[
     row.operator === 'not_includes' ||
     row.operator === 'is_not' ||
     row.operator === 'not_equals';
+  if (row.groupMode === 'all') {
+    return results.every(Boolean);
+  }
   return exclusionOperator ? results.every(Boolean) : results.some(Boolean);
 };
 

--- a/services/automationRulesStorage.ts
+++ b/services/automationRulesStorage.ts
@@ -15,6 +15,7 @@ import {
   openPreferencesDatabase,
   PREFERENCES_STORE_NAMES,
 } from './preferencesDb';
+import { isConditionRowComplete, normalizeConditionRow } from '../utils/automationRuleRows';
 
 const STORE_NAME = PREFERENCES_STORE_NAMES.automationRules;
 
@@ -106,9 +107,16 @@ export function normalizeAutomationRuleCriteria(criteria: Partial<AutomationRule
         .filter((condition): condition is AutomationTextCondition => Boolean(condition))
     : [];
 
+  const conditionRows = Array.isArray(criteria?.conditionRows)
+    ? criteria.conditionRows
+        .map((row) => normalizeConditionRow(row))
+        .filter(isConditionRowComplete)
+    : [];
+
   return {
     matchMode: criteria?.matchMode === 'any' ? 'any' : 'all',
     textConditions,
+    conditionRows,
     filters: {
       searchQuery: typeof filters.searchQuery === 'string' ? filters.searchQuery.trim() : '',
       models: normalizeStringList(filters.models),

--- a/services/automationRulesStorage.ts
+++ b/services/automationRulesStorage.ts
@@ -22,7 +22,7 @@ const STORE_NAME = PREFERENCES_STORE_NAMES.automationRules;
 const inMemoryRules = new Map<string, AutomationRule>();
 let isPersistenceDisabled = false;
 
-const TEXT_FIELDS: AutomationTextField[] = ['prompt', 'negativePrompt', 'filename', 'metadata'];
+const TEXT_FIELDS: AutomationTextField[] = ['prompt', 'negativePrompt', 'filename', 'metadata', 'search'];
 const TEXT_OPERATORS: AutomationTextOperator[] = ['contains', 'not_contains', 'equals', 'not_equals'];
 const RATINGS = new Set<ImageRating>([1, 2, 3, 4, 5]);
 

--- a/services/automationRulesStorage.ts
+++ b/services/automationRulesStorage.ts
@@ -1,0 +1,314 @@
+/// <reference lib="dom" />
+
+import type {
+  AdvancedFilters,
+  AutomationRule,
+  AutomationRuleAction,
+  AutomationRuleCriteria,
+  AutomationRuleFilterCriteria,
+  AutomationTextCondition,
+  AutomationTextField,
+  AutomationTextOperator,
+  ImageRating,
+} from '../types';
+import {
+  openPreferencesDatabase,
+  PREFERENCES_STORE_NAMES,
+} from './preferencesDb';
+
+const STORE_NAME = PREFERENCES_STORE_NAMES.automationRules;
+
+const inMemoryRules = new Map<string, AutomationRule>();
+let isPersistenceDisabled = false;
+
+const TEXT_FIELDS: AutomationTextField[] = ['prompt', 'negativePrompt', 'filename', 'metadata'];
+const TEXT_OPERATORS: AutomationTextOperator[] = ['contains', 'not_contains', 'equals', 'not_equals'];
+const RATINGS = new Set<ImageRating>([1, 2, 3, 4, 5]);
+
+function disablePersistence(error?: unknown) {
+  if (isPersistenceDisabled) {
+    return;
+  }
+
+  console.error(
+    'IndexedDB open error for automation rules storage. Automation rule persistence will be disabled for this session.',
+    error,
+  );
+  isPersistenceDisabled = true;
+}
+
+async function openDatabase(): Promise<IDBDatabase | null> {
+  return openPreferencesDatabase({
+    context: 'automation rules storage',
+    disablePersistence,
+  });
+}
+
+const normalizeStringList = (values: unknown): string[] => {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      values
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter(Boolean),
+    ),
+  );
+};
+
+const normalizeTagList = (values: unknown): string[] =>
+  normalizeStringList(values).map((value) => value.toLowerCase());
+
+const normalizeRatings = (values: unknown): ImageRating[] => {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  return Array.from(new Set(values))
+    .filter((value): value is ImageRating => typeof value === 'number' && RATINGS.has(value as ImageRating))
+    .sort((a, b) => a - b);
+};
+
+const normalizeAdvancedFilters = (filters: unknown): AdvancedFilters => {
+  if (!filters || typeof filters !== 'object') {
+    return {};
+  }
+
+  return filters as AdvancedFilters;
+};
+
+export function normalizeAutomationRuleCriteria(criteria: Partial<AutomationRuleCriteria> | undefined): AutomationRuleCriteria {
+  const filters = (criteria?.filters ?? {}) as Partial<AutomationRuleFilterCriteria>;
+
+  const textConditions = Array.isArray(criteria?.textConditions)
+    ? criteria.textConditions
+        .map((condition, index): AutomationTextCondition | null => {
+          if (!condition || typeof condition !== 'object') {
+            return null;
+          }
+
+          const field = TEXT_FIELDS.includes(condition.field) ? condition.field : 'prompt';
+          const operator = TEXT_OPERATORS.includes(condition.operator) ? condition.operator : 'contains';
+          const value = typeof condition.value === 'string' ? condition.value.trim() : '';
+          if (!value) {
+            return null;
+          }
+
+          return {
+            id: typeof condition.id === 'string' && condition.id ? condition.id : `condition-${index}`,
+            field,
+            operator,
+            value,
+          };
+        })
+        .filter((condition): condition is AutomationTextCondition => Boolean(condition))
+    : [];
+
+  return {
+    matchMode: criteria?.matchMode === 'any' ? 'any' : 'all',
+    textConditions,
+    filters: {
+      searchQuery: typeof filters.searchQuery === 'string' ? filters.searchQuery.trim() : '',
+      models: normalizeStringList(filters.models),
+      excludedModels: normalizeStringList(filters.excludedModels),
+      loras: normalizeStringList(filters.loras),
+      excludedLoras: normalizeStringList(filters.excludedLoras),
+      samplers: normalizeStringList(filters.samplers),
+      excludedSamplers: normalizeStringList(filters.excludedSamplers),
+      schedulers: normalizeStringList(filters.schedulers),
+      excludedSchedulers: normalizeStringList(filters.excludedSchedulers),
+      generators: normalizeStringList(filters.generators),
+      excludedGenerators: normalizeStringList(filters.excludedGenerators),
+      gpuDevices: normalizeStringList(filters.gpuDevices),
+      excludedGpuDevices: normalizeStringList(filters.excludedGpuDevices),
+      tags: normalizeTagList(filters.tags),
+      excludedTags: normalizeTagList(filters.excludedTags),
+      tagMatchMode: filters.tagMatchMode === 'all' ? 'all' : 'any',
+      autoTags: normalizeStringList(filters.autoTags),
+      excludedAutoTags: normalizeStringList(filters.excludedAutoTags),
+      favoriteFilterMode:
+        filters.favoriteFilterMode === 'include' || filters.favoriteFilterMode === 'exclude'
+          ? filters.favoriteFilterMode
+          : 'neutral',
+      ratings: normalizeRatings(filters.ratings),
+      advancedFilters: normalizeAdvancedFilters(filters.advancedFilters),
+    },
+  };
+}
+
+export function normalizeAutomationRuleActions(actions: Partial<AutomationRuleAction> | undefined): AutomationRuleAction {
+  return {
+    addTags: normalizeTagList(actions?.addTags),
+    addToCollectionIds: normalizeStringList(actions?.addToCollectionIds),
+  };
+}
+
+export function normalizeAutomationRule(
+  rule: Partial<AutomationRule> & Pick<AutomationRule, 'id' | 'name' | 'createdAt' | 'updatedAt'>,
+): AutomationRule {
+  return {
+    id: rule.id,
+    name: rule.name.trim() || 'Untitled Rule',
+    enabled: rule.enabled !== false,
+    criteria: normalizeAutomationRuleCriteria(rule.criteria),
+    actions: normalizeAutomationRuleActions(rule.actions),
+    runOnNewImages: rule.runOnNewImages !== false,
+    createdAt: rule.createdAt,
+    updatedAt: rule.updatedAt,
+    lastAppliedAt: rule.lastAppliedAt ?? null,
+    lastMatchCount: Number.isFinite(rule.lastMatchCount) ? Math.max(0, Number(rule.lastMatchCount)) : 0,
+    lastChangeCount: Number.isFinite(rule.lastChangeCount) ? Math.max(0, Number(rule.lastChangeCount)) : 0,
+  };
+}
+
+const sortRules = (rules: AutomationRule[]): AutomationRule[] =>
+  [...rules].sort((a, b) => {
+    const dateDelta = a.createdAt - b.createdAt;
+    if (dateDelta !== 0) {
+      return dateDelta;
+    }
+    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  });
+
+export async function getAllAutomationRules(): Promise<AutomationRule[]> {
+  if (isPersistenceDisabled) {
+    return sortRules(Array.from(inMemoryRules.values()));
+  }
+
+  const db = await openDatabase();
+  if (!db) {
+    return sortRules(Array.from(inMemoryRules.values()));
+  }
+
+  return new Promise((resolve) => {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+
+    const close = () => {
+      try {
+        db.close();
+      } catch (error) {
+        console.warn('Failed to close automation rules storage after load', error);
+      }
+    };
+
+    transaction.oncomplete = close;
+    transaction.onabort = close;
+    transaction.onerror = close;
+
+    request.onsuccess = () => {
+      const rules = ((request.result || []) as AutomationRule[]).map((rule) => normalizeAutomationRule(rule));
+      inMemoryRules.clear();
+      rules.forEach((rule) => inMemoryRules.set(rule.id, rule));
+      resolve(sortRules(rules));
+    };
+
+    request.onerror = () => {
+      console.error('Failed to load automation rules', request.error);
+      resolve(sortRules(Array.from(inMemoryRules.values())));
+    };
+  });
+}
+
+export async function saveAutomationRule(rule: AutomationRule): Promise<void> {
+  const normalizedRule = normalizeAutomationRule({
+    ...rule,
+    updatedAt: Date.now(),
+  });
+  inMemoryRules.set(normalizedRule.id, normalizedRule);
+
+  if (isPersistenceDisabled) {
+    return;
+  }
+
+  const db = await openDatabase();
+  if (!db) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(normalizedRule);
+
+    const close = () => {
+      try {
+        db.close();
+      } catch (error) {
+        console.warn('Failed to close automation rules storage after save', error);
+      }
+    };
+
+    transaction.oncomplete = () => {
+      close();
+      resolve();
+    };
+    transaction.onabort = () => {
+      close();
+      reject(transaction.error);
+    };
+    transaction.onerror = () => {
+      close();
+      reject(transaction.error);
+    };
+
+    request.onerror = () => {
+      console.error('Failed to save automation rule', request.error);
+      reject(request.error);
+    };
+  }).catch((error) => {
+    console.error('IndexedDB save error for automation rule:', error);
+    disablePersistence(error);
+  });
+}
+
+export async function deleteAutomationRule(ruleId: string): Promise<void> {
+  inMemoryRules.delete(ruleId);
+
+  if (isPersistenceDisabled) {
+    return;
+  }
+
+  const db = await openDatabase();
+  if (!db) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.delete(ruleId);
+
+    const close = () => {
+      try {
+        db.close();
+      } catch (error) {
+        console.warn('Failed to close automation rules storage after delete', error);
+      }
+    };
+
+    transaction.oncomplete = () => {
+      close();
+      resolve();
+    };
+    transaction.onabort = () => {
+      close();
+      reject(transaction.error);
+    };
+    transaction.onerror = () => {
+      close();
+      reject(transaction.error);
+    };
+
+    request.onerror = () => {
+      console.error('Failed to delete automation rule', request.error);
+      reject(request.error);
+    };
+  }).catch((error) => {
+    console.error('IndexedDB delete error for automation rule:', error);
+    disablePersistence(error);
+  });
+}

--- a/services/preferencesDb.ts
+++ b/services/preferencesDb.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 
 export const PREFERENCES_DB_NAME = 'image-metahub-preferences';
-export const PREFERENCES_DB_VERSION = 6;
+export const PREFERENCES_DB_VERSION = 7;
 
 export const PREFERENCES_STORE_NAMES = {
   folderSelection: 'folderSelection',
@@ -10,6 +10,7 @@ export const PREFERENCES_STORE_NAMES = {
   clusterPreferences: 'clusterPreferences',
   smartCollections: 'smartCollections',
   shadowMetadata: 'shadowMetadata',
+  automationRules: 'automationRules',
 } as const;
 
 type DisablePersistenceFn = (error?: unknown) => void;
@@ -174,14 +175,15 @@ function upgradePreferencesDatabase(request: IDBOpenDBRequest, oldVersion: numbe
   ensureIndex(smartCollectionsStore, 'type', 'type', { unique: false });
 
   ensureObjectStore(db, transaction, PREFERENCES_STORE_NAMES.shadowMetadata, { keyPath: 'imageId' });
+  ensureObjectStore(db, transaction, PREFERENCES_STORE_NAMES.automationRules, { keyPath: 'id' });
 
   const manualTagsStore = ensureObjectStore(db, transaction, PREFERENCES_STORE_NAMES.manualTags, { keyPath: 'name' });
   if (oldVersion < 5) {
     seedManualTagsFromAnnotations(annotationStore, manualTagsStore);
   }
 
-  if (oldVersion < 6) {
-    console.log('Shared preferences database upgraded to v6.');
+  if (oldVersion < 7) {
+    console.log('Shared preferences database upgraded to v7.');
   }
 }
 

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, AutoTag, IndexedImageTransferProgress, InclusionFilterMode, ImageRating, SmartCollection, type AdvancedFilters, type FilterOptions, type SelectedFiltersUpdate, type TagMatchMode } from '../types';
+import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, AutoTag, IndexedImageTransferProgress, InclusionFilterMode, ImageRating, SmartCollection, AutomationRule, type AdvancedFilters, type FilterOptions, type SelectedFiltersUpdate, type TagMatchMode } from '../types';
 import { loadSelectedFolders, saveSelectedFolders, loadExcludedFolders, saveExcludedFolders } from '../services/folderSelectionStorage';
 import {
   loadAllAnnotations,
@@ -21,6 +21,17 @@ import {
   resolveSmartCollectionImages,
   saveSmartCollection,
 } from '../services/imageAnnotationsStorage';
+import {
+    deleteAutomationRule,
+    getAllAutomationRules,
+    normalizeAutomationRule,
+    saveAutomationRule,
+} from '../services/automationRulesStorage';
+import {
+    applyAutomationRuleToImages,
+    previewAutomationRule,
+    type AutomationRulePreview,
+} from '../services/automationRuleEngine';
 import { normalizeFacetValue, sanitizeIndexedImageFacets } from '../utils/facetNormalization';
 import { parseLocalDateFilterEndExclusive, parseLocalDateFilterStart } from '../utils/dateFilterUtils';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
@@ -262,6 +273,21 @@ const syncCollectionCounts = (collections: SmartCollection[], images: IndexedIma
         ),
     );
 
+const uniqueIds = (imageIds: string[]): string[] =>
+    Array.from(new Set(imageIds.filter((imageId) => typeof imageId === 'string' && imageId.trim().length > 0)));
+
+const addImagesToCollectionRecord = (collection: SmartCollection, imageIds: string[]): SmartCollection => {
+    const nextImageIds = uniqueIds([...(collection.imageIds ?? []), ...imageIds]);
+    return normalizeSmartCollection(
+        {
+            ...collection,
+            imageIds: nextImageIds,
+            updatedAt: Date.now(),
+        },
+        collection.sortIndex,
+    );
+};
+
 const normalizePath = (path: string) => {
     if (!path) return '';
     return path.replace(/\\/g, '/').replace(/[\\/]+$/, '');
@@ -390,6 +416,8 @@ interface ImageState {
   selectedImages: Set<string>;
   activeImageScope: IndexedImage[] | null;
   collections: SmartCollection[];
+  automationRules: AutomationRule[];
+  isAutomationRulesLoaded: boolean;
   activeCollectionId: string | null;
   previewImage: IndexedImage | null;
   focusedImageIndex: number | null;
@@ -521,9 +549,16 @@ interface ImageState {
   setSelectedImage: (image: IndexedImage | null) => void;
   setActiveImageScope: (images: IndexedImage[] | null) => void;
   loadCollections: () => Promise<void>;
+  loadAutomationRules: () => Promise<void>;
   createCollection: (collection: Omit<SmartCollection, 'id' | 'imageCount' | 'createdAt' | 'updatedAt'> & { id?: string }) => Promise<SmartCollection>;
   updateCollection: (collectionId: string, updates: Partial<Omit<SmartCollection, 'id' | 'createdAt'>>) => Promise<SmartCollection | null>;
   deleteCollectionById: (collectionId: string) => Promise<void>;
+  createAutomationRule: (rule: Omit<AutomationRule, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }) => Promise<AutomationRule>;
+  updateAutomationRule: (ruleId: string, updates: Partial<Omit<AutomationRule, 'id' | 'createdAt'>>) => Promise<AutomationRule | null>;
+  deleteAutomationRuleById: (ruleId: string) => Promise<void>;
+  previewAutomationRule: (rule: AutomationRule, images?: IndexedImage[]) => AutomationRulePreview;
+  applyAutomationRuleNow: (ruleId: string, images?: IndexedImage[]) => Promise<AutomationRulePreview | null>;
+  applyEnabledAutomationRulesToImages: (images: IndexedImage[]) => Promise<AutomationRulePreview[]>;
   setActiveCollectionId: (collectionId: string | null) => void;
   reorderCollections: (orderedCollectionIds: string[]) => Promise<void>;
   addImagesToCollection: (collectionId: string, imageIds: string[]) => Promise<SmartCollection | null>;
@@ -858,6 +893,9 @@ export const useImageStore = create<ImageState>((set, get) => {
             return _updateState(state, merged);
         });
 
+        if (get().isAnnotationsLoaded) {
+            void get().importMetadataTags(updatesToMerge);
+        }
         maybeQueueLineageBuild(700);
 
         traceCacheDebug('store:flushPendingMerges', () => ({
@@ -921,6 +959,109 @@ export const useImageStore = create<ImageState>((set, get) => {
 
     const getImageById = (state: ImageState, imageId: string): IndexedImage | undefined => {
         return state.images.find(img => img.id === imageId) || state.filteredImages.find(img => img.id === imageId);
+    };
+
+    const applyAutomationRuleToCurrentState = async (
+        rule: AutomationRule,
+        sourceImages?: IndexedImage[],
+    ): Promise<AutomationRulePreview> => {
+        const sourceIds = sourceImages && sourceImages.length > 0
+            ? new Set(sourceImages.map((image) => image.id))
+            : null;
+        let preview: AutomationRulePreview = {
+            matchedImageIds: [],
+            matchCount: 0,
+            changeCount: 0,
+            tagChangeCount: 0,
+            collectionChangeCount: 0,
+        };
+        let updatedRule: AutomationRule | null = null;
+        let annotationsToPersist: ImageAnnotations[] = [];
+        let collectionsToPersist: SmartCollection[] = [];
+        const tagCatalogUpdates = new Set<string>();
+
+        set(state => {
+            const targetImages = sourceIds
+                ? state.images.filter((image) => sourceIds.has(image.id))
+                : state.images;
+            const result = applyAutomationRuleToImages(rule, targetImages, state.annotations, state.collections);
+            preview = {
+                matchedImageIds: result.matchedImageIds,
+                matchCount: result.matchCount,
+                changeCount: result.changeCount,
+                tagChangeCount: result.tagChangeCount,
+                collectionChangeCount: result.collectionChangeCount,
+            };
+
+            const nextAnnotations = new Map(state.annotations);
+            for (const annotation of result.updatedAnnotations) {
+                nextAnnotations.set(annotation.imageId, annotation);
+            }
+
+            annotationsToPersist = result.updatedAnnotations;
+            rule.actions.addTags.forEach((tag) => {
+                const normalized = normalizeTagName(tag);
+                if (normalized) {
+                    tagCatalogUpdates.add(normalized);
+                }
+            });
+
+            const collectionAddMap = result.collectionImageAdds;
+            collectionsToPersist = [];
+            const nextCollections = state.collections.map((collection) => {
+                const adds = collectionAddMap.get(collection.id);
+                if (!adds || adds.length === 0) {
+                    return collection;
+                }
+
+                const updatedCollection = addImagesToCollectionRecord(collection, adds);
+                collectionsToPersist.push(updatedCollection);
+                return updatedCollection;
+            });
+
+            updatedRule = normalizeAutomationRule({
+                ...rule,
+                lastAppliedAt: Date.now(),
+                lastMatchCount: preview.matchCount,
+                lastChangeCount: preview.changeCount,
+                updatedAt: Date.now(),
+            });
+
+            const updatedImages = annotationsToPersist.length > 0
+                ? applyAnnotationsToImages(state.images, nextAnnotations)
+                : state.images;
+            const syncedCollections = collectionsToPersist.length > 0
+                ? syncCollectionCounts(nextCollections, updatedImages)
+                : state.collections;
+            const nextRules = state.automationRules.map((existingRule) =>
+                existingRule.id === rule.id ? updatedRule as AutomationRule : existingRule
+            );
+
+            const newState = {
+                ...state,
+                annotations: nextAnnotations,
+                images: updatedImages,
+                collections: syncedCollections,
+                automationRules: nextRules,
+            };
+
+            return { ...newState, ...filterAndSort(newState) };
+        });
+
+        await Promise.all([
+            annotationsToPersist.length > 0 ? bulkSaveAnnotations(annotationsToPersist) : Promise.resolve(),
+            ...Array.from(tagCatalogUpdates).map((tagName) => ensureManualTagExists(tagName)),
+            ...collectionsToPersist.map((collection) => saveSmartCollection(collection)),
+            updatedRule ? saveAutomationRule(updatedRule) : Promise.resolve(),
+        ]).catch(error => {
+            console.error('Failed to apply automation rule:', error);
+        });
+
+        if (annotationsToPersist.length > 0 || tagCatalogUpdates.size > 0) {
+            await get().refreshAvailableTags();
+        }
+
+        return preview;
     };
 
     let lineageBuildTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1756,6 +1897,8 @@ export const useImageStore = create<ImageState>((set, get) => {
         selectedImages: new Set(),
         activeImageScope: null,
         collections: [],
+        automationRules: [],
+        isAutomationRulesLoaded: false,
         activeCollectionId: null,
         focusedImageIndex: null,
         isStackingEnabled: false,
@@ -2284,13 +2427,16 @@ export const useImageStore = create<ImageState>((set, get) => {
             }
 
             flushPendingImages(true);
-            flushPendingMerges();
+        flushPendingMerges();
             set(state => {
                 const updates = new Map(updatedImages.map(img => [img.id, img]));
                 const merged = state.images.map(img => updates.get(img.id) ?? img);
                 return _updateState(state, merged);
             });
 
+            if (get().isAnnotationsLoaded) {
+                void get().importMetadataTags(updatedImages);
+            }
             maybeQueueLineageBuild(700);
         },
 
@@ -2550,6 +2696,13 @@ export const useImageStore = create<ImageState>((set, get) => {
                 };
             });
         },
+        loadAutomationRules: async () => {
+            const rules = await getAllAutomationRules();
+            set({
+                automationRules: rules,
+                isAutomationRulesLoaded: true,
+            });
+        },
         createCollection: async (collection) => {
             const state = get();
             const nextSortIndex = getNextCollectionSortIndex(state.collections);
@@ -2578,6 +2731,79 @@ export const useImageStore = create<ImageState>((set, get) => {
             });
 
             return nextCollection;
+        },
+        createAutomationRule: async (rule) => {
+            const nextRule = normalizeAutomationRule({
+                ...rule,
+                id: rule.id ?? crypto.randomUUID(),
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+
+            await saveAutomationRule(nextRule);
+
+            set((state) => ({
+                automationRules: [...state.automationRules, nextRule],
+                isAutomationRulesLoaded: true,
+            }));
+
+            return nextRule;
+        },
+        updateAutomationRule: async (ruleId, updates) => {
+            const currentRule = get().automationRules.find((rule) => rule.id === ruleId);
+            if (!currentRule) {
+                return null;
+            }
+
+            const nextRule = normalizeAutomationRule({
+                ...currentRule,
+                ...updates,
+                updatedAt: Date.now(),
+            });
+
+            await saveAutomationRule(nextRule);
+
+            set((state) => ({
+                automationRules: state.automationRules.map((rule) => rule.id === ruleId ? nextRule : rule),
+            }));
+
+            return nextRule;
+        },
+        deleteAutomationRuleById: async (ruleId) => {
+            await deleteAutomationRule(ruleId);
+            set((state) => ({
+                automationRules: state.automationRules.filter((rule) => rule.id !== ruleId),
+            }));
+        },
+        previewAutomationRule: (rule, imagesToPreview) => {
+            const state = get();
+            return previewAutomationRule(
+                rule,
+                imagesToPreview && imagesToPreview.length > 0 ? imagesToPreview : state.images,
+                state.annotations,
+                state.collections,
+            );
+        },
+        applyAutomationRuleNow: async (ruleId, imagesToApply) => {
+            const rule = get().automationRules.find((entry) => entry.id === ruleId);
+            if (!rule) {
+                return null;
+            }
+
+            return applyAutomationRuleToCurrentState(rule, imagesToApply);
+        },
+        applyEnabledAutomationRulesToImages: async (imagesToApply) => {
+            const state = get();
+            if (!state.isAnnotationsLoaded || imagesToApply.length === 0) {
+                return [];
+            }
+
+            const rules = state.automationRules.filter((rule) => rule.enabled && rule.runOnNewImages);
+            const previews: AutomationRulePreview[] = [];
+            for (const rule of rules) {
+                previews.push(await applyAutomationRuleToCurrentState(rule, imagesToApply));
+            }
+            return previews;
         },
         updateCollection: async (collectionId, updates) => {
             const currentCollection = get().collections.find((collection) => collection.id === collectionId);
@@ -3733,43 +3959,45 @@ export const useImageStore = create<ImageState>((set, get) => {
                 updatedAnnotations.push(updatedAnnotation);
             }
 
-            if (updatedAnnotations.length === 0) return;
+            if (updatedAnnotations.length > 0) {
+                // Update state
+                set(state => {
+                    const newAnnotations = new Map(state.annotations);
+                    for (const annotation of updatedAnnotations) {
+                        newAnnotations.set(annotation.imageId, annotation);
+                    }
 
-            // Update state
-            set(state => {
-                const newAnnotations = new Map(state.annotations);
-                for (const annotation of updatedAnnotations) {
-                    newAnnotations.set(annotation.imageId, annotation);
-                }
+                    const updatedImages = state.images.map(img => {
+                        const annotation = newAnnotations.get(img.id);
+                        return annotation ? { ...img, tags: annotation.tags, rating: annotation.rating } : img;
+                    });
 
-                const updatedImages = state.images.map(img => {
-                    const annotation = newAnnotations.get(img.id);
-                    return annotation ? { ...img, tags: annotation.tags, rating: annotation.rating } : img;
+                    const newState = {
+                        ...state,
+                        annotations: newAnnotations,
+                        images: updatedImages,
+                    };
+
+                    return { ...newState, ...filterAndSort(newState) };
                 });
 
-                const newState = {
-                    ...state,
-                    annotations: newAnnotations,
-                    images: updatedImages,
-                };
+                const importedTagNames = Array.from(new Set(
+                    updatedAnnotations.flatMap(annotation => annotation.tags)
+                ));
 
-                return { ...newState, ...filterAndSort(newState) };
-            });
+                // Persist annotations
+                await Promise.all([
+                    bulkSaveAnnotations(updatedAnnotations),
+                    ...importedTagNames.map(tagName => ensureManualTagExists(tagName)),
+                ]).catch(error => {
+                    console.error('Failed to import metadata tags:', error);
+                });
 
-            const importedTagNames = Array.from(new Set(
-                updatedAnnotations.flatMap(annotation => annotation.tags)
-            ));
+                // Refresh available tags
+                await get().refreshAvailableTags();
+            }
 
-            // Persist annotations
-            await Promise.all([
-                bulkSaveAnnotations(updatedAnnotations),
-                ...importedTagNames.map(tagName => ensureManualTagExists(tagName)),
-            ]).catch(error => {
-                console.error('Failed to import metadata tags:', error);
-            });
-
-            // Refresh available tags
-            await get().refreshAvailableTags();
+            await get().applyEnabledAutomationRulesToImages(images);
         },
 
         flushPendingImages: () => {
@@ -3871,6 +4099,8 @@ export const useImageStore = create<ImageState>((set, get) => {
             selectedImages: new Set(),
             activeImageScope: null,
             collections: [],
+            automationRules: [],
+            isAutomationRulesLoaded: false,
             activeCollectionId: null,
             searchQuery: '',
             availableModels: [],

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -2793,11 +2793,16 @@ export const useImageStore = create<ImageState>((set, get) => {
             return applyAutomationRuleToCurrentState(rule, imagesToApply);
         },
         applyEnabledAutomationRulesToImages: async (imagesToApply) => {
-            const state = get();
-            if (!state.isAnnotationsLoaded || imagesToApply.length === 0) {
+            const initialState = get();
+            if (!initialState.isAnnotationsLoaded || imagesToApply.length === 0) {
                 return [];
             }
 
+            if (!initialState.isAutomationRulesLoaded) {
+                await get().loadAutomationRules();
+            }
+
+            const state = get();
             const rules = state.automationRules.filter((rule) => rule.enabled && rule.runOnNewImages);
             const previews: AutomationRulePreview[] = [];
             for (const rule of rules) {

--- a/types.ts
+++ b/types.ts
@@ -720,12 +720,46 @@ export interface SelectedFiltersUpdate {
 export type AutomationRuleMatchMode = 'all' | 'any';
 export type AutomationTextField = 'prompt' | 'negativePrompt' | 'filename' | 'metadata';
 export type AutomationTextOperator = 'contains' | 'not_contains' | 'equals' | 'not_equals';
+export type AutomationConditionField =
+  | AutomationTextField
+  | 'model'
+  | 'lora'
+  | 'sampler'
+  | 'scheduler'
+  | 'generator'
+  | 'gpu'
+  | 'tag'
+  | 'autoTag'
+  | 'dimension'
+  | 'favorite'
+  | 'rating'
+  | 'steps'
+  | 'cfg'
+  | 'telemetry'
+  | 'verifiedTelemetry';
+export type AutomationConditionOperator =
+  | AutomationTextOperator
+  | 'includes'
+  | 'not_includes'
+  | 'is'
+  | 'is_not'
+  | 'at_least'
+  | 'at_most'
+  | 'between';
 
 export interface AutomationTextCondition {
   id: string;
   field: AutomationTextField;
   operator: AutomationTextOperator;
   value: string;
+}
+
+export interface AutomationConditionRow {
+  id: string;
+  field: AutomationConditionField;
+  operator: AutomationConditionOperator;
+  value: string;
+  valueEnd?: string;
 }
 
 export interface AutomationRuleFilterCriteria extends SelectedFiltersUpdate {
@@ -743,6 +777,7 @@ export interface AutomationRuleFilterCriteria extends SelectedFiltersUpdate {
 export interface AutomationRuleCriteria {
   matchMode: AutomationRuleMatchMode;
   textConditions: AutomationTextCondition[];
+  conditionRows?: AutomationConditionRow[];
   filters: AutomationRuleFilterCriteria;
 }
 

--- a/types.ts
+++ b/types.ts
@@ -717,6 +717,54 @@ export interface SelectedFiltersUpdate {
   excludedGpuDevices?: string[];
 }
 
+export type AutomationRuleMatchMode = 'all' | 'any';
+export type AutomationTextField = 'prompt' | 'negativePrompt' | 'filename' | 'metadata';
+export type AutomationTextOperator = 'contains' | 'not_contains' | 'equals' | 'not_equals';
+
+export interface AutomationTextCondition {
+  id: string;
+  field: AutomationTextField;
+  operator: AutomationTextOperator;
+  value: string;
+}
+
+export interface AutomationRuleFilterCriteria extends SelectedFiltersUpdate {
+  searchQuery?: string;
+  tags?: string[];
+  excludedTags?: string[];
+  tagMatchMode?: TagMatchMode;
+  autoTags?: string[];
+  excludedAutoTags?: string[];
+  favoriteFilterMode?: InclusionFilterMode;
+  ratings?: ImageRating[];
+  advancedFilters?: AdvancedFilters;
+}
+
+export interface AutomationRuleCriteria {
+  matchMode: AutomationRuleMatchMode;
+  textConditions: AutomationTextCondition[];
+  filters: AutomationRuleFilterCriteria;
+}
+
+export interface AutomationRuleAction {
+  addTags: string[];
+  addToCollectionIds: string[];
+}
+
+export interface AutomationRule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  criteria: AutomationRuleCriteria;
+  actions: AutomationRuleAction;
+  runOnNewImages: boolean;
+  createdAt: number;
+  updatedAt: number;
+  lastAppliedAt?: number | null;
+  lastMatchCount?: number;
+  lastChangeCount?: number;
+}
+
 export interface IndexedImage {
   id: string; // Unique ID, e.g., file path
   name: string;

--- a/types.ts
+++ b/types.ts
@@ -718,7 +718,7 @@ export interface SelectedFiltersUpdate {
 }
 
 export type AutomationRuleMatchMode = 'all' | 'any';
-export type AutomationTextField = 'prompt' | 'negativePrompt' | 'filename' | 'metadata';
+export type AutomationTextField = 'prompt' | 'negativePrompt' | 'filename' | 'metadata' | 'search';
 export type AutomationTextOperator = 'contains' | 'not_contains' | 'equals' | 'not_equals';
 export type AutomationConditionField =
   | AutomationTextField

--- a/types.ts
+++ b/types.ts
@@ -760,6 +760,7 @@ export interface AutomationConditionRow {
   operator: AutomationConditionOperator;
   value: string;
   valueEnd?: string;
+  groupMode?: AutomationRuleMatchMode;
 }
 
 export interface AutomationRuleFilterCriteria extends SelectedFiltersUpdate {

--- a/utils/automationRuleRows.ts
+++ b/utils/automationRuleRows.ts
@@ -1,0 +1,441 @@
+import type {
+  AdvancedFilters,
+  AutomationConditionField,
+  AutomationConditionOperator,
+  AutomationConditionRow,
+  AutomationRule,
+  AutomationRuleCriteria,
+  AutomationRuleFilterCriteria,
+  AutomationTextField,
+  AutomationTextOperator,
+  ImageRating,
+  IndexedImage,
+  TagInfo,
+} from '../types';
+
+export interface ConditionValueSource {
+  images: IndexedImage[];
+  availableModels: string[];
+  availableLoras: string[];
+  availableSamplers: string[];
+  availableSchedulers: string[];
+  availableGenerators: string[];
+  availableGpuDevices: string[];
+  availableDimensions: string[];
+  availableTags: TagInfo[];
+  availableAutoTags: TagInfo[];
+}
+
+export interface CurrentRuleFiltersSnapshot extends AutomationRuleFilterCriteria {}
+
+export const TEXT_CONDITION_FIELDS: AutomationConditionField[] = ['prompt', 'negativePrompt', 'filename', 'metadata'];
+export const FACET_CONDITION_FIELDS: AutomationConditionField[] = [
+  'model',
+  'lora',
+  'sampler',
+  'scheduler',
+  'generator',
+  'gpu',
+  'tag',
+  'autoTag',
+  'dimension',
+];
+export const NUMBER_CONDITION_FIELDS: AutomationConditionField[] = ['rating', 'steps', 'cfg'];
+export const BOOLEAN_CONDITION_FIELDS: AutomationConditionField[] = ['favorite', 'telemetry', 'verifiedTelemetry'];
+const CONDITION_FIELD_VALUES: AutomationConditionField[] = [
+  'prompt',
+  'negativePrompt',
+  'filename',
+  'metadata',
+  'model',
+  'lora',
+  'sampler',
+  'scheduler',
+  'generator',
+  'gpu',
+  'tag',
+  'autoTag',
+  'dimension',
+  'favorite',
+  'rating',
+  'steps',
+  'cfg',
+  'telemetry',
+  'verifiedTelemetry',
+];
+
+export const CONDITION_FIELD_LABELS: Record<AutomationConditionField, string> = {
+  prompt: 'Prompt',
+  negativePrompt: 'Negative Prompt',
+  filename: 'Filename',
+  metadata: 'Metadata',
+  model: 'Checkpoint',
+  lora: 'LoRA',
+  sampler: 'Sampler',
+  scheduler: 'Scheduler',
+  generator: 'Generator',
+  gpu: 'GPU',
+  tag: 'Manual Tag',
+  autoTag: 'Auto Tag',
+  dimension: 'Dimensions',
+  favorite: 'Favorite',
+  rating: 'Rating',
+  steps: 'Steps',
+  cfg: 'CFG',
+  telemetry: 'Telemetry',
+  verifiedTelemetry: 'Verified Telemetry',
+};
+
+export const OPERATOR_LABELS: Record<AutomationConditionOperator, string> = {
+  contains: 'contains',
+  not_contains: 'does not contain',
+  equals: 'equals',
+  not_equals: 'does not equal',
+  includes: 'includes',
+  not_includes: 'does not include',
+  is: 'is',
+  is_not: 'is not',
+  at_least: 'at least',
+  at_most: 'at most',
+  between: 'between',
+};
+
+const createRowId = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `condition-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const normalizeList = (values: string[] | undefined, lower = false): string[] =>
+  Array.from(
+    new Set(
+      (values ?? [])
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map((value) => lower ? value.toLowerCase() : value),
+    ),
+  );
+
+const addRowsFromValues = (
+  rows: AutomationConditionRow[],
+  field: AutomationConditionField,
+  operator: AutomationConditionOperator,
+  values: string[] | undefined,
+) => {
+  for (const value of normalizeList(values, field === 'tag')) {
+    rows.push({ id: createRowId(), field, operator, value });
+  }
+};
+
+const isTextField = (field: AutomationConditionField): field is AutomationTextField =>
+  TEXT_CONDITION_FIELDS.includes(field);
+
+const isTextOperator = (operator: AutomationConditionOperator): operator is AutomationTextOperator =>
+  operator === 'contains' || operator === 'not_contains' || operator === 'equals' || operator === 'not_equals';
+
+export function getConditionFieldOptions(): Array<{ value: AutomationConditionField; label: string }> {
+  return CONDITION_FIELD_VALUES.map((field) => ({ value: field, label: CONDITION_FIELD_LABELS[field] }));
+}
+
+export function getOperatorsForField(field: AutomationConditionField): AutomationConditionOperator[] {
+  if (TEXT_CONDITION_FIELDS.includes(field)) {
+    return ['contains', 'not_contains', 'equals', 'not_equals'];
+  }
+  if (FACET_CONDITION_FIELDS.includes(field)) {
+    return ['includes', 'not_includes'];
+  }
+  if (NUMBER_CONDITION_FIELDS.includes(field)) {
+    return ['equals', 'at_least', 'at_most', 'between'];
+  }
+  return ['is', 'is_not'];
+}
+
+export function getDefaultOperatorForField(field: AutomationConditionField): AutomationConditionOperator {
+  return getOperatorsForField(field)[0] ?? 'contains';
+}
+
+export function createDefaultConditionRow(): AutomationConditionRow {
+  return {
+    id: createRowId(),
+    field: 'prompt',
+    operator: 'contains',
+    value: '',
+  };
+}
+
+const normalizeField = (field: unknown): AutomationConditionField =>
+  CONDITION_FIELD_VALUES.includes(field as AutomationConditionField)
+    ? field as AutomationConditionField
+    : 'prompt';
+
+export function normalizeConditionRow(row: Partial<AutomationConditionRow>): AutomationConditionRow {
+  const field = normalizeField(row.field);
+  const operator = getOperatorsForField(field).includes(row.operator as AutomationConditionOperator)
+    ? row.operator as AutomationConditionOperator
+    : getDefaultOperatorForField(field);
+  return {
+    id: row.id || createRowId(),
+    field,
+    operator,
+    value: typeof row.value === 'string' ? row.value : '',
+    valueEnd: typeof row.valueEnd === 'string' ? row.valueEnd : '',
+  };
+}
+
+export function isConditionRowComplete(row: AutomationConditionRow): boolean {
+  if (row.field === 'favorite' || row.field === 'telemetry' || row.field === 'verifiedTelemetry') {
+    return true;
+  }
+  if (!row.value.trim()) {
+    return false;
+  }
+  if (row.operator === 'between') {
+    return Boolean(row.valueEnd?.trim());
+  }
+  return true;
+}
+
+export function ruleToConditionRows(rule: AutomationRule): AutomationConditionRow[] {
+  if (rule.criteria.conditionRows?.length) {
+    return rule.criteria.conditionRows.map(normalizeConditionRow);
+  }
+
+  const rows: AutomationConditionRow[] = [];
+  for (const condition of rule.criteria.textConditions ?? []) {
+    rows.push({
+      id: condition.id || createRowId(),
+      field: condition.field,
+      operator: condition.operator,
+      value: condition.value,
+    });
+  }
+
+  rows.push(...filterCriteriaToConditionRows(rule.criteria.filters));
+  return rows;
+}
+
+export function filterCriteriaToConditionRows(filters: AutomationRuleFilterCriteria): AutomationConditionRow[] {
+  const rows: AutomationConditionRow[] = [];
+
+  if (filters.searchQuery?.trim()) {
+    rows.push({ id: createRowId(), field: 'metadata', operator: 'contains', value: filters.searchQuery.trim() });
+  }
+
+  addRowsFromValues(rows, 'model', 'includes', filters.models);
+  addRowsFromValues(rows, 'model', 'not_includes', filters.excludedModels);
+  addRowsFromValues(rows, 'lora', 'includes', filters.loras);
+  addRowsFromValues(rows, 'lora', 'not_includes', filters.excludedLoras);
+  addRowsFromValues(rows, 'sampler', 'includes', filters.samplers);
+  addRowsFromValues(rows, 'sampler', 'not_includes', filters.excludedSamplers);
+  addRowsFromValues(rows, 'scheduler', 'includes', filters.schedulers);
+  addRowsFromValues(rows, 'scheduler', 'not_includes', filters.excludedSchedulers);
+  addRowsFromValues(rows, 'generator', 'includes', filters.generators);
+  addRowsFromValues(rows, 'generator', 'not_includes', filters.excludedGenerators);
+  addRowsFromValues(rows, 'gpu', 'includes', filters.gpuDevices);
+  addRowsFromValues(rows, 'gpu', 'not_includes', filters.excludedGpuDevices);
+  addRowsFromValues(rows, 'tag', 'includes', filters.tags);
+  addRowsFromValues(rows, 'tag', 'not_includes', filters.excludedTags);
+  addRowsFromValues(rows, 'autoTag', 'includes', filters.autoTags);
+  addRowsFromValues(rows, 'autoTag', 'not_includes', filters.excludedAutoTags);
+
+  if (filters.favoriteFilterMode === 'include' || filters.favoriteFilterMode === 'exclude') {
+    rows.push({
+      id: createRowId(),
+      field: 'favorite',
+      operator: filters.favoriteFilterMode === 'include' ? 'is' : 'is_not',
+      value: 'true',
+    });
+  }
+
+  for (const rating of filters.ratings ?? []) {
+    rows.push({ id: createRowId(), field: 'rating', operator: 'equals', value: String(rating) });
+  }
+
+  const advanced = filters.advancedFilters ?? {};
+  if (advanced.dimension) {
+    rows.push({ id: createRowId(), field: 'dimension', operator: 'includes', value: advanced.dimension });
+  }
+  if (advanced.steps) rows.push(...rangeToRows('steps', advanced.steps));
+  if (advanced.cfg) rows.push(...rangeToRows('cfg', advanced.cfg));
+  if (advanced.telemetryState === 'present' || advanced.telemetryState === 'missing') {
+    rows.push({
+      id: createRowId(),
+      field: 'telemetry',
+      operator: advanced.telemetryState === 'present' ? 'is' : 'is_not',
+      value: 'present',
+    });
+  }
+  if (advanced.hasVerifiedTelemetry === true) {
+    rows.push({ id: createRowId(), field: 'verifiedTelemetry', operator: 'is', value: 'true' });
+  }
+
+  return rows;
+}
+
+const rangeToRows = (
+  field: 'steps' | 'cfg',
+  range: NonNullable<AdvancedFilters['steps']>,
+): AutomationConditionRow[] => {
+  const hasMin = range.min !== null && range.min !== undefined;
+  const hasMax = range.max !== null && range.max !== undefined;
+  if (hasMin && hasMax && range.min === range.max) {
+    return [{ id: createRowId(), field, operator: 'equals', value: String(range.min) }];
+  }
+  if (hasMin && hasMax) {
+    return [{ id: createRowId(), field, operator: 'between', value: String(range.min), valueEnd: String(range.max) }];
+  }
+  if (hasMin) {
+    return [{ id: createRowId(), field, operator: 'at_least', value: String(range.min) }];
+  }
+  if (hasMax) {
+    return [{ id: createRowId(), field, operator: 'at_most', value: String(range.max) }];
+  }
+  return [];
+};
+
+export function conditionRowsToCriteria(
+  rows: AutomationConditionRow[],
+  matchMode: AutomationRuleCriteria['matchMode'],
+): AutomationRuleCriteria {
+  const completeRows = rows.map(normalizeConditionRow).filter(isConditionRowComplete);
+  const filters: AutomationRuleFilterCriteria = {
+    tagMatchMode: 'any',
+    favoriteFilterMode: 'neutral',
+    advancedFilters: {},
+  };
+  const textConditions = [];
+
+  for (const row of completeRows) {
+    if (isTextField(row.field) && isTextOperator(row.operator)) {
+      textConditions.push({ id: row.id, field: row.field, operator: row.operator, value: row.value.trim() });
+      continue;
+    }
+
+    applyRowToFilters(row, filters);
+  }
+
+  return {
+    matchMode,
+    textConditions,
+    conditionRows: completeRows,
+    filters,
+  };
+}
+
+const pushFilterValue = (
+  filters: AutomationRuleFilterCriteria,
+  key: keyof AutomationRuleFilterCriteria,
+  value: string,
+  lower = false,
+) => {
+  const normalized = lower ? value.trim().toLowerCase() : value.trim();
+  if (!normalized) return;
+  const current = Array.isArray(filters[key]) ? filters[key] as string[] : [];
+  (filters as Record<string, unknown>)[key] = Array.from(new Set([...current, normalized]));
+};
+
+const applyRowToFilters = (row: AutomationConditionRow, filters: AutomationRuleFilterCriteria) => {
+  const isExclude = row.operator === 'not_includes' || row.operator === 'is_not' || row.operator === 'not_equals';
+  switch (row.field) {
+    case 'model': pushFilterValue(filters, isExclude ? 'excludedModels' : 'models', row.value); break;
+    case 'lora': pushFilterValue(filters, isExclude ? 'excludedLoras' : 'loras', row.value); break;
+    case 'sampler': pushFilterValue(filters, isExclude ? 'excludedSamplers' : 'samplers', row.value); break;
+    case 'scheduler': pushFilterValue(filters, isExclude ? 'excludedSchedulers' : 'schedulers', row.value); break;
+    case 'generator': pushFilterValue(filters, isExclude ? 'excludedGenerators' : 'generators', row.value); break;
+    case 'gpu': pushFilterValue(filters, isExclude ? 'excludedGpuDevices' : 'gpuDevices', row.value); break;
+    case 'tag': pushFilterValue(filters, isExclude ? 'excludedTags' : 'tags', row.value, true); break;
+    case 'autoTag': pushFilterValue(filters, isExclude ? 'excludedAutoTags' : 'autoTags', row.value); break;
+    case 'dimension':
+      filters.advancedFilters = { ...filters.advancedFilters, dimension: row.value.trim() };
+      break;
+    case 'favorite':
+      filters.favoriteFilterMode = row.operator === 'is_not' ? 'exclude' : 'include';
+      break;
+    case 'rating':
+      filters.ratings = Array.from(new Set([...(filters.ratings ?? []), Number(row.value) as ImageRating]))
+        .filter((rating): rating is ImageRating => [1, 2, 3, 4, 5].includes(rating));
+      break;
+    case 'steps':
+    case 'cfg':
+      filters.advancedFilters = {
+        ...filters.advancedFilters,
+        [row.field]: rowToRange(row),
+      };
+      break;
+    case 'telemetry':
+      filters.advancedFilters = {
+        ...filters.advancedFilters,
+        telemetryState: row.operator === 'is_not' ? 'missing' : 'present',
+      };
+      break;
+    case 'verifiedTelemetry':
+      if (row.operator === 'is') {
+        filters.advancedFilters = { ...filters.advancedFilters, hasVerifiedTelemetry: true };
+      }
+      break;
+  }
+};
+
+const rowToRange = (row: AutomationConditionRow): NonNullable<AdvancedFilters['steps']> => {
+  const value = Number(row.value);
+  const valueEnd = Number(row.valueEnd);
+  if (row.operator === 'between') {
+    return { min: Number.isFinite(value) ? value : null, max: Number.isFinite(valueEnd) ? valueEnd : null };
+  }
+  if (row.operator === 'at_least') return { min: Number.isFinite(value) ? value : null, max: null };
+  if (row.operator === 'at_most') return { min: null, max: Number.isFinite(value) ? value : null };
+  return { min: Number.isFinite(value) ? value : null, max: Number.isFinite(value) ? value : null };
+};
+
+export function getConditionValueOptions(
+  field: AutomationConditionField,
+  source: ConditionValueSource,
+): string[] {
+  switch (field) {
+    case 'model': return source.availableModels;
+    case 'lora': return source.availableLoras;
+    case 'sampler': return source.availableSamplers;
+    case 'scheduler': return source.availableSchedulers;
+    case 'generator': return source.availableGenerators;
+    case 'gpu': return source.availableGpuDevices;
+    case 'tag': return source.availableTags.map((tag) => tag.name);
+    case 'autoTag': return source.availableAutoTags.map((tag) => tag.name);
+    case 'dimension': return source.availableDimensions;
+    case 'rating': return ['1', '2', '3', '4', '5'];
+    case 'telemetry': return ['present'];
+    case 'verifiedTelemetry': return ['true'];
+    case 'favorite': return ['true'];
+    case 'prompt':
+    case 'negativePrompt':
+    case 'filename':
+    case 'metadata':
+      return getTextValueSuggestions(field, source.images);
+    default:
+      return [];
+  }
+}
+
+export function getTextValueSuggestions(field: AutomationConditionField, images: IndexedImage[], limit = 80): string[] {
+  const counts = new Map<string, number>();
+  for (const image of images) {
+    const text = getTextForField(field, image).toLowerCase();
+    for (const rawToken of text.split(/[\s,]+/)) {
+      const token = rawToken.replace(/^[^a-z0-9_-]+|[^a-z0-9_-]+$/gi, '').trim();
+      if (token.length < 2 || /^\d+$/.test(token)) continue;
+      counts.set(token, (counts.get(token) ?? 0) + 1);
+    }
+  }
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([token]) => token);
+}
+
+const getTextForField = (field: AutomationConditionField, image: IndexedImage): string => {
+  switch (field) {
+    case 'negativePrompt': return image.negativePrompt ?? image.metadata?.normalizedMetadata?.negativePrompt ?? '';
+    case 'filename': return image.name ?? '';
+    case 'metadata': return image.metadataString ?? '';
+    case 'prompt': return image.prompt ?? image.metadata?.normalizedMetadata?.prompt ?? '';
+    default: return '';
+  }
+};

--- a/utils/automationRuleRows.ts
+++ b/utils/automationRuleRows.ts
@@ -139,9 +139,10 @@ const addRowsFromValues = (
   field: AutomationConditionField,
   operator: AutomationConditionOperator,
   values: string[] | undefined,
+  groupMode?: AutomationConditionRow['groupMode'],
 ) => {
   for (const value of normalizeList(values, field === 'tag')) {
-    rows.push({ id: createRowId(), field, operator, value });
+    rows.push({ id: createRowId(), field, operator, value, groupMode });
   }
 };
 
@@ -197,6 +198,7 @@ export function normalizeConditionRow(row: Partial<AutomationConditionRow>): Aut
     operator,
     value: typeof row.value === 'string' ? row.value : '',
     valueEnd: typeof row.valueEnd === 'string' ? row.valueEnd : '',
+    groupMode: row.groupMode === 'all' || row.groupMode === 'any' ? row.groupMode : undefined,
   };
 }
 
@@ -251,7 +253,7 @@ export function filterCriteriaToConditionRows(filters: AutomationRuleFilterCrite
   addRowsFromValues(rows, 'generator', 'not_includes', filters.excludedGenerators);
   addRowsFromValues(rows, 'gpu', 'includes', filters.gpuDevices);
   addRowsFromValues(rows, 'gpu', 'not_includes', filters.excludedGpuDevices);
-  addRowsFromValues(rows, 'tag', 'includes', filters.tags);
+  addRowsFromValues(rows, 'tag', 'includes', filters.tags, filters.tagMatchMode === 'all' ? 'all' : undefined);
   addRowsFromValues(rows, 'tag', 'not_includes', filters.excludedTags);
   addRowsFromValues(rows, 'autoTag', 'includes', filters.autoTags);
   addRowsFromValues(rows, 'autoTag', 'not_includes', filters.excludedAutoTags);
@@ -349,7 +351,12 @@ const applyRowToFilters = (row: AutomationConditionRow, filters: AutomationRuleF
     case 'scheduler': pushFilterValue(filters, isExclude ? 'excludedSchedulers' : 'schedulers', row.value); break;
     case 'generator': pushFilterValue(filters, isExclude ? 'excludedGenerators' : 'generators', row.value); break;
     case 'gpu': pushFilterValue(filters, isExclude ? 'excludedGpuDevices' : 'gpuDevices', row.value); break;
-    case 'tag': pushFilterValue(filters, isExclude ? 'excludedTags' : 'tags', row.value, true); break;
+    case 'tag':
+      pushFilterValue(filters, isExclude ? 'excludedTags' : 'tags', row.value, true);
+      if (!isExclude && row.groupMode === 'all') {
+        filters.tagMatchMode = 'all';
+      }
+      break;
     case 'autoTag': pushFilterValue(filters, isExclude ? 'excludedAutoTags' : 'autoTags', row.value); break;
     case 'dimension':
       filters.advancedFilters = { ...filters.advancedFilters, dimension: row.value.trim() };

--- a/utils/automationRuleRows.ts
+++ b/utils/automationRuleRows.ts
@@ -28,7 +28,7 @@ export interface ConditionValueSource {
 
 export interface CurrentRuleFiltersSnapshot extends AutomationRuleFilterCriteria {}
 
-export const TEXT_CONDITION_FIELDS: AutomationConditionField[] = ['prompt', 'negativePrompt', 'filename', 'metadata'];
+export const TEXT_CONDITION_FIELDS: AutomationConditionField[] = ['prompt', 'negativePrompt', 'filename', 'metadata', 'search'];
 export const FACET_CONDITION_FIELDS: AutomationConditionField[] = [
   'model',
   'lora',
@@ -43,6 +43,7 @@ export const FACET_CONDITION_FIELDS: AutomationConditionField[] = [
 export const NUMBER_CONDITION_FIELDS: AutomationConditionField[] = ['rating', 'steps', 'cfg'];
 export const BOOLEAN_CONDITION_FIELDS: AutomationConditionField[] = ['favorite'];
 const ALL_CONDITION_FIELD_VALUES: AutomationConditionField[] = [
+  'search',
   'prompt',
   'negativePrompt',
   'filename',
@@ -64,6 +65,7 @@ const ALL_CONDITION_FIELD_VALUES: AutomationConditionField[] = [
   'verifiedTelemetry',
 ];
 const CONDITION_FIELD_VALUES: AutomationConditionField[] = [
+  'search',
   'prompt',
   'negativePrompt',
   'filename',
@@ -84,6 +86,7 @@ const CONDITION_FIELD_VALUES: AutomationConditionField[] = [
 ];
 
 export const CONDITION_FIELD_LABELS: Record<AutomationConditionField, string> = {
+  search: 'Search',
   prompt: 'Prompt',
   negativePrompt: 'Negative Prompt',
   filename: 'Filename',
@@ -238,7 +241,7 @@ export function filterCriteriaToConditionRows(filters: AutomationRuleFilterCrite
   const rows: AutomationConditionRow[] = [];
 
   if (filters.searchQuery?.trim()) {
-    rows.push({ id: createRowId(), field: 'metadata', operator: 'contains', value: filters.searchQuery.trim() });
+    rows.push({ id: createRowId(), field: 'search', operator: 'contains', value: filters.searchQuery.trim() });
   }
 
   addRowsFromValues(rows, 'model', 'includes', filters.models);
@@ -315,6 +318,12 @@ export function conditionRowsToCriteria(
 
   for (const row of completeRows) {
     if (isTextField(row.field) && isTextOperator(row.operator)) {
+      if (row.field === 'search') {
+        if (row.operator === 'contains') {
+          filters.searchQuery = row.value.trim();
+        }
+        continue;
+      }
       textConditions.push({ id: row.id, field: row.field, operator: row.operator, value: row.value.trim() });
       continue;
     }
@@ -420,6 +429,7 @@ export function getConditionValueOptions(
     case 'negativePrompt':
     case 'filename':
     case 'metadata':
+    case 'search':
       return getTextValueSuggestions(field, source.images);
     default:
       return [];
@@ -444,6 +454,17 @@ export function getTextValueSuggestions(field: AutomationConditionField, images:
 
 const getTextForField = (field: AutomationConditionField, image: IndexedImage): string => {
   switch (field) {
+    case 'search':
+      return [
+        image.name,
+        image.prompt,
+        image.negativePrompt,
+        image.metadataString,
+        ...(image.models ?? []),
+        ...(image.loras ?? []).map((lora) => typeof lora === 'string' ? lora : lora?.name ?? lora?.model_name ?? ''),
+        image.sampler,
+        image.scheduler,
+      ].filter(Boolean).join(' ');
     case 'negativePrompt': return image.negativePrompt ?? image.metadata?.normalizedMetadata?.negativePrompt ?? '';
     case 'filename': return image.name ?? '';
     case 'metadata': return image.metadataString ?? '';

--- a/utils/automationRuleRows.ts
+++ b/utils/automationRuleRows.ts
@@ -41,8 +41,8 @@ export const FACET_CONDITION_FIELDS: AutomationConditionField[] = [
   'dimension',
 ];
 export const NUMBER_CONDITION_FIELDS: AutomationConditionField[] = ['rating', 'steps', 'cfg'];
-export const BOOLEAN_CONDITION_FIELDS: AutomationConditionField[] = ['favorite', 'telemetry', 'verifiedTelemetry'];
-const CONDITION_FIELD_VALUES: AutomationConditionField[] = [
+export const BOOLEAN_CONDITION_FIELDS: AutomationConditionField[] = ['favorite'];
+const ALL_CONDITION_FIELD_VALUES: AutomationConditionField[] = [
   'prompt',
   'negativePrompt',
   'filename',
@@ -63,6 +63,25 @@ const CONDITION_FIELD_VALUES: AutomationConditionField[] = [
   'telemetry',
   'verifiedTelemetry',
 ];
+const CONDITION_FIELD_VALUES: AutomationConditionField[] = [
+  'prompt',
+  'negativePrompt',
+  'filename',
+  'metadata',
+  'model',
+  'lora',
+  'sampler',
+  'scheduler',
+  'generator',
+  'gpu',
+  'tag',
+  'autoTag',
+  'dimension',
+  'favorite',
+  'rating',
+  'steps',
+  'cfg',
+];
 
 export const CONDITION_FIELD_LABELS: Record<AutomationConditionField, string> = {
   prompt: 'Prompt',
@@ -82,15 +101,15 @@ export const CONDITION_FIELD_LABELS: Record<AutomationConditionField, string> = 
   rating: 'Rating',
   steps: 'Steps',
   cfg: 'CFG',
-  telemetry: 'Telemetry',
-  verifiedTelemetry: 'Verified Telemetry',
+  telemetry: 'Performance Data',
+  verifiedTelemetry: 'Verified Performance Data',
 };
 
 export const OPERATOR_LABELS: Record<AutomationConditionOperator, string> = {
   contains: 'contains',
   not_contains: 'does not contain',
   equals: 'equals',
-  not_equals: 'does not equal',
+  not_equals: 'is not exactly',
   includes: 'includes',
   not_includes: 'does not include',
   is: 'is',
@@ -138,7 +157,7 @@ export function getConditionFieldOptions(): Array<{ value: AutomationConditionFi
 
 export function getOperatorsForField(field: AutomationConditionField): AutomationConditionOperator[] {
   if (TEXT_CONDITION_FIELDS.includes(field)) {
-    return ['contains', 'not_contains', 'equals', 'not_equals'];
+    return ['contains', 'not_contains'];
   }
   if (FACET_CONDITION_FIELDS.includes(field)) {
     return ['includes', 'not_includes'];
@@ -163,7 +182,7 @@ export function createDefaultConditionRow(): AutomationConditionRow {
 }
 
 const normalizeField = (field: unknown): AutomationConditionField =>
-  CONDITION_FIELD_VALUES.includes(field as AutomationConditionField)
+  ALL_CONDITION_FIELD_VALUES.includes(field as AutomationConditionField)
     ? field as AutomationConditionField
     : 'prompt';
 
@@ -201,12 +220,12 @@ export function ruleToConditionRows(rule: AutomationRule): AutomationConditionRo
 
   const rows: AutomationConditionRow[] = [];
   for (const condition of rule.criteria.textConditions ?? []) {
-    rows.push({
+    rows.push(normalizeConditionRow({
       id: condition.id || createRowId(),
       field: condition.field,
       operator: condition.operator,
       value: condition.value,
-    });
+    }));
   }
 
   rows.push(...filterCriteriaToConditionRows(rule.criteria.filters));
@@ -256,18 +275,6 @@ export function filterCriteriaToConditionRows(filters: AutomationRuleFilterCrite
   }
   if (advanced.steps) rows.push(...rangeToRows('steps', advanced.steps));
   if (advanced.cfg) rows.push(...rangeToRows('cfg', advanced.cfg));
-  if (advanced.telemetryState === 'present' || advanced.telemetryState === 'missing') {
-    rows.push({
-      id: createRowId(),
-      field: 'telemetry',
-      operator: advanced.telemetryState === 'present' ? 'is' : 'is_not',
-      value: 'present',
-    });
-  }
-  if (advanced.hasVerifiedTelemetry === true) {
-    rows.push({ id: createRowId(), field: 'verifiedTelemetry', operator: 'is', value: 'true' });
-  }
-
   return rows;
 }
 
@@ -401,8 +408,6 @@ export function getConditionValueOptions(
     case 'autoTag': return source.availableAutoTags.map((tag) => tag.name);
     case 'dimension': return source.availableDimensions;
     case 'rating': return ['1', '2', '3', '4', '5'];
-    case 'telemetry': return ['present'];
-    case 'verifiedTelemetry': return ['true'];
     case 'favorite': return ['true'];
     case 'prompt':
     case 'negativePrompt':


### PR DESCRIPTION
## Summary
- Adds persistent automation rules for applying tags and adding images to collections.
- Adds a guided row-based rules editor with existing filter facets, collection actions, manual apply, enable/disable, duplicate, and previews.
- Integrates Rules into the sidebar action area and adds an Advanced path from Create Collection to start a collection rule.
- Preserves additive/idempotent behavior: rules add tags or collection membership without removing existing user organization.

## Validation
- `npx vitest run` completed with 53 test files passing and 1 existing Analytics test file failing.
- Passing coverage includes `AutomationRulesModal`, `automationRuleRows`, `automationRuleEngine`, storage, store filters, collections, and CLI.

## Known Test Failure
`__tests__/Analytics.test.tsx` fails 4 tests because the Analytics component renders an empty body in the test environment, so expected buttons/text are not present:
- `Full Library`
- `performance`
- `50%`

This failure is outside the automation rules surface and was present during validation of this branch.