### PR TITLE
Refine ImageModal interactions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1511,6 +1511,9 @@ export default function App() {
   const hasActiveVisibleImageModal = openImageModalEntries.some(
     (modal) => !modal.isMinimized && modal.modalId === activeImageModalId
   );
+  const libraryContentFocusClass = hasActiveVisibleImageModal
+    ? 'blur-[1px] opacity-95'
+    : 'blur-0 opacity-100';
 
   const activeFolderHasProgress = (() => {
     const progressDirectoryIds = Object.keys(directoryProgress);
@@ -1867,7 +1870,7 @@ export default function App() {
                   />
                 )}
 
-              <div className="flex-1 min-h-0">
+              <div className={`flex-1 min-h-0 transition-[filter,opacity] duration-150 ease-out ${libraryContentFocusClass}`}>
                 {libraryView === 'library' ? (
                   shouldShowLibraryPlaceholder ? (
                     <div className="flex h-full items-center justify-center text-sm text-gray-500">
@@ -2006,8 +2009,9 @@ export default function App() {
 
         {hasActiveVisibleImageModal && (
           <div
-            className="fixed inset-0 z-50 bg-black/10 backdrop-blur-[2px] transition-opacity duration-200"
+            className="fixed inset-0 z-[58] bg-transparent"
             onClick={handleDeactivateImageModal}
+            aria-hidden="true"
           />
         )}
 

--- a/App.tsx
+++ b/App.tsx
@@ -1177,14 +1177,22 @@ export default function App() {
       .filter((modal) => !modal.isMinimized)
       .sort((left, right) => right.zIndex - left.zIndex)[0];
     const nextActiveModalId = nextActiveModal?.modalId ?? null;
+    const currentActiveModal = activeImageModalId
+      ? openImageModals.find((modal) => modal.modalId === activeImageModalId && !modal.isMinimized)
+      : null;
 
-    if (nextActiveModalId !== activeImageModalId) {
+    if (selectedImageId && nextActiveModalId !== activeImageModalId) {
       setActiveImageModalId(nextActiveModalId);
       return;
     }
 
-    if (nextActiveModal) {
-      const nextActiveImage = getImageByIdFromStore(nextActiveModal.imageId);
+    if (activeImageModalId && !currentActiveModal) {
+      setActiveImageModalId(nextActiveModalId);
+      return;
+    }
+
+    if (currentActiveModal) {
+      const nextActiveImage = getImageByIdFromStore(currentActiveModal.imageId);
       if (nextActiveImage && selectedImageId !== nextActiveImage.id) {
         setSelectedImage(nextActiveImage);
       }
@@ -1247,17 +1255,12 @@ export default function App() {
     );
   }, []);
 
-  const handleMinimizeAllImageModals = useCallback(() => {
-    setOpenImageModals((current) => {
-      if (current.every((modal) => modal.isMinimized)) {
-        return current;
-      }
-
-      return current.map((modal) => (
-        modal.isMinimized ? modal : { ...modal, isMinimized: true }
-      ));
-    });
-  }, []);
+  const handleDeactivateImageModal = useCallback(() => {
+    setActiveImageModalId(null);
+    if (useImageStore.getState().selectedImage !== null) {
+      setSelectedImage(null);
+    }
+  }, [setSelectedImage]);
 
   const handleCloseImageModal = useCallback((modalId: string, imageId: string) => {
     setOpenImageModals((current) => current.filter((modal) => modal.modalId !== modalId));
@@ -1505,7 +1508,9 @@ export default function App() {
         isMinimized: boolean;
       }>;
   }, [activeImageModalId, getImageByIdFromStore, openImageModals]);
-  const hasVisibleImageModal = openImageModalEntries.some((modal) => !modal.isMinimized);
+  const hasActiveVisibleImageModal = openImageModalEntries.some(
+    (modal) => !modal.isMinimized && modal.modalId === activeImageModalId
+  );
 
   const activeFolderHasProgress = (() => {
     const progressDirectoryIds = Object.keys(directoryProgress);
@@ -1999,10 +2004,10 @@ export default function App() {
           />
         ))}
 
-        {hasVisibleImageModal && (
+        {hasActiveVisibleImageModal && (
           <div
             className="fixed inset-0 z-50 bg-black/10 backdrop-blur-[2px] transition-opacity duration-200"
-            onClick={handleMinimizeAllImageModals}
+            onClick={handleDeactivateImageModal}
           />
         )}
 

--- a/App.tsx
+++ b/App.tsx
@@ -56,6 +56,14 @@ interface OpenImageModalState {
   zIndex: number;
   initialWindowOffset: number;
   isMinimized: boolean;
+  windowState?: ImageModalWindowState;
+}
+
+interface ImageModalWindowState {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 const SIDEBAR_WIDTH_STORAGE_KEY = 'image-metahub-sidebar-width';
@@ -1255,6 +1263,34 @@ export default function App() {
     );
   }, []);
 
+  const handleImageModalWindowStateChange = useCallback((
+    modalId: string,
+    windowState: ImageModalWindowState
+  ) => {
+    setOpenImageModals((current) => {
+      const targetIndex = current.findIndex((modal) => modal.modalId === modalId);
+      if (targetIndex === -1) {
+        return current;
+      }
+
+      const targetModal = current[targetIndex];
+      const currentWindowState = targetModal.windowState;
+      if (
+        currentWindowState &&
+        currentWindowState.x === windowState.x &&
+        currentWindowState.y === windowState.y &&
+        currentWindowState.width === windowState.width &&
+        currentWindowState.height === windowState.height
+      ) {
+        return current;
+      }
+
+      const next = [...current];
+      next[targetIndex] = { ...targetModal, windowState };
+      return next;
+    });
+  }, []);
+
   const handleDeactivateImageModal = useCallback(() => {
     setActiveImageModalId(null);
     if (useImageStore.getState().selectedImage !== null) {
@@ -2003,6 +2039,8 @@ export default function App() {
             isActive={activeImageModalId === modal.modalId && !modal.isMinimized}
             onActivate={() => handleActivateImageModal(modal.modalId)}
             initialWindowOffset={modal.initialWindowOffset}
+            initialWindowState={modal.windowState}
+            onWindowStateChange={(windowState) => handleImageModalWindowStateChange(modal.modalId, windowState)}
             isMinimized={modal.isMinimized}
             onMinimize={() => handleMinimizeImageModal(modal.modalId)}
           />

--- a/App.tsx
+++ b/App.tsx
@@ -2050,7 +2050,7 @@ export default function App() {
 
         {hasActiveVisibleImageModal && (
           <div
-            className="fixed inset-0 z-[58] bg-transparent"
+            className="fixed inset-0 z-[54] bg-transparent"
             onClick={handleDeactivateImageModal}
             aria-hidden="true"
           />

--- a/App.tsx
+++ b/App.tsx
@@ -1052,6 +1052,10 @@ export default function App() {
           ? 'scope'
           : 'filtered';
 
+    const existingModalForSelectedImage = openImageModals.find((modal) => modal.imageId === selectedImage.id);
+    const selectedModalId = existingModalForSelectedImage?.modalId ?? `image-modal-${Date.now()}-${selectedImage.id}`;
+    setActiveImageModalId(selectedModalId);
+
     setOpenImageModals((current) => {
       const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;
       const existingModal = current.find((modal) => modal.imageId === selectedImage.id);
@@ -1090,12 +1094,10 @@ export default function App() {
             ? 'scope'
             : 'filtered';
 
-      const modalId = `image-modal-${Date.now()}-${selectedImage.id}`;
-
       return [
         ...current,
         {
-          modalId,
+          modalId: selectedModalId,
           imageId: selectedImage.id,
           navigationImageIds,
           navigationSource: navigationSourceType,
@@ -1105,7 +1107,7 @@ export default function App() {
         },
       ];
     });
-  }, [clusterNavigationContext, safeActiveImageScope, safeClusterNavigationContext, safeFilteredImages, selectedImage]);
+  }, [clusterNavigationContext, openImageModals, safeActiveImageScope, safeClusterNavigationContext, safeFilteredImages, selectedImage]);
 
   const filteredNavigationImageIds = useMemo(
     () => safeFilteredImages.map((image) => image.id),

--- a/App.tsx
+++ b/App.tsx
@@ -1988,6 +1988,7 @@ export default function App() {
         {openImageModalEntries.map((modal) => (
           <ImageModal
             key={modal.modalId}
+            modalId={modal.modalId}
             image={modal.image}
             onClose={() => handleCloseImageModal(modal.modalId, modal.image.id)}
             onImageDeleted={handleImageDeleted}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -177,6 +177,7 @@ const Footer: React.FC<FooterProps> = ({
             {windowItems.map((windowItem) => (
               <div
                 key={windowItem.id}
+                data-image-modal-window-id={windowItem.id}
                 onMouseEnter={(event) => handleWindowHover(event, windowItem.id)}
                 onAuxClick={(event) => {
                   if (event.button !== 1) {

--- a/components/ImageLineageSection.tsx
+++ b/components/ImageLineageSection.tsx
@@ -102,20 +102,7 @@ const ImageLineageSection: React.FC<ImageLineageSectionProps> = ({
     () => getDerivedImages(image.id, 4),
     [getDerivedImages, image.id, derivedImageIds, lineageBuildState.lastBuiltAt]
   );
-  const isResolving = lineageBuildState.status === 'building' || lineageBuildState.status === 'scheduled';
-
   if (!resolvedLineage && derivedImages.length === 0) {
-    if (isResolving) {
-      return (
-        <div className="space-y-2 rounded-lg border border-blue-200/70 bg-blue-50/60 p-3 text-sm text-gray-700 dark:border-blue-500/20 dark:bg-blue-500/5 dark:text-gray-200">
-          <div className="font-semibold text-gray-800 dark:text-gray-100">Lineage</div>
-          <div className="rounded-md border border-dashed border-gray-300 bg-white/70 px-3 py-2 text-sm text-gray-600 dark:border-gray-600 dark:bg-gray-900/30 dark:text-gray-300">
-            Resolving lineage in the background...
-          </div>
-        </div>
-      );
-    }
-
     return null;
   }
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -79,6 +79,8 @@ interface ImageModalProps {
   isActive?: boolean;
   onActivate?: () => void;
   initialWindowOffset?: number;
+  initialWindowState?: ModalWindowState;
+  onWindowStateChange?: (windowState: ModalWindowState) => void;
   isMinimized?: boolean;
   onMinimize?: () => void;
 }
@@ -119,8 +121,10 @@ type ModalInteractionState =
     };
 
 type DetailsSidebarResizeState = {
+  axis: 'horizontal' | 'vertical';
   startX: number;
-  startWidth: number;
+  startY: number;
+  startSize: number;
 } | null;
 
 const MODAL_MARGIN = 20;
@@ -132,7 +136,9 @@ const MODAL_MIN_VISIBLE_WIDTH = 120;
 const MODAL_RECOVERABLE_TOP_HEIGHT = 80;
 const WINDOW_PROXY_ANIMATION_DURATION_MS = 140;
 const DETAILS_SIDEBAR_DEFAULT_WIDTH = 340;
+const DETAILS_SIDEBAR_DEFAULT_HEIGHT = 320;
 const DETAILS_SIDEBAR_MIN_WIDTH = 300;
+const DETAILS_SIDEBAR_MIN_HEIGHT = 240;
 const DETAILS_SIDEBAR_MAX_RATIO = 0.7;
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
@@ -159,6 +165,15 @@ const clampDetailsSidebarWidth = (width: number, modalWidth: number) => {
   );
 
   return clamp(width, DETAILS_SIDEBAR_MIN_WIDTH, maxWidth);
+};
+
+const clampDetailsSidebarHeight = (height: number, modalHeight: number) => {
+  const maxHeight = Math.max(
+    DETAILS_SIDEBAR_MIN_HEIGHT,
+    Math.floor(modalHeight * DETAILS_SIDEBAR_MAX_RATIO)
+  );
+
+  return clamp(height, DETAILS_SIDEBAR_MIN_HEIGHT, maxHeight);
 };
 
 const animateWindowProxy = async (fromRect: DOMRect, toRect: DOMRect, zIndex: number) => {
@@ -616,6 +631,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
   isActive = true,
   onActivate,
   initialWindowOffset = 0,
+  initialWindowState,
+  onWindowStateChange,
   isMinimized = false,
   onMinimize,
 }) => {
@@ -639,12 +656,17 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<'details' | 'workflow'>('details');
   const [sidebarWidth, setSidebarWidth] = useState(DETAILS_SIDEBAR_DEFAULT_WIDTH);
+  const [sidebarHeight, setSidebarHeight] = useState(DETAILS_SIDEBAR_DEFAULT_HEIGHT);
   const [sidebarResizeState, setSidebarResizeState] = useState<DetailsSidebarResizeState>(null);
   const isResizingSidebar = sidebarResizeState !== null;
   const [detailsPlacement, setDetailsPlacement] = useState<'right' | 'bottom'>('right');
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
   const [modalWindow, setModalWindow] = useState<ModalWindowState>(() => {
+    if (initialWindowState) {
+      return clampModalWindowToViewport(initialWindowState);
+    }
+
     const defaultWindow = createDefaultModalWindow();
     return clampModalWindowToViewport({
       ...defaultWindow,
@@ -885,7 +907,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
     modalWindowRef.current = modalWindow;
     liveModalWindowRef.current = modalWindow;
     applyModalWindowStyles(modalWindow);
-  }, [applyModalWindowStyles, modalWindow]);
+    onWindowStateChange?.(modalWindow);
+  }, [applyModalWindowStyles, modalWindow, onWindowStateChange]);
 
   useEffect(() => {
     return () => {
@@ -1141,11 +1164,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
       initialY: currentWindow.y,
     });
   }, [isFullscreen, isWindowMaximized]);
-
-  const resetModalWindow = useCallback(() => {
-    setIsWindowMaximized(false);
-    setModalWindow(createDefaultModalWindow());
-  }, []);
 
   const toggleWindowMaximize = useCallback(() => {
     if (isWindowMaximized) {
@@ -1708,9 +1726,16 @@ const ImageModal: React.FC<ImageModalProps> = ({
         return;
       }
 
-      const deltaX = event.clientX - sidebarResizeState.startX;
-      const nextWidth = sidebarResizeState.startWidth - deltaX;
-      setSidebarWidth(clampDetailsSidebarWidth(nextWidth, modalRect.width));
+      if (sidebarResizeState.axis === 'horizontal') {
+        const deltaX = event.clientX - sidebarResizeState.startX;
+        const nextWidth = sidebarResizeState.startSize - deltaX;
+        setSidebarWidth(clampDetailsSidebarWidth(nextWidth, modalRect.width));
+        return;
+      }
+
+      const deltaY = event.clientY - sidebarResizeState.startY;
+      const nextHeight = sidebarResizeState.startSize - deltaY;
+      setSidebarHeight(clampDetailsSidebarHeight(nextHeight, modalRect.height));
     };
 
     const handlePointerUp = () => {
@@ -1721,7 +1746,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     window.addEventListener('pointerup', handlePointerUp);
     window.addEventListener('pointercancel', handlePointerUp);
     window.addEventListener('blur', handlePointerUp);
-    document.body.style.cursor = 'col-resize';
+    document.body.style.cursor = sidebarResizeState.axis === 'horizontal' ? 'col-resize' : 'row-resize';
     document.body.style.userSelect = 'none';
 
     return () => {
@@ -1734,16 +1759,21 @@ const ImageModal: React.FC<ImageModalProps> = ({
     };
   }, [sidebarResizeState]);
 
-  const handleDetailsSidebarResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+  const handleDetailsSidebarResizeStart = useCallback((
+    event: React.PointerEvent<HTMLDivElement>,
+    axis: 'horizontal' | 'vertical'
+  ) => {
     event.preventDefault();
     event.stopPropagation();
     event.currentTarget.setPointerCapture(event.pointerId);
 
     setSidebarResizeState({
+      axis,
       startX: event.clientX,
-      startWidth: sidebarWidth,
+      startY: event.clientY,
+      startSize: axis === 'horizontal' ? sidebarWidth : sidebarHeight,
     });
-  }, [sidebarWidth]);
+  }, [sidebarHeight, sidebarWidth]);
 
   useEffect(() => {
     if (!isRenaming) {
@@ -1799,6 +1829,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
     const modalElement = modalShellRef.current;
     const targetElement = getFooterWindowElement(modalId);
+    onWindowStateChange?.(clampModalWindowToViewport(liveModalWindowRef.current));
 
     if (!modalElement || !targetElement || shouldSkipWindowAnimation(enableAnimations)) {
       onMinimize();
@@ -1817,7 +1848,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     } finally {
       onMinimize();
     }
-  }, [enableAnimations, modalId, onMinimize, zIndex]);
+  }, [enableAnimations, modalId, onMinimize, onWindowStateChange, zIndex]);
 
   const handlePromoteAutoTag = async (tag: string) => {
     await addTagToImage(image.id, tag);
@@ -2041,29 +2072,39 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
           {onNavigatePrevious && (
             <button
-              onClick={onNavigatePrevious}
-              className={`absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-black/35 p-2 text-white/90 transition-[opacity,background-color] duration-300 ease-out hover:bg-black/55 ${mediaOverlayVisibilityClass}`}
+              data-no-window-drag="true"
+              type="button"
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onNavigatePrevious();
+              }}
+              className="absolute inset-y-0 left-0 z-20 w-16 cursor-pointer bg-gradient-to-r from-white/15 to-transparent opacity-0 transition-opacity duration-150 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none sm:w-20 lg:w-24"
+              aria-label="Previous image"
               title="Previous image"
-            >
-              ←
-            </button>
+            />
           )}
           {onNavigateNext && (
             <button
-              onClick={onNavigateNext}
-              className={`absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-black/35 p-2 text-white/90 transition-[opacity,background-color] duration-300 ease-out hover:bg-black/55 ${mediaOverlayVisibilityClass}`}
+              data-no-window-drag="true"
+              type="button"
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onNavigateNext();
+              }}
+              className="absolute inset-y-0 right-0 z-20 w-16 cursor-pointer bg-gradient-to-l from-white/15 to-transparent opacity-0 transition-opacity duration-150 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none sm:w-20 lg:w-24"
+              aria-label="Next image"
               title="Next image"
-            >
-              →
-            </button>
+            />
           )}
 
-          <div data-no-window-drag="true" className="absolute top-4 left-4 bg-black/60 text-white px-3 py-1 rounded-full text-sm font-medium backdrop-blur-sm border border-white/20">
+          <div data-no-window-drag="true" className="absolute top-4 left-4 z-30 bg-black/60 text-white px-3 py-1 rounded-full text-sm font-medium backdrop-blur-sm border border-white/20">
             {currentIndex + 1} / {totalImages}
           </div>
 
           {!isVideo && (
-            <div data-no-window-drag="true" className={`absolute bottom-4 left-4 flex flex-col gap-2 rounded-lg border border-white/10 bg-black/35 p-2 backdrop-blur-sm transition-opacity duration-300 ease-out ${mediaOverlayVisibilityClass}`}>
+            <div data-no-window-drag="true" className={`absolute bottom-4 left-4 z-30 flex flex-col gap-2 rounded-lg border border-white/10 bg-black/35 p-2 backdrop-blur-sm transition-opacity duration-300 ease-out ${mediaOverlayVisibilityClass}`}>
               <button
                 onClick={handleZoomIn}
                 disabled={zoom >= 5}
@@ -2096,9 +2137,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
             </div>
           )}
 
-          <div data-no-window-drag="true" className={`absolute top-4 right-4 flex flex-col items-end gap-2 transition-opacity duration-300 ease-out ${mediaOverlayVisibilityClass}`}>
+          <div data-no-window-drag="true" className={`absolute top-4 right-4 z-30 flex items-end gap-2 transition-opacity duration-300 ease-out ${mediaOverlayVisibilityClass}`}>
             {isFullscreen ? (
-              <div className="flex flex-col items-end gap-2">
+              <div className="flex flex-row items-center gap-2">
                 <button
                   onClick={toggleFullscreen}
                   className="rounded-full border border-white/10 bg-black/35 p-2 text-white/90 transition-colors hover:bg-black/55"
@@ -2116,7 +2157,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 </button>
               </div>
             ) : (
-              <div className="flex flex-col items-end gap-2">
+              <div className="flex flex-row items-center gap-2">
                 <button
                   onClick={() => setDetailsPlacement((current) => current === 'right' ? 'bottom' : 'right')}
                   className="rounded-full border border-white/10 bg-black/35 p-2 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/55"
@@ -2130,13 +2171,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   title={showSidebar ? 'Hide sidebar' : 'Show sidebar'}
                 >
                   {showSidebar ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-                <button
-                  onClick={resetModalWindow}
-                  className="rounded-full border border-white/10 bg-black/35 p-2 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/55"
-                  title="Reset window"
-                >
-                  <Repeat className="h-4 w-4" />
                 </button>
                 <button
                   onClick={toggleFullscreen}
@@ -2157,19 +2191,27 @@ const ImageModal: React.FC<ImageModalProps> = ({
           data-window-drag-region="details"
           className={`w-full ${
             showSidebarOnBottom
-              ? 'h-[42%] min-h-[240px] border-t border-gray-800/80'
+              ? `border-t border-gray-800/80 ${isResizingSidebar ? 'transition-none' : 'transition-[height] duration-300 ease-in-out'}`
               : `h-full border-l border-transparent ${isResizingSidebar ? 'transition-none' : 'transition-[width] duration-300 ease-in-out'}`
           } relative flex flex-col`}
           style={
             showSidebarOnBottom
-              ? {}
+              ? { height: sidebarHeight, minHeight: DETAILS_SIDEBAR_MIN_HEIGHT, maxHeight: `${DETAILS_SIDEBAR_MAX_RATIO * 100}%` }
               : { width: sidebarWidth, minWidth: DETAILS_SIDEBAR_MIN_WIDTH, maxWidth: `${DETAILS_SIDEBAR_MAX_RATIO * 100}%` }
           }
           onContextMenu={handleSelectionContextMenu}
         >
-          {!showSidebarOnBottom && (
+          {showSidebarOnBottom ? (
             <div
-              onPointerDown={handleDetailsSidebarResizeStart}
+              onPointerDown={(event) => handleDetailsSidebarResizeStart(event, 'vertical')}
+              className="absolute inset-x-0 top-0 z-50 flex h-3 -translate-y-1/2 cursor-row-resize items-center justify-center touch-none"
+              title="Drag to resize details sidebar"
+            >
+              <div className={`h-1 w-16 rounded-full transition-colors duration-150 ${isResizingSidebar ? 'bg-blue-400/90 shadow-[0_0_16px_rgba(96,165,250,0.55)]' : 'bg-gray-500/70 hover:bg-blue-400/80'}`} />
+            </div>
+          ) : (
+            <div
+              onPointerDown={(event) => handleDetailsSidebarResizeStart(event, 'horizontal')}
               className="absolute left-0 top-0 z-50 flex h-full w-3 -translate-x-1/2 cursor-col-resize items-center justify-center touch-none"
               title="Drag to resize details sidebar"
             >
@@ -3092,6 +3134,10 @@ export default React.memo(ImageModal, (prevProps, nextProps) => {
     prevProps.isActive === nextProps.isActive &&
     prevProps.modalId === nextProps.modalId &&
     prevProps.initialWindowOffset === nextProps.initialWindowOffset &&
+    prevProps.initialWindowState?.x === nextProps.initialWindowState?.x &&
+    prevProps.initialWindowState?.y === nextProps.initialWindowState?.y &&
+    prevProps.initialWindowState?.width === nextProps.initialWindowState?.width &&
+    prevProps.initialWindowState?.height === nextProps.initialWindowState?.height &&
     prevProps.isMinimized === nextProps.isMinimized;
 
   return propsEqual;

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1650,6 +1650,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
     return null;
   }
 
+  const modalShellStateClass = isActive
+    ? 'border-gray-800 shadow-2xl ring-1 ring-white/10'
+    : 'border-gray-800/70 shadow-lg ring-1 ring-white/5 opacity-90';
+  const titleBarStateClass = isActive
+    ? 'border-gray-800 bg-gray-950/95'
+    : 'border-gray-900 bg-gray-950/80';
+  const titleTextClass = isActive ? 'text-gray-100' : 'text-gray-400';
+  const titleMetaClass = isActive ? 'text-gray-500' : 'text-gray-600';
+
   return (
     <div
       className={`fixed inset-0 transition-all duration-300 ${
@@ -1663,7 +1672,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         className={`${
           isFullscreen 
             ? 'fixed inset-0 h-full w-full rounded-none'
-            : 'fixed bg-gray-900 border border-gray-800 rounded-2xl shadow-2xl overflow-hidden ring-1 ring-white/10'
+            : `fixed bg-gray-900 border rounded-2xl overflow-hidden ${modalShellStateClass}`
         } pointer-events-auto flex flex-col animate-in fade-in zoom-in-95 ${isWindowInteractionActive ? 'select-none' : ''}`}
         onPointerDown={() => onActivate?.()}
         onClick={(e) => {
@@ -1684,7 +1693,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
       >
         {!isFullscreen && (
           <div
-            className="flex items-center justify-between gap-3 border-b border-gray-800 bg-gray-950/95 px-4 py-1.5 backdrop-blur-sm cursor-move"
+            className={`flex items-center justify-between gap-3 border-b px-4 py-1.5 backdrop-blur-sm cursor-move transition-colors duration-150 ${titleBarStateClass}`}
             onPointerDown={handleWindowSurfacePointerDown}
             onDoubleClick={toggleWindowMaximize}
           >
@@ -1730,11 +1739,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   </button>
                 </div>
               ) : (
-                <div className="truncate text-sm font-semibold text-gray-100" title={image.name}>
+                <div className={`truncate text-sm font-semibold ${titleTextClass}`} title={image.name}>
                   {image.name}
                 </div>
               )}
-              <div className="flex items-center gap-2 text-[11px] text-gray-500">
+              <div className={`flex items-center gap-2 text-[11px] ${titleMetaClass}`}>
                 <span className="min-w-0 truncate" title={imageFullPath}>
                   {imageFullPath}
                 </span>

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, FC, useCallback, useMemo, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useState, FC, useCallback, useMemo, useRef } from 'react';
 import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollection } from '../types';
 import { FileOperations } from '../services/fileOperations';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
@@ -64,6 +64,7 @@ const buildTagSuggestions = (
 };
 
 interface ImageModalProps {
+  modalId?: string;
   image: IndexedImage;
   onClose: () => void;
   onImageDeleted?: (imageId: string) => void;
@@ -124,8 +125,76 @@ const DEFAULT_MODAL_MAX_WIDTH = 1600;
 const DEFAULT_MODAL_MAX_HEIGHT = 1080;
 const MODAL_MIN_VISIBLE_WIDTH = 120;
 const MODAL_RECOVERABLE_TOP_HEIGHT = 80;
+const WINDOW_PROXY_ANIMATION_DURATION_MS = 140;
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const getFooterWindowElement = (modalId?: string): HTMLElement | null => {
+  if (!modalId || typeof document === 'undefined') {
+    return null;
+  }
+
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-image-modal-window-id]')
+  ).find((element) => element.dataset.imageModalWindowId === modalId) ?? null;
+};
+
+const shouldSkipWindowAnimation = (animationsEnabled: boolean) =>
+  !animationsEnabled ||
+  typeof window === 'undefined' ||
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+const animateWindowProxy = async (fromRect: DOMRect, toRect: DOMRect, zIndex: number) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const proxy = document.createElement('div');
+  const scaleX = Math.max(toRect.width / Math.max(fromRect.width, 1), 0.04);
+  const scaleY = Math.max(toRect.height / Math.max(fromRect.height, 1), 0.04);
+
+  proxy.style.position = 'fixed';
+  proxy.style.left = `${fromRect.left}px`;
+  proxy.style.top = `${fromRect.top}px`;
+  proxy.style.width = `${fromRect.width}px`;
+  proxy.style.height = `${fromRect.height}px`;
+  proxy.style.border = '1px solid rgba(148, 163, 184, 0.45)';
+  proxy.style.borderRadius = '12px';
+  proxy.style.background = 'rgba(31, 41, 55, 0.72)';
+  proxy.style.boxShadow = '0 18px 45px rgba(0, 0, 0, 0.35)';
+  proxy.style.pointerEvents = 'none';
+  proxy.style.transformOrigin = 'top left';
+  proxy.style.willChange = 'transform, opacity';
+  proxy.style.zIndex = `${Math.max(zIndex + 1, 100)}`;
+
+  document.body.appendChild(proxy);
+
+  try {
+    if (typeof proxy.animate !== 'function') {
+      return;
+    }
+
+    const animation = proxy.animate(
+      [
+        { opacity: 0.72, transform: 'translate3d(0, 0, 0) scale(1, 1)' },
+        {
+          opacity: 0.18,
+          transform: `translate3d(${toRect.left - fromRect.left}px, ${toRect.top - fromRect.top}px, 0) scale(${scaleX}, ${scaleY})`,
+        },
+      ],
+      {
+        duration: WINDOW_PROXY_ANIMATION_DURATION_MS,
+        easing: 'cubic-bezier(0.2, 0, 0, 1)',
+      }
+    );
+
+    await animation.finished;
+  } catch {
+    // Animation cancellation should not block the window action.
+  } finally {
+    proxy.remove();
+  }
+};
 
 const getModalViewportMetrics = () => {
   if (typeof window === 'undefined') {
@@ -515,6 +584,7 @@ const VideoPlayer: React.FC<{
 
 
 const ImageModal: React.FC<ImageModalProps> = ({
+  modalId,
   image,
   onClose,
   onImageDeleted,
@@ -570,8 +640,46 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const liveModalWindowRef = useRef<ModalWindowState>(modalWindow);
   const modalPaintFrameRef = useRef<number | null>(null);
   const restoredModalWindowRef = useRef<ModalWindowState | null>(null);
+  const isMinimizeAnimatingRef = useRef(false);
+  const wasMinimizedRef = useRef(isMinimized);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const canDragExternally = typeof window !== 'undefined' && !!window.electronAPI?.startFileDrag;
+  const enableAnimations = useSettingsStore((state) => state.enableAnimations);
+
+  useEffect(() => {
+    if (!isMinimized) {
+      isMinimizeAnimatingRef.current = false;
+    }
+  }, [isMinimized]);
+
+  useLayoutEffect(() => {
+    const wasMinimized = wasMinimizedRef.current;
+    wasMinimizedRef.current = isMinimized;
+
+    if (isMinimized || !wasMinimized || shouldSkipWindowAnimation(enableAnimations)) {
+      return;
+    }
+
+    const modalElement = modalShellRef.current;
+    const targetElement = getFooterWindowElement(modalId);
+
+    if (!modalElement || !targetElement) {
+      return;
+    }
+
+    const modalRect = modalElement.getBoundingClientRect();
+    const targetRect = targetElement.getBoundingClientRect();
+
+    modalElement.style.pointerEvents = 'none';
+    modalElement.style.opacity = '0';
+
+    const restoreModalInteractivity = () => {
+      modalElement.style.pointerEvents = '';
+      modalElement.style.opacity = '';
+    };
+
+    void animateWindowProxy(targetRect, modalRect, zIndex).then(restoreModalInteractivity, restoreModalInteractivity);
+  }, [enableAnimations, isMinimized, modalId, zIndex]);
 
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
@@ -1641,6 +1749,33 @@ const ImageModal: React.FC<ImageModalProps> = ({
     removeAutoTagFromImage(image.id, tag);
   };
 
+  const handleMinimizeWithAnimation = useCallback(async () => {
+    if (!onMinimize || isMinimizeAnimatingRef.current) {
+      return;
+    }
+
+    const modalElement = modalShellRef.current;
+    const targetElement = getFooterWindowElement(modalId);
+
+    if (!modalElement || !targetElement || shouldSkipWindowAnimation(enableAnimations)) {
+      onMinimize();
+      return;
+    }
+
+    const modalRect = modalElement.getBoundingClientRect();
+    const targetRect = targetElement.getBoundingClientRect();
+
+    isMinimizeAnimatingRef.current = true;
+    modalElement.style.pointerEvents = 'none';
+    modalElement.style.opacity = '0';
+
+    try {
+      await animateWindowProxy(modalRect, targetRect, zIndex);
+    } finally {
+      onMinimize();
+    }
+  }, [enableAnimations, modalId, onMinimize, zIndex]);
+
   const handlePromoteAutoTag = async (tag: string) => {
     await addTagToImage(image.id, tag);
     removeAutoTagFromImage(image.id, tag);
@@ -1655,9 +1790,12 @@ const ImageModal: React.FC<ImageModalProps> = ({
     : 'border-gray-800/70 shadow-lg ring-1 ring-white/5';
   const titleBarStateClass = isActive
     ? 'border-gray-800 bg-gray-950/95'
-    : 'border-gray-900 bg-gray-950/80';
+    : 'border-gray-700 bg-gray-800/95';
   const titleTextClass = isActive ? 'text-gray-100' : 'text-gray-400';
   const titleMetaClass = isActive ? 'text-gray-500' : 'text-gray-600';
+  const modalEntryAnimationClass = !enableAnimations || (wasMinimizedRef.current && !isMinimized)
+    ? ''
+    : 'animate-in fade-in zoom-in-95';
 
   return (
     <div
@@ -1673,7 +1811,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
           isFullscreen 
             ? 'fixed inset-0 h-full w-full rounded-none'
             : `fixed bg-gray-900 border rounded-2xl overflow-hidden ${modalShellStateClass}`
-        } pointer-events-auto flex flex-col animate-in fade-in zoom-in-95 ${isWindowInteractionActive ? 'select-none' : ''}`}
+        } pointer-events-auto flex flex-col ${modalEntryAnimationClass} ${isWindowInteractionActive ? 'select-none' : ''}`}
         onPointerDown={() => onActivate?.()}
         onClick={(e) => {
           e.stopPropagation();
@@ -1781,7 +1919,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 <Pencil className="w-3.5 h-3.5" />
               </button>
               <button
-                onClick={onMinimize}
+                onClick={() => void handleMinimizeWithAnimation()}
                 onPointerDown={(event) => event.stopPropagation()}
                 className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white"
                 title="Minimize window"
@@ -2907,6 +3045,7 @@ export default React.memo(ImageModal, (prevProps, nextProps) => {
     prevProps.isIndexing === nextProps.isIndexing &&
     prevProps.zIndex === nextProps.zIndex &&
     prevProps.isActive === nextProps.isActive &&
+    prevProps.modalId === nextProps.modalId &&
     prevProps.initialWindowOffset === nextProps.initialWindowOffset &&
     prevProps.isMinimized === nextProps.isMinimized;
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -118,6 +118,11 @@ type ModalInteractionState =
         | 'bottom-right';
     };
 
+type DetailsSidebarResizeState = {
+  startX: number;
+  startWidth: number;
+} | null;
+
 const MODAL_MARGIN = 20;
 const MIN_MODAL_WIDTH = 760;
 const MIN_MODAL_HEIGHT = 520;
@@ -126,6 +131,9 @@ const DEFAULT_MODAL_MAX_HEIGHT = 1080;
 const MODAL_MIN_VISIBLE_WIDTH = 120;
 const MODAL_RECOVERABLE_TOP_HEIGHT = 80;
 const WINDOW_PROXY_ANIMATION_DURATION_MS = 140;
+const DETAILS_SIDEBAR_DEFAULT_WIDTH = 340;
+const DETAILS_SIDEBAR_MIN_WIDTH = 300;
+const DETAILS_SIDEBAR_MAX_RATIO = 0.7;
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
@@ -143,6 +151,15 @@ const shouldSkipWindowAnimation = (animationsEnabled: boolean) =>
   !animationsEnabled ||
   typeof window === 'undefined' ||
   window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+const clampDetailsSidebarWidth = (width: number, modalWidth: number) => {
+  const maxWidth = Math.max(
+    DETAILS_SIDEBAR_MIN_WIDTH,
+    Math.floor(modalWidth * DETAILS_SIDEBAR_MAX_RATIO)
+  );
+
+  return clamp(width, DETAILS_SIDEBAR_MIN_WIDTH, maxWidth);
+};
 
 const animateWindowProxy = async (fromRect: DOMRect, toRect: DOMRect, zIndex: number) => {
   if (typeof document === 'undefined') {
@@ -621,8 +638,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const [showPerformance, setShowPerformance] = useState(true);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<'details' | 'workflow'>('details');
-  const [sidebarWidth, setSidebarWidth] = useState(340);
-  const [isResizingSidebar, setIsResizingSidebar] = useState(false);
+  const [sidebarWidth, setSidebarWidth] = useState(DETAILS_SIDEBAR_DEFAULT_WIDTH);
+  const [sidebarResizeState, setSidebarResizeState] = useState<DetailsSidebarResizeState>(null);
+  const isResizingSidebar = sidebarResizeState !== null;
   const [detailsPlacement, setDetailsPlacement] = useState<'right' | 'bottom'>('right');
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
@@ -1680,27 +1698,52 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [clearMediaOverlayHideTimer]);
 
   useEffect(() => {
-    if (!isResizingSidebar) return;
+    if (!sidebarResizeState || typeof window === 'undefined') {
+      return;
+    }
 
-    const handleMouseMove = (e: MouseEvent) => {
-      if (modalShellRef.current) {
-        const modalRect = modalShellRef.current.getBoundingClientRect();
-        const newWidth = modalRect.right - e.clientX;
-        setSidebarWidth(Math.max(300, Math.min(newWidth, Math.floor(modalRect.width * 0.7))));
+    const handlePointerMove = (event: PointerEvent) => {
+      const modalRect = modalShellRef.current?.getBoundingClientRect();
+      if (!modalRect) {
+        return;
       }
+
+      const deltaX = event.clientX - sidebarResizeState.startX;
+      const nextWidth = sidebarResizeState.startWidth - deltaX;
+      setSidebarWidth(clampDetailsSidebarWidth(nextWidth, modalRect.width));
     };
 
-    const handleMouseUp = () => {
-      setIsResizingSidebar(false);
+    const handlePointerUp = () => {
+      setSidebarResizeState(null);
     };
 
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerUp);
+    window.addEventListener('blur', handlePointerUp);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handlePointerUp);
+      window.removeEventListener('blur', handlePointerUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
     };
-  }, [isResizingSidebar]);
+  }, [sidebarResizeState]);
+
+  const handleDetailsSidebarResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture(event.pointerId);
+
+    setSidebarResizeState({
+      startX: event.clientX,
+      startWidth: sidebarWidth,
+    });
+  }, [sidebarWidth]);
 
   useEffect(() => {
     if (!isRenaming) {
@@ -2110,27 +2153,29 @@ const ImageModal: React.FC<ImageModalProps> = ({
         {/* Metadata Panel */}
         {showSidebar && (
         <>
-          {!showSidebarOnBottom && (
-             <div
-               onMouseDown={(e) => { e.preventDefault(); setIsResizingSidebar(true); }}
-               className={`w-1 cursor-col-resize hover:bg-gray-500/50 bg-gray-800/80 shrink-0 transition-colors ${isResizingSidebar ? 'bg-gray-500/80 z-50' : 'z-40'}`}
-               title="Resize sidebar"
-             />
-          )}
         <div
           data-window-drag-region="details"
           className={`w-full ${
             showSidebarOnBottom
               ? 'h-[42%] min-h-[240px] border-t border-gray-800/80'
-              : 'h-full border-l border-transparent'
+              : `h-full border-l border-transparent ${isResizingSidebar ? 'transition-none' : 'transition-[width] duration-300 ease-in-out'}`
           } relative flex flex-col`}
           style={
             showSidebarOnBottom
               ? {}
-              : { width: sidebarWidth, minWidth: 300, maxWidth: "70%" }
+              : { width: sidebarWidth, minWidth: DETAILS_SIDEBAR_MIN_WIDTH, maxWidth: `${DETAILS_SIDEBAR_MAX_RATIO * 100}%` }
           }
           onContextMenu={handleSelectionContextMenu}
         >
+          {!showSidebarOnBottom && (
+            <div
+              onPointerDown={handleDetailsSidebarResizeStart}
+              className="absolute left-0 top-0 z-50 flex h-full w-3 -translate-x-1/2 cursor-col-resize items-center justify-center touch-none"
+              title="Drag to resize details sidebar"
+            >
+              <div className={`h-16 w-1 rounded-full transition-colors duration-150 ${isResizingSidebar ? 'bg-blue-400/90 shadow-[0_0_16px_rgba(96,165,250,0.55)]' : 'bg-gray-500/70 hover:bg-blue-400/80'}`} />
+            </div>
+          )}
           <div className="p-6 space-y-4 overflow-y-auto flex-1">
           {/* Annotations Section */}
           <div className="bg-gray-900/50 p-3 rounded-lg border border-gray-700/50 space-y-2">

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1652,7 +1652,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   const modalShellStateClass = isActive
     ? 'border-gray-800 shadow-2xl ring-1 ring-white/10'
-    : 'border-gray-800/70 shadow-lg ring-1 ring-white/5 opacity-90';
+    : 'border-gray-800/70 shadow-lg ring-1 ring-white/5';
   const titleBarStateClass = isActive
     ? 'border-gray-800 bg-gray-950/95'
     : 'border-gray-900 bg-gray-950/80';

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -122,6 +122,8 @@ const MIN_MODAL_WIDTH = 760;
 const MIN_MODAL_HEIGHT = 520;
 const DEFAULT_MODAL_MAX_WIDTH = 1600;
 const DEFAULT_MODAL_MAX_HEIGHT = 1080;
+const MODAL_MIN_VISIBLE_WIDTH = 120;
+const MODAL_RECOVERABLE_TOP_HEIGHT = 80;
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
@@ -184,18 +186,36 @@ const createMaximizedModalWindow = (): ModalWindowState => {
   };
 };
 
+const getRecoverableModalPositionBounds = (width: number, height: number) => {
+  const metrics = getModalViewportMetrics();
+  const visibleWidth = Math.min(MODAL_MIN_VISIBLE_WIDTH, Math.max(1, width));
+  const recoverableTopHeight = Math.min(MODAL_RECOVERABLE_TOP_HEIGHT, Math.max(1, height));
+  const minX = -width + visibleWidth;
+  const maxX = metrics.viewportWidth - visibleWidth;
+  const minY = 0;
+  const maxY = Math.max(0, metrics.viewportHeight - recoverableTopHeight);
+
+  return {
+    minX: Math.min(minX, maxX),
+    maxX: Math.max(minX, maxX),
+    minY: Math.min(minY, maxY),
+    maxY: Math.max(minY, maxY),
+  };
+};
+
 const clampModalWindowToViewport = (windowState: ModalWindowState): ModalWindowState => {
   const metrics = getModalViewportMetrics();
   const maxWidth = Math.max(metrics.minWidth, metrics.viewportWidth - metrics.margin * 2);
   const maxHeight = Math.max(metrics.minHeight, metrics.viewportHeight - metrics.margin * 2);
   const width = clamp(windowState.width, metrics.minWidth, maxWidth);
   const height = clamp(windowState.height, metrics.minHeight, maxHeight);
+  const bounds = getRecoverableModalPositionBounds(width, height);
 
   return {
     width,
     height,
-    x: clamp(windowState.x, metrics.margin, metrics.viewportWidth - metrics.margin - width),
-    y: clamp(windowState.y, metrics.margin, metrics.viewportHeight - metrics.margin - height),
+    x: clamp(windowState.x, bounds.minX, bounds.maxX),
+    y: clamp(windowState.y, bounds.minY, bounds.maxY),
   };
 };
 
@@ -778,17 +798,19 @@ const ImageModal: React.FC<ImageModalProps> = ({
       const currentWindow = liveModalWindowRef.current;
 
       if (modalInteraction.mode === 'drag') {
+        const bounds = getRecoverableModalPositionBounds(currentWindow.width, currentWindow.height);
+
         scheduleModalWindowPaint({
           ...currentWindow,
           x: clamp(
             modalInteraction.initialX + (event.clientX - modalInteraction.startX),
-            metrics.margin,
-            metrics.viewportWidth - metrics.margin - currentWindow.width
+            bounds.minX,
+            bounds.maxX
           ),
           y: clamp(
             modalInteraction.initialY + (event.clientY - modalInteraction.startY),
-            metrics.margin,
-            metrics.viewportHeight - metrics.margin - currentWindow.height
+            bounds.minY,
+            bounds.maxY
           ),
         });
         return;
@@ -821,7 +843,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
       if (resizeFromLeft) {
         nextX = clamp(
           modalInteraction.initialX + deltaX,
-          metrics.margin,
+          -modalInteraction.initialWidth + MODAL_MIN_VISIBLE_WIDTH,
           modalInteraction.initialX + modalInteraction.initialWidth - metrics.minWidth
         );
         nextWidth = modalInteraction.initialWidth - (nextX - modalInteraction.initialX);
@@ -838,7 +860,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
       if (resizeFromTop) {
         nextY = clamp(
           modalInteraction.initialY + deltaY,
-          metrics.margin,
+          0,
           modalInteraction.initialY + modalInteraction.initialHeight - metrics.minHeight
         );
         nextHeight = modalInteraction.initialHeight - (nextY - modalInteraction.initialY);

--- a/components/settings/AppearanceSettingsPanel.tsx
+++ b/components/settings/AppearanceSettingsPanel.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Check } from 'lucide-react';
 import { useSettingsStore } from '../../store/useSettingsStore';
+import { SettingRow } from './SettingRow';
 import { SettingsPanel } from './SettingsPanel';
 import { SettingsSectionCard } from './SettingsSectionCard';
+import { SettingSwitch } from './SettingSwitch';
 
 const themeOptions = [
   { id: 'system', name: 'System', colors: ['#525252', '#a3a3a3'] },
@@ -16,9 +18,11 @@ const themeOptions = [
 export const AppearanceSettingsPanel: React.FC = () => {
   const theme = useSettingsStore((state) => state.theme);
   const setTheme = useSettingsStore((state) => state.setTheme);
+  const enableAnimations = useSettingsStore((state) => state.enableAnimations);
+  const setEnableAnimations = useSettingsStore((state) => state.setEnableAnimations);
 
   return (
-    <SettingsPanel title="Appearance" description="Choose the app theme.">
+    <SettingsPanel title="Appearance" description="Choose the app theme and motion preferences.">
       <SettingsSectionCard title="Theme">
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
           {themeOptions.map((option) => (
@@ -48,6 +52,14 @@ export const AppearanceSettingsPanel: React.FC = () => {
             </button>
           ))}
         </div>
+      </SettingsSectionCard>
+
+      <SettingsSectionCard title="Motion">
+        <SettingRow
+          label="Enable animations"
+          description="Use small interface animations, including modal minimize and restore."
+          control={<SettingSwitch checked={enableAnimations} onChange={setEnableAnimations} />}
+        />
       </SettingsSectionCard>
     </SettingsPanel>
   );

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -103,6 +103,7 @@ interface SettingsState {
   sensitiveTags: string[];
   blurSensitiveImages: boolean;
   enableSafeMode: boolean;
+  enableAnimations: boolean;
 
   // A1111 Integration settings
   a1111Enabled: boolean;
@@ -141,6 +142,7 @@ interface SettingsState {
   setSensitiveTags: (tags: string[]) => void;
   setBlurSensitiveImages: (value: boolean) => void;
   setEnableSafeMode: (value: boolean) => void;
+  setEnableAnimations: (value: boolean) => void;
   setA1111Enabled: (value: boolean) => void;
   setA1111ServerUrl: (url: string) => void;
   toggleA1111AutoStart: () => void;
@@ -184,6 +186,7 @@ export const useSettingsStore = create<SettingsState>()(
       sensitiveTags: ['nsfw', 'private', 'hidden'],
       blurSensitiveImages: true,
       enableSafeMode: true,
+      enableAnimations: true,
 
       // A1111 Integration initial state
       a1111Enabled: true,
@@ -234,6 +237,7 @@ export const useSettingsStore = create<SettingsState>()(
       },
       setBlurSensitiveImages: (value) => set({ blurSensitiveImages: !!value }),
       setEnableSafeMode: (value) => set({ enableSafeMode: !!value }),
+      setEnableAnimations: (value) => set({ enableAnimations: !!value }),
       updateKeybinding: (scope, action, keybinding) =>
         set((state) => ({
           keymap: {
@@ -282,6 +286,7 @@ export const useSettingsStore = create<SettingsState>()(
         sensitiveTags: ['nsfw', 'private', 'hidden'],
         blurSensitiveImages: true,
         enableSafeMode: true,
+        enableAnimations: true,
         a1111Enabled: true,
         a1111ServerUrl: 'http://127.0.0.1:7860',
         a1111AutoStart: false,
@@ -350,6 +355,10 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.enableSafeMode !== 'boolean') {
           state.enableSafeMode = true;
+        }
+
+        if (state && typeof state.enableAnimations !== 'boolean') {
+          state.enableAnimations = true;
         }
 
         if (state && typeof state.a1111Enabled !== 'boolean') {


### PR DESCRIPTION
## Summary

- Keeps ImageModal active when an image is opened from the grid or table.
- Adds smoother ImageModal minimize/restore behavior with a global animation toggle.
- Improves ImageModal details sidebar resizing, viewer controls, side navigation zones, and lineage display behavior.

## Why

Opening an image from the grid/table should leave its modal focused immediately. The modal interactions also needed to feel more predictable and less noisy: resized windows should restore at their previous size, lineage placeholders should not appear for images without lineage, and resizing/navigation controls should be easier to use.

## Validation

- TypeScript was run locally by the requester and passed.