### PR TITLE
Add audio playback support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -151,7 +151,7 @@ It reads:
 * PNG `tEXt` / `iTXt`
 * JPEG/WEBP EXIF/XMP/comment payloads
 * sidecar-style embedded JSON where applicable
-* video container metadata and `ffprobe` output for supported video formats
+* video/audio container metadata and `ffprobe` output for supported media formats
 
 The output is then normalized by `services/parsers/metadataParserFactory.ts`, which dispatches to generator-specific parsers such as:
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ Supported media types:
 
 * **Images**: PNG, JPG, JPEG, WEBP, GIF
 * **Video**: MP4, WEBM, MKV, MOV, AVI
+* **Audio**: MP3, WAV, FLAC, OGG, OGA, M4A, AAC, OPUS, AIFF, AIF, WMA
 
-For video metadata, Image MetaHub uses container metadata plus `ffprobe` when available to extract duration, codec, frame count, and resolution.
+For video and audio metadata, Image MetaHub uses container metadata plus `ffprobe` when available to extract duration, codec, frame count, resolution, sample rate, channels, and bit rate. Audio files can be indexed even when a codec is not playable by Chromium/Electron on the current system.
 
 ### MetaHub Save Node
 

--- a/__tests__/mediaTypes.test.ts
+++ b/__tests__/mediaTypes.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  inferMimeTypeFromName,
+  isAudioFileName,
+  isSupportedMediaFileName,
+  resolveMediaType,
+} from '../utils/mediaTypes.js';
+
+describe('media type helpers', () => {
+  it.each([
+    ['track.mp3', 'audio/mpeg'],
+    ['track.wav', 'audio/wav'],
+    ['track.flac', 'audio/flac'],
+    ['track.ogg', 'audio/ogg'],
+    ['track.oga', 'audio/ogg'],
+    ['track.m4a', 'audio/mp4'],
+    ['track.aac', 'audio/aac'],
+    ['track.opus', 'audio/opus'],
+    ['track.aiff', 'audio/aiff'],
+    ['track.aif', 'audio/aiff'],
+    ['track.wma', 'audio/x-ms-wma'],
+  ])('maps %s to %s', (fileName, mimeType) => {
+    expect(inferMimeTypeFromName(fileName)).toBe(mimeType);
+    expect(isAudioFileName(fileName)).toBe(true);
+    expect(isSupportedMediaFileName(fileName)).toBe(true);
+    expect(resolveMediaType(fileName)).toBe('audio');
+  });
+});

--- a/__tests__/metadataEngine.audio.test.ts
+++ b/__tests__/metadataEngine.audio.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { parseImageFile } from '../services/metadataEngine';
+
+let tempDir: string | null = null;
+const previousFfprobePath = process.env.FFPROBE_PATH;
+
+afterEach(async () => {
+  if (previousFfprobePath === undefined) {
+    delete process.env.FFPROBE_PATH;
+  } else {
+    process.env.FFPROBE_PATH = previousFfprobePath;
+  }
+  if (tempDir) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+describe('metadataEngine audio fallback', () => {
+  it('normalizes audio files even when ffprobe is unavailable', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-audio-'));
+    const filePath = path.join(tempDir, 'sample.mp3');
+    await fs.writeFile(filePath, Buffer.from([0x49, 0x44, 0x33, 0x03, 0x00, 0x00]));
+    process.env.FFPROBE_PATH = 'definitely-missing-ffprobe-binary';
+
+    const result = await parseImageFile(filePath);
+
+    expect(result.rawSource).toBe('audio');
+    expect(result.metadata?.media_type).toBe('audio');
+    expect(result.metadata?.audio).toBeNull();
+    expect(result.dimensions).toEqual({ width: 0, height: 0 });
+    expect(result.errors).toContain('ffprobe not available or failed to read media metadata.');
+  });
+});

--- a/__tests__/useImageStore.filters.test.ts
+++ b/__tests__/useImageStore.filters.test.ts
@@ -356,12 +356,22 @@ describe('useImageStore tri-state filters', () => {
         },
       } as any,
     });
+    const audioImage = createImage({
+      name: 'song.mp3',
+      id: 'dir-1::song.mp3',
+      fileType: 'audio/mpeg',
+      metadata: {
+        normalizedMetadata: {
+          media_type: 'audio',
+        },
+      } as any,
+    });
 
     useImageStore.getState().resetState();
     useImageStore.setState({
       directories: [directory],
-      images: [txt2imgImage, img2imgImage, videoImage],
-      filteredImages: [txt2imgImage, img2imgImage, videoImage],
+      images: [txt2imgImage, img2imgImage, videoImage, audioImage],
+      filteredImages: [txt2imgImage, img2imgImage, videoImage, audioImage],
       sortOrder: 'asc',
     });
 
@@ -374,6 +384,12 @@ describe('useImageStore tri-state filters', () => {
       generationModes: ['img2img'],
     });
     expect(useImageStore.getState().filteredImages.map((image) => image.name)).toEqual(['img2img.png']);
