### PR TITLE
Add similar prompt compare flow and improve compare metadata UX

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,6 +31,8 @@ import ProOnlyModal from './components/ProOnlyModal';
 import SmartLibrary from './components/SmartLibrary';
 import { ModelView } from './components/ModelView';
 import NodeView from './components/NodeView';
+import FindSimilarModal from './components/FindSimilarModal';
+import ModelPromptPickerModal from './components/ModelPromptPickerModal';
 import CollectionsWorkspace from './components/CollectionsWorkspace';
 import GridToolbar from './components/GridToolbar';
 import AnalyticsSummaryStrip from './components/AnalyticsSummaryStrip';
@@ -54,6 +56,7 @@ import { useGenerateWithComfyUI } from './hooks/useGenerateWithComfyUI';
 import { type IndexedImage, type BaseMetadata } from './types';
 import { type SettingsFocusSection, type SettingsTab, type SettingsTabInput, resolveSettingsTab } from './components/settings/types';
 import { buildSlideshowPlaylist } from './utils/slideshowPlaylist';
+import { getModelPromptOverlapGroups, type ModelPromptOverlapGroup } from './services/similarImageSearch';
 
 interface OpenImageModalState {
   modalId: string;
@@ -73,6 +76,11 @@ interface ImageModalWindowState {
   y: number;
   width: number;
   height: number;
+}
+
+interface FindSimilarState {
+  sourceImage: IndexedImage;
+  currentViewImages: IndexedImage[];
 }
 
 const SIDEBAR_WIDTH_STORAGE_KEY = 'image-metahub-sidebar-width';
@@ -367,6 +375,11 @@ export default function App() {
   const [isSaveFilteredCollectionModalOpen, setIsSaveFilteredCollectionModalOpen] = useState(false);
   const [openImageModals, setOpenImageModals] = useState<OpenImageModalState[]>([]);
   const [activeImageModalId, setActiveImageModalId] = useState<string | null>(null);
+  const [findSimilarState, setFindSimilarState] = useState<FindSimilarState | null>(null);
+  const [modelPromptPickerState, setModelPromptPickerState] = useState<{
+    modelName: string;
+    groups: ModelPromptOverlapGroup[];
+  } | null>(null);
   const lastOpenedModalImageIdRef = useRef<string | null>(null);
   const suppressSelectedImageModalOpenRef = useRef<string | null>(null);
   const appProfilerOnRender = useMemo(() => createProfilerOnRender('App'), []);
@@ -1669,6 +1682,41 @@ export default function App() {
       : libraryView === 'node'
       ? nodeViewResultImages
       : safeFilteredImages;
+
+  const openFindSimilar = useCallback((sourceImage: IndexedImage, currentViewImages?: IndexedImage[]) => {
+    setFindSimilarState({
+      sourceImage,
+      currentViewImages: (currentViewImages && currentViewImages.length > 0 ? currentViewImages : safeFilteredImages)
+        .filter((image) => Boolean(image)),
+    });
+  }, [safeFilteredImages]);
+
+  const closeFindSimilar = useCallback(() => {
+    setFindSimilarState(null);
+  }, []);
+
+  const handleOpenFindSimilarCompare = useCallback((images: IndexedImage[]) => {
+    setComparisonImages(images);
+    openComparisonModal();
+    setFindSimilarState(null);
+  }, [openComparisonModal, setComparisonImages]);
+
+  const openModelPromptPicker = useCallback((modelName: string) => {
+    setModelPromptPickerState({
+      modelName,
+      groups: getModelPromptOverlapGroups(modelName, safeImages),
+    });
+  }, [safeImages]);
+
+  const closeModelPromptPicker = useCallback(() => {
+    setModelPromptPickerState(null);
+  }, []);
+
+  const handleSelectModelPromptGroup = useCallback((group: ModelPromptOverlapGroup) => {
+    setModelPromptPickerState(null);
+    openFindSimilar(group.sourceImage, safeImages);
+  }, [openFindSimilar, safeImages]);
+
   const canSaveCurrentFilteredAsCollection = libraryView !== 'smart' && displayImages.length > 0;
   const slideshowPlaylistPreview = useMemo(
     () =>
@@ -1772,6 +1820,9 @@ export default function App() {
         }
 
         const navigationImageIds = resolveModalNavigationImageIds(modal);
+        const navigationImages = navigationImageIds
+          .map((imageId) => getImageByIdFromStore(imageId))
+          .filter((candidate): candidate is IndexedImage => Boolean(candidate));
         const currentIndex = navigationImageIds.findIndex((imageId) => imageId === modal.imageId);
         const directoryPath = directoryPathById.get(image.directoryId);
         if (!directoryPath) {
@@ -1781,6 +1832,7 @@ export default function App() {
         return {
           ...modal,
           image,
+          navigationImages,
           directoryPath,
           currentIndex: currentIndex === -1 ? 0 : currentIndex,
           totalImages: navigationImageIds.length,
@@ -1788,6 +1840,7 @@ export default function App() {
       })
       .filter(Boolean) as Array<OpenImageModalState & {
         image: IndexedImage;
+        navigationImages: IndexedImage[];
         directoryPath: string;
         currentIndex: number;
         totalImages: number;
@@ -2201,6 +2254,7 @@ export default function App() {
                           onPageChange={setCurrentPage}
                           onBatchExport={handleOpenBatchExport}
                           onImageRenamed={handleImageRenamed}
+                          onFindSimilar={(image) => openFindSimilar(image, displayImages)}
                         />
                       ) : (
                         <ImageTable
@@ -2209,6 +2263,7 @@ export default function App() {
                           selectedImages={safeSelectedImages}
                           onBatchExport={handleOpenBatchExport}
                           onImageRenamed={handleImageRenamed}
+                          onFindSimilar={(image) => openFindSimilar(image, displayImages)}
                         />
                   )
                 ) : libraryView === 'model' ? (
@@ -2219,6 +2274,7 @@ export default function App() {
                       setSelectedFilters({ models: [modelName] });
                       setLibraryView('library');
                     }}
+                    onFindMatchingPrompts={openModelPromptPicker}
                   />
                 ) : libraryView === 'collections' ? (
                   <CollectionsWorkspace
@@ -2237,6 +2293,7 @@ export default function App() {
                         activeCollection={activeCollection}
                         isCollectionsView
                         onImageRenamed={handleImageRenamed}
+                        onFindSimilar={(image) => openFindSimilar(image, displayImages)}
                       />
                     ) : (
                       <ImageTable
@@ -2247,6 +2304,7 @@ export default function App() {
                         activeCollection={activeCollection}
                         isCollectionsView
                         onImageRenamed={handleImageRenamed}
+                        onFindSimilar={(image) => openFindSimilar(image, displayImages)}
                       />
                     )}
                   </CollectionsWorkspace>
@@ -2329,6 +2387,7 @@ export default function App() {
             startSlideshow={modal.startSlideshow}
             diagnosticsFlowId={modal.diagnosticsFlowId}
             onSlideshowStartAcknowledged={() => handleSlideshowStartAcknowledged(modal.modalId)}
+            onFindSimilar={(image) => openFindSimilar(image, modal.navigationImages)}
           />
         ))}
 
@@ -2361,6 +2420,23 @@ export default function App() {
           onStartTrial={startTrial}
           isExpired={isExpired}
           isPro={isPro}
+        />
+
+        <ModelPromptPickerModal
+          isOpen={modelPromptPickerState !== null}
+          modelName={modelPromptPickerState?.modelName ?? null}
+          groups={modelPromptPickerState?.groups ?? []}
+          onClose={closeModelPromptPicker}
+          onSelect={handleSelectModelPromptGroup}
+        />
+
+        <FindSimilarModal
+          isOpen={findSimilarState !== null}
+          sourceImage={findSimilarState?.sourceImage ?? null}
+          allImages={safeImages}
+          currentViewImages={findSimilarState?.currentViewImages}
+          onClose={closeFindSimilar}
+          onOpenCompare={handleOpenFindSimilarCompare}
         />
 
         {/* Generate Modals */}

--- a/App.tsx
+++ b/App.tsx
@@ -53,7 +53,7 @@ import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } fr
 import { ComfyUIGenerateModal, type GenerationParams as ComfyUIGenerationParams } from './components/ComfyUIGenerateModal';
 import { useGenerateWithA1111 } from './hooks/useGenerateWithA1111';
 import { useGenerateWithComfyUI } from './hooks/useGenerateWithComfyUI';
-import { type IndexedImage, type BaseMetadata } from './types';
+import { type IndexedImage, type BaseMetadata, type SimilarSearchCriteria } from './types';
 import { type SettingsFocusSection, type SettingsTab, type SettingsTabInput, resolveSettingsTab } from './components/settings/types';
 import { buildSlideshowPlaylist } from './utils/slideshowPlaylist';
 import { getModelPromptOverlapGroups, type ModelPromptOverlapGroup } from './services/similarImageSearch';
@@ -81,6 +81,7 @@ interface ImageModalWindowState {
 interface FindSimilarState {
   sourceImage: IndexedImage;
   currentViewImages: IndexedImage[];
+  initialCriteria?: Partial<SimilarSearchCriteria>;
 }
 
 const SIDEBAR_WIDTH_STORAGE_KEY = 'image-metahub-sidebar-width';
@@ -1683,11 +1684,16 @@ export default function App() {
       ? nodeViewResultImages
       : safeFilteredImages;
 
-  const openFindSimilar = useCallback((sourceImage: IndexedImage, currentViewImages?: IndexedImage[]) => {
+  const openFindSimilar = useCallback((
+    sourceImage: IndexedImage,
+    currentViewImages?: IndexedImage[],
+    initialCriteria?: Partial<SimilarSearchCriteria>,
+  ) => {
     setFindSimilarState({
       sourceImage,
       currentViewImages: (currentViewImages && currentViewImages.length > 0 ? currentViewImages : safeFilteredImages)
         .filter((image) => Boolean(image)),
+      initialCriteria,
     });
   }, [safeFilteredImages]);
 
@@ -2254,7 +2260,7 @@ export default function App() {
                           onPageChange={setCurrentPage}
                           onBatchExport={handleOpenBatchExport}
                           onImageRenamed={handleImageRenamed}
-                          onFindSimilar={(image) => openFindSimilar(image, displayImages)}
+                          onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
                         />
                       ) : (
                         <ImageTable
@@ -2263,7 +2269,7 @@ export default function App() {
                           selectedImages={safeSelectedImages}
                           onBatchExport={handleOpenBatchExport}
                           onImageRenamed={handleImageRenamed}
-                          onFindSimilar={(image) => openFindSimilar(image, displayImages)}
+                          onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
                         />
                   )
                 ) : libraryView === 'model' ? (
@@ -2293,7 +2299,7 @@ export default function App() {
                         activeCollection={activeCollection}
                         isCollectionsView
                         onImageRenamed={handleImageRenamed}
-                        onFindSimilar={(image) => openFindSimilar(image, displayImages)}
+                        onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
                       />
                     ) : (
                       <ImageTable
@@ -2304,7 +2310,7 @@ export default function App() {
                         activeCollection={activeCollection}
                         isCollectionsView
                         onImageRenamed={handleImageRenamed}
-                        onFindSimilar={(image) => openFindSimilar(image, displayImages)}
+                        onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
                       />
                     )}
                   </CollectionsWorkspace>
@@ -2435,6 +2441,7 @@ export default function App() {
           sourceImage={findSimilarState?.sourceImage ?? null}
           allImages={safeImages}
           currentViewImages={findSimilarState?.currentViewImages}
+          initialCriteria={findSimilarState?.initialCriteria}
           onClose={closeFindSimilar}
           onOpenCompare={handleOpenFindSimilarCompare}
         />

--- a/__tests__/ComparisonModal.interaction.test.tsx
+++ b/__tests__/ComparisonModal.interaction.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ComparisonModal from '../components/ComparisonModal';
+import { useImageStore } from '../store/useImageStore';
+import type { IndexedImage } from '../types';
+
+vi.mock('../components/ComparisonPane', () => ({
+  default: ({ image, onHoverChange }: { image: IndexedImage; onHoverChange?: (isHovered: boolean) => void }) => (
+    <div
+      data-testid={`pane-${image.id}`}
+      onMouseEnter={() => onHoverChange?.(true)}
+      onMouseLeave={() => onHoverChange?.(false)}
+    >
+      {image.name}
+    </div>
+  ),
+}));
+
+vi.mock('../components/ComparisonOverlayView', () => ({
+  default: () => <div data-testid="overlay-view">overlay</div>,
+}));
+
+vi.mock('../components/ComparisonMetadataPanel', () => ({
+  default: ({
+    image,
+    isExpanded,
+    isHighlighted,
+  }: {
+    image: IndexedImage;
+    isExpanded: boolean;
+    isHighlighted?: boolean;
+  }) => (
+    <div
+      data-testid={`metadata-${image.id}`}
+      data-expanded={isExpanded ? 'true' : 'false'}
+      data-highlighted={isHighlighted ? 'true' : 'false'}
+    >
+      {image.name}
+    </div>
+  ),
+}));
+
+const createImage = (id: string, prompt: string): IndexedImage => ({
+  id,
+  name: `${id}.png`,
+  handle: {} as FileSystemFileHandle,
+  metadata: {
+    normalizedMetadata: {
+      prompt,
+    },
+  } as any,
+  metadataString: '',
+  lastModified: 1,
+  models: [],
+  loras: [],
+  sampler: '',
+  scheduler: '',
+  directoryId: 'dir-1',
+});
+
+describe('ComparisonModal interactions', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+  });
+
+  it('opens with metadata collapsed and highlights the matching metadata card on pane hover', () => {
+    const first = createImage('img-1', 'first prompt');
+    const second = createImage('img-2', 'second prompt');
+
+    useImageStore.setState({
+      comparisonImages: [first, second],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+    } as any);
+
+    render(<ComparisonModal isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByTestId('metadata-img-1').getAttribute('data-expanded')).toBe('false');
+    expect(screen.getByTestId('metadata-img-2').getAttribute('data-expanded')).toBe('false');
+
+    fireEvent.mouseEnter(screen.getByTestId('pane-img-2'));
+    expect(screen.getByTestId('metadata-img-1').getAttribute('data-highlighted')).toBe('false');
+    expect(screen.getByTestId('metadata-img-2').getAttribute('data-highlighted')).toBe('true');
+
+    fireEvent.mouseLeave(screen.getByTestId('pane-img-2'));
+    expect(screen.getByTestId('metadata-img-2').getAttribute('data-highlighted')).toBe('false');
+  });
+});

--- a/__tests__/FindSimilarModal.test.tsx
+++ b/__tests__/FindSimilarModal.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import FindSimilarModal from '../components/FindSimilarModal';
+import type { IndexedImage } from '../types';
+
+vi.mock('../hooks/useResolvedThumbnail', () => ({
+  useResolvedThumbnail: () => ({
+    thumbnailStatus: 'ready',
+    thumbnailUrl: 'thumb://image',
+  }),
+}));
+
+const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
+  id: overrides.id ?? 'dir-1::image.png',
+  name: overrides.name ?? 'image.png',
+  handle: overrides.handle ?? ({} as FileSystemFileHandle),
+  metadata: overrides.metadata ?? ({ normalizedMetadata: { prompt: overrides.prompt ?? '' } } as any),
+  metadataString: overrides.metadataString ?? '',
+  lastModified: overrides.lastModified ?? 1,
+  directoryId: overrides.directoryId ?? 'dir-1',
+  models: overrides.models ?? [],
+  loras: overrides.loras ?? [],
+  scheduler: overrides.scheduler ?? '',
+  workflowNodes: overrides.workflowNodes ?? [],
+  prompt: overrides.prompt ?? '',
+  negativePrompt: overrides.negativePrompt ?? '',
+  ...overrides,
+});
+
+describe('FindSimilarModal', () => {
+  it('opens with compare-oriented defaults and preselects distinct checkpoints first', async () => {
+    const onOpenCompare = vi.fn();
+    const source = createImage({
+      id: 'source',
+      name: 'source.png',
+      prompt: 'Space cathedral',
+      models: ['model-a'],
+      lastModified: 100,
+    });
+    const altA = createImage({
+      id: 'alt-a',
+      name: 'alt-a.png',
+      prompt: 'space   cathedral',
+      models: ['model-b'],
+      lastModified: 95,
+    });
+    const altB = createImage({
+      id: 'alt-b',
+      name: 'alt-b.png',
+      prompt: 'Space cathedral',
+      models: ['model-c'],
+      lastModified: 90,
+    });
+    const altCNewest = createImage({
+      id: 'alt-c-new',
+      name: 'alt-c-new.png',
+      prompt: 'Space cathedral',
+      models: ['model-d'],
+      lastModified: 85,
+    });
+    const altCOlder = createImage({
+      id: 'alt-c-old',
+      name: 'alt-c-old.png',
+      prompt: 'Space cathedral',
+      models: ['model-d'],
+      lastModified: 80,
+    });
+
+    render(
+      <FindSimilarModal
+        isOpen
+        sourceImage={source}
+        allImages={[source, altA, altB, altCNewest, altCOlder]}
+        currentViewImages={[source, altA, altB, altCNewest, altCOlder]}
+        onClose={vi.fn()}
+        onOpenCompare={onOpenCompare}
+      />,
+    );
+
+    expect((screen.getByRole('checkbox', { name: /prompt/i }) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole('checkbox', { name: /lora names/i }) as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByRole('checkbox', { name: /seed/i }) as HTMLInputElement).checked).toBe(false);
+    expect(screen.getByText('Current view')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText('Selected 3 of 3 compare slots.')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /open in compare/i }));
+
+    expect(onOpenCompare).toHaveBeenCalledWith([source, altA, altB, altCNewest]);
+  });
+});

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -140,7 +140,7 @@ const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
   ...overrides,
 });
 
-const Harness = ({ images }: { images: IndexedImage[] }) => {
+const Harness = ({ images, onFindSimilar }: { images: IndexedImage[]; onFindSimilar?: (image: IndexedImage) => void }) => {
   const selectedImages = useImageStore((state) => state.selectedImages);
 
   return (
@@ -152,6 +152,7 @@ const Harness = ({ images }: { images: IndexedImage[] }) => {
       totalPages={1}
       onPageChange={vi.fn()}
       onBatchExport={vi.fn()}
+      onFindSimilar={onFindSimilar}
     />
   );
 };
@@ -387,6 +388,30 @@ describe('ImageGrid context menu', () => {
     fireEvent.click(screen.getByText('Motos'));
 
     expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
+  });
+
+  it('shows a find similar action in the image context menu', () => {
+    const onFindSimilar = vi.fn();
+    const image = createImage({ id: 'img-1', name: 'alpha.png', prompt: 'Test prompt' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<Harness images={[image]} onFindSimilar={onFindSimilar} />);
+
+    fireEvent.click(screen.getByText('Find similar...'));
+    expect(onFindSimilar).toHaveBeenCalledWith(image);
   });
 
   it('adds selected images explicitly even for collections with auto-add tags', () => {

--- a/__tests__/ImageTable.contextMenu.test.tsx
+++ b/__tests__/ImageTable.contextMenu.test.tsx
@@ -202,6 +202,39 @@ describe('ImageTable context menu', () => {
 
     expect(addImagesToCollection).toHaveBeenCalledWith('collection-1', ['img-1']);
   });
+
+  it('shows a find similar action in the image-table context menu', () => {
+    const onFindSimilar = vi.fn();
+    const image = createImage({ id: 'img-1', name: 'alpha.png', prompt: 'Test prompt' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+
+    useImageStore.setState({
+      images: [image],
+      filteredImages: [image],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      collections: [],
+      createCollection: vi.fn().mockResolvedValue(undefined),
+      addImagesToCollection: vi.fn().mockResolvedValue(undefined),
+      removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+      updateCollection: vi.fn().mockResolvedValue(undefined),
+      bulkSetImageRating: vi.fn(),
+      transferProgress: null,
+    } as any);
+
+    render(
+      <ImageTable
+        images={[image]}
+        onImageClick={vi.fn()}
+        selectedImages={new Set()}
+        onBatchExport={vi.fn()}
+        onFindSimilar={onFindSimilar}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Find similar...'));
+    expect(onFindSimilar).toHaveBeenCalledWith(image);
+  });
 });
 
 describe('ImageTable selection opening behavior', () => {

--- a/__tests__/ModelPromptPickerModal.test.tsx
+++ b/__tests__/ModelPromptPickerModal.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ModelPromptPickerModal from '../components/ModelPromptPickerModal';
+import type { IndexedImage } from '../types';
+import type { ModelPromptOverlapGroup } from '../services/similarImageSearch';
+
+const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
+  id: overrides.id ?? 'dir-1::image.png',
+  name: overrides.name ?? 'image.png',
+  handle: overrides.handle ?? ({} as FileSystemFileHandle),
+  metadata: overrides.metadata ?? ({} as any),
+  metadataString: overrides.metadataString ?? '',
+  lastModified: overrides.lastModified ?? 1,
+  directoryId: overrides.directoryId ?? 'dir-1',
+  models: overrides.models ?? [],
+  loras: overrides.loras ?? [],
+  scheduler: overrides.scheduler ?? '',
+  workflowNodes: overrides.workflowNodes ?? [],
+  prompt: overrides.prompt ?? '',
+  negativePrompt: overrides.negativePrompt ?? '',
+  ...overrides,
+});
+
+describe('ModelPromptPickerModal', () => {
+  it('renders overlap rows and forwards the selected group', () => {
+    const onSelect = vi.fn();
+    const group: ModelPromptOverlapGroup = {
+      normalizedPrompt: 'space cathedral',
+      promptPreview: 'Space cathedral with glowing arches',
+      sourceCount: 3,
+      alternateCheckpointCount: 2,
+      sourceImage: createImage({
+        id: 'source',
+        name: 'source.png',
+        prompt: 'Space cathedral with glowing arches',
+        models: ['model-a'],
+      }),
+    };
+
+    render(
+      <ModelPromptPickerModal
+        isOpen
+        modelName="model-a"
+        groups={[group]}
+        onClose={vi.fn()}
+        onSelect={onSelect}
+      />,
+    );
+
+    expect(screen.getByText('Space cathedral with glowing arches')).toBeTruthy();
+    expect(screen.getByText('3 in this checkpoint')).toBeTruthy();
+    expect(screen.getByText('2 alternate checkpoints')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /space cathedral with glowing arches/i }));
+    expect(onSelect).toHaveBeenCalledWith(group);
+  });
+});

--- a/__tests__/ModelView.similar-search.test.tsx
+++ b/__tests__/ModelView.similar-search.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ModelView } from '../components/ModelView';
+import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+import type { IndexedImage } from '../types';
+
+vi.mock('../hooks/useResolvedThumbnail', () => ({
+  useResolvedThumbnail: () => ({
+    thumbnailStatus: 'ready',
+    thumbnailUrl: 'thumb://image',
+  }),
+}));
+
+vi.mock('../hooks/useThumbnail', () => ({
+  useThumbnail: vi.fn(),
+}));
+
+vi.mock('../contexts/A1111ProgressContext', () => ({
+  useA1111ProgressContext: () => ({
+    progressState: null,
+  }),
+}));
+
+const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
+  id: overrides.id ?? 'dir-1::image.png',
+  name: overrides.name ?? 'image.png',
+  handle: overrides.handle ?? ({} as FileSystemFileHandle),
+  metadata: overrides.metadata ?? ({} as any),
+  metadataString: overrides.metadataString ?? '',
+  lastModified: overrides.lastModified ?? 1,
+  directoryId: overrides.directoryId ?? 'dir-1',
+  models: overrides.models ?? [],
+  loras: overrides.loras ?? [],
+  scheduler: overrides.scheduler ?? '',
+  workflowNodes: overrides.workflowNodes ?? [],
+  prompt: overrides.prompt ?? '',
+  negativePrompt: overrides.negativePrompt ?? '',
+  ...overrides,
+});
+
+describe('ModelView similar-search entry point', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+    useSettingsStore.getState().resetState();
+    useSettingsStore.setState({
+      itemsPerPage: -1,
+      viewMode: 'grid',
+      toggleViewMode: vi.fn(),
+      setItemsPerPage: vi.fn(),
+    } as any);
+  });
+
+  it('keeps primary card click for filtering and exposes a separate prompt-match action', () => {
+    const onModelSelect = vi.fn();
+    const onFindMatchingPrompts = vi.fn();
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png', models: ['model-a'], prompt: 'Prompt A' }),
+      createImage({ id: 'img-2', name: 'beta.png', models: ['model-a'], prompt: 'Prompt B' }),
+    ];
+
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      selectionTotalImages: images.length,
+      selectionDirectoryCount: 1,
+      enrichmentProgress: null,
+    } as any);
+
+    render(<ModelView onModelSelect={onModelSelect} onFindMatchingPrompts={onFindMatchingPrompts} />);
+
+    fireEvent.click(screen.getByText('model-a'));
+    expect(onModelSelect).toHaveBeenCalledWith('model-a');
+
+    fireEvent.click(screen.getByRole('button', { name: /find matching prompts for model-a/i }));
+    expect(onFindMatchingPrompts).toHaveBeenCalledWith('model-a');
+    expect(onModelSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/similarImageSearch.test.ts
+++ b/__tests__/similarImageSearch.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import type { IndexedImage } from '../types';
+import {
+  DEFAULT_SIMILAR_SEARCH_CRITERIA,
+  findSimilarImages,
+  normalizePromptForSimilarSearch,
+  promptsExactlyMatchNormalized,
+} from '../services/similarImageSearch';
+
+const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
+  id: overrides.id ?? 'dir-1::image.png',
+  name: overrides.name ?? 'image.png',
+  handle: overrides.handle ?? ({} as FileSystemFileHandle),
+  metadata: overrides.metadata ?? ({} as any),
+  metadataString: overrides.metadataString ?? '',
+  lastModified: overrides.lastModified ?? 1,
+  directoryId: overrides.directoryId ?? 'dir-1',
+  models: overrides.models ?? [],
+  loras: overrides.loras ?? [],
+  scheduler: overrides.scheduler ?? '',
+  workflowNodes: overrides.workflowNodes ?? [],
+  prompt: overrides.prompt ?? '',
+  negativePrompt: overrides.negativePrompt ?? '',
+  ...overrides,
+});
+
+describe('similarImageSearch helpers', () => {
+  it('normalizes prompt text for exact matching', () => {
+    expect(normalizePromptForSimilarSearch('  Hello\r\nWorld   ')).toBe('hello world');
+    expect(promptsExactlyMatchNormalized('Hello\n World', ' hello   world ')).toBe(true);
+    expect(promptsExactlyMatchNormalized('Hello world', 'Hello moon')).toBe(false);
+  });
+
+  it('matches prompt-only groups while excluding the source checkpoint in different mode', () => {
+    const source = createImage({
+      id: 'source',
+      prompt: 'A castle on a hill',
+      models: ['model-a'],
+      lastModified: 10,
+    });
+    const images = [
+      source,
+      createImage({ id: 'same-model', prompt: 'A castle on a hill', models: ['model-a'], lastModified: 30 }),
+      createImage({ id: 'alt-model', prompt: 'a castle   on a hill', models: ['model-b'], lastModified: 20 }),
+      createImage({ id: 'no-prompt-match', prompt: 'A forest', models: ['model-c'], lastModified: 40 }),
+    ];
+
+    const result = findSimilarImages({
+      sourceImage: source,
+      allImages: images,
+      currentViewImages: images,
+      criteria: DEFAULT_SIMILAR_SEARCH_CRITERIA,
+    });
+
+    expect(result.results.map((entry) => entry.image.id)).toEqual(['alt-model']);
+    expect(result.results[0]?.matchedFields).toContain('prompt');
+    expect(result.results[0]?.matchedFields).toContain('checkpoint');
+  });
+
+  it('supports prompt plus exact seed matching', () => {
+    const source = createImage({
+      id: 'source',
+      prompt: 'Robot portrait',
+      seed: 42,
+      models: ['model-a'],
+    });
+    const images = [
+      source,
+      createImage({ id: 'seed-match', prompt: 'Robot portrait', seed: 42, models: ['model-b'] }),
+      createImage({ id: 'seed-miss', prompt: 'Robot portrait', seed: 7, models: ['model-c'] }),
+    ];
+
+    const result = findSimilarImages({
+      sourceImage: source,
+      allImages: images,
+      currentViewImages: images,
+      criteria: {
+        ...DEFAULT_SIMILAR_SEARCH_CRITERIA,
+        seed: true,
+      },
+    });
+
+    expect(result.results.map((entry) => entry.image.id)).toEqual(['seed-match']);
+  });
+
+  it('supports prompt plus exact LoRA-name matching', () => {
+    const source = createImage({
+      id: 'source',
+      prompt: 'Character sheet',
+      models: ['model-a'],
+      loras: [{ name: 'style-lora', weight: 0.8 }, { name: 'detail-lora', weight: 1 }],
+    });
+    const images = [
+      source,
+      createImage({
+        id: 'lora-match',
+        prompt: 'Character sheet',
+        models: ['model-b'],
+        loras: ['style-lora', 'detail-lora'],
+      }),
+      createImage({
+        id: 'lora-miss',
+        prompt: 'Character sheet',
+        models: ['model-c'],
+        loras: ['style-lora'],
+      }),
+    ];
+
+    const result = findSimilarImages({
+      sourceImage: source,
+      allImages: images,
+      currentViewImages: images,
+      criteria: {
+        ...DEFAULT_SIMILAR_SEARCH_CRITERIA,
+        lora: true,
+      },
+    });
+
+    expect(result.results.map((entry) => entry.image.id)).toEqual(['lora-match']);
+  });
+
+  it('supports prompt plus exact LoRA weight matching', () => {
+    const source = createImage({
+      id: 'source',
+      prompt: 'Studio portrait',
+      models: ['model-a'],
+      loras: [{ name: 'style-lora', weight: 0.75 }],
+    });
+    const images = [
+      source,
+      createImage({
+        id: 'weight-match',
+        prompt: 'Studio portrait',
+        models: ['model-b'],
+        loras: [{ name: 'style-lora', weight: 0.75 }],
+      }),
+      createImage({
+        id: 'weight-miss',
+        prompt: 'Studio portrait',
+        models: ['model-c'],
+        loras: [{ name: 'style-lora', weight: 0.7 }],
+      }),
+    ];
+
+    const result = findSimilarImages({
+      sourceImage: source,
+      allImages: images,
+      currentViewImages: images,
+      criteria: {
+        ...DEFAULT_SIMILAR_SEARCH_CRITERIA,
+        lora: true,
+        matchLoraWeight: true,
+      },
+    });
+
+    expect(result.results.map((entry) => entry.image.id)).toEqual(['weight-match']);
+  });
+
+  it('disables unavailable source criteria and falls back to the remaining active rules', () => {
+    const source = createImage({
+      id: 'source',
+      prompt: 'Ocean at dusk',
+      models: [],
+      loras: [],
+    });
+    const images = [
+      source,
+      createImage({ id: 'prompt-match', prompt: 'Ocean at dusk', models: ['model-b'] }),
+      createImage({ id: 'prompt-miss', prompt: 'City at dusk', models: ['model-c'] }),
+    ];
+
+    const result = findSimilarImages({
+      sourceImage: source,
+      allImages: images,
+      currentViewImages: images,
+      criteria: {
+        ...DEFAULT_SIMILAR_SEARCH_CRITERIA,
+        lora: true,
+        checkpointMode: 'same',
+      },
+    });
+
+    expect(result.effectiveCriteria.lora).toBe(false);
+    expect(result.effectiveCriteria.checkpointMode).toBe('ignore');
+    expect(result.results.map((entry) => entry.image.id)).toEqual(['prompt-match']);
+  });
+});

