### PR TITLE
Fix clustering worst-case comparisons

### DIFF
--- a/__tests__/clusteringEngine.test.ts
+++ b/__tests__/clusteringEngine.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { generateClusters, LightweightImage } from '../services/clusteringEngine';
+
+describe('clustering engine', () => {
+  it('keeps low-threshold clustering behavior for zero-overlap pairs in the same bucket', async () => {
+    const images: LightweightImage[] = [
+      {
+        id: 'a',
+        lastModified: 1,
+        prompt: 'aaaaaaaaab aaaaaaaaac',
+      },
+      {
+        id: 'b',
+        lastModified: 2,
+        prompt: 'aaaaaaaaad aaaaaaaaae',
+      },
+      {
+        id: 'bridge',
+        lastModified: 3,
+        prompt: 'aaaaaaaaab aaaaaaaaac aaaaaaaaad aaaaaaaaae',
+      },
+    ];
+
+    const clusters = await generateClusters(images, { threshold: 0.33 });
+
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].imageIds).toEqual(['a', 'b', 'bridge']);
+  });
+});

--- a/__tests__/similarityMetrics.test.ts
+++ b/__tests__/similarityMetrics.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { normalizedLevenshtein } from '../utils/similarityMetrics';
+
+describe('similarity metrics', () => {
+  it('returns the exact Levenshtein similarity when a bounded comparison can still pass', () => {
+    const promptA = 'portrait, blue hair, cinematic light, sharp focus';
+    const promptB = 'portrait, blue hair, cinematic lighting, sharp focus';
+    const exact = normalizedLevenshtein(promptA, promptB);
+
+    expect(normalizedLevenshtein(promptA, promptB, exact - 0.01)).toBeCloseTo(exact);
+  });
+
+  it('short-circuits bounded Levenshtein comparisons that cannot meet the minimum similarity', () => {
+    const promptA = 'portrait, blue hair, cinematic light, sharp focus';
+    const promptB = 'landscape, red forest, foggy morning, wide angle';
+
+    expect(normalizedLevenshtein(promptA, promptB, 0.95)).toBe(0);
+  });
+});