+
+    useImageStore.getState().setAdvancedFilters({
+      generationModes: [],
+      mediaTypes: ['audio'],
+    });
+    expect(useImageStore.getState().filteredImages.map((image) => image.name)).toEqual(['song.mp3']);
   });
 
   it('filters by multiple selected ratings with OR logic', () => {

--- a/cli.ts
+++ b/cli.ts
@@ -6,6 +6,7 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import os from 'os';
 import { parseImageFile } from './services/metadataEngine';
+import { isSupportedMediaFileName } from './utils/mediaTypes.js';
 
 const program = new Command();
 
@@ -42,8 +43,7 @@ function formatOutput(
 }
 
 function isImageFile(entry: string) {
-  const ext = path.extname(entry).toLowerCase();
-  return ['.png', '.jpg', '.jpeg', '.mp4', '.webm', '.mkv', '.mov', '.avi'].includes(ext);
+  return isSupportedMediaFileName(entry);
 }
 
 async function collectFiles(dir: string, recursive: boolean): Promise<string[]> {
@@ -63,8 +63,8 @@ async function collectFiles(dir: string, recursive: boolean): Promise<string[]> 
 
 program
   .command('parse')
-  .description('Parse metadata from a single image (PNG/JPG/WebP)')
-  .argument('<file>', 'Image file to parse')
+  .description('Parse metadata from a single media file (image, video, or audio)')
+  .argument('<file>', 'Media file to parse')
   .option('--json', 'Output as JSON', true)
   .option('--pretty', 'Pretty-print JSON output', false)
   .option('--raw', 'Include raw metadata payload when available', false)

--- a/components/AdvancedFilters.tsx
+++ b/components/AdvancedFilters.tsx
@@ -342,6 +342,7 @@ const AdvancedFilters: React.FC<AdvancedFiltersProps> = ({
                       {([
                         ['image', 'Images'],
                         ['video', 'Videos'],
+                        ['audio', 'Audio'],
                       ] as const).map(([value, label]) => (
                         <label key={value} className="flex items-start gap-3 rounded-lg border border-gray-800 bg-gray-950/30 p-3 cursor-pointer">
                           <input

--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Music } from 'lucide-react';
+
+interface AudioPlayerProps {
+  src: string;
+  title: string;
+  autoPlay?: boolean;
+  compact?: boolean;
+  onContextMenu?: React.MouseEventHandler;
+}
+
+const AudioPlayer: React.FC<AudioPlayerProps> = ({
+  src,
+  title,
+  autoPlay = false,
+  compact = false,
+  onContextMenu,
+}) => {
+  return (
+    <div
+      data-media-element="true"
+      className={`flex w-full flex-col items-center justify-center bg-black text-gray-100 ${compact ? 'gap-3 p-4' : 'h-full gap-5 p-8'}`}
+      onContextMenu={onContextMenu}
+    >
+      <div className={`rounded-full border border-cyan-400/30 bg-cyan-400/10 text-cyan-200 ${compact ? 'p-3' : 'p-6'}`}>
+        <Music className={compact ? 'h-8 w-8' : 'h-16 w-16'} />
+      </div>
+      <div className="max-w-full text-center">
+        <p className={`truncate font-medium text-gray-100 ${compact ? 'text-sm' : 'text-lg'}`} title={title}>
+          {title}
+        </p>
+        <p className="mt-1 text-xs text-gray-400">Audio</p>
+      </div>
+      <audio
+        src={src}
+        controls
+        autoPlay={autoPlay}
+        preload="metadata"
+        className="w-full max-w-2xl"
+      />
+    </div>
+  );
+};
+
+export default AudioPlayer;

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -14,6 +14,7 @@ import { Heart, Info, Copy, Folder, Download, Clipboard, Sparkles, GitCompare, S
   EyeOff,
   Package,
   Play,
+  Music,
   Tag,
   RefreshCw
 } from 'lucide-react';
@@ -37,6 +38,7 @@ import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal
 import { transferIndexedImages } from '../services/fileTransferService';
 import { thumbnailManager } from '../services/thumbnailManager';
 import { getContextMenuRatingTargetIds } from '../utils/ratingSelection';
+import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 
 interface ImageCardProps {
   image: IndexedImage;
@@ -53,16 +55,6 @@ interface ImageCardProps {
   isMarkedArchived?: boolean;   // For deduplication: marked for archive
   isBlurred?: boolean;
 }
-
-const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mkv', '.mov', '.avi'];
-
-const isVideoFileName = (fileName: string, fileType?: string | null): boolean => {
-  if (fileType && fileType.startsWith('video/')) {
-    return true;
-  }
-  const lower = fileName.toLowerCase();
-  return VIDEO_EXTENSIONS.some((ext) => lower.endsWith(ext));
-};
 
 const isTypingTarget = (target: EventTarget | null): boolean => {
   if (!(target instanceof HTMLElement)) {
@@ -90,6 +82,16 @@ const joinDisplayPath = (basePath: string, relativePath: string): string => {
   }
 
   return `${normalizedBase}/${normalizedRelative}`;
+};
+
+const formatAudioDuration = (seconds?: number | null): string | null => {
+  if (seconds == null || !Number.isFinite(seconds)) {
+    return null;
+  }
+  const totalSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
 };
 
 const abbreviatePathForDisplay = (relativePath: string): string => {
@@ -145,6 +147,8 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
   const toggleImageSelection = useImageStore((state) => state.toggleImageSelection);
   const canDragExternally = typeof window !== 'undefined' && !!window.electronAPI?.startFileDrag;
   const isVideo = isVideoFileName(image.name, image.fileType);
+  const isAudio = isAudioFileName(image.name, image.fileType);
+  const audioDuration = formatAudioDuration((image.metadata as any)?.normalizedMetadata?.audio?.duration_seconds);
 
   const relativeImagePath = getRelativeImagePath(image);
   const directoryPath = directories.find((dir) => dir.id === image.directoryId)?.path || '';
@@ -182,7 +186,7 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
       return;
     }
 
-    if (isVideo) {
+    if (isVideo || isAudio) {
       setImageUrl(null);
       return;
     }
@@ -193,7 +197,7 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
     }
 
     setImageUrl(null);
-  }, [thumbnail?.thumbnailStatus, thumbnail?.thumbnailUrl, thumbnailsDisabled, isVideo]);
+  }, [thumbnail?.thumbnailStatus, thumbnail?.thumbnailUrl, thumbnailsDisabled, isVideo, isAudio]);
 
   useEffect(() => {
     return () => {
@@ -422,6 +426,18 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
               <p className="text-xs">Preview unavailable</p>
             </div>
           </div>
+        ) : isAudio ? (
+          <div className="flex h-full w-full items-center justify-center bg-gray-900">
+            <div className="flex flex-col items-center gap-2 px-3 text-center text-gray-300">
+              <div className="rounded-full border border-cyan-400/30 bg-cyan-400/10 p-3 text-cyan-200">
+                <Music className="h-7 w-7" />
+              </div>
+              <span className="max-w-full truncate text-xs font-medium text-gray-200">Audio</span>
+              {audioDuration && (
+                <span className="rounded bg-black/30 px-2 py-0.5 font-mono text-[11px] text-gray-300">{audioDuration}</span>
+              )}
+            </div>
+          </div>
         ) : imageUrl ? (
           <img
             src={imageUrl}
@@ -441,6 +457,12 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
             <div className="rounded-full bg-black/50 p-2 shadow-lg">
               <Play className="h-6 w-6 text-white/90" />
             </div>
+          </div>
+        )}
+
+        {isAudio && (
+          <div className="absolute right-2 bottom-2 z-10 rounded-full bg-black/50 p-1.5 text-cyan-100 shadow-lg pointer-events-none">
+            <Music className="h-4 w-4" />
           </div>
         )}
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -31,6 +31,8 @@ import RatingStars from './RatingStars';
 import TagInputCombobox from './TagInputCombobox';
 import { getRecentTagChips } from '../utils/tagSuggestions';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
+import AudioPlayer from './AudioPlayer';
+import { isAudioFileName, isVideoFileName, SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
 
 
 const TAG_SUGGESTION_LIMIT = 5;
@@ -394,15 +396,10 @@ const formatVRAM = (vramMb: number, gpuDevice?: string | null): string => {
   return `${vramGb.toFixed(1)} GB`;
 };
 
-const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mkv', '.mov', '.avi'];
-
-const isVideoFileName = (fileName: string, fileType?: string | null): boolean => {
-  if (fileType && fileType.startsWith('video/')) {
-    return true;
-  }
-  const lower = fileName.toLowerCase();
-  return VIDEO_EXTENSIONS.some((ext) => lower.endsWith(ext));
-};
+const SUPPORTED_MEDIA_EXTENSION_REGEX = new RegExp(
+  `(${SUPPORTED_MEDIA_EXTENSIONS.map((ext) => ext.replace('.', '\\.')).join('|')})$`,
+  'i'
+);
 
 const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void }> = ({ label, value, isPrompt = false, onCopy }) => {
   if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
@@ -638,7 +635,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 }) => {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [isRenaming, setIsRenaming] = useState(false);
-  const [newName, setNewName] = useState(image.name.replace(/\.(png|jpg|jpeg|webp|mp4|webm|mkv|mov|avi)$/i, ''));
+  const [newName, setNewName] = useState(image.name.replace(SUPPORTED_MEDIA_EXTENSION_REGEX, ''));
   const [showRawMetadata, setShowRawMetadata] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
@@ -765,8 +762,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const liveImage = imageFromStore ?? image;
   const thumbnail = useResolvedThumbnail(liveImage);
   const isVideo = isVideoFileName(image.name, image.fileType);
-  const showA1111Actions = !isVideo && a1111Enabled;
-  const showComfyUIActions = !isVideo && comfyUIEnabled;
+  const isAudio = isAudioFileName(image.name, image.fileType);
+  const isPlayableMedia = isVideo || isAudio;
+  const showA1111Actions = !isPlayableMedia && a1111Enabled;
+  const showComfyUIActions = !isPlayableMedia && comfyUIEnabled;
   const showComfyUIHeading = showA1111Actions && visibleProviders.length > 1;
   const a1111GenerateLabel = singleVisibleProvider?.id === 'a1111' ? 'Generate' : 'Generate with A1111';
   const currentTags = liveImage.tags || [];
@@ -1076,10 +1075,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
      topics: [],
   } as BaseMetadata : nMeta;
 
-  const effectiveDuration = shadowMetadata?.duration ?? (nMeta as any)?.video?.duration_seconds;
+  const effectiveDuration = shadowMetadata?.duration ?? (nMeta as any)?.video?.duration_seconds ?? (nMeta as any)?.audio?.duration_seconds;
 
 
   const videoInfo = (nMeta as any)?.video;
+  const audioInfo = (nMeta as any)?.audio;
   const motionModel = (nMeta as any)?.motion_model;
 
   useEffect(() => {
@@ -1296,7 +1296,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   const copyImage = async () => {
     hideContextMenu();
-    if (isVideo) {
+    if (isPlayableMedia) {
       return;
     }
     const result = await copyImageToClipboard(image, directoryPath);
@@ -1424,7 +1424,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [zoom]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    if (!(e.target instanceof Element) || !e.target.closest('img, video, canvas, [data-media-element="true"]')) {
+    if (!(e.target instanceof Element) || !e.target.closest('img, video, audio, canvas, [data-media-element="true"]')) {
       return;
     }
 
@@ -1488,7 +1488,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     let isMounted = true;
     const hasPreview = Boolean(preferredThumbnailUrl);
 
-    setImageUrl(isVideo ? null : (preferredThumbnailUrl ?? null));
+    setImageUrl(isPlayableMedia ? null : (preferredThumbnailUrl ?? null));
 
     const loadImage = async () => {
       if (!isMounted) return;
@@ -1535,14 +1535,14 @@ const ImageModal: React.FC<ImageModalProps> = ({
       }
     };
 
-    if (!isVideo) {
+    if (!isPlayableMedia) {
       prefetchNeighbors();
     }
 
     return () => {
       isMounted = false;
     };
-  }, [image.id, image.handle, image.thumbnailHandle, image.name, directoryPath, preferredThumbnailUrl, isVideo]);
+  }, [image.id, image.handle, image.thumbnailHandle, image.name, directoryPath, preferredThumbnailUrl, isPlayableMedia]);
 
   const handleToggleFavorite = useCallback(() => {
     toggleFavorite(image.id);
@@ -1569,16 +1569,16 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   useEffect(() => {
     const imageContainer = imageContainerRef.current;
-    if (imageContainer) {
+    if (imageContainer && !isPlayableMedia) {
       imageContainer.addEventListener('wheel', handleWheel, { passive: false });
     }
 
     return () => {
-      if (imageContainer) {
+      if (imageContainer && !isPlayableMedia) {
         imageContainer.removeEventListener('wheel', handleWheel);
       }
     };
-  }, [handleWheel]);
+  }, [handleWheel, isPlayableMedia]);
 
   const handleDelete = useCallback(async () => {
     if (isIndexing) {
@@ -1777,7 +1777,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   useEffect(() => {
     if (!isRenaming) {
-      setNewName(image.name.replace(/\.(png|jpg|jpeg|webp|mp4|webm|mkv|mov|avi)$/i, ''));
+      setNewName(image.name.replace(SUPPORTED_MEDIA_EXTENSION_REGEX, ''));
     }
   }, [image.name, isRenaming]);
 
@@ -1926,7 +1926,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                         void confirmRename();
                       } else if (event.key === 'Escape') {
                         setIsRenaming(false);
-                        setNewName(image.name.replace(/\.(png|jpg|jpeg|webp|mp4|webm|mkv|mov|avi)$/i, ''));
+                        setNewName(image.name.replace(SUPPORTED_MEDIA_EXTENSION_REGEX, ''));
                       }
                     }}
                     className="min-w-0 flex-1 rounded-lg border border-gray-600 bg-gray-900 px-2 py-1 text-sm font-semibold text-white outline-none transition-colors focus:border-blue-500"
@@ -1942,7 +1942,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   <button
                     onClick={() => {
                       setIsRenaming(false);
-                      setNewName(image.name.replace(/\.(png|jpg|jpeg|webp|mp4|webm|mkv|mov|avi)$/i, ''));
+                      setNewName(image.name.replace(SUPPORTED_MEDIA_EXTENSION_REGEX, ''));
                     }}
                     className="rounded-lg bg-gray-700 px-2.5 py-1 text-xs font-medium text-gray-100 transition-colors hover:bg-gray-600"
                     title="Cancel rename"
@@ -2036,14 +2036,24 @@ const ImageModal: React.FC<ImageModalProps> = ({
           } bg-black flex items-center justify-center ${isFullscreen ? 'p-0' : 'p-2'} relative group overflow-hidden`}
           onPointerDown={handleImageContainerPointerDown}
           onPointerMove={revealMediaOverlay}
-          onMouseDown={isVideo ? undefined : handleMouseDown}
-          onMouseMove={isVideo ? undefined : handleMouseMove}
-          onMouseUp={isVideo ? undefined : handleMouseUp}
-          onMouseLeave={isVideo ? undefined : handleMouseUp}
-          style={{ cursor: !isVideo && zoom > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default' }}
+          onMouseDown={isPlayableMedia ? undefined : handleMouseDown}
+          onMouseMove={isPlayableMedia ? undefined : handleMouseMove}
+          onMouseUp={isPlayableMedia ? undefined : handleMouseUp}
+          onMouseLeave={isPlayableMedia ? undefined : handleMouseUp}
+          style={{ cursor: !isPlayableMedia && zoom > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default' }}
         >
           {imageUrl ? (
-            isVideo ? (
+            isAudio ? (
+              <div data-no-window-drag="true" className="h-full w-full" onContextMenu={handleContextMenu}>
+                <AudioPlayer
+                  key={image.id}
+                  src={imageUrl}
+                  title={image.name}
+                  autoPlay
+                  onContextMenu={handleContextMenu}
+                />
+              </div>
+            ) : isVideo ? (
               <div data-no-window-drag="true" className="max-h-full max-w-full">
                 <VideoPlayer
                   key={image.id}
@@ -2103,7 +2113,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
             {currentIndex + 1} / {totalImages}
           </div>
 
-          {!isVideo && (
+          {!isPlayableMedia && (
             <div data-no-window-drag="true" className={`absolute bottom-4 left-4 z-30 flex flex-col gap-2 rounded-lg border border-white/10 bg-black/35 p-2 backdrop-blur-sm transition-opacity duration-300 ease-out ${mediaOverlayVisibilityClass}`}>
               <button
                 onClick={handleZoomIn}
@@ -2465,6 +2475,18 @@ const ImageModal: React.FC<ImageModalProps> = ({
                             return formats[0];
                           })()} 
                         />
+                      </div>
+                    )}
+                    {audioInfo && (
+                      <div className="grid grid-cols-2 gap-2">
+                        {effectiveDuration != null && (
+                          <MetadataItem label="Duration" value={formatDurationSeconds(Number(effectiveDuration))} />
+                        )}
+                        <MetadataItem label="Audio Codec" value={audioInfo.codec} />
+                        <MetadataItem label="Audio Format" value={audioInfo.format} />
+                        <MetadataItem label="Sample Rate" value={audioInfo.sample_rate ? `${audioInfo.sample_rate} Hz` : undefined} />
+                        <MetadataItem label="Channels" value={audioInfo.channels} />
+                        <MetadataItem label="Bit Rate" value={audioInfo.bit_rate ? `${audioInfo.bit_rate} bps` : undefined} />
                       </div>
                     )}
                     {motionModel?.name && (
@@ -2965,8 +2987,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
             <>
               <button
                 onClick={copyImage}
-                className={`w-full text-left px-4 py-2 text-sm text-gray-200 transition-colors flex items-center gap-2 ${isVideo ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-700 hover:text-white'}`}
-                disabled={isVideo}
+                className={`w-full text-left px-4 py-2 text-sm text-gray-200 transition-colors flex items-center gap-2 ${isPlayableMedia ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-700 hover:text-white'}`}
+                disabled={isPlayableMedia}
               >
                 <Copy className="w-4 h-4" />
                 Copy to Clipboard

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -20,6 +20,8 @@ import RatingStars from './RatingStars';
 import TagInputCombobox from './TagInputCombobox';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { getRecentTagChips } from '../utils/tagSuggestions';
+import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
+import AudioPlayer from './AudioPlayer';
 
 const formatLoRA = (lora: string | LoRAInfo): string => {
   if (typeof lora === 'string') {
@@ -77,16 +79,6 @@ const formatDurationSeconds = (seconds: number): string => {
   const minutes = Math.floor(seconds / 60);
   const remainingSeconds = Math.floor(seconds % 60);
   return `${minutes}m ${remainingSeconds}s`;
-};
-
-const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mkv', '.mov', '.avi'];
-
-const isVideoFileName = (fileName: string, fileType?: string | null): boolean => {
-  if (fileType && fileType.startsWith('video/')) {
-    return true;
-  }
-  const lower = fileName.toLowerCase();
-  return VIDEO_EXTENSIONS.some((ext) => lower.endsWith(ext));
 };
 
 const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void }> = ({ label, value, isPrompt = false, onCopy }) => {
@@ -179,8 +171,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const activeImage = previewImageFromStore || previewImage;
   const thumbnail = useResolvedThumbnail(activeImage);
   const isVideo = !!activeImage && isVideoFileName(activeImage.name, activeImage.fileType);
-  const showA1111Actions = !isVideo && a1111Enabled;
-  const showComfyUIActions = !isVideo && comfyUIEnabled;
+  const isAudio = !!activeImage && isAudioFileName(activeImage.name, activeImage.fileType);
+  const showA1111Actions = !isVideo && !isAudio && a1111Enabled;
+  const showComfyUIActions = !isVideo && !isAudio && comfyUIEnabled;
   const showComfyUIHeading = showA1111Actions && visibleProviders.length > 1;
   const a1111GenerateLabel = singleVisibleProvider?.id === 'a1111' ? 'Generate' : 'Generate with A1111';
   const comfyGenerateLabel = singleVisibleProvider?.id === 'comfyui' ? 'Generate' : 'Generate with ComfyUI';
@@ -204,7 +197,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     }
 
     const hasPreview = Boolean(preferredThumbnailUrl);
-    setImageUrl(isVideo ? null : preferredThumbnailUrl);
+    setImageUrl(isVideo || isAudio ? null : preferredThumbnailUrl);
 
     const loadImage = async () => {
       if (!isMounted) return;
@@ -229,7 +222,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [activeImage?.id, activeImage?.handle, activeImage?.thumbnailHandle, activeImage?.name, activeImage?.directoryId, directories, preferredThumbnailUrl, isVideo]);
+  }, [activeImage?.id, activeImage?.handle, activeImage?.thumbnailHandle, activeImage?.name, activeImage?.directoryId, directories, preferredThumbnailUrl, isVideo, isAudio]);
 
   useEffect(() => {
     if (!contextMenu.visible) {
@@ -261,6 +254,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
 
   const nMeta: BaseMetadata | undefined = activeImage.metadata?.normalizedMetadata;
   const videoInfo = (nMeta as any)?.video;
+  const audioInfo = (nMeta as any)?.audio;
   const motionModel = (nMeta as any)?.motion_model;
 
   const copyToClipboard = (text: string, type: string) => {
@@ -380,7 +374,13 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
         {/* Image */}
         <div className="bg-black flex items-center justify-center rounded-lg">
           {imageUrl ? (
-            isVideo ? (
+            isAudio ? (
+              <AudioPlayer
+                src={imageUrl}
+                title={activeImage.name}
+                compact
+              />
+            ) : isVideo ? (
               <video
                 src={imageUrl}
                 className="max-w-full max-h-96 object-contain"
@@ -560,6 +560,18 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                   )}
                   <MetadataItem label="Video Codec" value={videoInfo.codec} />
                   <MetadataItem label="Video Format" value={videoInfo.format} />
+                </div>
+              )}
+              {audioInfo && (
+                <div className="grid grid-cols-2 gap-2 text-sm">
+                  {audioInfo.duration_seconds != null && (
+                    <MetadataItem label="Duration" value={formatDurationSeconds(Number(audioInfo.duration_seconds))} />
+                  )}
+                  <MetadataItem label="Audio Codec" value={audioInfo.codec} />
+                  <MetadataItem label="Audio Format" value={audioInfo.format} />
+                  <MetadataItem label="Sample Rate" value={audioInfo.sample_rate ? `${audioInfo.sample_rate} Hz` : undefined} />
+                  <MetadataItem label="Channels" value={audioInfo.channels} />
+                  <MetadataItem label="Bit Rate" value={audioInfo.bit_rate ? `${audioInfo.bit_rate} bps` : undefined} />
                 </div>
               )}
               {motionModel?.name && (

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -4,7 +4,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { type IndexedImage, type Directory, SmartCollection } from '../types';
 import { useContextMenu } from '../hooks/useContextMenu';
 import { useImageStore } from '../store/useImageStore';
-import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, RefreshCw, Star } from 'lucide-react';
+import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Star } from 'lucide-react';
 import { useThumbnail } from '../hooks/useThumbnail';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -16,6 +16,7 @@ import { RATING_VALUES, RatingValueIcons, getRatingBadgeClasses, getRatingChipCl
 import { getContextMenuRatingTargetIds } from '../utils/ratingSelection';
 import { useReparseMetadata } from '../hooks/useReparseMetadata';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
+import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 
 interface ImageTableProps {
   images: IndexedImage[];
@@ -29,19 +30,19 @@ interface ImageTableProps {
 type SortField = 'filename' | 'model' | 'steps' | 'cfg' | 'size' | 'seed';
 type SortDirection = 'asc' | 'desc' | null;
 
-const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mkv', '.mov', '.avi'];
-
-const isVideoFileName = (fileName: string, fileType?: string | null): boolean => {
-  if (fileType && fileType.startsWith('video/')) {
-    return true;
-  }
-  const lower = fileName.toLowerCase();
-  return VIDEO_EXTENSIONS.some((ext) => lower.endsWith(ext));
-};
-
 const getRelativeImagePath = (image: IndexedImage): string => {
   const [, relativePath = ''] = image.id.split('::');
   return relativePath || image.name;
+};
+
+const formatAudioDuration = (seconds?: number | null): string | null => {
+  if (seconds == null || !Number.isFinite(seconds)) {
+    return null;
+  }
+  const totalSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
 };
 
 const joinDisplayPath = (basePath: string, relativePath: string): string => {
@@ -768,6 +769,8 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
   const thumbnailsDisabled = useSettingsStore((state) => state.disableThumbnails);
   const showFullFilePath = useSettingsStore((state) => state.showFullFilePath);
   const isVideo = isVideoFileName(image.name, image.fileType);
+  const isAudio = isAudioFileName(image.name, image.fileType);
+  const audioDuration = formatAudioDuration((image.metadata as any)?.normalizedMetadata?.audio?.duration_seconds);
   const relativeImagePath = getRelativeImagePath(image);
   const directoryPath = directories.find((dir) => dir.id === image.directoryId)?.path || '';
   const fullImagePath = joinDisplayPath(directoryPath, relativeImagePath);
@@ -788,7 +791,7 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
       return;
     }
 
-    if (isVideo) {
+    if (isVideo || isAudio) {
       setImageUrl(null);
       setIsLoading(false);
       return;
@@ -802,7 +805,7 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
 
     setImageUrl(null);
     setIsLoading(true);
-  }, [thumbnail?.thumbnailHandle, image.handle, thumbnail?.thumbnailStatus, thumbnail?.thumbnailUrl, thumbnailsDisabled, isVideo]);
+  }, [thumbnail?.thumbnailHandle, image.handle, thumbnail?.thumbnailStatus, thumbnail?.thumbnailUrl, thumbnailsDisabled, isVideo, isAudio]);
 
   const handlePreviewClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -835,6 +838,22 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
         <div className="relative w-12 h-12 bg-gray-700 rounded overflow-hidden flex items-center justify-center">
           {isLoading ? (
             <div className="w-4 h-4 border-2 border-gray-500 border-t-transparent rounded-full animate-spin"></div>
+          ) : isAudio ? (
+            <>
+              <div className="flex h-full w-full flex-col items-center justify-center bg-gray-900 text-cyan-200">
+                <Music className="h-5 w-5" />
+                {audioDuration && (
+                  <span className="mt-0.5 font-mono text-[9px] text-gray-300">{audioDuration}</span>
+                )}
+              </div>
+              <button
+                onClick={handlePreviewClick}
+                className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-blue-500/70"
+                title="Show details"
+              >
+                <Info className="h-4 w-4 text-white" />
+              </button>
+            </>
           ) : imageUrl ? (
             <>
               <img

--- a/electron.mjs
+++ b/electron.mjs
@@ -128,7 +128,7 @@ async function readMediaMetadataWithFfprobe(filePath) {
     comment: tags.comment,
     description: tags.description,
     title: tags.title,
-    video: videoStream ? buildVideoInfoFromProbe(videoStream, format) : null,
+    video: videoStream ? buildVideoInfoFromProbe(videoStream, format) : buildVideoInfoFromProbe({}, format),
     audio: audioStream ? buildAudioInfoFromProbe(audioStream, format) : null,
   };
 }

--- a/electron.mjs
+++ b/electron.mjs
@@ -21,6 +21,10 @@ import {
   normalizeLauncherWorkingDirectory,
   resolveLauncherWorkingDirectory,
 } from './utils/generatorLauncher.mjs';
+import {
+  inferMimeTypeFromName,
+  isSupportedMediaFileName,
+} from './utils/mediaTypes.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -30,7 +34,7 @@ const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 
 // Parser version - increment when parser logic changes
 // This ensures cache is invalidated when parsing rules change
-const PARSER_VERSION = 6; // v6: Persist ComfyUI workflow node types for Node View
+const PARSER_VERSION = 7; // v7: Add audio media indexing and metadata
 
 // Get platform-specific icon
 function getIconPath() {
@@ -43,26 +47,13 @@ function getIconPath() {
 }
 
 const execFileAsync = promisify(execFile);
-const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.mkv', '.mov', '.avi']);
 const DEFAULT_WINDOW_WIDTH = 1400;
 const DEFAULT_WINDOW_HEIGHT = 900;
 const MIN_WINDOW_WIDTH = 800;
 const MIN_WINDOW_HEIGHT = 600;
 const FILE_STAT_CONCURRENCY = 64;
 
-const getMimeTypeFromName = (name) => {
-  const lower = name.toLowerCase();
-  if (lower.endsWith('.png')) return 'image/png';
-  if (lower.endsWith('.webp')) return 'image/webp';
-  if (lower.endsWith('.gif')) return 'image/gif';
-  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
-  if (lower.endsWith('.mp4')) return 'video/mp4';
-  if (lower.endsWith('.webm')) return 'video/webm';
-  if (lower.endsWith('.mkv')) return 'video/x-matroska';
-  if (lower.endsWith('.mov')) return 'video/quicktime';
-  if (lower.endsWith('.avi')) return 'video/x-msvideo';
-  return 'application/octet-stream';
-};
+const getMimeTypeFromName = (name) => inferMimeTypeFromName(name);
 
 const parseFrameRate = (value) => {
   if (typeof value !== 'string' || !value.includes('/')) {
@@ -91,7 +82,31 @@ const buildVideoInfoFromProbe = (stream, format) => {
   };
 };
 
-async function readVideoMetadataWithFfprobe(filePath) {
+const normalizeProbeNumber = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const buildAudioInfoFromProbe = (stream, format) => {
+  const durationValue = normalizeProbeNumber(stream?.duration) ?? normalizeProbeNumber(format?.duration);
+
+  return {
+    duration_seconds: durationValue,
+    codec: stream?.codec_name || null,
+    format: format?.format_name || null,
+    sample_rate: normalizeProbeNumber(stream?.sample_rate),
+    channels: normalizeProbeNumber(stream?.channels),
+    bit_rate: normalizeProbeNumber(stream?.bit_rate) ?? normalizeProbeNumber(format?.bit_rate),
+  };
+};
+
+async function readMediaMetadataWithFfprobe(filePath) {
   const ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
   const { stdout } = await execFileAsync(ffprobePath, [
     '-v', 'quiet',
@@ -106,14 +121,20 @@ async function readVideoMetadataWithFfprobe(filePath) {
   const format = payload?.format ?? {};
   const tags = format.tags ?? {};
   const streams = Array.isArray(payload?.streams) ? payload.streams : [];
-  const videoStream = streams.find((stream) => stream?.codec_type === 'video') ?? {};
+  const videoStream = streams.find((stream) => stream?.codec_type === 'video') ?? null;
+  const audioStream = streams.find((stream) => stream?.codec_type === 'audio') ?? null;
 
   return {
     comment: tags.comment,
     description: tags.description,
     title: tags.title,
-    video: buildVideoInfoFromProbe(videoStream, format),
+    video: videoStream ? buildVideoInfoFromProbe(videoStream, format) : null,
+    audio: audioStream ? buildAudioInfoFromProbe(audioStream, format) : null,
   };
+}
+
+async function readVideoMetadataWithFfprobe(filePath) {
+  return readMediaMetadataWithFfprobe(filePath);
 }
 
 let mainWindow;
@@ -1154,10 +1175,7 @@ async function statMediaEntries(directory, entries, baseDirectory) {
     if (!entry.isFile()) {
       return false;
     }
-    const lowerName = entry.name.toLowerCase();
-    const isImage = lowerName.endsWith('.png') || lowerName.endsWith('.jpg') || lowerName.endsWith('.jpeg') || lowerName.endsWith('.webp') || lowerName.endsWith('.gif');
-    const isVideo = Array.from(VIDEO_EXTENSIONS).some((ext) => lowerName.endsWith(ext));
-    return isImage || isVideo;
+    return isSupportedMediaFileName(entry.name);
   });
 
   const fileRecords = await mapWithConcurrency(mediaEntries, FILE_STAT_CONCURRENCY, async (entry) => {
@@ -2199,7 +2217,7 @@ function setupFileOperationHandlers() {
     }
   });
 
-  ipcMain.handle('read-video-metadata', async (event, args) => {
+  const handleReadMediaMetadata = async (args) => {
     try {
       const filePath = args?.filePath;
       if (!filePath) {
@@ -2214,7 +2232,7 @@ function setupFileOperationHandlers() {
         return { success: false, error: 'Access denied', errorType: 'PERMISSION_DENIED' };
       }
 
-      const metadata = await readVideoMetadataWithFfprobe(filePath);
+      const metadata = await readMediaMetadataWithFfprobe(filePath);
       return { success: true, ...metadata };
     } catch (error) {
       const isBinaryMissing = error?.code === 'ENOENT' || error?.message?.includes('ffprobe');
@@ -2223,7 +2241,10 @@ function setupFileOperationHandlers() {
         error: isBinaryMissing ? 'FFPROBE_NOT_FOUND' : (error?.message || String(error)),
       };
     }
-  });
+  };
+
+  ipcMain.handle('read-media-metadata', async (event, args) => handleReadMediaMetadata(args));
+  ipcMain.handle('read-video-metadata', async (event, args) => handleReadMediaMetadata(args));
 
   // Handle getting skipped versions
   ipcMain.handle('get-skipped-versions', () => {

--- a/preload.js
+++ b/preload.js
@@ -135,6 +135,7 @@ const electronAPI = {
   readFilesBatch: (filePaths) => ipcRenderer.invoke('read-files-batch', filePaths),
   readFilesHeadBatch: (args) => ipcRenderer.invoke('read-files-head-batch', args),
   readFilesTailBatch: (args) => ipcRenderer.invoke('read-files-tail-batch', args),
+  readMediaMetadata: (args) => ipcRenderer.invoke('read-media-metadata', args),
   readVideoMetadata: (args) => ipcRenderer.invoke('read-video-metadata', args),
   getFileStats: (filePath) => ipcRenderer.invoke('get-file-stats', filePath),
   writeFile: (filePath, data) => ipcRenderer.invoke('write-file', filePath, data),

--- a/services/automationRuleEngine.ts
+++ b/services/automationRuleEngine.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types';
 import { getImageGenerator, getImageGpuDevice, hasTelemetryData } from '../utils/analyticsUtils';
 import { parseLocalDateFilterEndExclusive, parseLocalDateFilterStart } from '../utils/dateFilterUtils';
+import { resolveMediaType } from '../utils/mediaTypes.js';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
 import { resolveSmartCollectionImageIds } from './imageAnnotationsStorage';
 
@@ -183,13 +184,11 @@ const matchesAdvancedFilters = (image: IndexedImage, filters: AutomationRuleFilt
 
   if (Array.isArray(advanced.generationModes) && advanced.generationModes.length > 0) {
     const explicitGenerationType = image.metadata?.normalizedMetadata?.generationType;
-    const isVideo =
-      image.metadata?.normalizedMetadata?.media_type === 'video' ||
-      (image.fileType ?? '').startsWith('video/');
+    const mediaType = image.metadata?.normalizedMetadata?.media_type ?? resolveMediaType(image.name, image.fileType);
     const resolvedGenerationMode =
       explicitGenerationType === 'txt2img' || explicitGenerationType === 'img2img'
         ? explicitGenerationType
-        : isVideo
+        : mediaType === 'video' || mediaType === 'audio'
           ? null
           : 'txt2img';
 
@@ -199,10 +198,14 @@ const matchesAdvancedFilters = (image: IndexedImage, filters: AutomationRuleFilt
   }
 
   if (Array.isArray(advanced.mediaTypes) && advanced.mediaTypes.length > 0) {
+    const metadataMediaType = image.metadata?.normalizedMetadata?.media_type;
+    const inferredMediaType = resolveMediaType(image.name, image.fileType);
     const resolvedMediaType =
-      image.metadata?.normalizedMetadata?.media_type === 'video' || (image.fileType ?? '').startsWith('video/')
-        ? 'video'
-        : 'image';
+      metadataMediaType === 'video' || metadataMediaType === 'audio' || metadataMediaType === 'image'
+        ? metadataMediaType
+        : inferredMediaType === 'video' || inferredMediaType === 'audio'
+          ? inferredMediaType
+          : 'image';
     if (!advanced.mediaTypes.includes(resolvedMediaType)) {
       return false;
     }

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -4,7 +4,7 @@ import { type IndexedImage } from '../types';
  * Parser version - increment when parser logic changes significantly
  * This ensures cache is invalidated when parsing rules change
  */
-export const PARSER_VERSION = 6; // v6: Persist ComfyUI workflow node types for Node View
+export const PARSER_VERSION = 7; // v7: Add audio media indexing and metadata
 
 // Simplified metadata structure for the JSON cache
 export interface CacheImageMetadata {

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -2,7 +2,7 @@
 /// <reference lib="dom.iterable" />
 import { IncrementalCacheWriter, type CacheImageMetadata } from './cacheManager';
 
-import { type IndexedImage, type ImageMetadata, type BaseMetadata, type VideoMetadata, type VideoInfo, isInvokeAIMetadata, isAutomatic1111Metadata, isComfyUIMetadata, isSwarmUIMetadata, isEasyDiffusionMetadata, isEasyDiffusionJson, isMidjourneyMetadata, isNijiMetadata, isForgeMetadata, isDalleMetadata, isFireflyMetadata, isDreamStudioMetadata, isDrawThingsMetadata, ComfyUIMetadata, InvokeAIMetadata, SwarmUIMetadata, EasyDiffusionMetadata, EasyDiffusionJson, MidjourneyMetadata, NijiMetadata, ForgeMetadata, DalleMetadata, FireflyMetadata, DrawThingsMetadata, FooocusMetadata } from '../types';
+import { type IndexedImage, type ImageMetadata, type BaseMetadata, type VideoMetadata, type VideoInfo, type AudioInfo, isInvokeAIMetadata, isAutomatic1111Metadata, isComfyUIMetadata, isSwarmUIMetadata, isEasyDiffusionMetadata, isEasyDiffusionJson, isMidjourneyMetadata, isNijiMetadata, isForgeMetadata, isDalleMetadata, isFireflyMetadata, isDreamStudioMetadata, isDrawThingsMetadata, ComfyUIMetadata, InvokeAIMetadata, SwarmUIMetadata, EasyDiffusionMetadata, EasyDiffusionJson, MidjourneyMetadata, NijiMetadata, ForgeMetadata, DalleMetadata, FireflyMetadata, DrawThingsMetadata, FooocusMetadata } from '../types';
 import { parse } from 'exifr';
 import { resolvePromptFromGraph, parseComfyUIMetadataEnhanced } from './parsers/comfyUIParser';
 import { parseVideoMetaHubMetadata } from './parsers/videoMetaHubParser';
@@ -10,6 +10,7 @@ import { parseInvokeAIMetadata } from './parsers/invokeAIParser';
 import { parseA1111Metadata } from './parsers/automatic1111Parser';
 import { parseSwarmUIMetadata } from './parsers/swarmUIParser';
 import { traceCacheDebug } from '../utils/cacheDebugTrace';
+import { buildSupportedMediaRegex, inferMimeTypeFromName, isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 
 type ThrottledFunction<T extends (...args: any[]) => any> = T & {
   cancel: () => void;
@@ -148,6 +149,7 @@ function classifyFileType(source?: CatalogFileEntry): string {
   if (type === 'image/webp') return 'webp';
   if (type === 'image/jpeg') return 'jpeg';
   if (type.startsWith('video/')) return 'video';
+  if (type.startsWith('audio/')) return 'audio';
   return type || 'unknown';
 }
 
@@ -201,35 +203,11 @@ function detectImageType(view: DataView): 'png' | 'jpeg' | 'webp' | null {
   return null;
 }
 
-function inferMimeTypeFromName(name: string): string {
-  const lower = name.toLowerCase();
-  if (lower.endsWith('.png')) return 'image/png';
-  if (lower.endsWith('.webp')) return 'image/webp';
-  if (lower.endsWith('.mp4')) return 'video/mp4';
-  if (lower.endsWith('.webm')) return 'video/webm';
-  if (lower.endsWith('.mkv')) return 'video/x-matroska';
-  if (lower.endsWith('.mov')) return 'video/quicktime';
-  if (lower.endsWith('.avi')) return 'video/x-msvideo';
-  if (lower.endsWith('.gif')) return 'image/gif';
-  return 'image/jpeg';
-}
-
-const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.mkv', '.mov', '.avi']);
-
-function isVideoFileName(name: string): boolean {
-  const lower = name.toLowerCase();
-  for (const ext of VIDEO_EXTENSIONS) {
-    if (lower.endsWith(ext)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-async function readVideoMetadataFromElectron(
+async function readMediaMetadataFromElectron(
   fileEntry: CatalogFileEntry
-): Promise<{ rawMetadata: VideoMetadata | null; videoInfo?: VideoInfo | null }> {
-  if (!isElectron || !(window as any).electronAPI?.readVideoMetadata) {
+): Promise<{ rawMetadata: VideoMetadata | null; videoInfo?: VideoInfo | null; audioInfo?: AudioInfo | null }> {
+  const readMediaMetadata = (window as any).electronAPI?.readMediaMetadata ?? (window as any).electronAPI?.readVideoMetadata;
+  if (!isElectron || !readMediaMetadata) {
     return { rawMetadata: null };
   }
 
@@ -239,7 +217,7 @@ async function readVideoMetadataFromElectron(
   }
 
   try {
-    const result = await (window as any).electronAPI.readVideoMetadata({ filePath: absolutePath });
+    const result = await readMediaMetadata({ filePath: absolutePath });
     if (!result?.success) {
       return { rawMetadata: null };
     }
@@ -263,9 +241,9 @@ async function readVideoMetadataFromElectron(
       rawMetadata.videometahub_data = metaHubData;
     }
 
-    return { rawMetadata, videoInfo: result.video || null };
+    return { rawMetadata, videoInfo: result.video || null, audioInfo: result.audio || null };
   } catch (error) {
-    console.error('[FileIndexer] Failed to read video metadata:', error);
+    console.error('[FileIndexer] Failed to read media metadata:', error);
     return { rawMetadata: null };
   }
 }
@@ -1359,12 +1337,15 @@ async function processSingleFileOptimized(
     let fileSizeValue: number | undefined = fileEntry.size;
     const inferredType = fileEntry.type ?? inferMimeTypeFromName(fileEntry.handle.name);
     const isVideo = isVideoFileName(fileEntry.handle.name) || inferredType.startsWith('video/');
+    const isAudio = isAudioFileName(fileEntry.handle.name) || inferredType.startsWith('audio/');
     let videoInfo: VideoInfo | null = null;
+    let audioInfo: AudioInfo | null = null;
 
-    if (isVideo) {
-      const videoResult = await readVideoMetadataFromElectron(fileEntry);
-      rawMetadata = videoResult.rawMetadata;
-      videoInfo = videoResult.videoInfo ?? null;
+    if (isVideo || isAudio) {
+      const mediaResult = await readMediaMetadataFromElectron(fileEntry);
+      rawMetadata = mediaResult.rawMetadata;
+      videoInfo = mediaResult.videoInfo ?? null;
+      audioInfo = mediaResult.audioInfo ?? null;
     } else if (fileData) {
       // OPTIMIZED: Parse directly from ArrayBuffer; avoid creating File/Blob
       const view = new DataView(fileData);
@@ -1593,6 +1574,18 @@ if (rawMetadata) {
       video: videoInfo,
     };
   }
+  if (!normalizedMetadata && isAudio) {
+    normalizedMetadata = {
+      prompt: '',
+      model: '',
+      width: 0,
+      height: 0,
+      steps: 0,
+      scheduler: '',
+      media_type: 'audio',
+      audio: audioInfo,
+    };
+  }
 
   // If we still couldn't normalize, try sidecar JSON as a final fallback.
   if (!normalizedMetadata) {
@@ -1604,6 +1597,25 @@ if (rawMetadata) {
       normalizedMetadata = parseEasyDiffusionJson(sidecarJson);
     }
   }
+}
+
+if (!normalizedMetadata && isAudio) {
+  normalizedMetadata = {
+    prompt: '',
+    model: '',
+    width: 0,
+    height: 0,
+    steps: 0,
+    scheduler: '',
+    media_type: 'audio',
+    audio: audioInfo,
+  };
+}
+if (normalizedMetadata && isAudio) {
+  normalizedMetadata.width = normalizedMetadata.width || 0;
+  normalizedMetadata.height = normalizedMetadata.height || 0;
+  normalizedMetadata.media_type = 'audio';
+  normalizedMetadata.audio = normalizedMetadata.audio ?? audioInfo;
 }
 
 // ==============================================================================
@@ -2175,7 +2187,8 @@ export async function processFiles(
     await pushUiBatch(true);
   }
 
-  const imageFiles = fileEntries.filter(entry => /\.(png|jpg|jpeg|webp|mp4|webm|mkv|mov|avi)$/i.test(entry.handle.name));
+  const supportedMediaRegex = buildSupportedMediaRegex();
+  const imageFiles = fileEntries.filter(entry => supportedMediaRegex.test(entry.handle.name));
 
   const asyncPool = async <T, R>(
     concurrency: number,

--- a/services/fileOperations.ts
+++ b/services/fileOperations.ts
@@ -1,8 +1,13 @@
 // File operations service for Electron environment
 import { IndexedImage } from '../types';
+import { SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
 
 // Check if we're running in Electron
 const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
+const SUPPORTED_MEDIA_EXTENSION_REGEX = new RegExp(
+  `(${SUPPORTED_MEDIA_EXTENSIONS.map((ext) => ext.replace('.', '\\.')).join('|')})$`,
+  'i'
+);
 
 export interface FileOperationsResult {
   success: boolean;
@@ -116,8 +121,7 @@ export class FileOperations {
    * Validate filename
    */
   static validateFilename(filename: string): { valid: boolean; error?: string } {
-    // Remove common image extension for validation
-    const nameWithoutExt = filename.replace(/\.(png|jpg|jpeg|webp|mp4|webm|mkv|mov|avi)$/i, '');
+    const nameWithoutExt = filename.replace(SUPPORTED_MEDIA_EXTENSION_REGEX, '');
     
     if (!nameWithoutExt.trim()) {
       return { valid: false, error: 'Filename cannot be empty' };

--- a/services/fileTransferService.ts
+++ b/services/fileTransferService.ts
@@ -7,6 +7,7 @@ import type {
   IndexedImageTransferMode,
   IndexedImageTransferResultItem,
 } from '../types';
+import { inferMimeTypeFromName } from '../utils/mediaTypes.js';
 
 interface TransferIndexedImagesParams {
   images: IndexedImage[];
@@ -57,19 +58,6 @@ function createMockFileHandle(fileName: string, absolutePath: string): FileSyste
       });
     },
   } as ElectronFileHandle as FileSystemFileHandle;
-}
-
-function inferMimeTypeFromName(name: string): string {
-  const lower = name.toLowerCase();
-  if (lower.endsWith('.png')) return 'image/png';
-  if (lower.endsWith('.webp')) return 'image/webp';
-  if (lower.endsWith('.gif')) return 'image/gif';
-  if (lower.endsWith('.mp4')) return 'video/mp4';
-  if (lower.endsWith('.webm')) return 'video/webm';
-  if (lower.endsWith('.mkv')) return 'video/x-matroska';
-  if (lower.endsWith('.mov')) return 'video/quicktime';
-  if (lower.endsWith('.avi')) return 'video/x-msvideo';
-  return 'image/jpeg';
 }
 
 function buildTransferredEntry(item: IndexedImageTransferResultItem) {

--- a/services/fileWatcher.mjs
+++ b/services/fileWatcher.mjs
@@ -1,6 +1,7 @@
 import chokidar from 'chokidar';
 import path from 'path';
 import fs from 'fs';
+import { SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
 
 // Active watchers: directoryId -> watcher instance
 const activeWatchers = new Map();
@@ -95,15 +96,15 @@ export function startWatching(directoryId, dirPath, mainWindow) {
       sendWatcherDebug(mainWindow, `[FileWatcher] Watcher ready for ${directoryId} - monitoring: ${dirPath}`);
     });
 
-    const enqueueImage = (imagePath, forceReindex = false) => {
-      sendWatcherDebug(mainWindow, `[FileWatcher] File detected: ${imagePath}`);
+    const enqueueMedia = (mediaPath, forceReindex = false) => {
+      sendWatcherDebug(mainWindow, `[FileWatcher] File detected: ${mediaPath}`);
       if (!pendingFiles.has(directoryId)) {
         pendingFiles.set(directoryId, new Map());
       }
-      sendWatcherDebug(mainWindow, `[FileWatcher] Adding image to batch: ${imagePath}`);
+      sendWatcherDebug(mainWindow, `[FileWatcher] Adding media to batch: ${mediaPath}`);
       const pendingMap = pendingFiles.get(directoryId);
-      const existing = pendingMap.get(imagePath);
-      pendingMap.set(imagePath, { forceReindex: Boolean(existing?.forceReindex || forceReindex) });
+      const existing = pendingMap.get(mediaPath);
+      pendingMap.set(mediaPath, { forceReindex: Boolean(existing?.forceReindex || forceReindex) });
 
       if (processingTimeouts.has(directoryId)) {
         clearTimeout(processingTimeouts.get(directoryId));
@@ -116,25 +117,24 @@ export function startWatching(directoryId, dirPath, mainWindow) {
 
     watcher.on('add', (filePath) => {
       const ext = path.extname(filePath).toLowerCase();
-      const imageExts = ['.png', '.jpg', '.jpeg', '.webp', '.mp4', '.webm', '.mkv', '.mov', '.avi'];
 
       if (ext === '.json') {
         const basePath = filePath.slice(0, -ext.length);
-        const matches = imageExts
-          .map((imageExt) => `${basePath}${imageExt}`)
+        const matches = SUPPORTED_MEDIA_EXTENSIONS
+          .map((mediaExt) => `${basePath}${mediaExt}`)
           .filter((candidate) => fs.existsSync(candidate));
         if (matches.length === 0) {
           return;
         }
-        matches.forEach((match) => enqueueImage(match, true));
+        matches.forEach((match) => enqueueMedia(match, true));
         return;
       }
 
-      if (!imageExts.includes(ext)) {
+      if (!SUPPORTED_MEDIA_EXTENSIONS.includes(ext)) {
         return;
       }
 
-      enqueueImage(filePath, false);
+      enqueueMedia(filePath, false);
     });
 
     watcher.on('error', (error) => {

--- a/services/fileWatcher.ts
+++ b/services/fileWatcher.ts
@@ -2,6 +2,7 @@ import chokidar, { FSWatcher } from 'chokidar';
 import path from 'path';
 import { BrowserWindow } from 'electron';
 import fs from 'fs';
+import { SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
 
 // Active watchers: directoryId -> watcher instance
 const activeWatchers = new Map<string, FSWatcher>();
@@ -86,7 +87,7 @@ export function startWatching(
 
     watcher.on('add', (filePath) => {
       const ext = path.extname(filePath).toLowerCase();
-      if (!['.png', '.jpg', '.jpeg', '.webp', '.mp4', '.webm', '.mkv', '.mov', '.avi'].includes(ext)) {
+      if (!SUPPORTED_MEDIA_EXTENSIONS.includes(ext)) {
         return;
       }
 
@@ -94,7 +95,7 @@ export function startWatching(
       if (!pendingFiles.has(directoryId)) {
         pendingFiles.set(directoryId, new Set());
       }
-      sendWatcherDebug(mainWindow, `[FileWatcher] Adding image to batch: ${filePath}`);
+      sendWatcherDebug(mainWindow, `[FileWatcher] Adding media to batch: ${filePath}`);
       pendingFiles.get(directoryId)!.add(filePath);
 
       if (processingTimeouts.has(directoryId)) {

--- a/services/mediaSourceCache.ts
+++ b/services/mediaSourceCache.ts
@@ -1,5 +1,6 @@
 import { IndexedImage } from '../types';
 import { thumbnailManager } from './thumbnailManager';
+import { inferMimeTypeFromName } from '../utils/mediaTypes.js';
 
 type CacheEntry = {
   url: string;
@@ -14,21 +15,8 @@ type MediaSourceLoadOptions = {
 
 const MAX_CACHE_ENTRIES = 12;
 
-const resolveImageMimeType = (fileName: string): string => {
-  const lowerName = fileName.toLowerCase();
-  if (lowerName.endsWith('.mp4')) return 'video/mp4';
-  if (lowerName.endsWith('.webm')) return 'video/webm';
-  if (lowerName.endsWith('.mkv')) return 'video/x-matroska';
-  if (lowerName.endsWith('.mov')) return 'video/quicktime';
-  if (lowerName.endsWith('.avi')) return 'video/x-msvideo';
-  if (lowerName.endsWith('.jpg') || lowerName.endsWith('.jpeg')) return 'image/jpeg';
-  if (lowerName.endsWith('.webp')) return 'image/webp';
-  if (lowerName.endsWith('.gif')) return 'image/gif';
-  return 'image/png';
-};
-
 const createImageUrlFromFileData = (data: unknown, fileName: string): { url: string; revoke: boolean } => {
-  const mimeType = resolveImageMimeType(fileName);
+  const mimeType = inferMimeTypeFromName(fileName, 'image/png');
 
   if (typeof data === 'string') {
     return { url: `data:${mimeType};base64,${data}`, revoke: false };

--- a/services/metadataEngine.ts
+++ b/services/metadataEngine.ts
@@ -149,7 +149,7 @@ async function readMediaMetadataWithFfprobe(filePath: string): Promise<{ comment
       comment: tags.comment,
       description: tags.description,
       title: tags.title,
-      video: videoStream ? buildVideoInfoFromProbe(videoStream, format) : null,
+      video: videoStream ? buildVideoInfoFromProbe(videoStream, format) : buildVideoInfoFromProbe({}, format),
       audio: audioStream ? buildAudioInfoFromProbe(audioStream, format) : null,
     };
   } catch (error) {

--- a/services/metadataEngine.ts
+++ b/services/metadataEngine.ts
@@ -4,8 +4,9 @@ import { createHash } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import exifr from 'exifr';
-import { BaseMetadata, ImageMetadata, type VideoInfo, isEasyDiffusionJson } from '../types';
+import { BaseMetadata, ImageMetadata, type AudioInfo, type VideoInfo, isEasyDiffusionJson } from '../types';
 import { parseImageMetadata as normalizeMetadata } from './parsers/metadataParserFactory';
+import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 
 interface Dimensions {
   width: number;
@@ -20,11 +21,16 @@ interface VideoProbeStream {
   height?: number;
   codec_name?: string;
   codec_type?: string;
+  duration?: string | number;
+  sample_rate?: string | number;
+  channels?: string | number;
+  bit_rate?: string | number;
 }
 
 interface VideoProbeFormat {
   duration?: string | number;
   format_name?: string;
+  bit_rate?: string | number;
   tags?: {
     comment?: string;
     description?: string;
@@ -47,7 +53,7 @@ export interface MetadataEngineResult {
   rawMetadata: ImageMetadata | null;
   metadata: BaseMetadata | null;
   dimensions?: Dimensions | null;
-  rawSource?: 'png' | 'jpeg' | 'sidecar' | 'video' | 'unknown';
+  rawSource?: 'png' | 'jpeg' | 'sidecar' | 'video' | 'audio' | 'unknown';
   errors?: string[];
   schema_version: string;
   _telemetry: {
@@ -68,12 +74,6 @@ const execFileAsync = promisify(execFile) as (
   args: string[],
   options: { encoding: BufferEncoding }
 ) => Promise<{ stdout: string; stderr: string }>;
-const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.mkv', '.mov', '.avi']);
-
-const isVideoFilePath = (filePath: string): boolean => {
-  const ext = path.extname(filePath).toLowerCase();
-  return VIDEO_EXTENSIONS.has(ext);
-};
 
 const parseFrameRate = (value: unknown): number | null => {
   if (typeof value !== 'string' || !value.includes('/')) {
@@ -102,7 +102,31 @@ const buildVideoInfoFromProbe = (stream: VideoProbeStream, format: VideoProbeFor
   };
 };
 
-async function readVideoMetadataWithFfprobe(filePath: string): Promise<{ comment?: string; description?: string; title?: string; video?: VideoInfo } | null> {
+const normalizeProbeNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const buildAudioInfoFromProbe = (stream: VideoProbeStream, format: VideoProbeFormat): AudioInfo => {
+  const durationValue = normalizeProbeNumber(stream.duration) ?? normalizeProbeNumber(format.duration);
+
+  return {
+    duration_seconds: durationValue,
+    codec: stream.codec_name || null,
+    format: format.format_name || null,
+    sample_rate: normalizeProbeNumber(stream.sample_rate),
+    channels: normalizeProbeNumber(stream.channels),
+    bit_rate: normalizeProbeNumber(stream.bit_rate) ?? normalizeProbeNumber(format.bit_rate),
+  };
+};
+
+async function readMediaMetadataWithFfprobe(filePath: string): Promise<{ comment?: string; description?: string; title?: string; video?: VideoInfo | null; audio?: AudioInfo | null } | null> {
   const ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
 
   try {
@@ -118,13 +142,15 @@ async function readVideoMetadataWithFfprobe(filePath: string): Promise<{ comment
     const format = payload.format ?? {};
     const tags = format.tags ?? {};
     const streams = Array.isArray(payload.streams) ? payload.streams : [];
-    const videoStream = streams.find((stream) => stream?.codec_type === 'video') ?? {};
+    const videoStream = streams.find((stream) => stream?.codec_type === 'video') ?? null;
+    const audioStream = streams.find((stream) => stream?.codec_type === 'audio') ?? null;
 
     return {
       comment: tags.comment,
       description: tags.description,
       title: tags.title,
-      video: buildVideoInfoFromProbe(videoStream, format),
+      video: videoStream ? buildVideoInfoFromProbe(videoStream, format) : null,
+      audio: audioStream ? buildAudioInfoFromProbe(audioStream, format) : null,
     };
   } catch (error) {
     return null;
@@ -408,30 +434,33 @@ export async function parseImageFile(filePath: string): Promise<MetadataEngineRe
   let rawMetadata: ImageMetadata | null = null;
   let rawSource: MetadataEngineResult['rawSource'] = 'unknown';
   let videoInfo: VideoInfo | null = null;
-  const isVideo = isVideoFilePath(absolutePath);
+  let audioInfo: AudioInfo | null = null;
+  const isVideo = isVideoFileName(absolutePath);
+  const isAudio = isAudioFileName(absolutePath);
 
-  if (isVideo) {
-    rawSource = 'video';
-    const videoMetadata = await readVideoMetadataWithFfprobe(absolutePath);
-    if (videoMetadata) {
+  if (isVideo || isAudio) {
+    rawSource = isAudio ? 'audio' : 'video';
+    const mediaMetadata = await readMediaMetadataWithFfprobe(absolutePath);
+    if (mediaMetadata) {
       const raw: MetadataRecord = {
-        description: videoMetadata.description,
-        comment: videoMetadata.comment,
-        title: videoMetadata.title,
+        description: mediaMetadata.description,
+        comment: mediaMetadata.comment,
+        title: mediaMetadata.title,
       };
 
-      if (videoMetadata.comment) {
+      if (mediaMetadata.comment) {
         try {
-          raw.videometahub_data = JSON.parse(videoMetadata.comment);
+          raw.videometahub_data = JSON.parse(mediaMetadata.comment);
         } catch (err: unknown) {
-          errors.push(`Failed to parse video metadata JSON: ${getErrorMessage(err)}`);
+          errors.push(`Failed to parse media metadata JSON: ${getErrorMessage(err)}`);
         }
       }
 
       rawMetadata = raw as ImageMetadata;
-      videoInfo = videoMetadata.video ?? null;
+      videoInfo = mediaMetadata.video ?? null;
+      audioInfo = mediaMetadata.audio ?? null;
     } else {
-      errors.push('ffprobe not available or failed to read video metadata.');
+      errors.push('ffprobe not available or failed to read media metadata.');
     }
   } else {
     const view = new DataView(arrayBuffer);
@@ -480,6 +509,12 @@ export async function parseImageFile(filePath: string): Promise<MetadataEngineRe
     metadata.height = metadata.height || (videoInfo.height ?? 0);
     metadata.video = metadata.video ?? videoInfo;
   }
+  if (metadata && isAudio) {
+    metadata.width = metadata.width || 0;
+    metadata.height = metadata.height || 0;
+    metadata.media_type = 'audio';
+    metadata.audio = metadata.audio ?? audioInfo;
+  }
   if (!metadata && isVideo && videoInfo) {
     metadata = {
       prompt: '',
@@ -492,10 +527,28 @@ export async function parseImageFile(filePath: string): Promise<MetadataEngineRe
       video: videoInfo,
     };
   }
+  if (!metadata && isAudio) {
+    metadata = {
+      prompt: '',
+      model: '',
+      width: 0,
+      height: 0,
+      steps: 0,
+      scheduler: '',
+      media_type: 'audio',
+      audio: audioInfo,
+    };
+  }
   if (isVideo && metadata) {
     dimensions = {
       width: metadata.width || 0,
       height: metadata.height || 0,
+    };
+  }
+  if (isAudio && metadata) {
+    dimensions = {
+      width: 0,
+      height: 0,
     };
   }
 

--- a/services/thumbnailManager.ts
+++ b/services/thumbnailManager.ts
@@ -1,35 +1,21 @@
 import { IndexedImage } from '../types';
 import cacheManager from './cacheManager';
 import { useImageStore } from '../store/useImageStore';
+import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 
 const MAX_THUMBNAIL_EDGE = 320;
 const MAX_CONCURRENT_THUMBNAILS = 12;
 const MAX_CONCURRENT_HIGH_PRIORITY_THUMBNAILS = 10;
 const MAX_CONCURRENT_BACKGROUND_THUMBNAILS = 2;
 
-const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.mkv', '.mov', '.avi']);
 type ElectronFileHandle = FileSystemFileHandle & { _filePath?: string };
 
 const isVideoAsset = (image: IndexedImage, file?: File): boolean => {
-  if (image.fileType && image.fileType.startsWith('video/')) {
-    return true;
-  }
-  const imageName = image.name?.toLowerCase() || '';
-  for (const ext of VIDEO_EXTENSIONS) {
-    if (imageName.endsWith(ext)) {
-      return true;
-    }
-  }
-  if (file?.type?.startsWith('video/')) {
-    return true;
-  }
-  const fileName = file?.name?.toLowerCase() || '';
-  for (const ext of VIDEO_EXTENSIONS) {
-    if (fileName.endsWith(ext)) {
-      return true;
-    }
-  }
-  return false;
+  return isVideoFileName(image.name, image.fileType) || (file ? isVideoFileName(file.name, file.type) : false);
+};
+
+const isAudioAsset = (image: IndexedImage, file?: File): boolean => {
+  return isAudioFileName(image.name, image.fileType) || (file ? isAudioFileName(file.name, file.type) : false);
 };
 
 const waitForVideoEvent = (video: HTMLVideoElement, eventName: string): Promise<void> =>
@@ -501,6 +487,11 @@ class ThumbnailManager {
     try {
       if (image.thumbnailUrl) {
         setSafe({ status: 'ready', thumbnailUrl: image.thumbnailUrl });
+        return;
+      }
+
+      if (isAudioAsset(image)) {
+        setSafe({ status: 'ready', thumbnailUrl: null });
         return;
       }
 

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -36,6 +36,7 @@ import { normalizeFacetValue, sanitizeIndexedImageFacets } from '../utils/facetN
 import { parseLocalDateFilterEndExclusive, parseLocalDateFilterStart } from '../utils/dateFilterUtils';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
 import { getImageGenerator, getImageGpuDevice, hasTelemetryData } from '../utils/analyticsUtils';
+import { resolveMediaType } from '../utils/mediaTypes.js';
 import { createCacheDebugSnapshot, traceCacheDebug } from '../utils/cacheDebugTrace';
 import { useLicenseStore } from './useLicenseStore';
 import { useSettingsStore } from './useSettingsStore';
@@ -1711,21 +1712,22 @@ export const useImageStore = create<ImageState>((set, get) => {
                         return advancedFilters.generationModes.includes(explicitGenerationType);
                     }
 
-                    const isVideo =
-                        normalizedMetadata?.media_type === 'video' ||
-                        (image.fileType ?? '').startsWith('video/');
+                    const mediaType = normalizedMetadata?.media_type ?? resolveMediaType(image.name, image.fileType);
+                    const isGeneratedImageCandidate = mediaType !== 'video' && mediaType !== 'audio';
 
-                    return !isVideo && advancedFilters.generationModes.includes('txt2img');
+                    return isGeneratedImageCandidate && advancedFilters.generationModes.includes('txt2img');
                 });
             }
             if (Array.isArray(advancedFilters.mediaTypes) && advancedFilters.mediaTypes.length > 0) {
                 results = results.filter(image => {
                     const metadataMediaType = image.metadata?.normalizedMetadata?.media_type;
-                    const fileType = image.fileType ?? '';
+                    const inferredMediaType = resolveMediaType(image.name, image.fileType);
                     const resolvedMediaType =
-                        metadataMediaType === 'video' || fileType.startsWith('video/')
-                            ? 'video'
-                            : 'image';
+                        metadataMediaType === 'video' || metadataMediaType === 'audio' || metadataMediaType === 'image'
+                            ? metadataMediaType
+                            : inferredMediaType === 'video' || inferredMediaType === 'audio'
+                                ? inferredMediaType
+                                : 'image';
                     return advancedFilters.mediaTypes.includes(resolvedMediaType);
                 });
             }

--- a/types.ts
+++ b/types.ts
@@ -266,6 +266,15 @@ export interface VideoInfo {
   codec?: string | null;
 }
 
+export interface AudioInfo {
+  duration_seconds?: number | null;
+  codec?: string | null;
+  format?: string | null;
+  sample_rate?: number | null;
+  channels?: number | null;
+  bit_rate?: number | null;
+}
+
 export interface MotionModelInfo {
   name?: string | null;
   hash?: string | null;
@@ -296,8 +305,9 @@ export interface ImageLineage {
 
 export interface BaseMetadata extends SharedBaseMetadata {
   clip_skip?: number;
-  media_type?: 'image' | 'video';
+  media_type?: 'image' | 'video' | 'audio';
   video?: VideoInfo | null;
+  audio?: AudioInfo | null;
   motion_model?: MotionModelInfo | null;
   generationType?: GenerationType;
   lineage?: ImageLineage | null;
@@ -375,7 +385,7 @@ export interface AdvancedFilters {
   cfg?: NumericRangeFilter;
   date?: DateRangeFilter;
   generationModes?: Array<'txt2img' | 'img2img'>;
-  mediaTypes?: Array<'image' | 'video'>;
+  mediaTypes?: Array<'image' | 'video' | 'audio'>;
   telemetryState?: 'present' | 'missing';
   hasVerifiedTelemetry?: boolean;
   generationTimeMs?: NumericRangeFilter;

--- a/types.ts
+++ b/types.ts
@@ -78,7 +78,8 @@ export interface ElectronAPI {
   }>;
   readFile: (filePath: string) => Promise<{ success: boolean; data?: Buffer; error?: string; errorType?: string; errorCode?: string }>;
   readFilesBatch: (filePaths: string[]) => Promise<{ success: boolean; files?: { success: boolean; data?: Buffer; path: string; error?: string; errorType?: string; errorCode?: string }[]; error?: string }>;
-  readVideoMetadata: (args: { filePath: string }) => Promise<{ success: boolean; comment?: string; description?: string; title?: string; video?: VideoInfo | null; error?: string }>;
+  readMediaMetadata: (args: { filePath: string }) => Promise<{ success: boolean; comment?: string; description?: string; title?: string; video?: VideoInfo | null; audio?: AudioInfo | null; error?: string }>;
+  readVideoMetadata: (args: { filePath: string }) => Promise<{ success: boolean; comment?: string; description?: string; title?: string; video?: VideoInfo | null; audio?: AudioInfo | null; error?: string }>;
   getFileStats: (filePath: string) => Promise<{ success: boolean; stats?: any; error?: string }>;
   writeFile: (filePath: string, data: any) => Promise<{ success: boolean; error?: string }>;
   exportBatchToFolder: (args: { files: { directoryPath: string; relativePath: string }[]; destDir: string; exportId?: string }) => Promise<{ success: boolean; exportedCount: number; failedCount: number; error?: string }>;

--- a/utils/mediaTypes.js
+++ b/utils/mediaTypes.js
@@ -1,0 +1,67 @@
+export const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.webp', '.gif'];
+export const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mkv', '.mov', '.avi'];
+export const AUDIO_EXTENSIONS = ['.mp3', '.wav', '.flac', '.ogg', '.oga', '.m4a', '.aac', '.opus', '.aiff', '.aif', '.wma'];
+
+export const SUPPORTED_MEDIA_EXTENSIONS = [
+  ...IMAGE_EXTENSIONS,
+  ...VIDEO_EXTENSIONS,
+  ...AUDIO_EXTENSIONS,
+];
+
+const MEDIA_MIME_TYPES = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mkv': 'video/x-matroska',
+  '.mov': 'video/quicktime',
+  '.avi': 'video/x-msvideo',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.flac': 'audio/flac',
+  '.ogg': 'audio/ogg',
+  '.oga': 'audio/ogg',
+  '.m4a': 'audio/mp4',
+  '.aac': 'audio/aac',
+  '.opus': 'audio/opus',
+  '.aiff': 'audio/aiff',
+  '.aif': 'audio/aiff',
+  '.wma': 'audio/x-ms-wma',
+};
+
+export const getFileExtension = (name = '') => {
+  const match = String(name).toLowerCase().match(/\.[^.\\/]+$/);
+  return match ? match[0] : '';
+};
+
+export const inferMimeTypeFromName = (name, fallback = 'application/octet-stream') => {
+  return MEDIA_MIME_TYPES[getFileExtension(name)] || fallback;
+};
+
+export const hasExtension = (name, extensions) => {
+  const ext = getFileExtension(name);
+  return extensions.includes(ext);
+};
+
+export const isImageFileName = (name) => hasExtension(name, IMAGE_EXTENSIONS);
+export const isVideoFileName = (name, fileType) =>
+  Boolean(fileType?.startsWith?.('video/')) || hasExtension(name, VIDEO_EXTENSIONS);
+export const isAudioFileName = (name, fileType) =>
+  Boolean(fileType?.startsWith?.('audio/')) || hasExtension(name, AUDIO_EXTENSIONS);
+export const isSupportedMediaFileName = (name) => hasExtension(name, SUPPORTED_MEDIA_EXTENSIONS);
+
+export const resolveMediaType = (name, fileType) => {
+  if (fileType?.startsWith?.('image/')) return 'image';
+  if (fileType?.startsWith?.('video/')) return 'video';
+  if (fileType?.startsWith?.('audio/')) return 'audio';
+  if (isImageFileName(name)) return 'image';
+  if (isVideoFileName(name)) return 'video';
+  if (isAudioFileName(name)) return 'audio';
+  return 'unknown';
+};
+
+export const buildSupportedMediaRegex = () =>
+  new RegExp(`(${SUPPORTED_MEDIA_EXTENSIONS.map((ext) => ext.replace('.', '\\.')).join('|')})$`, 'i');


### PR DESCRIPTION
## Summary
- Add shared media helpers and audio-aware metadata types.
- Index common audio formats with ffprobe metadata when available and a safe fallback when unavailable.
- Add audio media filtering, library placeholders, and playback in the preview sidebar and viewer modal.
- Document supported audio formats and codec playback caveats.

## Validation
- `npx tsc -b --pretty false`
- `npm test -- --run __tests__/mediaTypes.test.ts __tests__/metadataEngine.audio.test.ts __tests__/useImageStore.filters.test.ts`
- `npm run build`

## Notes
- Full `npm test -- --run` was not used as the final gate because existing CLI/Analytics tests timed out in this environment; focused audio/filter tests and the production build passed.