--- a/__tests__/similarImageSearch.test.ts
+++ b/__tests__/similarImageSearch.test.ts
@@ -3,6 +3,7 @@ import type { IndexedImage } from '../types';
 import {
   DEFAULT_SIMILAR_SEARCH_CRITERIA,
   findSimilarImages,
+  getModelPromptOverlapGroups,
   normalizePromptForSimilarSearch,
   promptsExactlyMatchNormalized,
 } from '../services/similarImageSearch';
@@ -183,5 +184,80 @@ describe('similarImageSearch helpers', () => {
     expect(result.effectiveCriteria.lora).toBe(false);
     expect(result.effectiveCriteria.checkpointMode).toBe('ignore');
     expect(result.results.map((entry) => entry.image.id)).toEqual(['prompt-match']);
+  });
+
+  it('falls back to normalized metadata prompt when the flattened prompt is empty', () => {
+    const source = createImage({
+      id: 'source',
+      prompt: '',
+      metadata: {
+        normalizedMetadata: {
+          prompt: 'Legacy prompt still present in normalized metadata',
+        },
+      } as any,
+      models: ['model-a'],
+    });
+    const images = [
+      source,
+      createImage({
+        id: 'prompt-match',
+        prompt: 'legacy prompt still present in normalized metadata',
+        models: ['model-b'],
+      }),
+      createImage({
+        id: 'prompt-miss',
+        prompt: 'Completely different prompt',
+        models: ['model-c'],
+      }),
+    ];
+
+    const result = findSimilarImages({
+      sourceImage: source,
+      allImages: images,
+      currentViewImages: images,
+      criteria: DEFAULT_SIMILAR_SEARCH_CRITERIA,
+    });
+
+    expect(result.availability.prompt).toBe(true);
+    expect(result.effectiveCriteria.prompt).toBe(true);
+    expect(result.results.map((entry) => entry.image.id)).toEqual(['prompt-match']);
+  });
+
+  it('only reports model prompt overlaps when another checkpoint has matching prompt images', () => {
+    const selectedModel = 'model-a';
+    const overlappingPrompt = 'Shared prompt';
+    const groups = getModelPromptOverlapGroups(selectedModel, [
+      createImage({
+        id: 'source-with-secondary-model',
+        prompt: overlappingPrompt,
+        models: ['model-b', 'model-a'],
+        lastModified: 10,
+      }),
+      createImage({
+        id: 'same-group',
+        prompt: overlappingPrompt,
+        models: ['model-a'],
+        lastModified: 20,
+      }),
+      createImage({
+        id: 'real-alternate',
+        prompt: overlappingPrompt,
+        models: ['model-c'],
+        lastModified: 30,
+      }),
+      createImage({
+        id: 'another-source-only-prompt',
+        prompt: 'Only inside selected model',
+        models: ['model-d', 'model-a'],
+        lastModified: 40,
+      }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      normalizedPrompt: 'shared prompt',
+      sourceCount: 2,
+      alternateCheckpointCount: 1,
+    });
   });
 });

