### PR TITLE
Add slideshow mode

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -47,16 +47,18 @@ import { useGenerateWithA1111 } from './hooks/useGenerateWithA1111';
 import { useGenerateWithComfyUI } from './hooks/useGenerateWithComfyUI';
 import { type IndexedImage, type BaseMetadata } from './types';
 import { type SettingsFocusSection, type SettingsTab, type SettingsTabInput, resolveSettingsTab } from './components/settings/types';
+import { buildSlideshowPlaylist } from './utils/slideshowPlaylist';
 
 interface OpenImageModalState {
   modalId: string;
   imageId: string;
   navigationImageIds: string[];
-  navigationSource: 'filtered' | 'cluster' | 'scope';
+  navigationSource: 'filtered' | 'cluster' | 'scope' | 'slideshow';
   zIndex: number;
   initialWindowOffset: number;
   isMinimized: boolean;
   windowState?: ImageModalWindowState;
+  startSlideshow?: boolean;
 }
 
 interface ImageModalWindowState {
@@ -1242,8 +1244,12 @@ export default function App() {
       return activeScopeNavigationImageIds ?? modal.navigationImageIds.filter((imageId) => imageLookup.has(imageId));
     }
 
+    if (modal.navigationSource === 'slideshow') {
+      return modal.navigationImageIds.filter((imageId) => Boolean(getImageByIdFromStore(imageId)));
+    }
+
     return modal.navigationImageIds.filter((imageId) => imageLookup.has(imageId));
-  }, [activeScopeNavigationImageIds, filteredNavigationImageIds, imageLookup]);
+  }, [activeScopeNavigationImageIds, filteredNavigationImageIds, getImageByIdFromStore, imageLookup]);
 
   useEffect(() => {
     if (openImageModals.length === 0) {
@@ -1428,6 +1434,14 @@ export default function App() {
     handleCloseImageModal(targetModal.modalId, targetModal.imageId);
   }, [handleCloseImageModal, openImageModals]);
 
+  const handleSlideshowStartAcknowledged = useCallback((modalId: string) => {
+    setOpenImageModals((current) =>
+      current.map((modal) =>
+        modal.modalId === modalId ? { ...modal, startSlideshow: false } : modal
+      )
+    );
+  }, []);
+
   const handleImageModalNavigate = useCallback((modalId: string, direction: 'next' | 'previous') => {
     const targetModal = openImageModals.find((modal) => modal.modalId === modalId);
     if (!targetModal) {
@@ -1573,6 +1587,68 @@ export default function App() {
       ? nodeViewResultImages
       : safeFilteredImages;
   const canSaveCurrentFilteredAsCollection = libraryView !== 'smart' && displayImages.length > 0;
+  const slideshowPlaylistPreview = useMemo(
+    () =>
+      buildSlideshowPlaylist({
+        scopeImages: displayImages,
+        selectedImageIds: safeSelectedImages,
+        allImages: safeImages,
+      }),
+    [displayImages, safeImages, safeSelectedImages]
+  );
+  const slideshowImageCount = slideshowPlaylistPreview.images.length;
+  const slideshowSourceLabel = slideshowPlaylistPreview.source === 'selection' ? 'selected files' : 'current view';
+
+  const handleStartSlideshow = useCallback(() => {
+    const playlist = slideshowPlaylistPreview.images;
+    if (playlist.length === 0) {
+      setError('No image or video files are available for a slideshow.');
+      return;
+    }
+
+    const firstImage = playlist[0];
+    const navigationImageIds = playlist.map((image) => image.id);
+    const existingModalForFirstImage = openImageModals.find((modal) => modal.imageId === firstImage.id);
+    const slideshowModalId = existingModalForFirstImage?.modalId ?? `image-modal-${Date.now()}-${firstImage.id}`;
+
+    setActiveImageModalId(slideshowModalId);
+    setSelectedImage(firstImage);
+    setOpenImageModals((current) => {
+      const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;
+      const existingModal = current.find((modal) => modal.imageId === firstImage.id);
+
+      if (existingModal) {
+        const nextZIndex = current.length > 1 ? highestZIndex + 1 : existingModal.zIndex;
+        return current.map((modal) =>
+          modal.modalId === existingModal.modalId
+            ? {
+                ...modal,
+                imageId: firstImage.id,
+                navigationImageIds,
+                navigationSource: 'slideshow',
+                zIndex: nextZIndex,
+                isMinimized: false,
+                startSlideshow: true,
+              }
+            : modal
+        );
+      }
+
+      return [
+        ...current,
+        {
+          modalId: slideshowModalId,
+          imageId: firstImage.id,
+          navigationImageIds,
+          navigationSource: 'slideshow',
+          zIndex: highestZIndex + 1,
+          initialWindowOffset: current.length * 28,
+          isMinimized: false,
+          startSlideshow: true,
+        },
+      ];
+    });
+  }, [openImageModals, setError, setSelectedImage, slideshowPlaylistPreview.images]);
 
   useEffect(() => {
     const scopedTotalPages = Math.ceil(displayImages.length / itemsPerPage);
@@ -2016,6 +2092,9 @@ export default function App() {
                       openComparisonModal();
                     }}
                     onBatchExport={handleOpenBatchExport}
+                    onStartSlideshow={handleStartSlideshow}
+                    slideshowImageCount={slideshowImageCount}
+                    slideshowSourceLabel={slideshowSourceLabel}
                   />
                 )}
 
@@ -2160,6 +2239,8 @@ export default function App() {
             onWindowStateChange={(windowState) => handleImageModalWindowStateChange(modal.modalId, windowState)}
             isMinimized={modal.isMinimized}
             onMinimize={() => handleMinimizeImageModal(modal.modalId)}
+            startSlideshow={modal.startSlideshow}
+            onSlideshowStartAcknowledged={() => handleSlideshowStartAcknowledged(modal.modalId)}
           />
         ))}
 

--- a/App.tsx
+++ b/App.tsx
@@ -359,6 +359,7 @@ export default function App() {
   const [openImageModals, setOpenImageModals] = useState<OpenImageModalState[]>([]);
   const [activeImageModalId, setActiveImageModalId] = useState<string | null>(null);
   const lastOpenedModalImageIdRef = useRef<string | null>(null);
+  const suppressSelectedImageModalOpenRef = useRef<string | null>(null);
 
   const queueCount = useGenerationQueueStore((state) =>
     state.items.filter((item) => item.status === 'waiting' || item.status === 'processing').length
@@ -1135,6 +1136,13 @@ export default function App() {
   useEffect(() => {
     if (!selectedImage) {
       lastOpenedModalImageIdRef.current = null;
+      suppressSelectedImageModalOpenRef.current = null;
+      return;
+    }
+
+    if (suppressSelectedImageModalOpenRef.current === selectedImage.id) {
+      suppressSelectedImageModalOpenRef.current = null;
+      lastOpenedModalImageIdRef.current = selectedImage.id;
       return;
     }
 
@@ -1311,6 +1319,7 @@ export default function App() {
     if (currentActiveModal) {
       const nextActiveImage = getImageByIdFromStore(currentActiveModal.imageId);
       if (nextActiveImage && selectedImageId !== nextActiveImage.id) {
+        suppressSelectedImageModalOpenRef.current = nextActiveImage.id;
         setSelectedImage(nextActiveImage);
       }
     } else {
@@ -1370,6 +1379,7 @@ export default function App() {
     const targetModal = openImageModals.find((modal) => modal.modalId === modalId);
     const targetImage = targetModal ? getImageByIdFromStore(targetModal.imageId) ?? null : null;
     if (targetImage && useImageStore.getState().selectedImage?.id !== targetImage.id) {
+      suppressSelectedImageModalOpenRef.current = targetImage.id;
       setSelectedImage(targetImage);
     }
   }, [getImageByIdFromStore, openImageModals, setSelectedImage]);
@@ -1472,6 +1482,7 @@ export default function App() {
 
     const nextImage = getImageByIdFromStore(nextImageId);
     if (nextImage && useImageStore.getState().selectedImage?.id !== nextImage.id) {
+      suppressSelectedImageModalOpenRef.current = nextImage.id;
       setSelectedImage(nextImage);
     }
   }, [getImageByIdFromStore, openImageModals, resolveModalNavigationImageIds, setSelectedImage]);
@@ -1612,6 +1623,7 @@ export default function App() {
     const slideshowModalId = existingModalForFirstImage?.modalId ?? `image-modal-${Date.now()}-${firstImage.id}`;
 
     setActiveImageModalId(slideshowModalId);
+    suppressSelectedImageModalOpenRef.current = firstImage.id;
     setSelectedImage(firstImage);
     setOpenImageModals((current) => {
       const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;

--- a/__tests__/GridToolbar.test.tsx
+++ b/__tests__/GridToolbar.test.tsx
@@ -65,6 +65,8 @@ describe('GridToolbar', () => {
         onGenerateComfyUI={vi.fn()}
         onCompare={vi.fn()}
         onBatchExport={vi.fn()}
+        onStartSlideshow={vi.fn()}
+        slideshowImageCount={0}
       />,
     );
 
@@ -90,6 +92,8 @@ describe('GridToolbar', () => {
         onGenerateComfyUI={vi.fn()}
         onCompare={vi.fn()}
         onBatchExport={vi.fn()}
+        onStartSlideshow={vi.fn()}
+        slideshowImageCount={0}
       />,
     );
 
@@ -100,5 +104,30 @@ describe('GridToolbar', () => {
     await waitFor(() => {
       expect(onAddCurrentFilteredToCollection).toHaveBeenCalledWith('collection-1');
     });
+  });
+
+  it('starts a slideshow from the current view without requiring a selection', () => {
+    const onStartSlideshow = vi.fn();
+
+    render(
+      <GridToolbar
+        selectedImages={new Set()}
+        images={[]}
+        directories={[]}
+        filteredImageActionCount={0}
+        onDeleteSelected={vi.fn()}
+        onGenerateA1111={vi.fn()}
+        onGenerateComfyUI={vi.fn()}
+        onCompare={vi.fn()}
+        onBatchExport={vi.fn()}
+        onStartSlideshow={onStartSlideshow}
+        slideshowImageCount={3}
+        slideshowSourceLabel="current folder"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start slideshow' }));
+
+    expect(onStartSlideshow).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/slideshowPlaylist.test.ts
+++ b/__tests__/slideshowPlaylist.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { IndexedImage } from '../types';
+import { buildSlideshowPlaylist, isSlideshowMedia } from '../utils/slideshowPlaylist';
+
+const createImage = (id: string, name: string, fileType?: string): IndexedImage => ({
+  id,
+  name,
+  handle: {} as FileSystemFileHandle,
+  metadata: {} as any,
+  metadataString: '',
+  lastModified: 1,
+  models: [],
+  loras: [],
+  scheduler: '',
+  fileType,
+});
+
+describe('buildSlideshowPlaylist', () => {
+  const first = createImage('1', 'first.png');
+  const second = createImage('2', 'second.mp4', 'video/mp4');
+  const third = createImage('3', 'third.gif');
+  const audio = createImage('4', 'song.mp3', 'audio/mpeg');
+  const outOfScope = createImage('5', 'elsewhere.webp');
+
+  it('uses visual media from the current scope when no images are selected', () => {
+    const playlist = buildSlideshowPlaylist({
+      scopeImages: [first, audio, second],
+      selectedImageIds: new Set(),
+      allImages: [first, audio, second],
+    });
+
+    expect(playlist.source).toBe('scope');
+    expect(playlist.images.map((image) => image.id)).toEqual(['1', '2']);
+  });
+
+  it('uses selected images before the broader current scope', () => {
+    const playlist = buildSlideshowPlaylist({
+      scopeImages: [first, second, third],
+      selectedImageIds: new Set(['3', '1']),
+      allImages: [first, second, third],
+    });
+
+    expect(playlist.source).toBe('selection');
+    expect(playlist.images.map((image) => image.id)).toEqual(['1', '3']);
+  });
+
+  it('appends selected images that are not in the current visible scope', () => {
+    const playlist = buildSlideshowPlaylist({
+      scopeImages: [first, second],
+      selectedImageIds: new Set(['5', '2']),
+      allImages: [first, second, third, outOfScope],
+    });
+
+    expect(playlist.images.map((image) => image.id)).toEqual(['2', '5']);
+  });
+
+  it('excludes selected audio while keeping gif and video items', () => {
+    const playlist = buildSlideshowPlaylist({
+      scopeImages: [first, second, third, audio],
+      selectedImageIds: new Set(['2', '3', '4']),
+      allImages: [first, second, third, audio],
+    });
+
+    expect(playlist.images.map((image) => image.id)).toEqual(['2', '3']);
+  });
+});
+
+describe('isSlideshowMedia', () => {
+  it('allows images and videos but rejects audio', () => {
+    expect(isSlideshowMedia(createImage('png', 'image.png'))).toBe(true);
+    expect(isSlideshowMedia(createImage('gif', 'animation.gif'))).toBe(true);
+    expect(isSlideshowMedia(createImage('video', 'clip.webm'))).toBe(true);
+    expect(isSlideshowMedia(createImage('audio', 'clip.wav'))).toBe(false);
+  });
+});

--- a/__tests__/slideshowPlaylist.test.ts
+++ b/__tests__/slideshowPlaylist.test.ts
@@ -63,6 +63,17 @@ describe('buildSlideshowPlaylist', () => {
 
     expect(playlist.images.map((image) => image.id)).toEqual(['2', '3']);
   });
+
+  it('falls back to the current scope when selected items contain no visual media', () => {
+    const playlist = buildSlideshowPlaylist({
+      scopeImages: [first, audio, second],
+      selectedImageIds: new Set(['4']),
+      allImages: [first, audio, second],
+    });
+
+    expect(playlist.source).toBe('scope');
+    expect(playlist.images.map((image) => image.id)).toEqual(['1', '2']);
+  });
 });
 
 describe('isSlideshowMedia', () => {

--- a/__tests__/useSettingsStore.slideshow.test.ts
+++ b/__tests__/useSettingsStore.slideshow.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SLIDESHOW_INTERVAL_SECONDS,
+  MAX_SLIDESHOW_INTERVAL_SECONDS,
+  MIN_SLIDESHOW_INTERVAL_SECONDS,
+  sanitizeSlideshowIntervalSeconds,
+  useSettingsStore,
+} from '../store/useSettingsStore';
+
+describe('useSettingsStore slideshow preferences', () => {
+  beforeEach(() => {
+    useSettingsStore.getState().resetState();
+  });
+
+  it('uses slideshow defaults', () => {
+    const state = useSettingsStore.getState();
+
+    expect(state.slideshowIntervalSeconds).toBe(DEFAULT_SLIDESHOW_INTERVAL_SECONDS);
+    expect(state.slideshowShowFilename).toBe(true);
+  });
+
+  it('clamps slideshow interval values', () => {
+    useSettingsStore.getState().setSlideshowIntervalSeconds(MAX_SLIDESHOW_INTERVAL_SECONDS + 100);
+    expect(useSettingsStore.getState().slideshowIntervalSeconds).toBe(MAX_SLIDESHOW_INTERVAL_SECONDS);
+
+    useSettingsStore.getState().setSlideshowIntervalSeconds(MIN_SLIDESHOW_INTERVAL_SECONDS - 1);
+    expect(useSettingsStore.getState().slideshowIntervalSeconds).toBe(MIN_SLIDESHOW_INTERVAL_SECONDS);
+
+    useSettingsStore.getState().setSlideshowIntervalSeconds(Number.NaN);
+    expect(useSettingsStore.getState().slideshowIntervalSeconds).toBe(DEFAULT_SLIDESHOW_INTERVAL_SECONDS);
+  });
+
+  it('sanitizes decimal intervals to whole seconds', () => {
+    expect(sanitizeSlideshowIntervalSeconds(6.8)).toBe(6);
+  });
+
+  it('persists the filename overlay preference in state', () => {
+    useSettingsStore.getState().setSlideshowShowFilename(false);
+
+    expect(useSettingsStore.getState().slideshowShowFilename).toBe(false);
+  });
+});

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -10,7 +10,8 @@ import {
   ChevronDown,
   Tag,
   RefreshCw,
-  Plus
+  Plus,
+  Play
 } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
@@ -35,6 +36,9 @@ interface GridToolbarProps {
   onGenerateComfyUI: (image: IndexedImage) => void;
   onCompare: (images: IndexedImage[]) => void;
   onBatchExport: () => void;
+  onStartSlideshow: () => void;
+  slideshowImageCount: number;
+  slideshowSourceLabel?: string;
 }
 
 const showNotification = (message: string, type: 'success' | 'error' = 'success') => {
@@ -61,6 +65,9 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   onGenerateComfyUI,
   onCompare,
   onBatchExport,
+  onStartSlideshow,
+  slideshowImageCount,
+  slideshowSourceLabel = 'current view',
 }) => {
   const [generateDropdownOpen, setGenerateDropdownOpen] = useState(false);
   const [isCollectionActionsOpen, setIsCollectionActionsOpen] = useState(false);
@@ -265,7 +272,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions) {
+  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions && slideshowImageCount === 0) {
     return null;
   }
 
@@ -290,6 +297,24 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       <div className="flex items-center justify-between gap-2 mb-1 px-5 min-h-[36px]">
         {/* Selection Context Toolbar - Centered or justified as needed */}
         <div className="flex items-center gap-1 flex-1 min-w-0">
+            {slideshowImageCount > 0 && (
+              <>
+                <Tooltip label={`Start slideshow from ${slideshowSourceLabel}`}>
+                  <button
+                    onClick={onStartSlideshow}
+                    className="p-1.5 text-gray-400 hover:text-blue-300 hover:bg-gray-700 rounded transition-colors"
+                    title={`Start slideshow from ${slideshowSourceLabel} (${slideshowImageCount} item${slideshowImageCount === 1 ? '' : 's'})`}
+                    aria-label="Start slideshow"
+                  >
+                    <Play className="w-4 h-4" />
+                  </button>
+                </Tooltip>
+                {(selectedCount > 0 || hasActiveFilters || canUseFilteredCollectionActions) && (
+                  <div className="w-px h-4 bg-gray-700 mx-1" />
+                )}
+              </>
+            )}
+
             {selectedCount > 0 && (
               <>
                 <span className="text-[11px] text-gray-400 mr-2 whitespace-nowrap">{selectedCount} selected</span>

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -841,15 +841,33 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [applyModalWindowStyles]);
 
   const setFullscreenMode = useCallback(async (nextIsFullscreen: boolean) => {
+    if (window.electronAPI?.setFullscreen) {
+      const result = await window.electronAPI.setFullscreen(nextIsFullscreen);
+      if (result.success) {
+        setIsFullscreen(result.isFullscreen ?? nextIsFullscreen);
+      }
+      return;
+    }
+
     if (nextIsFullscreen === isFullscreen) {
       return;
     }
 
     if (window.electronAPI?.toggleFullscreen) {
-      const result = await window.electronAPI.toggleFullscreen();
-      if (result.success) {
-        setIsFullscreen(result.isFullscreen ?? nextIsFullscreen);
+      const stateResult = await window.electronAPI.getFullscreenState?.();
+      const currentFullscreenState = stateResult?.success
+        ? Boolean(stateResult.isFullscreen)
+        : isFullscreen;
+
+      if (currentFullscreenState !== nextIsFullscreen) {
+        const result = await window.electronAPI.toggleFullscreen();
+        if (result.success) {
+          setIsFullscreen(result.isFullscreen ?? nextIsFullscreen);
+        }
+        return;
       }
+
+      setIsFullscreen(currentFullscreenState);
       return;
     }
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -691,8 +691,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const enableAnimations = useSettingsStore((state) => state.enableAnimations);
   const slideshowIntervalSeconds = useSettingsStore((state) => state.slideshowIntervalSeconds);
   const slideshowShowFilename = useSettingsStore((state) => state.slideshowShowFilename);
-  const setSlideshowIntervalSeconds = useSettingsStore((state) => state.setSlideshowIntervalSeconds);
-  const setSlideshowShowFilename = useSettingsStore((state) => state.setSlideshowShowFilename);
 
   useEffect(() => {
     if (!isMinimized) {
@@ -2264,7 +2262,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
           {isSlideshowMode && (
             <div
               data-no-window-drag="true"
-              className="absolute bottom-4 left-1/2 z-40 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-lg border border-white/10 bg-black/60 px-3 py-2 text-white shadow-xl backdrop-blur-sm"
+              className="absolute bottom-4 left-1/2 z-40 flex -translate-x-1/2 items-center justify-center gap-2 rounded-lg border border-white/10 bg-black/60 px-3 py-2 text-white shadow-xl backdrop-blur-sm"
               onClick={(event) => event.stopPropagation()}
               onPointerDown={(event) => event.stopPropagation()}
             >
@@ -2276,28 +2274,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
               >
                 {isSlideshowPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
                 {isSlideshowPlaying ? 'Pause' : 'Play'}
-              </button>
-              <label className="flex items-center gap-1.5 text-xs text-white/80">
-                <span>Every</span>
-                <input
-                  type="number"
-                  min={1}
-                  max={120}
-                  value={slideshowIntervalSeconds}
-                  onChange={(event) => setSlideshowIntervalSeconds(Number(event.target.value))}
-                  className="w-16 rounded-md border border-white/15 bg-black/40 px-2 py-1 text-right text-sm text-white outline-none focus:border-blue-400"
-                  aria-label="Slideshow interval in seconds"
-                />
-                <span>s</span>
-              </label>
-              <button
-                type="button"
-                onClick={() => setSlideshowShowFilename(!slideshowShowFilename)}
-                className="inline-flex items-center gap-1.5 rounded-md bg-white/10 px-2.5 py-1.5 text-xs font-medium text-white/90 transition-colors hover:bg-white/20"
-                title={slideshowShowFilename ? 'Hide filenames' : 'Show filenames'}
-              >
-                {slideshowShowFilename ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
-                Filename
               </button>
               <button
                 type="button"

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -86,6 +86,8 @@ interface ImageModalProps {
   onWindowStateChange?: (windowState: ModalWindowState) => void;
   isMinimized?: boolean;
   onMinimize?: () => void;
+  startSlideshow?: boolean;
+  onSlideshowStartAcknowledged?: () => void;
 }
 
 interface ModalWindowState {
@@ -633,12 +635,16 @@ const ImageModal: React.FC<ImageModalProps> = ({
   onWindowStateChange,
   isMinimized = false,
   onMinimize,
+  startSlideshow = false,
+  onSlideshowStartAcknowledged,
 }) => {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [isRenaming, setIsRenaming] = useState(false);
   const [newName, setNewName] = useState(image.name.replace(SUPPORTED_MEDIA_EXTENSION_REGEX, ''));
   const [showRawMetadata, setShowRawMetadata] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isSlideshowMode, setIsSlideshowMode] = useState(false);
+  const [isSlideshowPlaying, setIsSlideshowPlaying] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     x: 0,
     y: 0,
@@ -683,6 +689,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const renameInputRef = useRef<HTMLInputElement>(null);
   const canDragExternally = typeof window !== 'undefined' && !!window.electronAPI?.startFileDrag;
   const enableAnimations = useSettingsStore((state) => state.enableAnimations);
+  const slideshowIntervalSeconds = useSettingsStore((state) => state.slideshowIntervalSeconds);
+  const slideshowShowFilename = useSettingsStore((state) => state.slideshowShowFilename);
+  const setSlideshowIntervalSeconds = useSettingsStore((state) => state.setSlideshowIntervalSeconds);
+  const setSlideshowShowFilename = useSettingsStore((state) => state.setSlideshowShowFilename);
 
   useEffect(() => {
     if (!isMinimized) {
@@ -832,14 +842,35 @@ const ImageModal: React.FC<ImageModalProps> = ({
     });
   }, [applyModalWindowStyles]);
 
-  const toggleFullscreen = useCallback(async () => {
+  const setFullscreenMode = useCallback(async (nextIsFullscreen: boolean) => {
+    if (nextIsFullscreen === isFullscreen) {
+      return;
+    }
+
     if (window.electronAPI?.toggleFullscreen) {
       const result = await window.electronAPI.toggleFullscreen();
       if (result.success) {
-        setIsFullscreen(result.isFullscreen ?? false);
+        setIsFullscreen(result.isFullscreen ?? nextIsFullscreen);
       }
+      return;
     }
-  }, []);
+
+    try {
+      if (nextIsFullscreen) {
+        await modalShellRef.current?.requestFullscreen?.();
+      } else if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      }
+      setIsFullscreen(nextIsFullscreen);
+    } catch (error) {
+      console.warn('Unable to toggle native fullscreen, using viewer fullscreen fallback:', error);
+      setIsFullscreen(nextIsFullscreen);
+    }
+  }, [isFullscreen]);
+
+  const toggleFullscreen = useCallback(async () => {
+    await setFullscreenMode(!isFullscreen);
+  }, [isFullscreen, setFullscreenMode]);
 
   const clearMediaOverlayHideTimer = useCallback(() => {
     if (typeof window === 'undefined' || mediaOverlayHideTimeoutRef.current === null) {
@@ -877,9 +908,18 @@ const ImageModal: React.FC<ImageModalProps> = ({
       setIsFullscreen(data.isFullscreen ?? false);
     });
 
+    const handleBrowserFullscreenChange = () => {
+      if (!window.electronAPI) {
+        setIsFullscreen(Boolean(document.fullscreenElement));
+      }
+    };
+
+    document.addEventListener('fullscreenchange', handleBrowserFullscreenChange);
+
     return () => {
       unsubscribeFullscreenChanged?.();
       unsubscribeFullscreenStateCheck?.();
+      document.removeEventListener('fullscreenchange', handleBrowserFullscreenChange);
     };
   }, [isActive]);
 
@@ -902,6 +942,21 @@ const ImageModal: React.FC<ImageModalProps> = ({
       }, 100);
     }
   }, [isActive]);
+
+  useEffect(() => {
+    if (!isActive || !startSlideshow) {
+      return;
+    }
+
+    onSlideshowStartAcknowledged?.();
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+    setIsSlideshowMode(true);
+    setIsSlideshowPlaying(totalImages > 1);
+    setFullscreenMode(true).catch((error) => {
+      console.error('Failed to enter slideshow fullscreen:', error);
+    });
+  }, [isActive, onSlideshowStartAcknowledged, setFullscreenMode, startSlideshow, totalImages]);
 
   useEffect(() => {
     modalWindowRef.current = modalWindow;
@@ -1553,6 +1608,16 @@ const ImageModal: React.FC<ImageModalProps> = ({
     setImageRating(image.id, rating);
   }, [image.id, setImageRating]);
 
+  const exitSlideshow = useCallback(() => {
+    setIsSlideshowMode(false);
+    setIsSlideshowPlaying(false);
+    if (isFullscreen) {
+      setFullscreenMode(false).catch((error) => {
+        console.error('Failed to exit slideshow fullscreen:', error);
+      });
+    }
+  }, [isFullscreen, setFullscreenMode]);
+
   const focusTagInput = useCallback(async () => {
     const focusInput = () => {
       tagInputRef.current?.focus();
@@ -1580,6 +1645,39 @@ const ImageModal: React.FC<ImageModalProps> = ({
       }
     };
   }, [handleWheel, isPlayableMedia]);
+
+  useEffect(() => {
+    if (!isSlideshowMode || currentIndex < totalImages - 1) {
+      return;
+    }
+
+    setIsSlideshowPlaying(false);
+  }, [currentIndex, isSlideshowMode, totalImages]);
+
+  useEffect(() => {
+    if (!isActive || !isSlideshowMode || !isSlideshowPlaying || totalImages <= 1) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      if (currentIndex >= totalImages - 1) {
+        setIsSlideshowPlaying(false);
+        return;
+      }
+
+      onNavigateNext?.();
+    }, slideshowIntervalSeconds * 1000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [
+    currentIndex,
+    isActive,
+    isSlideshowMode,
+    isSlideshowPlaying,
+    onNavigateNext,
+    slideshowIntervalSeconds,
+    totalImages,
+  ]);
 
   const handleDelete = useCallback(async () => {
     if (isIndexing) {
@@ -1631,9 +1729,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
           return;
         }
 
-      event.stopPropagation();
-        if (isFullscreen) {
-          toggleFullscreen();
+        event.stopPropagation();
+        if (isSlideshowMode) {
+          exitSlideshow();
+        } else if (isFullscreen) {
+          void toggleFullscreen();
         } else {
           onClose();
         }
@@ -1647,7 +1747,14 @@ const ImageModal: React.FC<ImageModalProps> = ({
       if (eventMatchesKeybinding(event, toggleFullscreenKeybinding)) {
         event.preventDefault();
         event.stopPropagation();
-        toggleFullscreen();
+        void toggleFullscreen();
+        return;
+      }
+
+      if (isSlideshowMode && event.key === ' ') {
+        event.preventDefault();
+        event.stopPropagation();
+        setIsSlideshowPlaying((current) => !current);
         return;
       }
 
@@ -1699,9 +1806,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
     handleDelete,
     handleToggleFavorite,
     hideContextMenu,
+    exitSlideshow,
     isActive,
     isFullscreen,
     isRenaming,
+    isSlideshowMode,
     onClose,
     onNavigateNext,
     onNavigatePrevious,
@@ -2107,8 +2216,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
             />
           )}
 
-          <div data-no-window-drag="true" className="absolute top-4 left-4 z-30 bg-black/60 text-white px-3 py-1 rounded-full text-sm font-medium backdrop-blur-sm border border-white/20">
-            {currentIndex + 1} / {totalImages}
+          <div data-no-window-drag="true" className="absolute top-4 left-4 z-30 max-w-[min(80vw,520px)] rounded-lg border border-white/20 bg-black/60 px-3 py-1 text-sm font-medium text-white backdrop-blur-sm">
+            <div className="whitespace-nowrap text-xs text-white/80">
+              {currentIndex + 1} / {totalImages}
+            </div>
+            {isSlideshowMode && slideshowShowFilename && (
+              <div className="mt-0.5 truncate" title={image.name}>
+                {image.name}
+              </div>
+            )}
           </div>
 
           {!isPlayableMedia && (
@@ -2141,6 +2257,56 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 title="Reset Zoom"
               >
                 Reset
+              </button>
+            </div>
+          )}
+
+          {isSlideshowMode && (
+            <div
+              data-no-window-drag="true"
+              className="absolute bottom-4 left-1/2 z-40 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-lg border border-white/10 bg-black/60 px-3 py-2 text-white shadow-xl backdrop-blur-sm"
+              onClick={(event) => event.stopPropagation()}
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              <button
+                type="button"
+                onClick={() => setIsSlideshowPlaying((current) => !current)}
+                className="inline-flex items-center gap-1.5 rounded-md bg-white/10 px-3 py-1.5 text-sm font-medium transition-colors hover:bg-white/20"
+                title={isSlideshowPlaying ? 'Pause slideshow (Space)' : 'Play slideshow (Space)'}
+              >
+                {isSlideshowPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+                {isSlideshowPlaying ? 'Pause' : 'Play'}
+              </button>
+              <label className="flex items-center gap-1.5 text-xs text-white/80">
+                <span>Every</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={120}
+                  value={slideshowIntervalSeconds}
+                  onChange={(event) => setSlideshowIntervalSeconds(Number(event.target.value))}
+                  className="w-16 rounded-md border border-white/15 bg-black/40 px-2 py-1 text-right text-sm text-white outline-none focus:border-blue-400"
+                  aria-label="Slideshow interval in seconds"
+                />
+                <span>s</span>
+              </label>
+              <button
+                type="button"
+                onClick={() => setSlideshowShowFilename(!slideshowShowFilename)}
+                className="inline-flex items-center gap-1.5 rounded-md bg-white/10 px-2.5 py-1.5 text-xs font-medium text-white/90 transition-colors hover:bg-white/20"
+                title={slideshowShowFilename ? 'Hide filenames' : 'Show filenames'}
+              >
+                {slideshowShowFilename ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+                Filename
+              </button>
+              <button
+                type="button"
+                onClick={exitSlideshow}
+                className="rounded-md bg-white/10 p-1.5 text-white/90 transition-colors hover:bg-white/20"
+                aria-label="Exit slideshow"
+                title="Exit slideshow"
+              >
+                <X className="h-4 w-4" />
               </button>
             </div>
           )}
@@ -3158,7 +3324,8 @@ export default React.memo(ImageModal, (prevProps, nextProps) => {
     prevProps.initialWindowState?.y === nextProps.initialWindowState?.y &&
     prevProps.initialWindowState?.width === nextProps.initialWindowState?.width &&
     prevProps.initialWindowState?.height === nextProps.initialWindowState?.height &&
-    prevProps.isMinimized === nextProps.isMinimized;
+    prevProps.isMinimized === nextProps.isMinimized &&
+    prevProps.startSlideshow === nextProps.startSlideshow;
 
   return propsEqual;
 });

--- a/components/settings/ViewerSettingsPanel.tsx
+++ b/components/settings/ViewerSettingsPanel.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { useSettingsStore } from '../../store/useSettingsStore';
+import {
+  MAX_SLIDESHOW_INTERVAL_SECONDS,
+  MIN_SLIDESHOW_INTERVAL_SECONDS,
+  useSettingsStore,
+} from '../../store/useSettingsStore';
 import {
   DEFAULT_RECENT_TAG_CHIP_LIMIT,
   DEFAULT_TAG_SUGGESTION_LIMIT,
@@ -22,6 +26,10 @@ export const ViewerSettingsPanel: React.FC = () => {
   const setTagSuggestionLimit = useSettingsStore((state) => state.setTagSuggestionLimit);
   const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
   const setRecentTagChipLimit = useSettingsStore((state) => state.setRecentTagChipLimit);
+  const slideshowIntervalSeconds = useSettingsStore((state) => state.slideshowIntervalSeconds);
+  const setSlideshowIntervalSeconds = useSettingsStore((state) => state.setSlideshowIntervalSeconds);
+  const slideshowShowFilename = useSettingsStore((state) => state.slideshowShowFilename);
+  const setSlideshowShowFilename = useSettingsStore((state) => state.setSlideshowShowFilename);
 
   return (
     <SettingsPanel title="Viewer" description="Control what appears in the library and how images open.">
@@ -40,6 +48,28 @@ export const ViewerSettingsPanel: React.FC = () => {
           label="Double-click to open"
           description="Keep single click for selection and open details on double click."
           control={<SettingSwitch checked={doubleClickToOpen} onChange={setDoubleClickToOpen} />}
+        />
+      </SettingsSectionCard>
+
+      <SettingsSectionCard title="Slideshow">
+        <SettingRow
+          label="Default interval"
+          description={`Seconds between slides. Range ${MIN_SLIDESHOW_INTERVAL_SECONDS}-${MAX_SLIDESHOW_INTERVAL_SECONDS}.`}
+          control={
+            <input
+              type="number"
+              min={MIN_SLIDESHOW_INTERVAL_SECONDS}
+              max={MAX_SLIDESHOW_INTERVAL_SECONDS}
+              value={slideshowIntervalSeconds}
+              onChange={(event) => setSlideshowIntervalSeconds(Number(event.target.value))}
+              className="w-24 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-right text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+            />
+          }
+        />
+        <SettingRow
+          label="Show filename overlay"
+          description="Show filenames while a slideshow is running."
+          control={<SettingSwitch checked={slideshowShowFilename} onChange={setSlideshowShowFilename} />}
         />
       </SettingsSectionCard>
 

--- a/electron.mjs
+++ b/electron.mjs
@@ -2316,6 +2316,24 @@ function setupFileOperationHandlers() {
     return { success: false, error: 'Main window not available' };
   });
 
+  ipcMain.handle('get-fullscreen-state', () => {
+    if (mainWindow) {
+      return { success: true, isFullscreen: mainWindow.isFullScreen() };
+    }
+    return { success: false, error: 'Main window not available' };
+  });
+
+  ipcMain.handle('set-fullscreen', (event, isFullscreen) => {
+    if (mainWindow) {
+      const nextFullscreenState = Boolean(isFullscreen);
+      if (mainWindow.isFullScreen() !== nextFullscreenState) {
+        mainWindow.setFullScreen(nextFullscreenState);
+      }
+      return { success: true, isFullscreen: mainWindow.isFullScreen() };
+    }
+    return { success: false, error: 'Main window not available' };
+  });
+
   // Handle reading multiple files in a batch
   ipcMain.handle('read-files-batch', async (event, filePaths) => {
     try {

--- a/preload.js
+++ b/preload.js
@@ -154,6 +154,8 @@ const electronAPI = {
   joinPaths: (...paths) => ipcRenderer.invoke('join-paths', ...paths),
   joinPathsBatch: (args) => ipcRenderer.invoke('join-paths-batch', args),
   toggleFullscreen: () => ipcRenderer.invoke('toggle-fullscreen'),
+  getFullscreenState: () => ipcRenderer.invoke('get-fullscreen-state'),
+  setFullscreen: (isFullscreen) => ipcRenderer.invoke('set-fullscreen', isFullscreen),
   startFileDrag: (args) => ipcRenderer.send('start-file-drag', args),
 
   // --- Caching ---

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -78,6 +78,21 @@ const defaultIndexingConcurrency = detectDefaultIndexingConcurrency();
 
 export type StartupVerificationMode = 'off' | 'idle' | 'strict';
 
+export const DEFAULT_SLIDESHOW_INTERVAL_SECONDS = 5;
+export const MIN_SLIDESHOW_INTERVAL_SECONDS = 1;
+export const MAX_SLIDESHOW_INTERVAL_SECONDS = 120;
+
+export const sanitizeSlideshowIntervalSeconds = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_SLIDESHOW_INTERVAL_SECONDS;
+  }
+
+  return Math.min(
+    MAX_SLIDESHOW_INTERVAL_SECONDS,
+    Math.max(MIN_SLIDESHOW_INTERVAL_SECONDS, Math.floor(value))
+  );
+};
+
 // Define the state shape
 interface SettingsState {
   // App settings
@@ -104,6 +119,8 @@ interface SettingsState {
   blurSensitiveImages: boolean;
   enableSafeMode: boolean;
   enableAnimations: boolean;
+  slideshowIntervalSeconds: number;
+  slideshowShowFilename: boolean;
 
   // A1111 Integration settings
   a1111Enabled: boolean;
@@ -143,6 +160,8 @@ interface SettingsState {
   setBlurSensitiveImages: (value: boolean) => void;
   setEnableSafeMode: (value: boolean) => void;
   setEnableAnimations: (value: boolean) => void;
+  setSlideshowIntervalSeconds: (value: number) => void;
+  setSlideshowShowFilename: (value: boolean) => void;
   setA1111Enabled: (value: boolean) => void;
   setA1111ServerUrl: (url: string) => void;
   toggleA1111AutoStart: () => void;
@@ -187,6 +206,8 @@ export const useSettingsStore = create<SettingsState>()(
       blurSensitiveImages: true,
       enableSafeMode: true,
       enableAnimations: true,
+      slideshowIntervalSeconds: DEFAULT_SLIDESHOW_INTERVAL_SECONDS,
+      slideshowShowFilename: true,
 
       // A1111 Integration initial state
       a1111Enabled: true,
@@ -238,6 +259,9 @@ export const useSettingsStore = create<SettingsState>()(
       setBlurSensitiveImages: (value) => set({ blurSensitiveImages: !!value }),
       setEnableSafeMode: (value) => set({ enableSafeMode: !!value }),
       setEnableAnimations: (value) => set({ enableAnimations: !!value }),
+      setSlideshowIntervalSeconds: (value) =>
+        set({ slideshowIntervalSeconds: sanitizeSlideshowIntervalSeconds(value) }),
+      setSlideshowShowFilename: (value) => set({ slideshowShowFilename: !!value }),
       updateKeybinding: (scope, action, keybinding) =>
         set((state) => ({
           keymap: {
@@ -287,6 +311,8 @@ export const useSettingsStore = create<SettingsState>()(
         blurSensitiveImages: true,
         enableSafeMode: true,
         enableAnimations: true,
+        slideshowIntervalSeconds: DEFAULT_SLIDESHOW_INTERVAL_SECONDS,
+        slideshowShowFilename: true,
         a1111Enabled: true,
         a1111ServerUrl: 'http://127.0.0.1:7860',
         a1111AutoStart: false,
@@ -359,6 +385,14 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.enableAnimations !== 'boolean') {
           state.enableAnimations = true;
+        }
+
+        if (state) {
+          state.slideshowIntervalSeconds = sanitizeSlideshowIntervalSeconds(state.slideshowIntervalSeconds);
+        }
+
+        if (state && typeof state.slideshowShowFilename !== 'boolean') {
+          state.slideshowShowFilename = true;
         }
 
         if (state && typeof state.a1111Enabled !== 'boolean') {

--- a/types.ts
+++ b/types.ts
@@ -143,6 +143,8 @@ export interface ElectronAPI {
   getTheme: () => Promise<{ shouldUseDarkColors: boolean }>;
   onThemeUpdated: (callback: (theme: { shouldUseDarkColors: boolean }) => void) => () => void;
   toggleFullscreen: () => Promise<{ success: boolean; isFullscreen?: boolean; error?: string }>;
+  getFullscreenState: () => Promise<{ success: boolean; isFullscreen?: boolean; error?: string }>;
+  setFullscreen: (isFullscreen: boolean) => Promise<{ success: boolean; isFullscreen?: boolean; error?: string }>;
   onFullscreenChanged: (callback: (state: { isFullscreen: boolean }) => void) => () => void;
   onFullscreenStateCheck: (callback: (state: { isFullscreen: boolean }) => void) => () => void;
   onExportBatchProgress: (callback: (progress: ExportBatchProgress) => void) => () => void;

--- a/utils/slideshowPlaylist.ts
+++ b/utils/slideshowPlaylist.ts
@@ -24,9 +24,11 @@ export const buildSlideshowPlaylist = ({
   selectedImageIds,
   allImages,
 }: BuildSlideshowPlaylistArgs): SlideshowPlaylist => {
+  const scopePlaylist = scopeImages.filter(isSlideshowMedia);
+
   if (selectedImageIds.size === 0) {
     return {
-      images: scopeImages.filter(isSlideshowMedia),
+      images: scopePlaylist,
       source: 'scope',
     };
   }
@@ -50,8 +52,17 @@ export const buildSlideshowPlaylist = ({
     }
   }
 
+  const selectedPlaylist = [...selectedInScope, ...selectedOutOfScope];
+
+  if (selectedPlaylist.length === 0) {
+    return {
+      images: scopePlaylist,
+      source: 'scope',
+    };
+  }
+
   return {
-    images: [...selectedInScope, ...selectedOutOfScope],
+    images: selectedPlaylist,
     source: 'selection',
   };
 };

--- a/utils/slideshowPlaylist.ts
+++ b/utils/slideshowPlaylist.ts
@@ -1,0 +1,57 @@
+import type { IndexedImage } from '../types';
+import { resolveMediaType } from './mediaTypes.js';
+
+export type SlideshowPlaylistSource = 'selection' | 'scope';
+
+export interface BuildSlideshowPlaylistArgs {
+  scopeImages: IndexedImage[];
+  selectedImageIds: Set<string>;
+  allImages: IndexedImage[];
+}
+
+export interface SlideshowPlaylist {
+  images: IndexedImage[];
+  source: SlideshowPlaylistSource;
+}
+
+export const isSlideshowMedia = (image: IndexedImage): boolean => {
+  const mediaType = resolveMediaType(image.name, image.fileType);
+  return mediaType === 'image' || mediaType === 'video';
+};
+
+export const buildSlideshowPlaylist = ({
+  scopeImages,
+  selectedImageIds,
+  allImages,
+}: BuildSlideshowPlaylistArgs): SlideshowPlaylist => {
+  if (selectedImageIds.size === 0) {
+    return {
+      images: scopeImages.filter(isSlideshowMedia),
+      source: 'scope',
+    };
+  }
+
+  const selectedInScope = scopeImages.filter(
+    (image) => selectedImageIds.has(image.id) && isSlideshowMedia(image)
+  );
+  const usedIds = new Set(selectedInScope.map((image) => image.id));
+  const allImageLookup = new Map(allImages.map((image) => [image.id, image]));
+  const selectedOutOfScope: IndexedImage[] = [];
+
+  for (const imageId of selectedImageIds) {
+    if (usedIds.has(imageId)) {
+      continue;
+    }
+
+    const image = allImageLookup.get(imageId);
+    if (image && isSlideshowMedia(image)) {
+      selectedOutOfScope.push(image);
+      usedIds.add(image.id);
+    }
+  }
+
+  return {
+    images: [...selectedInScope, ...selectedOutOfScope],
+    source: 'selection',
+  };
+};


### PR DESCRIPTION
## Summary
- Add a slideshow playlist builder that prefers selected visual media and falls back to the current browse scope.
- Add persistent Viewer settings for slideshow interval and filename overlay.
- Wire slideshow launch into the existing ImageModal so playback opens fullscreen and stays in a single modal while navigating.

## Fixes and behavior
- Prevent slideshow navigation from opening a new ImageModal for every image.
- Keep slideshow settings in SettingsModal instead of rendering preference controls during playback.
- Support keyboard controls during slideshow: ArrowLeft, ArrowRight, Space, and Esc.

## Validation
- `npm test -- slideshow GridToolbar useSettingsStore`
- `npm run build`