### PR TITLE
Preserve image selection when opening images

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1320,10 +1320,16 @@ export default function App() {
       ? navigationImageOverride!
       : safeClusterNavigationContext.length > 0
         ? safeClusterNavigationContext
-        : safeFilteredImages;
+        : safeActiveImageScope ?? safeFilteredImages;
     const navigationImageIds = navigationSource.map((entry) => entry.id);
     const navigationSourceType: OpenImageModalState['navigationSource'] =
-      navigationSourceOverride ?? (safeClusterNavigationContext.length > 0 ? 'cluster' : 'filtered');
+      navigationSourceOverride ?? (
+        safeClusterNavigationContext.length > 0
+          ? 'cluster'
+          : safeActiveImageScope
+            ? 'scope'
+            : 'filtered'
+      );
 
     setOpenImageModals((current) => {
       const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;
@@ -1359,7 +1365,7 @@ export default function App() {
         },
       ];
     });
-  }, [safeClusterNavigationContext, safeFilteredImages]);
+  }, [safeActiveImageScope, safeClusterNavigationContext, safeFilteredImages]);
 
   const handleGridImageClick = useCallback((image: IndexedImage, event: React.MouseEvent) => {
     if (event.button === 1) {

--- a/App.tsx
+++ b/App.tsx
@@ -1869,7 +1869,7 @@ export default function App() {
                       ) : (
                         <ImageTable
                           images={paginatedImages}
-                          onImageClick={handleImageSelection}
+                          onImageClick={handleGridImageClick}
                           selectedImages={safeSelectedImages}
                           onBatchExport={handleOpenBatchExport}
                         />
@@ -1903,7 +1903,7 @@ export default function App() {
                     ) : (
                       <ImageTable
                         images={paginatedImages}
-                        onImageClick={handleImageSelection}
+                        onImageClick={handleGridImageClick}
                         selectedImages={safeSelectedImages}
                         onBatchExport={handleOpenBatchExport}
                         activeCollection={activeCollection}

--- a/App.tsx
+++ b/App.tsx
@@ -1310,14 +1310,20 @@ export default function App() {
     }
   }, [getImageByIdFromStore, openImageModals, resolveModalNavigationImageIds, setSelectedImage]);
 
-  const handleOpenImageModalInBackground = useCallback((image: IndexedImage) => {
-    const navigationSource =
-      safeClusterNavigationContext.length > 0
+  const handleOpenImageModalInBackground = useCallback((
+    image: IndexedImage,
+    navigationImageOverride?: IndexedImage[],
+    navigationSourceOverride?: OpenImageModalState['navigationSource']
+  ) => {
+    const hasNavigationOverride = Boolean(navigationImageOverride?.length);
+    const navigationSource = hasNavigationOverride
+      ? navigationImageOverride!
+      : safeClusterNavigationContext.length > 0
         ? safeClusterNavigationContext
         : safeFilteredImages;
     const navigationImageIds = navigationSource.map((entry) => entry.id);
     const navigationSourceType: OpenImageModalState['navigationSource'] =
-      safeClusterNavigationContext.length > 0 ? 'cluster' : 'filtered';
+      navigationSourceOverride ?? (safeClusterNavigationContext.length > 0 ? 'cluster' : 'filtered');
 
     setOpenImageModals((current) => {
       const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;
@@ -1927,6 +1933,9 @@ export default function App() {
                     isQueueOpen={isQueueOpen}
                     onToggleQueue={() => setIsQueueOpen((prev) => !prev)}
                     onBatchExport={handleOpenBatchExport}
+                    onOpenImageInBackground={(image, navigationImages) => {
+                      handleOpenImageModalInBackground(image, navigationImages, 'cluster');
+                    }}
                   />
                 )}
               </div>

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import ImageGrid from '../components/ImageGrid';
+import { useImageSelection } from '../hooks/useImageSelection';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import type { IndexedImage } from '../types';
@@ -136,6 +137,23 @@ const Harness = ({ images }: { images: IndexedImage[] }) => {
     <ImageGrid
       images={images}
       onImageClick={vi.fn()}
+      selectedImages={selectedImages}
+      currentPage={1}
+      totalPages={1}
+      onPageChange={vi.fn()}
+      onBatchExport={vi.fn()}
+    />
+  );
+};
+
+const SelectionHarness = ({ images }: { images: IndexedImage[] }) => {
+  const selectedImages = useImageStore((state) => state.selectedImages);
+  const { handleImageSelection } = useImageSelection();
+
+  return (
+    <ImageGrid
+      images={images}
+      onImageClick={handleImageSelection}
       selectedImages={selectedImages}
       currentPage={1}
       totalPages={1}
@@ -314,5 +332,180 @@ describe('ImageGrid context menu', () => {
     fireEvent.click(screen.getByText('Carros'));
 
     expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
+  });
+});
+
+describe('ImageGrid selection opening behavior', () => {
+  beforeEach(() => {
+    showContextMenuMock.mockReset();
+    hideContextMenuMock.mockReset();
+    contextMenuStateMock.visible = false;
+    contextMenuStateMock.image = undefined;
+    useImageStore.getState().resetState();
+    useSettingsStore.getState().resetState();
+    useSettingsStore.setState({
+      itemsPerPage: 20,
+      imageSize: 120,
+      disableThumbnails: false,
+      showFilenames: false,
+      showFullFilePath: false,
+      doubleClickToOpen: false,
+      sensitiveTags: [],
+      blurSensitiveImages: false,
+      enableSafeMode: false,
+    } as any);
+  });
+
+  it('preserves checked images when plain-clicking another image to open it', () => {
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png' }),
+      createImage({ id: 'img-2', name: 'beta.png' }),
+      createImage({ id: 'img-3', name: 'gamma.png' }),
+    ];
+
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1', 'img-2']),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<SelectionHarness images={images} />);
+
+    fireEvent.click(screen.getByAltText('gamma.png'));
+
+    expect(useImageStore.getState().selectedImage?.id).toBe('img-3');
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
+  });
+
+  it('preserves checked images while previewing and double-click opening when double-click mode is enabled', () => {
+    const onImageClick = vi.fn();
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png' }),
+      createImage({ id: 'img-2', name: 'beta.png' }),
+      createImage({ id: 'img-3', name: 'gamma.png' }),
+    ];
+
+    useSettingsStore.setState({ doubleClickToOpen: true } as any);
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1', 'img-2']),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(
+      <ImageGrid
+        images={images}
+        onImageClick={onImageClick}
+        selectedImages={useImageStore.getState().selectedImages}
+        currentPage={1}
+        totalPages={1}
+        onPageChange={vi.fn()}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    const imageThumb = screen.getByAltText('gamma.png');
+    fireEvent.click(imageThumb);
+
+    expect(useImageStore.getState().previewImage?.id).toBe('img-3');
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
+    expect(onImageClick).not.toHaveBeenCalled();
+
+    fireEvent.doubleClick(imageThumb);
+
+    expect(onImageClick).toHaveBeenCalledTimes(1);
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
+  });
+
+  it('preserves checked images when middle-clicking an image', () => {
+    const onImageClick = vi.fn();
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png' }),
+      createImage({ id: 'img-2', name: 'beta.png' }),
+      createImage({ id: 'img-3', name: 'gamma.png' }),
+    ];
+
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1', 'img-2']),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<Harness images={images} />);
+
+    const imageThumb = screen.getByAltText('gamma.png');
+    fireEvent.mouseDown(imageThumb, { button: 1 });
+    fireEvent(imageThumb, new MouseEvent('auxclick', { bubbles: true, button: 1 }));
+
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
+  });
+
+  it('still toggles selection from the checkbox', () => {
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png' }),
+      createImage({ id: 'img-2', name: 'beta.png' }),
+    ];
+
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1']),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<Harness images={images} />);
+
+    fireEvent.click(screen.getByTitle('Deselect image'));
+
+    expect(useImageStore.getState().selectedImages).toEqual(new Set());
+  });
+
+  it('clears checked images when clicking empty grid space without modifiers', () => {
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png' }),
+      createImage({ id: 'img-2', name: 'beta.png' }),
+    ];
+
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1', 'img-2']),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    const { container } = render(<Harness images={images} />);
+    const gridArea = container.querySelector('[data-area="grid"]') as HTMLElement;
+
+    fireEvent.mouseDown(gridArea, { button: 0, clientX: 4, clientY: 4 });
+
+    expect(useImageStore.getState().selectedImages).toEqual(new Set());
   });
 });

--- a/__tests__/ImageTable.contextMenu.test.tsx
+++ b/__tests__/ImageTable.contextMenu.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import ImageTable from '../components/ImageTable';
+import { useImageSelection } from '../hooks/useImageSelection';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import type { IndexedImage } from '../types';
@@ -30,6 +31,11 @@ vi.mock('../hooks/useContextMenu', () => ({
     exportImage: vi.fn(),
     copyRawMetadata: vi.fn(),
   }),
+}));
+
+vi.mock('react-virtualized-auto-sizer', () => ({
+  default: ({ children }: { children: (size: { height: number; width: number }) => React.ReactNode }) =>
+    children({ height: 600, width: 1200 }),
 }));
 
 vi.mock('../hooks/useThumbnail', () => ({
@@ -85,6 +91,20 @@ const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
   workflowNodes: overrides.workflowNodes ?? [],
   ...overrides,
 });
+
+const SelectionHarness = ({ images }: { images: IndexedImage[] }) => {
+  const selectedImages = useImageStore((state) => state.selectedImages);
+  const { handleImageSelection } = useImageSelection();
+
+  return (
+    <ImageTable
+      images={images}
+      onImageClick={handleImageSelection}
+      selectedImages={selectedImages}
+      onBatchExport={vi.fn()}
+    />
+  );
+};
 
 describe('ImageTable context menu', () => {
   beforeEach(() => {
@@ -181,5 +201,77 @@ describe('ImageTable context menu', () => {
     fireEvent.click(screen.getByText('Carros'));
 
     expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
+  });
+});
+
+describe('ImageTable selection opening behavior', () => {
+  beforeEach(() => {
+    showContextMenuMock.mockReset();
+    hideContextMenuMock.mockReset();
+    contextMenuStateMock.visible = false;
+    contextMenuStateMock.image = undefined;
+    useImageStore.getState().resetState();
+    useSettingsStore.getState().resetState();
+    useSettingsStore.setState({
+      disableThumbnails: false,
+      showFullFilePath: false,
+    } as any);
+  });
+
+  it('preserves checked images when plain-clicking another row to open it', () => {
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png' }),
+      createImage({ id: 'img-2', name: 'beta.png' }),
+      createImage({ id: 'img-3', name: 'gamma.png' }),
+    ];
+
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1', 'img-2']),
+      transferProgress: null,
+    } as any);
+
+    render(<SelectionHarness images={images} />);
+
+    fireEvent.click(screen.getByText('gamma.png'));
+
+    expect(useImageStore.getState().selectedImage?.id).toBe('img-3');
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
+  });
+
+  it('emits middle-click as an open gesture without changing checked images', () => {
+    const onImageClick = vi.fn();
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png' }),
+      createImage({ id: 'img-2', name: 'beta.png' }),
+      createImage({ id: 'img-3', name: 'gamma.png' }),
+    ];
+
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(['img-1', 'img-2']),
+      transferProgress: null,
+    } as any);
+
+    render(
+      <ImageTable
+        images={images}
+        onImageClick={onImageClick}
+        selectedImages={useImageStore.getState().selectedImages}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    const target = screen.getByText('gamma.png');
+    fireEvent.mouseDown(target, { button: 1 });
+    fireEvent(target, new MouseEvent('auxclick', { bubbles: true, button: 1 }));
+
+    expect(onImageClick).toHaveBeenCalledTimes(1);
+    expect(onImageClick.mock.calls[0]?.[0]).toMatchObject({ id: 'img-3' });
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
   });
 });