--- a/components/ComparisonMetadataPanel.tsx
+++ b/components/ComparisonMetadataPanel.tsx
@@ -109,6 +109,7 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
   otherImageMetadata,
   className,
   compareLabel,
+  isHighlighted = false,
 }) => {
   const metadata = image.metadata?.normalizedMetadata;
   const isDiffMode = viewMode === 'diff';
@@ -152,10 +153,10 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
 
   if (!metadata) {
     return (
-      <div className={`p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 ${className ?? ''}`}>
+      <div className={`p-4 bg-gray-800/50 rounded-lg border ${isHighlighted ? 'border-cyan-500/70 shadow-[0_0_0_1px_rgba(34,211,238,0.25)] bg-cyan-500/5' : 'border-gray-700/50'} ${className ?? ''}`}>
         <button
           onClick={onToggleExpanded}
-          className="w-full p-3 flex items-center justify-between text-left hover:bg-gray-700/30 transition-colors rounded-lg"
+          className={`w-full p-3 flex items-center justify-between text-left transition-colors rounded-lg ${isHighlighted ? 'bg-cyan-500/10 hover:bg-cyan-500/15' : 'hover:bg-gray-700/30'}`}
         >
           <span className="font-semibold text-gray-200 truncate flex-1" title={image.name}>
             {image.name}
@@ -173,11 +174,11 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
   }
 
   return (
-    <div className={`bg-gray-800/50 rounded-lg border border-gray-700/50 overflow-hidden ${className ?? ''}`}>
+    <div className={`bg-gray-800/50 rounded-lg border overflow-hidden transition-colors ${isHighlighted ? 'border-cyan-500/70 shadow-[0_0_0_1px_rgba(34,211,238,0.25)] bg-cyan-500/5' : 'border-gray-700/50'} ${className ?? ''}`}>
       {/* Toggle Button */}
       <button
         onClick={onToggleExpanded}
-        className="w-full p-3 flex items-center justify-between text-left hover:bg-gray-700/30 transition-colors"
+        className={`w-full p-3 flex items-center justify-between text-left transition-colors ${isHighlighted ? 'bg-cyan-500/10 hover:bg-cyan-500/15' : 'hover:bg-gray-700/30'}`}
       >
         <span className="font-semibold text-gray-200 truncate flex-1 mr-2" title={image.name}>
           {image.name}

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -32,6 +32,7 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   const [viewMode, setViewMode] = useState<ComparisonViewMode>('side-by-side');
   const [layoutMode, setLayoutMode] = useState<ComparisonLayoutMode>('strip');
   const [metadataViewMode, setMetadataViewMode] = useState<'standard' | 'diff'>('standard');
+  const [activeMetadataIndex, setActiveMetadataIndex] = useState<number | null>(null);
 
   const imageCount = comparisonImages.length;
   const supportsOverlayModes = imageCount === 2;
@@ -81,7 +82,8 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   };
 
   useEffect(() => {
-    setExpandedMetadataIndexes(new Set(comparisonImages.map((_, index) => index)));
+    setExpandedMetadataIndexes(new Set());
+    setActiveMetadataIndex(null);
   }, [comparisonImages]);
 
   useEffect(() => {
@@ -256,6 +258,7 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
             mode={viewMode as Exclude<ComparisonViewMode, 'side-by-side'>}
             sharedZoom={sharedZoom}
             onZoomChange={updateSharedZoom}
+            onActiveImageChange={setActiveMetadataIndex}
           />
         ) : (
           <div className="h-full overflow-auto bg-gray-950 p-2">
@@ -278,12 +281,15 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
                     key={image.id}
                     image={image}
                     directoryPath={directoryPathById.get(image.directoryId) || ''}
-                    syncEnabled={syncEnabled}
-                    externalZoom={syncEnabled ? sharedZoom : undefined}
-                    onZoomChange={handleZoomChange}
-                    className={`h-full rounded-xl border border-gray-800 overflow-hidden ${isOddLastGridItem ? 'md:col-span-2' : ''}`}
-                    imageLabel={`Image ${index + 1}`}
-                  />
+                  syncEnabled={syncEnabled}
+                  externalZoom={syncEnabled ? sharedZoom : undefined}
+                  onZoomChange={handleZoomChange}
+                  onHoverChange={(isHovered) =>
+                    setActiveMetadataIndex((current) => (isHovered ? index : current === index ? null : current))
+                  }
+                  className={`h-full rounded-xl border border-gray-800 overflow-hidden ${isOddLastGridItem ? 'md:col-span-2' : ''}`}
+                  imageLabel={`Image ${index + 1}`}
+                />
                 );
               })}
             </div>