--- a/services/clusteringEngine.ts
+++ b/services/clusteringEngine.ts
@@ -315,7 +315,21 @@ function mergeSimilarClusters(
 
   const comparisonChunk = 2000;
   let pendingComparisons = 0;
+  let accountedComparisons = 0;
+  const totalPairComparisons = (clusters.length * (clusters.length - 1)) / 2;
   const minJaccard = Math.max(0, (threshold - 0.4) / 0.6);
+
+  const recordComparisons = (count: number) => {
+    if (count <= 0) return;
+    accountedComparisons += count;
+    if (!onComparisonProgress) return;
+
+    pendingComparisons += count;
+    if (pendingComparisons >= comparisonChunk) {
+      onComparisonProgress(pendingComparisons);
+      pendingComparisons = 0;
+    }
+  };
 
   const jaccardFromTokens = (a: Set<string>, b: Set<string>): number => {
     if (a.size === 0 && b.size === 0) return 1;
@@ -335,6 +349,7 @@ function mergeSimilarClusters(
   for (let i = 0; i < clusters.length; i++) {
     parent.set(i, i);
   }
+  let componentCount = clusters.length;
 
   // Track similarities of merged pairs for each group
   const groupSimilarities = new Map<number, number[]>();
@@ -351,6 +366,7 @@ function mergeSimilarClusters(
     const rootJ = find(j);
     if (rootI !== rootJ) {
       parent.set(rootI, rootJ);
+      componentCount -= 1;
       // Track similarity for this merge
       if (!groupSimilarities.has(rootJ)) {
         groupSimilarities.set(rootJ, []);
@@ -359,36 +375,103 @@ function mergeSimilarClusters(
     }
   }
 
-  // Compare all pairs
-  for (let i = 0; i < clusters.length; i++) {
-    for (let j = i + 1; j < clusters.length; j++) {
-      const jaccard = jaccardFromTokens(clusters[i].tokens, clusters[j].tokens);
-      if (jaccard < minJaccard) {
-        if (onComparisonProgress) {
-          pendingComparisons += 1;
-          if (pendingComparisons >= comparisonChunk) {
-            onComparisonProgress(pendingComparisons);
-            pendingComparisons = 0;
-          }
+  const requiredOverlap = (a: Set<string>, b: Set<string>): number => {
+    return Math.ceil((minJaccard * (a.size + b.size)) / (1 + minJaccard));
+  };
+
+  const comparePair = (i: number, j: number): boolean => {
+    if (componentCount === 1) {
+      return true;
+    }
+
+    if (find(i) === find(j)) {
+      recordComparisons(1);
+      return false;
+    }
+
+    const jaccard = jaccardFromTokens(clusters[i].tokens, clusters[j].tokens);
+    if (jaccard < minJaccard) {
+      recordComparisons(1);
+      return false;
+    }
+
+    const levenshtein = normalizedLevenshtein(
+      clusters[i].basePrompt,
+      clusters[j].basePrompt,
+      (threshold - jaccard * 0.6) / 0.4
+    );
+    const similarity = jaccard * 0.6 + levenshtein * 0.4;
+
+    if (similarity >= threshold) {
+      union(i, j, similarity);
+    }
+
+    recordComparisons(1);
+    return false;
+  };
+
+  const compareCandidatePairs = (): boolean => {
+    if (minJaccard <= 0) {
+      return false;
+    }
+
+    const tokenPostings = new Map<string, number[]>();
+    for (let i = 0; i < clusters.length; i++) {
+      for (const token of clusters[i].tokens) {
+        const postings = tokenPostings.get(token);
+        if (postings) {
+          postings.push(i);
+        } else {
+          tokenPostings.set(token, [i]);
         }
+      }
+    }
+
+    const postingWork = [...tokenPostings.values()].reduce(
+      (sum, postings) => sum + (postings.length * (postings.length - 1)) / 2,
+      0
+    );
+
+    if (postingWork >= totalPairComparisons) {
+      return false;
+    }
+
+    const overlapCounts = new Map<number, number>();
+    for (const postings of tokenPostings.values()) {
+      for (let a = 0; a < postings.length; a++) {
+        const i = postings[a];
+        for (let b = a + 1; b < postings.length; b++) {
+          const j = postings[b];
+          const key = i * clusters.length + j;
+          overlapCounts.set(key, (overlapCounts.get(key) || 0) + 1);
+        }
+      }
+    }
+
+    for (const [key, overlap] of overlapCounts.entries()) {
+      const i = Math.floor(key / clusters.length);
+      const j = key % clusters.length;
+      if (overlap < requiredOverlap(clusters[i].tokens, clusters[j].tokens)) {
         continue;
       }
 
-      const levenshtein = normalizedLevenshtein(
-        clusters[i].basePrompt,
-        clusters[j].basePrompt
-      );
-      const similarity = jaccard * 0.6 + levenshtein * 0.4;
-
-      if (similarity >= threshold) {
-        union(i, j, similarity);
+      if (comparePair(i, j)) {
+        break;
       }
+    }
 
-      if (onComparisonProgress) {
-        pendingComparisons += 1;
-        if (pendingComparisons >= comparisonChunk) {
-          onComparisonProgress(pendingComparisons);
-          pendingComparisons = 0;
+    recordComparisons(totalPairComparisons - accountedComparisons);
+    return true;
+  };
+
+  if (!compareCandidatePairs()) {
+    // Compare all pairs
+    pairwiseScan:
+    for (let i = 0; i < clusters.length; i++) {
+      for (let j = i + 1; j < clusters.length; j++) {
+        if (comparePair(i, j)) {
+          recordComparisons(totalPairComparisons - accountedComparisons);
+          break pairwiseScan;
         }
       }
     }

--- a/utils/similarityMetrics.ts
+++ b/utils/similarityMetrics.ts
@@ -8,52 +8,126 @@
  */
 
 /**
- * Calculate Levenshtein distance between two strings
- * Classic dynamic programming algorithm O(n*m)
+ * Calculate Levenshtein distance between two strings.
+ *
+ * When maxDistance is provided, this uses a bounded band and may return any
+ * value above maxDistance once the strings can no longer match the caller's
+ * threshold. That keeps clustering fast for very long tag-heavy prompts.
  */
-function levenshteinDistance(str1: string, str2: string): number {
-  const len1 = str1.length;
-  const len2 = str2.length;
+function levenshteinDistance(str1: string, str2: string, maxDistance = Infinity): number {
+  let len1 = str1.length;
+  let len2 = str2.length;
 
-  // Create a 2D array for memoization
-  const matrix: number[][] = Array(len1 + 1)
-    .fill(null)
-    .map(() => Array(len2 + 1).fill(0));
+  if (len1 === 0) return len2;
+  if (len2 === 0) return len1;
 
-  // Initialize first row and column
-  for (let i = 0; i <= len1; i++) {
-    matrix[i][0] = i;
+  let start = 0;
+  while (start < len1 && start < len2 && str1[start] === str2[start]) {
+    start++;
   }
+
+  while (
+    len1 > start &&
+    len2 > start &&
+    str1[len1 - 1] === str2[len2 - 1]
+  ) {
+    len1--;
+    len2--;
+  }
+
+  str1 = str1.slice(start, len1);
+  str2 = str2.slice(start, len2);
+  len1 = str1.length;
+  len2 = str2.length;
+
+  if (len1 === 0) return len2;
+  if (len2 === 0) return len1;
+
+  if (len1 > len2) {
+    [str1, str2] = [str2, str1];
+    [len1, len2] = [len2, len1];
+  }
+
+  const bounded = Number.isFinite(maxDistance);
+  const limit = bounded ? Math.floor(maxDistance) : len2;
+
+  if (bounded && len2 - len1 > limit) {
+    return limit + 1;
+  }
+
+  const previous = new Array<number>(len2 + 1);
+  const current = new Array<number>(len2 + 1);
   for (let j = 0; j <= len2; j++) {
-    matrix[0][j] = j;
+    previous[j] = j;
   }
 
-  // Fill in the rest of the matrix
+  const unreachable = limit + 1;
+
   for (let i = 1; i <= len1; i++) {
-    for (let j = 1; j <= len2; j++) {
+    current[0] = i;
+    let rowMin = current[0];
+
+    const jStart = bounded ? Math.max(1, i - limit) : 1;
+    const jEnd = bounded ? Math.min(len2, i + limit) : len2;
+
+    for (let j = 1; j < jStart; j++) {
+      current[j] = unreachable;
+    }
+
+    for (let j = jStart; j <= jEnd; j++) {
       const cost = str1[i - 1] === str2[j - 1] ? 0 : 1;
-      matrix[i][j] = Math.min(
-        matrix[i - 1][j] + 1, // deletion
-        matrix[i][j - 1] + 1, // insertion
-        matrix[i - 1][j - 1] + cost // substitution
+      const distance = Math.min(
+        previous[j] + 1,
+        current[j - 1] + 1,
+        previous[j - 1] + cost
       );
+      current[j] = distance;
+      if (distance < rowMin) {
+        rowMin = distance;
+      }
+    }
+
+    for (let j = jEnd + 1; j <= len2; j++) {
+      current[j] = unreachable;
+    }
+
+    if (bounded && rowMin > limit) {
+      return limit + 1;
+    }
+
+    for (let j = 0; j <= len2; j++) {
+      previous[j] = current[j];
     }
   }
 
-  return matrix[len1][len2];
+  return previous[len2];
 }
 
 /**
  * Normalized Levenshtein similarity (0-1 scale)
  * 1.0 = identical strings, 0.0 = completely different
  */
-export function normalizedLevenshtein(str1: string, str2: string): number {
+export function normalizedLevenshtein(
+  str1: string,
+  str2: string,
+  minSimilarity = 0
+): number {
   if (str1 === str2) return 1.0;
   if (str1.length === 0 && str2.length === 0) return 1.0;
   if (str1.length === 0 || str2.length === 0) return 0.0;
 
-  const distance = levenshteinDistance(str1, str2);
   const maxLen = Math.max(str1.length, str2.length);
+  const boundedMinSimilarity = Math.max(0, Math.min(1, minSimilarity));
+  const maxDistance =
+    boundedMinSimilarity > 0
+      ? Math.floor((1 - boundedMinSimilarity) * maxLen)
+      : Infinity;
+
+  const distance = levenshteinDistance(str1, str2, maxDistance);
+
+  if (boundedMinSimilarity > 0 && distance > maxDistance) {
+    return 0.0;
+  }
 
   return 1 - distance / maxLen;
 }


### PR DESCRIPTION
## Summary

Fixes a clustering performance edge case where large prompt-similarity buckets could trigger excessive pairwise comparisons.

## What Changed

- Added candidate-pair generation based on token overlap so clustering can skip pairs that cannot meet the similarity threshold.
- Falls back to the all-pairs scan when the Jaccard floor is zero, preserving low-threshold Levenshtein-driven behavior for zero-overlap pairs.
- Avoids redundant comparisons once union-find has already connected prompts into the same component.
- Stops scanning early when a bucket has already collapsed into a single cluster.
- Added bounded Levenshtein scoring for comparisons that cannot possibly satisfy the remaining threshold requirement.
- Added focused tests for bounded Levenshtein behavior and low-threshold zero-overlap clustering.

## Why

Some libraries can create large buckets of unique but related prompts. The previous phase 3 path could degrade into expensive all-pairs text similarity checks, making clustering appear stuck while slowly progressing.

## Validation

- `npm test -- --run __tests__/clusteringEngine.test.ts __tests__/similarityMetrics.test.ts` passed
- `npm test -- --run __tests__/cli.test.ts` passed on rerun
- `npm test -- --run __tests__/Analytics.test.tsx` passed as part of targeted rerun
- `npm run build` passed
- Full `npm test -- --run` hit two 5s timeout flakes (`cli.test.ts`, `Analytics.test.tsx`); both passed when rerun in targeted commands