--- a/components/FacetFilterSection.tsx
+++ b/components/FacetFilterSection.tsx
@@ -122,6 +122,20 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                 placeholder={searchPlaceholder ?? `Filter ${title.toLowerCase()}...`}
                 className="w-full bg-transparent text-sm text-gray-200 outline-none placeholder:text-gray-500"
               />
+              {query.length > 0 && (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    setQuery('');
+                  }}
+                  className="rounded-md p-0.5 text-gray-500 transition-colors hover:bg-gray-700 hover:text-gray-200"
+                  title={`Clear ${title.toLowerCase()} search`}
+                  aria-label={`Clear ${title.toLowerCase()} search`}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              )}
             </label>
           )}
 

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -323,10 +323,7 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
             if (e.ctrlKey || e.metaKey) {
               toggleImageSelection(image.id);
             } else {
-              useImageStore.setState({
-                selectedImages: new Set([image.id]),
-                previewImage: image
-              });
+              setPreviewImage(image);
             }
           } else {
             onImageClick(image, e);
@@ -1269,11 +1266,6 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         nextIndex = -1;
       }
 
-      if (nextIndex !== -1 && nextIndex !== currentIndex) {
-         if (!e.ctrlKey && !e.shiftKey) {
-             useImageStore.setState({ selectedImages: new Set([images[nextIndex].id]) });
-         }
-      }
     };
 
     document.addEventListener('keydown', handleKeyDown);

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -814,7 +814,20 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
       className={`border-b border-gray-700 hover:bg-gray-800/50 cursor-pointer transition-colors group grid items-center ${
         isSelected ? 'bg-blue-900/30 border-blue-700' : ''
       }`}