@@ -341,6 +347,7 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
                 otherImageMetadata={otherImageMetadata}
                 className={isOddLastGridItem ? 'md:col-span-2' : ''}
                 compareLabel={index === 0 ? 'Reference' : metadataViewMode === 'diff' ? 'vs Image 1' : undefined}
+                isHighlighted={activeMetadataIndex === index}
               />
             );
           })}

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -12,6 +12,7 @@ interface ComparisonOverlayViewProps {
   mode: Exclude<ComparisonViewMode, 'side-by-side'>;
   sharedZoom: ZoomState;
   onZoomChange: (zoom: number, x: number, y: number) => void;
+  onActiveImageChange?: (index: number | null) => void;
 }
 
 const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
@@ -22,6 +23,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   mode,
   sharedZoom,
   onZoomChange,
+  onActiveImageChange,
 }) => {
   const { imageUrl: leftUrl, loadError: leftError, isLoading: isLeftLoading } = useComparisonImageSource(leftImage, leftDirectory);
   const { imageUrl: rightUrl, loadError: rightError, isLoading: isRightLoading } = useComparisonImageSource(rightImage, rightDirectory);
@@ -54,6 +56,13 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     setSliderValue(clamp(percent, 0, 100));
   };
 
+  const updateActiveImageFromClientX = (clientX: number) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const percent = ((clientX - rect.left) / rect.width) * 100;
+    onActiveImageChange?.(percent <= sliderValue ? 0 : 1);
+  };
+
   useEffect(() => {
     if (!isDraggingHandle) return;
 
@@ -61,12 +70,14 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
       e.preventDefault();
       e.stopPropagation();
       updateSliderFromClientX(e.clientX);
+      updateActiveImageFromClientX(e.clientX);
     };
 
     const handleUp = (e: PointerEvent) => {
       e.preventDefault();
       e.stopPropagation();
       setIsDraggingHandle(false);
+      onActiveImageChange?.(null);
     };
 
     window.addEventListener('pointermove', handleMove, { passive: false });
@@ -124,8 +135,25 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
             >
               <div
                 className="relative w-full h-full overflow-hidden bg-black"
-                onMouseEnter={mode === 'hover' ? () => setIsHovering(true) : undefined}
-                onMouseLeave={mode === 'hover' ? () => setIsHovering(false) : undefined}
+                onMouseEnter={
+                  mode === 'hover'
+                    ? () => {
+                        setIsHovering(true);
+                        onActiveImageChange?.(1);
+                      }
+                    : undefined
+                }
+                onMouseLeave={
+                  mode === 'hover'
+                    ? () => {
+                        setIsHovering(false);
+                        onActiveImageChange?.(null);
+                      }
+                    : mode === 'slider'
+                      ? () => onActiveImageChange?.(null)
+                      : undefined
+                }
+                onMouseMove={mode === 'slider' ? (event) => updateActiveImageFromClientX(event.clientX) : undefined}
               >
                 {isLoading && !ready && (
                   <div className="absolute inset-0 flex items-center justify-center">

--- a/components/ComparisonPane.tsx
+++ b/components/ComparisonPane.tsx
@@ -12,6 +12,7 @@ const ComparisonPane: FC<ComparisonPaneProps> = ({
   syncEnabled,
   externalZoom,
   onZoomChange,
+  onHoverChange,
   className,
   imageLabel,
 }) => {
@@ -42,7 +43,11 @@ const ComparisonPane: FC<ComparisonPaneProps> = ({
   }
 
   return (
-    <div className={`relative group bg-black min-h-0 ${className ?? ''}`}>
+    <div
+      className={`relative group bg-black min-h-0 ${className ?? ''}`}
+      onMouseEnter={() => onHoverChange?.(true)}
+      onMouseLeave={() => onHoverChange?.(false)}
+    >
       <TransformWrapper
         ref={transformRef}
         initialScale={1}

--- a/components/FindSimilarModal.tsx
+++ b/components/FindSimilarModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { Check, FolderTree, GitCompare, Layers, Search, SlidersHorizontal, X } from 'lucide-react';
 import type { IndexedImage, SimilarSearchCriteria, SimilarSearchResult } from '../types';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+import { useThumbnail } from '../hooks/useThumbnail';
 import {
   DEFAULT_SIMILAR_SEARCH_CRITERIA,
   findSimilarImages,
@@ -15,6 +16,7 @@ interface FindSimilarModalProps {
   sourceImage: IndexedImage | null;
   allImages: IndexedImage[];
   currentViewImages?: IndexedImage[];
+  initialCriteria?: Partial<SimilarSearchCriteria>;
   onClose: () => void;
   onOpenCompare: (images: IndexedImage[]) => void;
 }
@@ -24,6 +26,7 @@ const panelClassName = 'flex max-h-[92vh] w-full max-w-7xl flex-col overflow-hid
 const pillButtonClassName = 'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors';
 
 const useThumbnailUrl = (image: IndexedImage | null) => {
+  useThumbnail(image);
   const resolved = useResolvedThumbnail(image || undefined);
   return resolved?.thumbnailUrl || image?.thumbnailUrl || '';
 };
@@ -67,7 +70,7 @@ const SimilarImageCard = ({
         {thumbnailUrl ? (
           <img src={thumbnailUrl} alt={image.name} className="h-full w-full object-cover" loading="lazy" />
         ) : (
-          <div className="flex h-full items-center justify-center text-sm text-gray-500">No preview</div>
+          <div className="h-full w-full bg-gradient-to-br from-gray-800 via-gray-900 to-gray-950" />
         )}
         <div className="absolute left-2 top-2 rounded-full bg-black/70 px-2 py-1 text-[10px] font-semibold text-gray-100">
           {badge}
@@ -123,6 +126,7 @@ export default function FindSimilarModal({
   sourceImage,
   allImages,
   currentViewImages,
+  initialCriteria,
   onClose,
   onOpenCompare,
 }: FindSimilarModalProps) {
@@ -134,8 +138,11 @@ export default function FindSimilarModal({
       return;
     }
 
-    setCriteria(DEFAULT_SIMILAR_SEARCH_CRITERIA);
-  }, [isOpen, sourceImage]);
+    setCriteria({
+      ...DEFAULT_SIMILAR_SEARCH_CRITERIA,
+      ...initialCriteria,
+    });
+  }, [initialCriteria, isOpen, sourceImage]);
 
   const availability = useMemo(
     () => (sourceImage ? getSimilarSearchAvailability(sourceImage) : null),
@@ -174,7 +181,6 @@ export default function FindSimilarModal({
     return null;
   }
 
-  const hasPrompt = availability.prompt;
   const compareDisabled = selectedIds.size === 0 || !execution.hasActiveCriterion;
 
   const toggleSelection = (result: SimilarSearchResult) => {
@@ -200,12 +206,7 @@ export default function FindSimilarModal({
     <div className={overlayClassName} role="dialog" aria-modal="true" aria-label="Find similar images">
       <div className={panelClassName}>
         <div className="flex items-center justify-between border-b border-gray-800 px-5 py-4">
-          <div>
-            <div className="text-lg font-semibold text-gray-100">Find similar...</div>
-            <div className="text-sm text-gray-400">
-              Same prompt, different checkpoint by default, without changing your global filters.
-            </div>
-          </div>
+          <div className="text-lg font-semibold text-gray-100">Find similar...</div>
           <button
             type="button"
             onClick={onClose}
@@ -224,7 +225,7 @@ export default function FindSimilarModal({
                 {sourceThumbnailUrl ? (
                   <img src={sourceThumbnailUrl} alt={sourceImage.name} className="h-full w-full object-cover" loading="lazy" />
                 ) : (
-                  <div className="flex h-full items-center justify-center text-sm text-gray-500">No preview</div>
+                  <div className="h-full w-full bg-gradient-to-br from-gray-800 via-gray-900 to-black" />
                 )}
               </div>
               <div className="space-y-2 p-4">
@@ -237,7 +238,7 @@ export default function FindSimilarModal({
                   <div title={formatLoraSummary(sourceImage)}>{formatLoraSummary(sourceImage)}</div>
                 </div>
                 <div className="max-h-24 overflow-auto rounded-lg border border-gray-800 bg-gray-900/80 p-3 text-xs leading-relaxed text-gray-300">
-                  {sourceImage.prompt || 'No prompt metadata'}
+                  {sourceImage.prompt || ''}
                 </div>
               </div>
             </div>
@@ -256,10 +257,7 @@ export default function FindSimilarModal({
                       disabled={!availability.prompt}
                       onChange={(event) => setCriteria((current) => ({ ...current, prompt: event.target.checked }))}
                     />
-                    <span>
-                      <span className="block font-medium">Prompt</span>
-                      <span className="text-xs text-gray-400">Exact normalized prompt match.</span>
-                    </span>
+                    <span className="block font-medium">Prompt</span>
                   </label>
 
                   <label className="flex items-start gap-3 text-sm text-gray-200">
@@ -275,10 +273,7 @@ export default function FindSimilarModal({
                         }))
                       }
                     />
-                    <span>
-                      <span className="block font-medium">LoRA names</span>
-                      <span className="text-xs text-gray-400">Require the same normalized LoRA set.</span>
-                    </span>
+                    <span className="block font-medium">LoRA names</span>
                   </label>
 
                   <label className="ml-6 flex items-start gap-3 text-sm text-gray-300">
@@ -290,10 +285,7 @@ export default function FindSimilarModal({
                         setCriteria((current) => ({ ...current, matchLoraWeight: event.target.checked }))
                       }
                     />
-                    <span>
-                      <span className="block font-medium">Also match LoRA weight</span>
-                      <span className="text-xs text-gray-500">Only active when LoRA matching is enabled.</span>
-                    </span>
+                    <span className="block font-medium">Match LoRA weight</span>
                   </label>
 
                   <label className="flex items-start gap-3 text-sm text-gray-200">
@@ -303,10 +295,7 @@ export default function FindSimilarModal({
                       disabled={!availability.seed}
                       onChange={(event) => setCriteria((current) => ({ ...current, seed: event.target.checked }))}
                     />
-                    <span>
-                      <span className="block font-medium">Seed</span>
-                      <span className="text-xs text-gray-400">Require the exact same seed.</span>
-                    </span>
+                    <span className="block font-medium">Seed</span>
                   </label>
                 </div>
               </div>
@@ -338,9 +327,6 @@ export default function FindSimilarModal({
                     Same
                   </ScopeButton>
                 </div>
-                {!availability.checkpoint && (
-                  <div className="mt-2 text-xs text-amber-300">Checkpoint matching is disabled because the source image has no checkpoint metadata.</div>
-                )}
               </div>
 
               <div>
@@ -372,13 +358,7 @@ export default function FindSimilarModal({
 
               {!execution.hasActiveCriterion && (
                 <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
-                  Enable at least one available criterion to search for matches.
-                </div>
-              )}
-
-              {!hasPrompt && (
-                <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
-                  This source image has no prompt metadata, so prompt matching is unavailable.
+                  No active criteria
                 </div>
               )}
             </div>
@@ -391,10 +371,7 @@ export default function FindSimilarModal({
                   <div className="text-sm font-semibold text-gray-100">
                     {execution.results.length} match{execution.results.length === 1 ? '' : 'es'}
                   </div>
-                  <div className="text-xs text-gray-400">
-                    Searching {execution.candidates.length} candidate image{execution.candidates.length === 1 ? '' : 's'} in{' '}
-                    {criteria.scope === 'current-view' ? 'the current view' : criteria.scope === 'all-images' ? 'the full library' : 'the same folder'}.
-                  </div>
+                  <div className="text-xs text-gray-400">{execution.candidates.length} candidates</div>
                 </div>
                 <div className="text-xs text-gray-400">
                   Selected {selectedResults.length} of 3 compare slots.
@@ -407,9 +384,6 @@ export default function FindSimilarModal({
                 <div className="flex h-full min-h-[240px] flex-col items-center justify-center rounded-2xl border border-dashed border-gray-800 bg-gray-950/50 px-6 text-center">
                   <Search className="mb-3 h-6 w-6 text-gray-500" />
                   <div className="text-sm font-semibold text-gray-200">No matches found</div>
-                  <div className="mt-2 max-w-md text-xs leading-relaxed text-gray-400">
-                    Try relaxing checkpoint matching, turning off seed matching, or switching the scope to the full library.
-                  </div>
                 </div>
               ) : (
                 <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
@@ -432,9 +406,7 @@ export default function FindSimilarModal({
             </div>
 
             <div className="flex flex-wrap items-center justify-between gap-3 border-t border-gray-800 px-5 py-4">
-              <div className="text-xs text-gray-400">
-                Compare will open with the source image plus the selected matches, capped at 4 images total.
-              </div>
+              <div />
               <div className="flex items-center gap-3">
                 <button
                   type="button"

--- a/components/FindSimilarModal.tsx
+++ b/components/FindSimilarModal.tsx
@@ -1,0 +1,463 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, FolderTree, GitCompare, Layers, Search, SlidersHorizontal, X } from 'lucide-react';
+import type { IndexedImage, SimilarSearchCriteria, SimilarSearchResult } from '../types';
+import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+import {
+  DEFAULT_SIMILAR_SEARCH_CRITERIA,
+  findSimilarImages,
+  getSimilarSearchAvailability,
+  getSimilarSearchSourceDetails,
+} from '../services/similarImageSearch';
+
+interface FindSimilarModalProps {
+  isOpen: boolean;
+  sourceImage: IndexedImage | null;
+  allImages: IndexedImage[];
+  currentViewImages?: IndexedImage[];
+  onClose: () => void;
+  onOpenCompare: (images: IndexedImage[]) => void;
+}
+
+const overlayClassName = 'fixed inset-0 z-[150] flex items-center justify-center bg-black/80 px-4 py-6 backdrop-blur-sm';
+const panelClassName = 'flex max-h-[92vh] w-full max-w-7xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl';
+const pillButtonClassName = 'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors';
+
+const useThumbnailUrl = (image: IndexedImage | null) => {
+  const resolved = useResolvedThumbnail(image || undefined);
+  return resolved?.thumbnailUrl || image?.thumbnailUrl || '';
+};
+
+const formatModelSummary = (image: IndexedImage) => image.models[0] || 'Unknown checkpoint';
+
+const formatLoraSummary = (image: IndexedImage) => {
+  if (!image.loras || image.loras.length === 0) {
+    return 'No LoRAs';
+  }
+
+  return image.loras
+    .map((lora) => (typeof lora === 'string' ? lora : lora.name || lora.model_name || 'Unknown LoRA'))
+    .join(', ');
+};
+
+const SimilarImageCard = ({
+  image,
+  selected,
+  badge,
+  onClick,
+}: {
+  image: IndexedImage;
+  selected: boolean;
+  badge: React.ReactNode;
+  onClick?: () => void;
+}) => {
+  const thumbnailUrl = useThumbnailUrl(image);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`group relative overflow-hidden rounded-xl border text-left transition-colors ${
+        selected
+          ? 'border-cyan-400 bg-cyan-500/10 shadow-lg shadow-cyan-500/10'
+          : 'border-gray-700 bg-gray-950/70 hover:border-gray-500 hover:bg-gray-950'
+      }`}
+    >
+      <div className="relative aspect-[4/5] overflow-hidden bg-gradient-to-br from-gray-800 via-gray-900 to-gray-950">
+        {thumbnailUrl ? (
+          <img src={thumbnailUrl} alt={image.name} className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-gray-500">No preview</div>
+        )}
+        <div className="absolute left-2 top-2 rounded-full bg-black/70 px-2 py-1 text-[10px] font-semibold text-gray-100">
+          {badge}
+        </div>
+        {selected && (
+          <div className="absolute right-2 top-2 rounded-full bg-cyan-500 p-1 text-white">
+            <Check className="h-3.5 w-3.5" />
+          </div>
+        )}
+      </div>
+      <div className="space-y-1 p-3">
+        <div className="truncate text-sm font-semibold text-gray-100" title={image.name}>
+          {image.name}
+        </div>
+        <div className="truncate text-xs text-cyan-200" title={formatModelSummary(image)}>
+          {formatModelSummary(image)}
+        </div>
+        <div className="truncate text-xs text-gray-400" title={formatLoraSummary(image)}>
+          {formatLoraSummary(image)}
+        </div>
+      </div>
+    </button>
+  );
+};
+
+const ScopeButton = ({
+  active,
+  disabled = false,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    className={`${pillButtonClassName} ${
+      active
+        ? 'border-cyan-400/70 bg-cyan-500/15 text-cyan-100'
+        : 'border-gray-700 bg-gray-950/70 text-gray-300 hover:border-gray-500 hover:text-white'
+    } ${disabled ? 'cursor-not-allowed opacity-50 hover:border-gray-700 hover:text-gray-300' : ''}`}
+  >
+    {children}
+  </button>
+);
+
+export default function FindSimilarModal({
+  isOpen,
+  sourceImage,
+  allImages,
+  currentViewImages,
+  onClose,
+  onOpenCompare,
+}: FindSimilarModalProps) {
+  const [criteria, setCriteria] = useState<SimilarSearchCriteria>(DEFAULT_SIMILAR_SEARCH_CRITERIA);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!isOpen || !sourceImage) {
+      return;
+    }
+
+    setCriteria(DEFAULT_SIMILAR_SEARCH_CRITERIA);
+  }, [isOpen, sourceImage]);
+
+  const availability = useMemo(
+    () => (sourceImage ? getSimilarSearchAvailability(sourceImage) : null),
+    [sourceImage],
+  );
+
+  const sourceDetails = useMemo(
+    () => (sourceImage ? getSimilarSearchSourceDetails(sourceImage) : null),
+    [sourceImage],
+  );
+  const sourceThumbnailUrl = useThumbnailUrl(sourceImage);
+
+  const execution = useMemo(() => {
+    if (!sourceImage) {
+      return null;
+    }
+
+    return findSimilarImages({
+      sourceImage,
+      allImages,
+      currentViewImages,
+      criteria,
+    });
+  }, [allImages, criteria, currentViewImages, sourceImage]);
+
+  useEffect(() => {
+    if (!execution) {
+      setSelectedIds(new Set());
+      return;
+    }
+
+    setSelectedIds(new Set(execution.results.filter((result) => result.preselected).map((result) => result.image.id)));
+  }, [execution]);
+
+  if (!isOpen || !sourceImage || !availability || !sourceDetails || !execution || typeof document === 'undefined') {
+    return null;
+  }
+
+  const hasPrompt = availability.prompt;
+  const compareDisabled = selectedIds.size === 0 || !execution.hasActiveCriterion;
+
+  const toggleSelection = (result: SimilarSearchResult) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(result.image.id)) {
+        next.delete(result.image.id);
+        return next;
+      }
+
+      if (next.size >= 3) {
+        return current;
+      }
+
+      next.add(result.image.id);
+      return next;
+    });
+  };
+
+  const selectedResults = execution.results.filter((result) => selectedIds.has(result.image.id)).slice(0, 3);
+
+  return createPortal(
+    <div className={overlayClassName} role="dialog" aria-modal="true" aria-label="Find similar images">
+      <div className={panelClassName}>
+        <div className="flex items-center justify-between border-b border-gray-800 px-5 py-4">
+          <div>
+            <div className="text-lg font-semibold text-gray-100">Find similar...</div>
+            <div className="text-sm text-gray-400">
+              Same prompt, different checkpoint by default, without changing your global filters.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-gray-700 p-2 text-gray-400 transition-colors hover:border-gray-500 hover:text-white"
+            aria-label="Close find similar dialog"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-[320px_minmax(0,1fr)]">
+          <aside className="border-b border-gray-800 p-5 lg:border-b-0 lg:border-r">
+            <div className="mb-5 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Source image</div>
+            <div className="overflow-hidden rounded-2xl border border-gray-800 bg-gray-950/80">
+              <div className="aspect-[4/5] overflow-hidden bg-gradient-to-br from-gray-800 via-gray-900 to-black">
+                {sourceThumbnailUrl ? (
+                  <img src={sourceThumbnailUrl} alt={sourceImage.name} className="h-full w-full object-cover" loading="lazy" />
+                ) : (
+                  <div className="flex h-full items-center justify-center text-sm text-gray-500">No preview</div>
+                )}
+              </div>
+              <div className="space-y-2 p-4">
+                <div className="truncate text-sm font-semibold text-gray-100" title={sourceImage.name}>
+                  {sourceImage.name}
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-gray-900/80 p-3 text-xs text-gray-300">
+                  <div className="mb-1 font-medium text-cyan-200">{formatModelSummary(sourceImage)}</div>
+                  <div className="mb-1">{sourceImage.seed != null ? `Seed ${sourceImage.seed}` : 'No seed'}</div>
+                  <div title={formatLoraSummary(sourceImage)}>{formatLoraSummary(sourceImage)}</div>
+                </div>
+                <div className="max-h-24 overflow-auto rounded-lg border border-gray-800 bg-gray-900/80 p-3 text-xs leading-relaxed text-gray-300">
+                  {sourceImage.prompt || 'No prompt metadata'}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-5 space-y-4">
+              <div>
+                <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">
+                  <SlidersHorizontal className="h-3.5 w-3.5" />
+                  Match rules
+                </div>
+                <div className="space-y-2 rounded-2xl border border-gray-800 bg-gray-950/80 p-4">
+                  <label className="flex items-start gap-3 text-sm text-gray-200">
+                    <input
+                      type="checkbox"
+                      checked={criteria.prompt}
+                      disabled={!availability.prompt}
+                      onChange={(event) => setCriteria((current) => ({ ...current, prompt: event.target.checked }))}
+                    />
+                    <span>
+                      <span className="block font-medium">Prompt</span>
+                      <span className="text-xs text-gray-400">Exact normalized prompt match.</span>
+                    </span>
+                  </label>
+
+                  <label className="flex items-start gap-3 text-sm text-gray-200">
+                    <input
+                      type="checkbox"
+                      checked={criteria.lora}
+                      disabled={!availability.lora}
+                      onChange={(event) =>
+                        setCriteria((current) => ({
+                          ...current,
+                          lora: event.target.checked,
+                          matchLoraWeight: event.target.checked ? current.matchLoraWeight : false,
+                        }))
+                      }
+                    />
+                    <span>
+                      <span className="block font-medium">LoRA names</span>
+                      <span className="text-xs text-gray-400">Require the same normalized LoRA set.</span>
+                    </span>
+                  </label>
+
+                  <label className="ml-6 flex items-start gap-3 text-sm text-gray-300">
+                    <input
+                      type="checkbox"
+                      checked={criteria.matchLoraWeight}
+                      disabled={!criteria.lora || !availability.lora}
+                      onChange={(event) =>
+                        setCriteria((current) => ({ ...current, matchLoraWeight: event.target.checked }))
+                      }
+                    />
+                    <span>
+                      <span className="block font-medium">Also match LoRA weight</span>
+                      <span className="text-xs text-gray-500">Only active when LoRA matching is enabled.</span>
+                    </span>
+                  </label>
+
+                  <label className="flex items-start gap-3 text-sm text-gray-200">
+                    <input
+                      type="checkbox"
+                      checked={criteria.seed}
+                      disabled={!availability.seed}
+                      onChange={(event) => setCriteria((current) => ({ ...current, seed: event.target.checked }))}
+                    />
+                    <span>
+                      <span className="block font-medium">Seed</span>
+                      <span className="text-xs text-gray-400">Require the exact same seed.</span>
+                    </span>
+                  </label>
+                </div>
+              </div>
+
+              <div>
+                <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">
+                  <Layers className="h-3.5 w-3.5" />
+                  Checkpoint
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                  <ScopeButton
+                    active={criteria.checkpointMode === 'different'}
+                    disabled={!availability.checkpoint}
+                    onClick={() => setCriteria((current) => ({ ...current, checkpointMode: 'different' }))}
+                  >
+                    Different
+                  </ScopeButton>
+                  <ScopeButton
+                    active={criteria.checkpointMode === 'ignore'}
+                    onClick={() => setCriteria((current) => ({ ...current, checkpointMode: 'ignore' }))}
+                  >
+                    Ignore
+                  </ScopeButton>
+                  <ScopeButton
+                    active={criteria.checkpointMode === 'same'}
+                    disabled={!availability.checkpoint}
+                    onClick={() => setCriteria((current) => ({ ...current, checkpointMode: 'same' }))}
+                  >
+                    Same
+                  </ScopeButton>
+                </div>
+                {!availability.checkpoint && (
+                  <div className="mt-2 text-xs text-amber-300">Checkpoint matching is disabled because the source image has no checkpoint metadata.</div>
+                )}
+              </div>
+
+              <div>
+                <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">
+                  <FolderTree className="h-3.5 w-3.5" />
+                  Scope
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <ScopeButton
+                    active={criteria.scope === 'current-view'}
+                    onClick={() => setCriteria((current) => ({ ...current, scope: 'current-view' }))}
+                  >
+                    Current view
+                  </ScopeButton>
+                  <ScopeButton
+                    active={criteria.scope === 'all-images'}
+                    onClick={() => setCriteria((current) => ({ ...current, scope: 'all-images' }))}
+                  >
+                    All images
+                  </ScopeButton>
+                  <ScopeButton
+                    active={criteria.scope === 'same-folder'}
+                    onClick={() => setCriteria((current) => ({ ...current, scope: 'same-folder' }))}
+                  >
+                    Same folder
+                  </ScopeButton>
+                </div>
+              </div>
+
+              {!execution.hasActiveCriterion && (
+                <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                  Enable at least one available criterion to search for matches.
+                </div>
+              )}
+
+              {!hasPrompt && (
+                <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                  This source image has no prompt metadata, so prompt matching is unavailable.
+                </div>
+              )}
+            </div>
+          </aside>
+
+          <section className="flex min-h-0 flex-col">
+            <div className="border-b border-gray-800 px-5 py-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold text-gray-100">
+                    {execution.results.length} match{execution.results.length === 1 ? '' : 'es'}
+                  </div>
+                  <div className="text-xs text-gray-400">
+                    Searching {execution.candidates.length} candidate image{execution.candidates.length === 1 ? '' : 's'} in{' '}
+                    {criteria.scope === 'current-view' ? 'the current view' : criteria.scope === 'all-images' ? 'the full library' : 'the same folder'}.
+                  </div>
+                </div>
+                <div className="text-xs text-gray-400">
+                  Selected {selectedResults.length} of 3 compare slots.
+                </div>
+              </div>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-auto px-5 py-5">
+              {execution.results.length === 0 ? (
+                <div className="flex h-full min-h-[240px] flex-col items-center justify-center rounded-2xl border border-dashed border-gray-800 bg-gray-950/50 px-6 text-center">
+                  <Search className="mb-3 h-6 w-6 text-gray-500" />
+                  <div className="text-sm font-semibold text-gray-200">No matches found</div>
+                  <div className="mt-2 max-w-md text-xs leading-relaxed text-gray-400">
+                    Try relaxing checkpoint matching, turning off seed matching, or switching the scope to the full library.
+                  </div>
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
+                  {execution.results.map((result, index) => (
+                    <SimilarImageCard
+                      key={result.image.id}
+                      image={result.image}
+                      selected={selectedIds.has(result.image.id)}
+                      badge={
+                        <span>
+                          #{index + 1}
+                          {result.primaryCheckpoint ? ` · ${result.primaryCheckpoint}` : ''}
+                        </span>
+                      }
+                      onClick={() => toggleSelection(result)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-gray-800 px-5 py-4">
+              <div className="text-xs text-gray-400">
+                Compare will open with the source image plus the selected matches, capped at 4 images total.
+              </div>
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded-xl border border-gray-700 px-4 py-2 text-sm text-gray-300 transition-colors hover:border-gray-500 hover:text-white"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onOpenCompare([sourceImage, ...selectedResults.map((result) => result.image)].slice(0, 4))}
+                  disabled={compareDisabled}
+                  className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/60 bg-cyan-500/20 px-4 py-2 text-sm font-semibold text-cyan-100 transition-colors hover:bg-cyan-500/30 disabled:cursor-not-allowed disabled:border-gray-700 disabled:bg-gray-800 disabled:text-gray-500"
+                >
+                  <GitCompare className="h-4 w-4" />
+                  Open in Compare
+                </button>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -7,7 +7,7 @@ import { type IndexedImage, type BaseMetadata, type Directory, ImageStack, Smart
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
 import { useContextMenu } from '../hooks/useContextMenu';
-import { Heart, Info, Copy, Folder, Download, Clipboard, Sparkles, GitCompare, Square,
+import { Heart, Info, Copy, Folder, Download, Clipboard, Sparkles, GitCompare, Square, Search,
   Archive,
   ChevronRight,
   CheckSquare,
@@ -831,6 +831,7 @@ interface ImageGridProps {
   activeCollection?: SmartCollection | null;
   isCollectionsView?: boolean;
   onImageRenamed?: (oldImageId: string, newImageId: string) => void;
+  onFindSimilar?: (image: IndexedImage) => void;
   markedBestIds?: Set<string>;      // IDs of images marked as best
   markedArchivedIds?: Set<string>;  // IDs of images marked for archive
 }
@@ -850,6 +851,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   activeCollection = null,
   isCollectionsView = false,
   onImageRenamed,
+  onFindSimilar,
   markedBestIds,
   markedArchivedIds,
 }) => {
@@ -1041,10 +1043,22 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     hideContextMenu();
   }, [contextMenu.image, hideContextMenu, canUseComparison, showProModal, addImageToComparison, comparisonCount]);
 
+  const openFindSimilar = useCallback(() => {
+    if (!contextMenu.image || !onFindSimilar) {
+      return;
+    }
+
+    onFindSimilar(contextMenu.image);
+    hideContextMenu();
+  }, [contextMenu.image, hideContextMenu, onFindSimilar]);
+
   const handleBatchExport = useCallback(() => {
     hideContextMenu();
     onBatchExport();
   }, [hideContextMenu, onBatchExport]);
+
+  const contextImagePrompt = contextMenu.image?.prompt || contextMenu.image?.metadata?.normalizedMetadata?.prompt;
+  const canFindSimilar = Boolean(contextImagePrompt) && Boolean(onFindSimilar);
 
   const getContextTargetImages = useCallback(() => {
     if (!contextMenu.image) {
@@ -1759,6 +1773,16 @@ const ImageGrid: React.FC<ImageGridProps> = ({
               Add to Compare {canUseComparison && comparisonCount > 0 ? `(${comparisonCount}/4)` : ''}
             </span>
             {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
+          </button>
+
+          <button
+            onClick={openFindSimilar}
+            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={!canFindSimilar}
+            title={canFindSimilar ? 'Find images with matching prompt and metadata' : 'Requires prompt metadata'}
+          >
+            <Search className="w-4 h-4" />
+            <span className="flex-1">Find similar...</span>
           </button>
 
           <div className="border-t border-gray-600 my-1"></div>

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -76,6 +76,7 @@ interface ImageModalProps {
   modalId?: string;
   image: IndexedImage;
   onClose: () => void;
+  onFindSimilar?: (image: IndexedImage) => void;
   onImageDeleted?: (imageId: string) => void;
   onImageRenamed?: (oldImageId: string, newImageId: string, newRelativePath: string) => void;
   currentIndex?: number;
@@ -634,6 +635,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   modalId,
   image,
   onClose,
+  onFindSimilar,
   onImageDeleted,
   onImageRenamed,
   currentIndex = 0,
@@ -1179,6 +1181,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [applyModalWindowStyles, isFullscreen, modalInteraction, scheduleModalWindowPaint]);
 
   const nMeta: BaseMetadata | undefined = image.metadata?.normalizedMetadata;
+  const canFindSimilar = Boolean(nMeta?.prompt) && Boolean(onFindSimilar);
   const effectiveMetadata: BaseMetadata | undefined = (nMeta && !showOriginal) ? {
     ...nMeta,
     prompt: shadowMetadata?.prompt ?? nMeta.prompt,
@@ -2873,6 +2876,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
               Add to Compare {canUseComparison && comparisonCount > 0 && `(${comparisonCount}/4)`}
               {!canUseComparison && initialized && <ProBadge size="sm" />}
             </button>
+            <button
+              onClick={() => onFindSimilar?.(image)}
+              disabled={!canFindSimilar}
+              className="w-full justify-center bg-teal-50 hover:bg-teal-100 dark:bg-teal-500/10 dark:hover:bg-teal-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed text-teal-700 dark:text-teal-300 border border-teal-200 dark:border-teal-500/30 px-3 py-2 rounded-lg text-xs font-medium transition-colors flex items-center gap-1.5"
+              title={canFindSimilar ? 'Find images with matching prompt and metadata' : 'Requires prompt metadata'}
+            >
+              <Search className="w-3 h-3" />
+              Find similar...
+            </button>
           </div>
 
           {/* A1111 Integration - Separate Buttons with Visual Hierarchy */}
@@ -3363,6 +3375,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
               >
                 <Copy className="w-4 h-4" />
                 Copy Model
+              </button>
+
+              <button
+                onClick={() => onFindSimilar?.(image)}
+                className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={!canFindSimilar}
+              >
+                <Search className="w-4 h-4" />
+                Find similar...
               </button>
 
               <div className="border-t border-gray-600 my-1"></div>

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -5,7 +5,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { type IndexedImage, type Directory, SmartCollection } from '../types';
 import { useContextMenu } from '../hooks/useContextMenu';
 import { useImageStore } from '../store/useImageStore';
-import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Star, Pencil } from 'lucide-react';
+import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Search, Star, Pencil } from 'lucide-react';
 import { useThumbnail } from '../hooks/useThumbnail';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -28,6 +28,7 @@ interface ImageTableProps {
   activeCollection?: SmartCollection | null;
   isCollectionsView?: boolean;
   onImageRenamed?: (oldImageId: string, newImageId: string) => void;
+  onFindSimilar?: (image: IndexedImage) => void;
 }
 
 type SortField = 'filename' | 'model' | 'steps' | 'cfg' | 'size' | 'seed';
@@ -71,6 +72,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
   activeCollection = null,
   isCollectionsView = false,
   onImageRenamed,
+  onFindSimilar,
 }) => {
   const directories = useImageStore((state) => state.directories);
   const transferProgress = useImageStore((state) => state.transferProgress);
@@ -136,6 +138,15 @@ const ImageTable: React.FC<ImageTableProps> = ({
     onBatchExport();
   };
 
+  const openFindSimilar = useCallback(() => {
+    if (!contextMenu.image || !onFindSimilar) {
+      return;
+    }
+
+    onFindSimilar(contextMenu.image);
+    hideContextMenu();
+  }, [contextMenu.image, hideContextMenu, onFindSimilar]);
+
   const getContextTargetImages = useCallback(() => {
     if (!contextMenu.image) {
       return [];
@@ -147,6 +158,9 @@ const ImageTable: React.FC<ImageTableProps> = ({
 
     return [contextMenu.image];
   }, [contextMenu.image, images, selectedImages]);
+
+  const contextImagePrompt = contextMenu.image?.prompt || contextMenu.image?.metadata?.normalizedMetadata?.prompt;
+  const canFindSimilar = Boolean(contextImagePrompt) && Boolean(onFindSimilar);
 
   const handleSetRating = useCallback((rating: 1 | 2 | 3 | 4 | 5 | null) => {
     const targetImageIds = getContextMenuRatingTargetIds(selectedImages, contextMenu.image?.id);
@@ -684,6 +698,16 @@ const ImageTable: React.FC<ImageTableProps> = ({
               <Copy className="w-4 h-4" />
               Copy Raw Metadata
             </button>
+
+          <button
+            onClick={openFindSimilar}
+            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={!canFindSimilar}
+            title={canFindSimilar ? 'Find images with matching prompt and metadata' : 'Requires prompt metadata'}
+          >
+            <Search className="w-4 h-4" />
+            Find similar...
+          </button>
 
           <button
             onClick={handleReparseMetadata}

--- a/components/ModelCard.tsx
+++ b/components/ModelCard.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Box } from 'lucide-react';
+import { Box, Search } from 'lucide-react';
 import { IndexedImage } from '../types';
 import { useThumbnail } from '../hooks/useThumbnail';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
@@ -9,9 +9,10 @@ interface ModelCardProps {
   images: IndexedImage[];
   imageCount: number;
   onClick: () => void;
+  onFindMatchingPrompts?: () => void;
 }
 
-const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, onClick }) => {
+const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, onClick, onFindMatchingPrompts }) => {
   const cardRef = useRef<HTMLButtonElement | null>(null);
   const [previewIndex, setPreviewIndex] = useState(0);
   const rafRef = useRef<number | null>(null);
@@ -83,6 +84,30 @@ const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, on
           <Box className="w-3.5 h-3.5" />
           {imageCount}
         </div>
+
+        {onFindMatchingPrompts && (
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={(event) => {
+              event.stopPropagation();
+              onFindMatchingPrompts();
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                event.stopPropagation();
+                onFindMatchingPrompts();
+              }
+            }}
+            className="absolute right-3 top-3 inline-flex items-center gap-1.5 rounded-full border border-cyan-400/40 bg-black/70 px-2.5 py-1 text-[11px] font-semibold text-cyan-100 transition-colors hover:border-cyan-300 hover:bg-cyan-500/20"
+            title={`Find matching prompts for ${modelName}`}
+            aria-label={`Find matching prompts for ${modelName}`}
+          >
+            <Search className="h-3.5 w-3.5" />
+            Match prompts
+          </div>
+        )}
         
         {/* Overlay gradient for text readability */}
         <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/80 to-transparent pointer-events-none" />

--- a/components/ModelPromptPickerModal.tsx
+++ b/components/ModelPromptPickerModal.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { ArrowRight, Search, X } from 'lucide-react';
+import type { ModelPromptOverlapGroup } from '../services/similarImageSearch';
+
+interface ModelPromptPickerModalProps {
+  isOpen: boolean;
+  modelName: string | null;
+  groups: ModelPromptOverlapGroup[];
+  onClose: () => void;
+  onSelect: (group: ModelPromptOverlapGroup) => void;
+}
+
+export default function ModelPromptPickerModal({
+  isOpen,
+  modelName,
+  groups,
+  onClose,
+  onSelect,
+}: ModelPromptPickerModalProps) {
+  if (!isOpen || !modelName || typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[151] flex items-center justify-center bg-black/80 px-4 py-6 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="Find matching prompts">
+      <div className="flex max-h-[88vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl">
+        <div className="flex items-center justify-between border-b border-gray-800 px-5 py-4">
+          <div>
+            <div className="text-lg font-semibold text-gray-100">Find matching prompts</div>
+            <div className="text-sm text-gray-400">
+              Prompt groups in <span className="font-medium text-cyan-200">{modelName}</span> that also exist under other checkpoints.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-gray-700 p-2 text-gray-400 transition-colors hover:border-gray-500 hover:text-white"
+            aria-label="Close prompt picker"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto p-5">
+          {groups.length === 0 ? (
+            <div className="flex min-h-[240px] flex-col items-center justify-center rounded-2xl border border-dashed border-gray-800 bg-gray-950/50 px-6 text-center">
+              <Search className="mb-3 h-6 w-6 text-gray-500" />
+              <div className="text-sm font-semibold text-gray-200">No overlapping prompts found</div>
+              <div className="mt-2 max-w-lg text-xs leading-relaxed text-gray-400">
+                This checkpoint does not currently share exact normalized prompts with any alternate checkpoint in the indexed library.
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {groups.map((group) => (
+                <button
+                  key={`${group.normalizedPrompt}-${group.sourceImage.id}`}
+                  type="button"
+                  onClick={() => onSelect(group)}
+                  className="flex w-full items-center justify-between gap-4 rounded-2xl border border-gray-800 bg-gray-950/70 px-4 py-4 text-left transition-colors hover:border-cyan-400/60 hover:bg-cyan-500/10"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-semibold text-gray-100" title={group.sourceImage.prompt || group.promptPreview}>
+                      {group.promptPreview}
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-2 text-xs text-gray-400">
+                      <span className="rounded-full border border-gray-700 px-2 py-1">
+                        {group.sourceCount} in this checkpoint
+                      </span>
+                      <span className="rounded-full border border-cyan-500/40 px-2 py-1 text-cyan-200">
+                        {group.alternateCheckpointCount} alternate checkpoint{group.alternateCheckpointCount === 1 ? '' : 's'}
+                      </span>
+                    </div>
+                  </div>
+                  <span className="inline-flex items-center gap-2 rounded-full border border-gray-700 px-3 py-1.5 text-xs font-medium text-gray-200">
+                    Open
+                    <ArrowRight className="h-3.5 w-3.5" />
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/components/ModelView.tsx
+++ b/components/ModelView.tsx
@@ -18,10 +18,11 @@ interface ModelViewProps {
   isQueueOpen?: boolean;
   onToggleQueue?: () => void;
   onModelSelect: (modelName: string) => void;
+  onFindMatchingPrompts?: (modelName: string) => void;
 }
 
 
-export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onToggleQueue, onModelSelect }) => {
+export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onToggleQueue, onModelSelect, onFindMatchingPrompts }) => {
   const images = useImageStore((state) => state.images);
   const filteredImages = useImageStore((state) => state.filteredImages);
   const selectionTotalImages = useImageStore((state) => state.selectionTotalImages);
@@ -101,6 +102,7 @@ export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onTog
                 images={entry.images}
                 imageCount={entry.count}
                 onClick={() => onModelSelect(entry.name)}
+                onFindMatchingPrompts={onFindMatchingPrompts ? () => onFindMatchingPrompts(entry.name) : undefined}
               />
             ))}
           </div>

--- a/services/similarImageSearch.ts
+++ b/services/similarImageSearch.ts
@@ -1,0 +1,515 @@
+import type {
+  CheckpointMatchMode,
+  IndexedImage,
+  SimilarSearchCriteria,
+  SimilarSearchResult,
+  SimilarSearchScope,
+} from '../types';
+import { normalizeFacetValue } from '../utils/facetNormalization';
+
+const DEFAULT_SCOPE: SimilarSearchScope = 'current-view';
+
+type NormalizedLoraEntry = {
+  name: string;
+  weight: number | null;
+};
+
+export type SimilarSearchAvailability = {
+  prompt: boolean;
+  lora: boolean;
+  seed: boolean;
+  checkpoint: boolean;
+};
+
+export type SimilarSearchSourceDetails = {
+  normalizedPrompt: string | null;
+  loras: NormalizedLoraEntry[];
+  seed: number | null;
+  checkpoints: string[];
+  primaryCheckpoint: string | null;
+  folderKey: string;
+};
+
+export type SimilarSearchExecution = {
+  results: SimilarSearchResult[];
+  availability: SimilarSearchAvailability;
+  effectiveCriteria: SimilarSearchCriteria;
+  source: SimilarSearchSourceDetails;
+  hasActiveCriterion: boolean;
+  candidates: IndexedImage[];
+};
+
+export type ModelPromptOverlapGroup = {
+  normalizedPrompt: string;
+  promptPreview: string;
+  sourceCount: number;
+  alternateCheckpointCount: number;
+  sourceImage: IndexedImage;
+};
+
+const LO_RA_WEIGHT_EPSILON = 1e-9;
+
+export const DEFAULT_SIMILAR_SEARCH_CRITERIA: SimilarSearchCriteria = {
+  prompt: true,
+  lora: false,
+  matchLoraWeight: false,
+  seed: false,
+  checkpointMode: 'different',
+  scope: DEFAULT_SCOPE,
+};
+
+const getRelativeImagePath = (image: IndexedImage): string => {
+  const [, relativePath = ''] = image.id.split('::');
+  return relativePath || image.name || '';
+};
+
+const getRelativeFolderPath = (image: IndexedImage): string => {
+  const normalizedPath = getRelativeImagePath(image).replace(/\\/g, '/');
+  const segments = normalizedPath.split('/').filter(Boolean);
+  if (segments.length <= 1) {
+    return '';
+  }
+
+  return segments.slice(0, -1).join('/');
+};
+
+const toLowerCaseKey = (value: string | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+};
+
+const normalizePromptLineEndings = (value: string) => value.replace(/\r\n?/g, '\n');
+
+export const normalizePromptForSimilarSearch = (prompt?: string | null): string => {
+  if (!prompt) {
+    return '';
+  }
+
+  return normalizePromptLineEndings(prompt)
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+};
+
+export const promptsExactlyMatchNormalized = (
+  left?: string | null,
+  right?: string | null,
+): boolean => {
+  const normalizedLeft = normalizePromptForSimilarSearch(left);
+  const normalizedRight = normalizePromptForSimilarSearch(right);
+  return Boolean(normalizedLeft) && normalizedLeft === normalizedRight;
+};
+
+const normalizeNumericWeight = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  return null;
+};
+
+const normalizeLoraEntries = (image: IndexedImage): NormalizedLoraEntry[] => {
+  const normalized = (image.loras || []).flatMap((lora) => {
+    if (typeof lora === 'string') {
+      const normalizedName = toLowerCaseKey(normalizeFacetValue(lora));
+      return normalizedName ? [{ name: normalizedName, weight: null }] : [];
+    }
+
+    const normalizedName = toLowerCaseKey(normalizeFacetValue(lora));
+    if (!normalizedName) {
+      return [];
+    }
+
+    const weight = normalizeNumericWeight(lora.weight ?? lora.model_weight);
+    return [{ name: normalizedName, weight }];
+  });
+
+  const deduped = new Map<string, NormalizedLoraEntry>();
+  for (const entry of normalized) {
+    const existing = deduped.get(entry.name);
+    if (!existing) {
+      deduped.set(entry.name, entry);
+      continue;
+    }
+
+    if (existing.weight == null && entry.weight != null) {
+      deduped.set(entry.name, entry);
+    }
+  }
+
+  return Array.from(deduped.values()).sort((left, right) => left.name.localeCompare(right.name));
+};
+
+const normalizeCheckpointList = (image: IndexedImage): string[] => {
+  const normalized = (image.models || [])
+    .map((model) => toLowerCaseKey(normalizeFacetValue(model)))
+    .filter((value): value is string => Boolean(value));
+
+  return Array.from(new Set(normalized));
+};
+
+const haveSameLoraNames = (left: NormalizedLoraEntry[], right: NormalizedLoraEntry[]) => {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((entry, index) => entry.name === right[index]?.name);
+};
+
+const haveSameLoraWeights = (left: NormalizedLoraEntry[], right: NormalizedLoraEntry[]) => {
+  if (!haveSameLoraNames(left, right)) {
+    return false;
+  }
+
+  return left.every((entry, index) => {
+    const other = right[index];
+    if (!other) {
+      return false;
+    }
+
+    if (entry.weight == null || other.weight == null) {
+      return entry.weight == null && other.weight == null;
+    }
+
+    return Math.abs(entry.weight - other.weight) <= LO_RA_WEIGHT_EPSILON;
+  });
+};
+
+export const getSimilarSearchAvailability = (image: IndexedImage): SimilarSearchAvailability => {
+  const normalizedPrompt = normalizePromptForSimilarSearch(image.prompt);
+  const loras = normalizeLoraEntries(image);
+  const checkpoints = normalizeCheckpointList(image);
+
+  return {
+    prompt: normalizedPrompt.length > 0,
+    lora: loras.length > 0,
+    seed: typeof image.seed === 'number' && Number.isFinite(image.seed),
+    checkpoint: checkpoints.length > 0,
+  };
+};
+
+export const getSimilarSearchSourceDetails = (image: IndexedImage): SimilarSearchSourceDetails => {
+  const normalizedPrompt = normalizePromptForSimilarSearch(image.prompt);
+  const checkpoints = normalizeCheckpointList(image);
+
+  return {
+    normalizedPrompt: normalizedPrompt || null,
+    loras: normalizeLoraEntries(image),
+    seed: typeof image.seed === 'number' && Number.isFinite(image.seed) ? image.seed : null,
+    checkpoints,
+    primaryCheckpoint: checkpoints[0] ?? null,
+    folderKey: `${image.directoryId || ''}::${getRelativeFolderPath(image)}`,
+  };
+};
+
+const getEffectiveCriteria = (
+  source: SimilarSearchSourceDetails,
+  criteria: SimilarSearchCriteria,
+): SimilarSearchCriteria => ({
+  ...criteria,
+  prompt: criteria.prompt && Boolean(source.normalizedPrompt),
+  lora: criteria.lora && source.loras.length > 0,
+  matchLoraWeight: criteria.lora && criteria.matchLoraWeight && source.loras.length > 0,
+  seed: criteria.seed && source.seed != null,
+  checkpointMode:
+    criteria.checkpointMode !== 'ignore' && source.checkpoints.length === 0
+      ? 'ignore'
+      : criteria.checkpointMode,
+});
+
+const hasAnyActiveCriterion = (criteria: SimilarSearchCriteria) =>
+  criteria.prompt || criteria.lora || criteria.seed || criteria.checkpointMode !== 'ignore';
+
+export const resolveSimilarSearchCandidates = ({
+  sourceImage,
+  allImages,
+  currentViewImages,
+  scope,
+}: {
+  sourceImage: IndexedImage;
+  allImages: IndexedImage[];
+  currentViewImages?: IndexedImage[];
+  scope: SimilarSearchScope;
+}): IndexedImage[] => {
+  if (scope === 'all-images') {
+    return allImages;
+  }
+
+  if (scope === 'same-folder') {
+    const sourceFolderKey = getSimilarSearchSourceDetails(sourceImage).folderKey;
+    return allImages.filter((image) => getSimilarSearchSourceDetails(image).folderKey === sourceFolderKey);
+  }
+
+  return currentViewImages && currentViewImages.length > 0 ? currentViewImages : allImages;
+};
+
+const buildMatchedFields = ({
+  criteria,
+  sharesCheckpoint,
+}: {
+  criteria: SimilarSearchCriteria;
+  sharesCheckpoint: boolean;
+}): SimilarSearchResult['matchedFields'] => {
+  const matchedFields: SimilarSearchResult['matchedFields'] = [];
+
+  if (criteria.prompt) {
+    matchedFields.push('prompt');
+  }
+  if (criteria.lora) {
+    matchedFields.push('lora');
+  }
+  if (criteria.lora && criteria.matchLoraWeight) {
+    matchedFields.push('loraWeight');
+  }
+  if (criteria.seed) {
+    matchedFields.push('seed');
+  }
+  if (criteria.checkpointMode !== 'ignore') {
+    matchedFields.push('checkpoint');
+  }
+  if (criteria.checkpointMode === 'ignore' && sharesCheckpoint) {
+    matchedFields.push('checkpoint');
+  }
+
+  return matchedFields;
+};
+
+const choosePreselectedIds = (results: Omit<SimilarSearchResult, 'preselected'>[], maxSelections = 3) => {
+  const preselected = new Set<string>();
+  const usedCheckpoints = new Set<string>();
+
+  for (const result of results) {
+    if (preselected.size >= maxSelections) {
+      break;
+    }
+
+    const checkpointKey = result.primaryCheckpoint || '__missing__';
+    if (usedCheckpoints.has(checkpointKey)) {
+      continue;
+    }
+
+    usedCheckpoints.add(checkpointKey);
+    preselected.add(result.image.id);
+  }
+
+  if (preselected.size >= maxSelections) {
+    return preselected;
+  }
+
+  for (const result of results) {
+    if (preselected.size >= maxSelections) {
+      break;
+    }
+
+    preselected.add(result.image.id);
+  }
+
+  return preselected;
+};
+
+const compareNewestFirst = (left: IndexedImage, right: IndexedImage) => right.lastModified - left.lastModified;
+
+export const findSimilarImages = ({
+  sourceImage,
+  allImages,
+  currentViewImages,
+  criteria,
+}: {
+  sourceImage: IndexedImage;
+  allImages: IndexedImage[];
+  currentViewImages?: IndexedImage[];
+  criteria: SimilarSearchCriteria;
+}): SimilarSearchExecution => {
+  const source = getSimilarSearchSourceDetails(sourceImage);
+  const availability = getSimilarSearchAvailability(sourceImage);
+  const effectiveCriteria = getEffectiveCriteria(source, criteria);
+  const candidates = resolveSimilarSearchCandidates({
+    sourceImage,
+    allImages,
+    currentViewImages,
+    scope: effectiveCriteria.scope,
+  });
+
+  if (!hasAnyActiveCriterion(effectiveCriteria)) {
+    return {
+      results: [],
+      availability,
+      effectiveCriteria,
+      source,
+      hasActiveCriterion: false,
+      candidates,
+    };
+  }
+
+  const sourceCheckpointSet = new Set(source.checkpoints);
+
+  const rawResults = candidates
+    .filter((image) => image.id !== sourceImage.id)
+    .map((image) => {
+      const candidateSource = getSimilarSearchSourceDetails(image);
+      const candidateCheckpointSet = new Set(candidateSource.checkpoints);
+      const sharesCheckpoint = source.checkpoints.some((checkpoint) => candidateCheckpointSet.has(checkpoint));
+
+      if (effectiveCriteria.prompt && candidateSource.normalizedPrompt !== source.normalizedPrompt) {
+        return null;
+      }
+
+      if (effectiveCriteria.lora && !haveSameLoraNames(candidateSource.loras, source.loras)) {
+        return null;
+      }
+
+      if (effectiveCriteria.lora && effectiveCriteria.matchLoraWeight && !haveSameLoraWeights(candidateSource.loras, source.loras)) {
+        return null;
+      }
+
+      if (effectiveCriteria.seed && candidateSource.seed !== source.seed) {
+        return null;
+      }
+
+      if (effectiveCriteria.checkpointMode === 'same' && !sharesCheckpoint) {
+        return null;
+      }
+
+      if (effectiveCriteria.checkpointMode === 'different') {
+        if (candidateSource.checkpoints.length === 0) {
+          return null;
+        }
+
+        if (sharesCheckpoint) {
+          return null;
+        }
+      }
+
+      return {
+        image,
+        matchedFields: buildMatchedFields({
+          criteria: effectiveCriteria,
+          sharesCheckpoint,
+        }),
+        primaryCheckpoint: candidateSource.primaryCheckpoint,
+        sharesCheckpoint,
+      } satisfies Omit<SimilarSearchResult, 'preselected'>;
+    })
+    .filter((result): result is Omit<SimilarSearchResult, 'preselected'> => Boolean(result))
+    .sort((left, right) => {
+      if (left.sharesCheckpoint !== right.sharesCheckpoint) {
+        return left.sharesCheckpoint ? 1 : -1;
+      }
+
+      const leftHasAlternate = left.primaryCheckpoint && !sourceCheckpointSet.has(left.primaryCheckpoint);
+      const rightHasAlternate = right.primaryCheckpoint && !sourceCheckpointSet.has(right.primaryCheckpoint);
+      if (leftHasAlternate !== rightHasAlternate) {
+        return leftHasAlternate ? -1 : 1;
+      }
+
+      return compareNewestFirst(left.image, right.image);
+    });
+
+  const preselectedIds = choosePreselectedIds(rawResults);
+  const results = rawResults.map((result) => ({
+    ...result,
+    preselected: preselectedIds.has(result.image.id),
+  }));
+
+  return {
+    results,
+    availability,
+    effectiveCriteria,
+    source,
+    hasActiveCriterion: true,
+    candidates,
+  };
+};
+
+const getPrimaryCheckpointKey = (image: IndexedImage) =>
+  getSimilarSearchSourceDetails(image).primaryCheckpoint;
+
+const buildPromptPreview = (prompt: string) => {
+  const normalized = normalizePromptLineEndings(prompt).trim().replace(/\s+/g, ' ');
+  if (normalized.length <= 120) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, 117)}...`;
+};
+
+export const getModelPromptOverlapGroups = (
+  modelName: string,
+  allImages: IndexedImage[],
+): ModelPromptOverlapGroup[] => {
+  const normalizedModel = toLowerCaseKey(modelName);
+  if (!normalizedModel) {
+    return [];
+  }
+
+  const imagesByPrompt = new Map<string, IndexedImage[]>();
+  for (const image of allImages) {
+    const normalizedPrompt = normalizePromptForSimilarSearch(image.prompt);
+    if (!normalizedPrompt) {
+      continue;
+    }
+
+    const checkpoints = normalizeCheckpointList(image);
+    if (!checkpoints.includes(normalizedModel)) {
+      continue;
+    }
+
+    const group = imagesByPrompt.get(normalizedPrompt) || [];
+    group.push(image);
+    imagesByPrompt.set(normalizedPrompt, group);
+  }
+
+  const globalImagesByPrompt = new Map<string, IndexedImage[]>();
+  for (const image of allImages) {
+    const normalizedPrompt = normalizePromptForSimilarSearch(image.prompt);
+    if (!normalizedPrompt) {
+      continue;
+    }
+
+    const group = globalImagesByPrompt.get(normalizedPrompt) || [];
+    group.push(image);
+    globalImagesByPrompt.set(normalizedPrompt, group);
+  }
+
+  return Array.from(imagesByPrompt.entries())
+    .map(([normalizedPrompt, sourceImages]) => {
+      const promptImages = globalImagesByPrompt.get(normalizedPrompt) || [];
+      const alternateCheckpoints = new Set<string>();
+
+      for (const image of promptImages) {
+        const primaryCheckpoint = getPrimaryCheckpointKey(image);
+        if (primaryCheckpoint && primaryCheckpoint !== normalizedModel) {
+          alternateCheckpoints.add(primaryCheckpoint);
+        }
+      }
+
+      if (alternateCheckpoints.size === 0) {
+        return null;
+      }
+
+      const sourceImage = [...sourceImages].sort(compareNewestFirst)[0];
+      return {
+        normalizedPrompt,
+        promptPreview: buildPromptPreview(sourceImage.prompt || ''),
+        sourceCount: sourceImages.length,
+        alternateCheckpointCount: alternateCheckpoints.size,
+        sourceImage,
+      } satisfies ModelPromptOverlapGroup;
+    })
+    .filter((group): group is ModelPromptOverlapGroup => Boolean(group))
+    .sort((left, right) => {
+      if (right.alternateCheckpointCount !== left.alternateCheckpointCount) {
+        return right.alternateCheckpointCount - left.alternateCheckpointCount;
+      }
+
+      if (right.sourceCount !== left.sourceCount) {
+        return right.sourceCount - left.sourceCount;
+      }
+
+      return compareNewestFirst(left.sourceImage, right.sourceImage);
+    });
+};

--- a/services/similarImageSearch.ts
+++ b/services/similarImageSearch.ts
@@ -84,6 +84,9 @@ const toLowerCaseKey = (value: string | null | undefined): string | null => {
 
 const normalizePromptLineEndings = (value: string) => value.replace(/\r\n?/g, '\n');
 
+const getImagePromptForSimilarSearch = (image: IndexedImage): string =>
+  image.prompt || image.metadata?.normalizedMetadata?.prompt || '';
+
 export const normalizePromptForSimilarSearch = (prompt?: string | null): string => {
   if (!prompt) {
     return '';
@@ -180,7 +183,7 @@ const haveSameLoraWeights = (left: NormalizedLoraEntry[], right: NormalizedLoraE
 };
 
 export const getSimilarSearchAvailability = (image: IndexedImage): SimilarSearchAvailability => {
-  const normalizedPrompt = normalizePromptForSimilarSearch(image.prompt);
+  const normalizedPrompt = normalizePromptForSimilarSearch(getImagePromptForSimilarSearch(image));
   const loras = normalizeLoraEntries(image);
   const checkpoints = normalizeCheckpointList(image);
 
@@ -193,7 +196,7 @@ export const getSimilarSearchAvailability = (image: IndexedImage): SimilarSearch
 };
 
 export const getSimilarSearchSourceDetails = (image: IndexedImage): SimilarSearchSourceDetails => {
-  const normalizedPrompt = normalizePromptForSimilarSearch(image.prompt);
+  const normalizedPrompt = normalizePromptForSimilarSearch(getImagePromptForSimilarSearch(image));
   const checkpoints = normalizeCheckpointList(image);
 
   return {
@@ -448,7 +451,7 @@ export const getModelPromptOverlapGroups = (
 
   const imagesByPrompt = new Map<string, IndexedImage[]>();
   for (const image of allImages) {
-    const normalizedPrompt = normalizePromptForSimilarSearch(image.prompt);
+    const normalizedPrompt = normalizePromptForSimilarSearch(getImagePromptForSimilarSearch(image));
     if (!normalizedPrompt) {
       continue;
     }
@@ -465,7 +468,7 @@ export const getModelPromptOverlapGroups = (
 
   const globalImagesByPrompt = new Map<string, IndexedImage[]>();
   for (const image of allImages) {
-    const normalizedPrompt = normalizePromptForSimilarSearch(image.prompt);
+    const normalizedPrompt = normalizePromptForSimilarSearch(getImagePromptForSimilarSearch(image));
     if (!normalizedPrompt) {
       continue;
     }
@@ -478,9 +481,14 @@ export const getModelPromptOverlapGroups = (
   return Array.from(imagesByPrompt.entries())
     .map(([normalizedPrompt, sourceImages]) => {
       const promptImages = globalImagesByPrompt.get(normalizedPrompt) || [];
+      const sourceImageIds = new Set(sourceImages.map((image) => image.id));
       const alternateCheckpoints = new Set<string>();
 
       for (const image of promptImages) {
+        if (sourceImageIds.has(image.id)) {
+          continue;
+        }
+
         const primaryCheckpoint = getPrimaryCheckpointKey(image);
         if (primaryCheckpoint && primaryCheckpoint !== normalizedModel) {
           alternateCheckpoints.add(primaryCheckpoint);
@@ -494,7 +502,7 @@ export const getModelPromptOverlapGroups = (
       const sourceImage = [...sourceImages].sort(compareNewestFirst)[0];
       return {
         normalizedPrompt,
-        promptPreview: buildPromptPreview(sourceImage.prompt || ''),
+        promptPreview: buildPromptPreview(getImagePromptForSimilarSearch(sourceImage)),
         sourceCount: sourceImages.length,
         alternateCheckpointCount: alternateCheckpoints.size,
         sourceImage,

--- a/types.ts
+++ b/types.ts
@@ -692,6 +692,7 @@ export interface ComparisonPaneProps {
   syncEnabled: boolean;
   externalZoom?: ZoomState;
   onZoomChange?: (zoom: number, x: number, y: number) => void;
+  onHoverChange?: (isHovered: boolean) => void;
   className?: string;
   imageLabel?: string;
 }
@@ -709,6 +710,7 @@ export interface ComparisonMetadataPanelProps {
   otherImageMetadata?: BaseMetadata | null;
   className?: string;
   compareLabel?: string;
+  isHighlighted?: boolean;
 }
 
 // ===== Smart Clustering & Auto-Tagging Types =====

--- a/types.ts
+++ b/types.ts
@@ -449,6 +449,26 @@ export interface AdvancedFilters {
   vramPeakMb?: NumericRangeFilter;
 }
 
+export type SimilarSearchScope = 'current-view' | 'all-images' | 'same-folder';
+export type CheckpointMatchMode = 'ignore' | 'same' | 'different';
+
+export interface SimilarSearchCriteria {
+  prompt: boolean;
+  lora: boolean;
+  matchLoraWeight: boolean;
+  seed: boolean;
+  checkpointMode: CheckpointMatchMode;
+  scope: SimilarSearchScope;
+}
+
+export interface SimilarSearchResult {
+  image: IndexedImage;
+  matchedFields: Array<'prompt' | 'lora' | 'loraWeight' | 'seed' | 'checkpoint'>;
+  preselected: boolean;
+  primaryCheckpoint: string | null;
+  sharesCheckpoint: boolean;
+}
+
 export interface SelectedFiltersUpdate {
   models?: string[];
   excludedModels?: string[];


### PR DESCRIPTION
## What changed

This PR adds a new `Find similar...` workflow centered on comparing images that share the same prompt and related metadata, and it improves clarity inside Compare Mode.

## Why

Comparing the same prompt across different checkpoints was too manual, and Compare Mode made it hard to tell which metadata block belonged to which image.

## User impact

- adds `Find similar...` from the image grid, table, and image modal
- adds a Model View action to find prompt overlaps across checkpoints
- opens the shared Find Similar modal and sends selected images directly into Compare Mode
- highlights the matching metadata panel in Compare Mode based on hover position
- opens Compare Mode with metadata collapsed by default
- removes noisy helper copy in the new modal and uses cleaner defaults for grid/table entry points

## Root cause

The app did not have a scoped workflow for exact prompt matching across checkpoints, and Compare Mode had no visual linkage between the image under the cursor and its metadata panel.

## Validation

- `npx vitest run __tests__/similarImageSearch.test.ts __tests__/FindSimilarModal.test.tsx __tests__/ModelView.similar-search.test.tsx __tests__/ModelPromptPickerModal.test.tsx __tests__/ImageGrid.contextMenu.test.tsx __tests__/ImageTable.contextMenu.test.tsx`
- `npx vitest run __tests__/ComparisonModal.test.ts __tests__/ComparisonModal.interaction.test.tsx`
- `npm run build`