+      onMouseDown={(e) => {
+        if (e.button === 1) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }}
       onClick={(e) => onImageClick(image, e)}
+      onAuxClick={(e) => {
+        if (e.button === 1) {
+          e.preventDefault();
+          e.stopPropagation();
+          onImageClick(image, e);
+        }
+      }}
       onContextMenu={(e) => onContextMenu && onContextMenu(image, e)}
       style={{ height: '64px', gridTemplateColumns }}
     >

--- a/components/SmartLibrary.tsx
+++ b/components/SmartLibrary.tsx
@@ -22,9 +22,15 @@ interface SmartLibraryProps {
   isQueueOpen?: boolean;
   onToggleQueue?: () => void;
   onBatchExport: () => void;
+  onOpenImageInBackground?: (image: IndexedImage, navigationImages: IndexedImage[]) => void;
 }
 
-const SmartLibrary: React.FC<SmartLibraryProps> = ({ isQueueOpen = false, onToggleQueue, onBatchExport }) => {
+const SmartLibrary: React.FC<SmartLibraryProps> = ({
+  isQueueOpen = false,
+  onToggleQueue,
+  onBatchExport,
+  onOpenImageInBackground,
+}) => {
   const filteredImages = useImageStore((state) => state.filteredImages);
   const clusters = useImageStore((state) => state.clusters);
   const directories = useImageStore((state) => state.directories);
@@ -239,6 +245,7 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({ isQueueOpen = false, onTogg
             totalPages={clusterTotalPages}
             onPageChange={setClusterPage}
             onBatchExport={onBatchExport}
+            onOpenImageInBackground={onOpenImageInBackground}
           />
         ) : paginatedEntries.length === 0 ? (
           <div className="h-full flex flex-col items-center justify-center text-center text-gray-400">

--- a/components/StackExpandedView.tsx
+++ b/components/StackExpandedView.tsx
@@ -34,7 +34,6 @@ const StackExpandedView: React.FC<StackExpandedViewProps> = ({
   const selectedImages = useImageStore((state) => state.selectedImages);
   const setSelectedImage = useImageStore((state) => state.setSelectedImage);
   const toggleImageSelection = useImageStore((state) => state.toggleImageSelection);
-  const clearImageSelection = useImageStore((state) => state.clearImageSelection);
   const setFocusedImageIndex = useImageStore((state) => state.setFocusedImageIndex);
   const setClusterNavigationContext = useImageStore((state) => state.setClusterNavigationContext);
 
@@ -124,13 +123,11 @@ const StackExpandedView: React.FC<StackExpandedViewProps> = ({
         return;
       }
 
-      clearImageSelection();
       setClusterNavigationContext(allImages);
       setSelectedImage(image);
     },
     [
       allImages,
-      clearImageSelection,
       safeSelectedImages,
       selectedImage,
       setFocusedImageIndex,

--- a/components/StackExpandedView.tsx
+++ b/components/StackExpandedView.tsx
@@ -17,6 +17,7 @@ interface StackExpandedViewProps {
   onPageChange: (page: number) => void;
   onBack: () => void;
   onBatchExport: () => void;
+  onOpenImageInBackground?: (image: IndexedImage, navigationImages: IndexedImage[]) => void;
 }
 
 const StackExpandedView: React.FC<StackExpandedViewProps> = ({
@@ -29,6 +30,7 @@ const StackExpandedView: React.FC<StackExpandedViewProps> = ({
   onPageChange,
   onBack,
   onBatchExport,
+  onOpenImageInBackground,
 }) => {
   const selectedImage = useImageStore((state) => state.selectedImage);
   const selectedImages = useImageStore((state) => state.selectedImages);
@@ -124,10 +126,17 @@ const StackExpandedView: React.FC<StackExpandedViewProps> = ({
       }
 
       setClusterNavigationContext(allImages);
+      if (event.button === 1 && onOpenImageInBackground) {
+        event.preventDefault();
+        onOpenImageInBackground(image, allImages);
+        return;
+      }
+
       setSelectedImage(image);
     },
     [
       allImages,
+      onOpenImageInBackground,
       safeSelectedImages,
       selectedImage,
       setFocusedImageIndex,

--- a/hooks/useImageSelection.ts
+++ b/hooks/useImageSelection.ts
@@ -40,10 +40,7 @@ export function useImageSelection() {
         if (event.ctrlKey || event.metaKey) {
             toggleImageSelection(image.id);
         } else {
-            // Single selection: Clear previous, set new selected image, AND update the set
-            // The set update is critical for the Selection Toolbar to appear
             setSelectedImage(image);
-            useImageStore.setState({ selectedImages: new Set([image.id]) });
         }
     }, [toggleImageSelection, setSelectedImage, setFocusedImageIndex]);
 


### PR DESCRIPTION
## Summary

Fixes the gallery selection behavior reported in issue #222 by separating image opening from bulk selection state.

## What changed

- Opening or previewing an image no longer clears the checked image batch.
- Double-click-to-open mode now previews/opens without overwriting checked images.
- Middle-click opens images in a background/minimized viewer from grid, table/list, and expanded stack views.
- Empty-space clicks still intentionally clear checked images.
- Added a small clear button to facet search fields for checkpoints, LoRAs, samplers, and schedulers.

## Validation

- `npm test -- ImageGrid ImageTable -- --run`
- `npx tsc -b`