### PR TITLE
Improve metadata editing and export workflows

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -85,8 +85,16 @@ interface FindSimilarState {
   initialCriteria?: Partial<SimilarSearchCriteria>;
 }
 
+type BatchExportSource = 'selected' | 'filtered';
+
+interface BatchExportRequestState {
+  imageIds?: string[];
+  preferredSource?: BatchExportSource;
+}
+
 const SIDEBAR_WIDTH_STORAGE_KEY = 'image-metahub-sidebar-width';
 const RIGHT_SIDEBAR_WIDTH_STORAGE_KEY = 'image-metahub-right-sidebar-width';
+const OPEN_BATCH_EXPORT_EVENT = 'imagemetahub:open-batch-export';
 const SIDEBAR_DEFAULT_WIDTH = 320;
 const SIDEBAR_MIN_WIDTH = 280;
 const SIDEBAR_MAX_WIDTH = 640;
@@ -374,6 +382,7 @@ export default function App() {
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
   const [newImagesToast, setNewImagesToast] = useState<{ message: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
+  const [batchExportRequest, setBatchExportRequest] = useState<BatchExportRequestState | null>(null);
   const [isSaveFilteredCollectionModalOpen, setIsSaveFilteredCollectionModalOpen] = useState(false);
   const [openImageModals, setOpenImageModals] = useState<OpenImageModalState[]>([]);
   const [activeImageModalId, setActiveImageModalId] = useState<string | null>(null);
@@ -1597,13 +1606,43 @@ export default function App() {
     handleImageSelection(image, event);
   }, [handleImageSelection, handleOpenImageModalInBackground]);
 
-  const handleOpenBatchExport = useCallback(() => {
-    if (!canUseBatchExport) {
+  const openBatchExportModal = useCallback((request: BatchExportRequestState | null = null) => {
+    const isSingleImageExportRequest = (request?.imageIds?.length ?? 0) === 1;
+
+    if (!isSingleImageExportRequest && !canUseBatchExport) {
       showProModal('batch_export');
       return;
     }
+
+    setBatchExportRequest(request);
     setIsBatchExportModalOpen(true);
   }, [canUseBatchExport, showProModal]);
+
+  const handleOpenBatchExport = useCallback(() => {
+    openBatchExportModal();
+  }, [openBatchExportModal]);
+
+  const handleCloseBatchExport = useCallback(() => {
+    setIsBatchExportModalOpen(false);
+    setBatchExportRequest(null);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleOpenBatchExportEvent = (event: Event) => {
+      const customEvent = event as CustomEvent<BatchExportRequestState | undefined>;
+      openBatchExportModal(customEvent.detail ?? null);
+    };
+
+    window.addEventListener(OPEN_BATCH_EXPORT_EVENT, handleOpenBatchExportEvent as EventListener);
+
+    return () => {
+      window.removeEventListener(OPEN_BATCH_EXPORT_EVENT, handleOpenBatchExportEvent as EventListener);
+    };
+  }, [openBatchExportModal]);
 
   const activeCollection = useMemo(
     () => safeCollections.find((collection) => collection.id === activeCollectionId) ?? null,
@@ -1947,10 +1986,13 @@ export default function App() {
 
       <BatchExportModal
         isOpen={isBatchExportModalOpen}
-        onClose={() => setIsBatchExportModalOpen(false)}
+        onClose={handleCloseBatchExport}
         selectedImageIds={safeSelectedImages}
         filteredImages={displayImages}
+        allImages={safeImages}
         directories={safeDirectories}
+        requestedImageIds={batchExportRequest?.imageIds ?? null}
+        preferredSource={batchExportRequest?.preferredSource ?? null}
       />
 
       {hasDirectories && (

--- a/App.tsx
+++ b/App.tsx
@@ -1993,6 +1993,7 @@ export default function App() {
         directories={safeDirectories}
         requestedImageIds={batchExportRequest?.imageIds ?? null}
         preferredSource={batchExportRequest?.preferredSource ?? null}
+        restrictToRequestedSelection={!canUseBatchExport && (batchExportRequest?.imageIds?.length ?? 0) === 1}
       />
 
       {hasDirectories && (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+
+
+### Improved
+
+- **Viewer Metadata Actions**: Image Modal and Image Preview Sidebar now share clearer entry points for editing metadata, exporting edited copies, exporting without metadata, and switching between original and edited metadata views.
+- **Export Pipeline Consistency**: Unified desktop export handling behind a single request model so regular export, batch export, metadata stripping, and metadata rewrite all follow the same scope-aware workflow.
+- **MetaHub Standard Metadata Compatibility**: Standardized exported metadata payloads so files saved from edited metadata remain parseable by the app and keep compatibility with A1111-style generation parameter import.
+
 ## [0.15.0] - 2026-04-22
 
 ### Added
@@ -13,8 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Find Similar + Compare Flow**: Added a new `Find similar...` workflow in the grid, table, Image Modal, and Model View for finding prompt matches and related images across checkpoints, then sending the results directly into Compare Mode.
 - **Slideshow Mode**: Added fullscreen slideshow playback for the current selection or active browse scope, with keyboard controls plus configurable interval and filename overlay settings.
 - **Audio Library Support**: Added indexing, metadata extraction, filtering, library views, and in-app playback for common audio formats including MP3, WAV, FLAC, OGG/OGA, M4A, AAC, OPUS, AIFF/AIF, and WMA.
-- **Image Rename Workflows**: Added inline rename in the grid plus rename actions in grid/table context menus and the Image Modal, while preserving subfolders and original extensions.
-- **Indexed Subfolder Transfers**: Bulk copy/move actions can now target indexed subfolders, including nested folders and symlinked or aliased destinations.
+- **Editable Metadata Workflow**: Added a metadata editor for normalized generation fields in the viewer, including prompt, negative prompt, model, resources/LoRAs, seed, steps, CFG, sampler, scheduler, dimensions, and notes, while keeping edits local and reversible through shadow metadata.
 
 ### Improved
 
@@ -23,7 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Windowed Viewer UX**: Floating image windows are more reliable around focus, activation, dragging, offscreen recovery, footer layering, sidebar resizing, and optional minimize/restore motion.
 - **Selection and Navigation Scope**: Opening images from the grid, table, stacks, collections, or background-open actions now preserves multi-selection and keeps navigation tied to the active scope.
 - **Tagging and Filtering Workflow**: Added clear buttons to facet searches, kept mixed-selection tags available in batch tagging, and allowed clicking existing batch-tag chips to apply that tag to the full selection.
-- **Large Library Responsiveness**: Improved worst-case Smart Library clustering behavior and added optional performance diagnostics for troubleshooting search, grid, thumbnail, and viewer responsiveness.
+- **Image Rename Workflows**: Added inline rename in the grid plus rename actions in grid/table context menus and the Image Modal, while preserving subfolders and original extensions.
+- **Indexed Subfolder Transfers**: Bulk copy/move actions can now target indexed subfolders, including nested folders and symlinked or aliased destinations.
+- **Unified Export Metadata Policies**: Added a shared export flow for single-image and batch export with metadata policies to preserve original metadata, strip metadata entirely, or save a standardized `Image MetaHub + A1111` compatible PNG copy.
+- **Large Library Responsiveness**: Improved Smart Library clustering behavior and added optional performance diagnostics for troubleshooting search, grid, thumbnail, and viewer responsiveness.
 
 ### Fixed
 

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -334,6 +334,48 @@ describe('ComfyUI Parser - Detection Methods', () => {
 });
 
 describe('ComfyUI Parser - MetaHub lineage metadata', () => {
+  it('parses Image MetaHub export payloads written with the standard metadata chunk', async () => {
+    const result = await parseImageMetadata({
+      imagemetahub_data: {
+        generator: 'Image MetaHub',
+        prompt: 'studio portrait',
+        negativePrompt: 'blur',
+        seed: 456,
+        steps: 32,
+        cfg: 7,
+        sampler_name: 'dpmpp_2m',
+        scheduler: 'karras',
+        model: 'portrait-xl.safetensors',
+        width: 768,
+        height: 1024,
+        loras: [{ name: 'skin-detail', weight: 0.65 }],
+        imh_pro: {
+          user_tags: 'portrait, retouch',
+          notes: 'Edited in Image MetaHub',
+        },
+      },
+    } as any);
+
+    expect(result).toMatchObject({
+      prompt: 'studio portrait',
+      negativePrompt: 'blur',
+      model: 'portrait-xl.safetensors',
+      seed: 456,
+      steps: 32,
+      cfg_scale: 7,
+      sampler: 'dpmpp_2m',
+      scheduler: 'karras',
+      width: 768,
+      height: 1024,
+      _detection_method: 'metahub_chunk',
+      _metahub_pro: {
+        user_tags: 'portrait, retouch',
+        notes: 'Edited in Image MetaHub',
+      },
+    });
+    expect(result?.loras).toEqual([{ name: 'skin-detail', weight: 0.65 }]);
+  });
+
   it('prefers parent_image for library lineage and keeps source_image as workflowSourceImage', async () => {
     const metadata: any = {
       imagemetahub_data: {

--- a/__tests__/editableMetadata.test.ts
+++ b/__tests__/editableMetadata.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildEffectiveMetadata,
+  buildMetadataClipboardPayload,
+  buildShadowMetadata,
+  getEditableMetadataFields,
+  sanitizeEditableMetadataFields,
+} from '../utils/editableMetadata';
+import type { BaseMetadata, ShadowMetadata } from '../types';
+
+describe('editableMetadata helpers', () => {
+  it('merges normalized metadata with shadow overrides into effective metadata', () => {
+    const normalizedMetadata: BaseMetadata = {
+      prompt: 'sunset over mountains',
+      negativePrompt: 'lowres',
+      model: 'base-model.safetensors',
+      width: 1024,
+      height: 768,
+      seed: 1234,
+      steps: 28,
+      cfg_scale: 6.5,
+      sampler: 'Euler',
+      scheduler: 'normal',
+      loras: [{ name: 'cinematic-light', weight: 0.7 }],
+    };
+
+    const shadowMetadata: ShadowMetadata = {
+      imageId: 'img-1',
+      updatedAt: 10,
+      prompt: 'edited prompt',
+      model: 'edited-model.safetensors',
+      resources: [
+        { id: 'model', type: 'model', name: 'edited-model.safetensors' },
+        { id: 'lora-1', type: 'lora', name: 'detailer', weight: 0.9 },
+      ],
+      cfg_scale: 8,
+      tags: ['favorite', 'export'],
+      notes: 'Keep this one',
+    };
+
+    const result = buildEffectiveMetadata(normalizedMetadata, shadowMetadata);
+
+    expect(result).toMatchObject({
+      prompt: 'edited prompt',
+      negativePrompt: 'lowres',
+      model: 'edited-model.safetensors',
+      models: ['edited-model.safetensors'],
+      width: 1024,
+      height: 768,
+      seed: 1234,
+      steps: 28,
+      cfg_scale: 8,
+      sampler: 'Euler',
+      scheduler: 'normal',
+      tags: ['favorite', 'export'],
+      notes: 'Keep this one',
+    });
+    expect(result?.loras).toEqual([{ name: 'detailer', weight: 0.9 }]);
+  });
+
+  it('returns the original metadata when showOriginal is enabled', () => {
+    const normalizedMetadata: BaseMetadata = {
+      prompt: 'original prompt',
+      model: 'original-model.safetensors',
+      width: 512,
+      height: 512,
+      steps: 20,
+      scheduler: 'normal',
+    };
+
+    const shadowMetadata: ShadowMetadata = {
+      imageId: 'img-2',
+      updatedAt: 20,
+      prompt: 'edited prompt',
+    };
+
+    expect(buildEffectiveMetadata(normalizedMetadata, shadowMetadata, true)).toBe(normalizedMetadata);
+  });
+
+  it('exposes editable fields using shadow metadata first and falls back to normalized values', () => {
+    const normalizedMetadata: BaseMetadata = {
+      prompt: 'forest trail',
+      negativePrompt: 'blurry',
+      model: 'model-a.safetensors',
+      width: 640,
+      height: 832,
+      seed: 99,
+      steps: 24,
+      cfg_scale: 5.5,
+      sampler: 'DPM++ 2M',
+      scheduler: 'karras',
+      loras: [{ name: 'style-a', weight: 0.6 }],
+    };
+
+    const shadowMetadata: ShadowMetadata = {
+      imageId: 'img-3',
+      updatedAt: 30,
+      negativePrompt: 'jpeg artifacts',
+      resources: [{ id: 'lora-2', type: 'lora', name: 'style-b', weight: 0.8 }],
+    };
+
+    expect(getEditableMetadataFields(normalizedMetadata, shadowMetadata)).toMatchObject({
+      prompt: 'forest trail',
+      negativePrompt: 'jpeg artifacts',
+      model: 'model-a.safetensors',
+      width: 640,
+      height: 832,
+      seed: 99,
+      steps: 24,
+      cfg_scale: 5.5,
+      sampler: 'DPM++ 2M',
+      scheduler: 'karras',
+      resources: [{ id: 'lora-2', type: 'lora', name: 'style-b', weight: 0.8 }],
+    });
+  });
+
+  it('sanitizes editable fields when building shadow metadata and clipboard payloads', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-23T12:00:00Z'));
+
+    const fields = sanitizeEditableMetadataFields({
+      model: '  model-b.safetensors  ',
+      steps: '30' as unknown as number,
+      cfg_scale: '7.5' as unknown as number,
+      tags: [' portrait ', '', 'portrait', 'studio'],
+      resources: [
+        { id: 'bad', type: 'lora', name: '   ', weight: 0.5 },
+        { id: 'good', type: 'lora', name: 'lighting', weight: '0.75' as unknown as number },
+      ],
+    });
+
+    expect(fields).toEqual({
+      model: 'model-b.safetensors',
+      steps: 30,
+      cfg_scale: 7.5,
+      tags: ['portrait', 'portrait', 'studio'],
+      resources: [{ id: 'good', type: 'lora', name: 'lighting', weight: 0.75 }],
+    });
+
+    const shadowMetadata = buildShadowMetadata('img-4', fields);
+    const clipboardPayload = buildMetadataClipboardPayload('img-4', fields);
+
+    expect(shadowMetadata).toMatchObject({
+      imageId: 'img-4',
+      updatedAt: Date.now(),
+      ...fields,
+    });
+    expect(clipboardPayload).toMatchObject({
+      schemaVersion: 1,
+      copiedAt: Date.now(),
+      sourceImageId: 'img-4',
+      metadata: fields,
+    });
+
+    vi.useRealTimers();
+  });
+});

--- a/__tests__/metadataClipboard.test.ts
+++ b/__tests__/metadataClipboard.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearEditableMetadataClipboard,
+  copyEditableMetadata,
+  readEditableMetadataClipboard,
+} from '../services/metadataClipboard';
+
+describe('metadataClipboard', () => {
+  beforeEach(() => {
+    clearEditableMetadataClipboard();
+    window.localStorage.clear();
+  });
+
+  it('copies editable metadata into memory and localStorage', () => {
+    const payload = copyEditableMetadata(
+      {
+        prompt: 'edited prompt',
+        steps: 32,
+        resources: [{ id: 'lora-1', type: 'lora', name: 'detailer', weight: 0.65 }],
+      },
+      'source-image',
+    );
+
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.sourceImageId).toBe('source-image');
+    expect(readEditableMetadataClipboard()).toMatchObject({
+      sourceImageId: 'source-image',
+      metadata: {
+        prompt: 'edited prompt',
+        steps: 32,
+        resources: [{ id: 'lora-1', type: 'lora', name: 'detailer', weight: 0.65 }],
+      },
+    });
+    expect(window.localStorage.getItem('image-metahub-editable-metadata-clipboard')).toContain('edited prompt');
+  });
+
+  it('rehydrates and sanitizes clipboard metadata from localStorage when memory is empty', () => {
+    window.localStorage.setItem(
+      'image-metahub-editable-metadata-clipboard',
+      JSON.stringify({
+        schemaVersion: 1,
+        copiedAt: 123,
+        sourceImageId: 'stored-image',
+        metadata: {
+          model: '  model-c.safetensors  ',
+          tags: [' keep ', '', 'keep'],
+          resources: [
+            { id: 'bad', type: 'lora', name: '   ' },
+            { id: 'good', type: 'lora', name: 'cinematic', weight: '0.8' },
+          ],
+        },
+      }),
+    );
+
+    expect(readEditableMetadataClipboard()).toEqual({
+      schemaVersion: 1,
+      copiedAt: 123,
+      sourceImageId: 'stored-image',
+      metadata: {
+        model: 'model-c.safetensors',
+        tags: ['keep', 'keep'],
+        resources: [{ id: 'good', type: 'lora', name: 'cinematic', weight: 0.8 }],
+      },
+    });
+  });
+});

--- a/__tests__/useContextMenu.test.tsx
+++ b/__tests__/useContextMenu.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useContextMenu } from '../hooks/useContextMenu';
+import { useImageStore } from '../store/useImageStore';
+import type { IndexedImage } from '../types';
+
+vi.mock('../contexts/A1111ProgressContext', () => ({
+  useA1111ProgressContext: () => ({
+    startPolling: vi.fn(),
+    stopPolling: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useFeatureAccess', () => ({
+  useFeatureAccess: () => ({
+    canUseA1111: true,
+    showProModal: vi.fn(),
+  }),
+}));
+
+const imageFixture: IndexedImage = {
+  id: 'img-1',
+  name: 'alpha.png',
+  handle: {} as FileSystemFileHandle,
+  metadata: {} as any,
+  metadataString: '',
+  lastModified: 1,
+  directoryId: 'dir-1',
+  models: [],
+  loras: [],
+  scheduler: '',
+  workflowNodes: [],
+};
+
+const Harness = ({ image }: { image: IndexedImage }) => {
+  const { showContextMenu, exportImage } = useContextMenu();
+
+  return (
+    <div>
+      <button onContextMenu={(event) => showContextMenu(event, image, 'D:/library')}>Open</button>
+      <button onClick={exportImage}>Export</button>
+    </div>
+  );
+};
+
+describe('useContextMenu export targeting', () => {
+  beforeEach(() => {
+    useImageStore.getState().resetState();
+  });
+
+  it('exports the full current selection when the clicked image is part of it', async () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+    useImageStore.setState({
+      selectedImages: new Set(['img-1', 'img-2', 'img-3']),
+    } as any);
+
+    render(<Harness image={imageFixture} />);
+
+    fireEvent.contextMenu(screen.getByText('Open'), { clientX: 20, clientY: 20 });
+    fireEvent.click(screen.getByText('Export'));
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'imagemetahub:open-batch-export',
+          detail: {
+            imageIds: ['img-1', 'img-2', 'img-3'],
+            preferredSource: 'selected',
+          },
+        })
+      );
+    });
+
+    dispatchSpy.mockRestore();
+  });
+
+  it('exports only the clicked image when it is outside the current selection', async () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+    useImageStore.setState({
+      selectedImages: new Set(['img-2', 'img-3']),
+    } as any);
+
+    render(<Harness image={imageFixture} />);
+
+    fireEvent.contextMenu(screen.getByText('Open'), { clientX: 40, clientY: 40 });
+    fireEvent.click(screen.getByText('Export'));
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'imagemetahub:open-batch-export',
+          detail: {
+            imageIds: ['img-1'],
+            preferredSource: 'selected',
+          },
+        })
+      );
+    });
+
+    dispatchSpy.mockRestore();
+  });
+});

--- a/components/BatchExportModal.tsx
+++ b/components/BatchExportModal.tsx
@@ -91,6 +91,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
   const [progress, setProgress] = useState<ExportBatchProgress | null>(null);
   const [activeExportId, setActiveExportId] = useState<string | null>(null);
   const [exportPath, setExportPath] = useState<string | null>(null);
+  const [isCancelling, setIsCancelling] = useState(false);
   const activeExportIdRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -110,6 +111,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
       setProgress(null);
       setActiveExportId(null);
       setExportPath(null);
+      setIsCancelling(false);
     }
   }, [isOpen, hasSelected, preferredSource, requestedImageIds]);
 
@@ -154,6 +156,28 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
     }
   };
 
+  const handleRequestClose = async () => {
+    if (!isExporting) {
+      onClose();
+      return;
+    }
+
+    const exportId = activeExportIdRef.current;
+    if (!exportId || !window.electronAPI?.cancelBatchExport || isCancelling) {
+      return;
+    }
+
+    setIsCancelling(true);
+    setStatus({ type: 'error', message: 'Canceling export...' });
+
+    try {
+      await window.electronAPI.cancelBatchExport({ exportId });
+    } catch (error: any) {
+      setStatus({ type: 'error', message: error?.message || 'Failed to cancel export.' });
+      setIsCancelling(false);
+    }
+  };
+
   const handleExport = async () => {
     if (!window.electronAPI) {
       setStatus({ type: 'error', message: 'Export is only available in the desktop app.' });
@@ -192,6 +216,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
     }
 
     setIsExporting(true);
+    setIsCancelling(false);
     setStatus(null);
     setExportPath(null);
 
@@ -222,7 +247,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
           metadataPolicy,
           applyShadowEdits,
           scope: getScopeFromSelection(source, files.length),
-          targetFormat: metadataPolicy === 'preserve' ? 'original' : 'png',
+          targetFormat: metadataPolicy === 'metahub_standard' ? 'png' : 'original',
         });
 
         if (!exportResult.success) {
@@ -265,7 +290,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
           metadataPolicy,
           applyShadowEdits,
           scope: getScopeFromSelection(source, files.length),
-          targetFormat: metadataPolicy === 'preserve' ? 'original' : 'png',
+          targetFormat: metadataPolicy === 'metahub_standard' ? 'png' : 'original',
         });
 
         if (!exportResult.success) {
@@ -284,6 +309,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
     } finally {
       setIsExporting(false);
       setActiveExportId(null);
+      setIsCancelling(false);
     }
   };
 
@@ -300,10 +326,10 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
             <h2 className="text-lg font-semibold text-white">Export Images</h2>
           </div>
           <button
-            onClick={onClose}
+            onClick={() => { void handleRequestClose(); }}
             className="p-2 hover:bg-gray-800 rounded-lg transition-colors"
-            title="Close"
-            disabled={isExporting}
+            title={isExporting ? 'Cancel export' : 'Close'}
+            disabled={isCancelling}
           >
             <X className="w-4 h-4 text-gray-400" />
           </button>
@@ -421,7 +447,9 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
           <div className="bg-gray-800/70 border border-gray-700 rounded-lg p-3 text-sm text-gray-300">
             {isExporting && progress ? (
               <span>
-                {progress.stage === 'finalizing'
+                {progress.stage === 'canceled'
+                  ? 'Canceling export...'
+                  : progress.stage === 'finalizing'
                   ? 'Finalizing ZIP...'
                   : `Exporting ${progress.processed} of ${progress.total} images.`}
               </span>
@@ -438,7 +466,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
             )}
             {metadataPolicy !== 'preserve' && (
               <span className="block text-xs text-amber-300/90 mt-1">
-                Rewritten exports are saved as PNG copies for metadata safety and compatibility.
+                Metadata stripping keeps the original format for PNG, JPEG, and WebP when possible. MetaHub metadata export still saves PNG copies for compatibility.
               </span>
             )}
             {metadataPolicy !== 'preserve' && unsupportedRewriteCount > 0 && (
@@ -485,11 +513,11 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
 
         <div className="flex items-center justify-end gap-3 p-5 border-t border-gray-700">
           <button
-            onClick={onClose}
-            className="px-3 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800 rounded-lg transition-colors"
-            disabled={isExporting}
+            onClick={() => { void handleRequestClose(); }}
+            className="px-3 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800 rounded-lg transition-colors disabled:opacity-60"
+            disabled={isCancelling}
           >
-            Cancel
+            {isExporting ? (isCancelling ? 'Canceling...' : 'Cancel Export') : 'Cancel'}
           </button>
           <button
             onClick={handleExport}

--- a/components/BatchExportModal.tsx
+++ b/components/BatchExportModal.tsx
@@ -18,6 +18,7 @@ interface BatchExportModalProps {
   directories: { id: string; path: string }[];
   requestedImageIds?: string[] | null;
   preferredSource?: BatchSource | null;
+  restrictToRequestedSelection?: boolean;
 }
 
 type BatchSource = 'selected' | 'filtered';
@@ -57,6 +58,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
   directories,
   requestedImageIds,
   preferredSource,
+  restrictToRequestedSelection = false,
 }) => {
   const availableImages = allImages ?? filteredImages;
   const effectiveSelectedImageIds = useMemo(
@@ -100,6 +102,12 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
       setSource('filtered');
     }
   }, [hasSelected, source]);
+
+  useEffect(() => {
+    if (restrictToRequestedSelection && source !== 'selected') {
+      setSource('selected');
+    }
+  }, [restrictToRequestedSelection, source]);
 
   useEffect(() => {
     if (isOpen && !wasOpenRef.current) {
@@ -188,6 +196,11 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
 
     if (imagesToExport.length === 0) {
       setStatus({ type: 'error', message: 'No images available for export.' });
+      return;
+    }
+
+    if (restrictToRequestedSelection && source !== 'selected') {
+      setStatus({ type: 'error', message: 'This export entry is limited to the requested image.' });
       return;
     }
 
@@ -356,15 +369,21 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
               <button
                 type="button"
                 onClick={() => setSource('filtered')}
+                disabled={restrictToRequestedSelection}
                 className={`flex-1 px-3 py-2 rounded-lg text-sm border transition-colors ${
                   source === 'filtered'
                     ? 'border-blue-500 bg-blue-500/10 text-blue-100'
                     : 'border-gray-700 text-gray-300 hover:border-gray-500'
-                }`}
+                } ${restrictToRequestedSelection ? 'opacity-50 cursor-not-allowed' : ''}`}
               >
                 Filtered ({filteredImages.length})
               </button>
             </div>
+            {restrictToRequestedSelection && (
+              <p className="text-xs text-amber-300/90">
+                This entry point is limited to the requested image. Multi-image export still requires Pro.
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">

--- a/components/BatchExportModal.tsx
+++ b/components/BatchExportModal.tsx
@@ -1,33 +1,91 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Download, X } from 'lucide-react';
-import { type ExportBatchProgress, type IndexedImage } from '../types';
+import { getShadowMetadata } from '../services/imageAnnotationsStorage';
+import { buildEffectiveMetadata } from '../utils/editableMetadata';
+import {
+  type ExportFileDescriptor,
+  type ExportBatchProgress,
+  type IndexedImage,
+  type MetadataExportPolicy,
+} from '../types';
 
 interface BatchExportModalProps {
   isOpen: boolean;
   onClose: () => void;
   selectedImageIds: Set<string>;
   filteredImages: IndexedImage[];
+  allImages?: IndexedImage[];
   directories: { id: string; path: string }[];
+  requestedImageIds?: string[] | null;
+  preferredSource?: BatchSource | null;
 }
 
 type BatchSource = 'selected' | 'filtered';
 type BatchOutput = 'folder' | 'zip';
+
+const PNG_REWRITE_SUPPORTED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+
+const getScopeFromSelection = (source: BatchSource, count: number) => {
+  if (source === 'selected') {
+    return count === 1 ? 'single' : 'selected';
+  }
+
+  return 'filtered';
+};
+
+const resolveDefaultSource = (
+  hasSelected: boolean,
+  preferredSource?: BatchSource | null
+): BatchSource => {
+  if (preferredSource === 'filtered') {
+    return 'filtered';
+  }
+
+  if (hasSelected) {
+    return 'selected';
+  }
+
+  return 'filtered';
+};
 
 const BatchExportModal: React.FC<BatchExportModalProps> = ({
   isOpen,
   onClose,
   selectedImageIds,
   filteredImages,
+  allImages,
   directories,
+  requestedImageIds,
+  preferredSource,
 }) => {
-  const selectedImages = useMemo(
-    () => filteredImages.filter(image => selectedImageIds.has(image.id)),
-    [filteredImages, selectedImageIds]
+  const availableImages = allImages ?? filteredImages;
+  const effectiveSelectedImageIds = useMemo(
+    () => (requestedImageIds && requestedImageIds.length > 0 ? requestedImageIds : Array.from(selectedImageIds)),
+    [requestedImageIds, selectedImageIds]
   );
+  const selectedImages = useMemo(() => {
+    const imageLookup = new Map<string, IndexedImage>();
+
+    for (const image of availableImages) {
+      imageLookup.set(image.id, image);
+    }
+
+    for (const image of filteredImages) {
+      if (!imageLookup.has(image.id)) {
+        imageLookup.set(image.id, image);
+      }
+    }
+
+    return effectiveSelectedImageIds
+      .map((imageId) => imageLookup.get(imageId))
+      .filter((image): image is IndexedImage => Boolean(image));
+  }, [availableImages, effectiveSelectedImageIds, filteredImages]);
   const hasSelected = selectedImages.length > 0;
 
-  const [source, setSource] = useState<BatchSource>(hasSelected ? 'selected' : 'filtered');
+  const [source, setSource] = useState<BatchSource>(resolveDefaultSource(hasSelected));
   const [output, setOutput] = useState<BatchOutput>('folder');
+  const [metadataPolicy, setMetadataPolicy] = useState<MetadataExportPolicy>('preserve');
+  const [applyShadowEdits, setApplyShadowEdits] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
   const [status, setStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [progress, setProgress] = useState<ExportBatchProgress | null>(null);
@@ -45,19 +103,28 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
     if (isOpen) {
       setStatus(null);
       setIsExporting(false);
-      setSource(hasSelected ? 'selected' : 'filtered');
+      setSource(resolveDefaultSource(hasSelected, preferredSource));
       setOutput('folder');
+      setMetadataPolicy('preserve');
+      setApplyShadowEdits(true);
       setProgress(null);
       setActiveExportId(null);
       setExportPath(null);
     }
-  }, [isOpen, hasSelected]);
+  }, [isOpen, hasSelected, preferredSource, requestedImageIds]);
 
   useEffect(() => {
     activeExportIdRef.current = activeExportId;
   }, [activeExportId]);
 
   const exportCount = source === 'selected' ? selectedImages.length : filteredImages.length;
+  const imagesToExport = source === 'selected' ? selectedImages : filteredImages;
+  const unsupportedRewriteCount = useMemo(() => (
+    imagesToExport.filter((image) => {
+      const ext = image.name.includes('.') ? image.name.slice(image.name.lastIndexOf('.')).toLowerCase() : '';
+      return !PNG_REWRITE_SUPPORTED_EXTENSIONS.has(ext);
+    }).length
+  ), [imagesToExport]);
   const progressPercent = progress && progress.total > 0
     ? Math.min(100, Math.round((progress.processed / progress.total) * 100))
     : 0;
@@ -93,25 +160,31 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
       return;
     }
 
-    const imagesToExport = source === 'selected' ? selectedImages : filteredImages;
     if (imagesToExport.length === 0) {
       setStatus({ type: 'error', message: 'No images available for export.' });
       return;
     }
 
     const directoryMap = new Map(directories.map(dir => [dir.id, dir.path]));
-    const files = imagesToExport
-      .map(image => {
+    const files = (await Promise.all(imagesToExport.map(async (image) => {
         const dirPath = directoryMap.get(image.directoryId || '');
         if (!dirPath) {
           return null;
         }
+
+        const shadowMetadata = applyShadowEdits ? await getShadowMetadata(image.id) : null;
+        const effectiveMetadata = metadataPolicy === 'metahub_standard'
+          ? buildEffectiveMetadata(image.metadata?.normalizedMetadata, shadowMetadata)
+          : null;
+
         return {
+          imageId: image.id,
           directoryPath: dirPath,
           relativePath: image.name,
+          effectiveMetadata,
         };
-      })
-      .filter(Boolean) as Array<{ directoryPath: string; relativePath: string }>;
+      })))
+      .filter(Boolean) as ExportFileDescriptor[];
 
     if (files.length === 0) {
       setStatus({ type: 'error', message: 'Selected images are missing their source folders.' });
@@ -146,6 +219,10 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
           files,
           destDir: destResult.path,
           exportId,
+          metadataPolicy,
+          applyShadowEdits,
+          scope: getScopeFromSelection(source, files.length),
+          targetFormat: metadataPolicy === 'preserve' ? 'original' : 'png',
         });
 
         if (!exportResult.success) {
@@ -185,6 +262,10 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
           files,
           destZipPath: saveResult.path,
           exportId,
+          metadataPolicy,
+          applyShadowEdits,
+          scope: getScopeFromSelection(source, files.length),
+          targetFormat: metadataPolicy === 'preserve' ? 'original' : 'png',
         });
 
         if (!exportResult.success) {
@@ -216,7 +297,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
             <div className="p-2 bg-blue-500/10 rounded-lg">
               <Download className="w-5 h-5 text-blue-300" />
             </div>
-            <h2 className="text-lg font-semibold text-white">Batch Export</h2>
+            <h2 className="text-lg font-semibold text-white">Export Images</h2>
           </div>
           <button
             onClick={onClose}
@@ -286,6 +367,57 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
             </div>
           </div>
 
+          <div className="space-y-2">
+            <p className="text-sm text-gray-400">Metadata in exported file</p>
+            <div className="space-y-2">
+              <button
+                type="button"
+                onClick={() => setMetadataPolicy('preserve')}
+                className={`w-full rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                  metadataPolicy === 'preserve'
+                    ? 'border-blue-500 bg-blue-500/10 text-blue-100'
+                    : 'border-gray-700 text-gray-300 hover:border-gray-500'
+                }`}
+              >
+                Preserve original
+              </button>
+              <button
+                type="button"
+                onClick={() => setMetadataPolicy('strip')}
+                className={`w-full rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                  metadataPolicy === 'strip'
+                    ? 'border-blue-500 bg-blue-500/10 text-blue-100'
+                    : 'border-gray-700 text-gray-300 hover:border-gray-500'
+                }`}
+              >
+                Remove all metadata
+              </button>
+              <button
+                type="button"
+                onClick={() => setMetadataPolicy('metahub_standard')}
+                className={`w-full rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                  metadataPolicy === 'metahub_standard'
+                    ? 'border-blue-500 bg-blue-500/10 text-blue-100'
+                    : 'border-gray-700 text-gray-300 hover:border-gray-500'
+                }`}
+              >
+                Save as MetaHub + A1111
+              </button>
+            </div>
+
+            {metadataPolicy === 'metahub_standard' && (
+              <label className="flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-2 text-sm text-gray-300">
+                <input
+                  type="checkbox"
+                  checked={applyShadowEdits}
+                  onChange={(event) => setApplyShadowEdits(event.target.checked)}
+                  className="h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500"
+                />
+                Apply local metadata edits when available
+              </label>
+            )}
+          </div>
+
           <div className="bg-gray-800/70 border border-gray-700 rounded-lg p-3 text-sm text-gray-300">
             {isExporting && progress ? (
               <span>
@@ -295,7 +427,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
               </span>
             ) : (
               <span>
-                Exporting <span className="font-semibold text-white">{exportCount}</span> images.
+                Exporting <span className="font-semibold text-white">{exportCount}</span> image{exportCount === 1 ? '' : 's'}.
               </span>
             )}
             {output === 'folder' && (
@@ -303,6 +435,16 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
             )}
             {output === 'zip' && (
               <span className="block text-xs text-gray-400 mt-1">ZIP will contain flattened files with auto-renamed collisions.</span>
+            )}
+            {metadataPolicy !== 'preserve' && (
+              <span className="block text-xs text-amber-300/90 mt-1">
+                Rewritten exports are saved as PNG copies for metadata safety and compatibility.
+              </span>
+            )}
+            {metadataPolicy !== 'preserve' && unsupportedRewriteCount > 0 && (
+              <span className="block text-xs text-amber-300/90 mt-1">
+                {unsupportedRewriteCount} file{unsupportedRewriteCount === 1 ? '' : 's'} in this export can only be preserved in v1 and may fail if rewritten.
+              </span>
             )}
             {isExporting && progress && (
               <div className="mt-3">

--- a/components/BatchExportModal.tsx
+++ b/components/BatchExportModal.tsx
@@ -93,6 +93,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
   const [exportPath, setExportPath] = useState<string | null>(null);
   const [isCancelling, setIsCancelling] = useState(false);
   const activeExportIdRef = useRef<string | null>(null);
+  const wasOpenRef = useRef(false);
 
   useEffect(() => {
     if (!hasSelected && source === 'selected') {
@@ -101,7 +102,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
   }, [hasSelected, source]);
 
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && !wasOpenRef.current) {
       setStatus(null);
       setIsExporting(false);
       setSource(resolveDefaultSource(hasSelected, preferredSource));
@@ -113,7 +114,8 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
       setExportPath(null);
       setIsCancelling(false);
     }
-  }, [isOpen, hasSelected, preferredSource, requestedImageIds]);
+    wasOpenRef.current = isOpen;
+  }, [isOpen, hasSelected, preferredSource]);
 
   useEffect(() => {
     activeExportIdRef.current = activeExportId;

--- a/components/BatchExportModal.tsx
+++ b/components/BatchExportModal.tsx
@@ -104,10 +104,12 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
   }, [hasSelected, source]);
 
   useEffect(() => {
-    if (restrictToRequestedSelection && source !== 'selected') {
+    // Only enforce 'selected' source when restricted AND images are actually available
+    // This prevents oscillation with the fallback effect below
+    if (restrictToRequestedSelection && hasSelected && source !== 'selected') {
       setSource('selected');
     }
-  }, [restrictToRequestedSelection, source]);
+  }, [restrictToRequestedSelection, hasSelected, source]);
 
   useEffect(() => {
     if (isOpen && !wasOpenRef.current) {

--- a/components/ChangelogModal.tsx
+++ b/components/ChangelogModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { X, ExternalLink, Github, Heart, Puzzle } from 'lucide-react';
+import { X, ExternalLink, Github, BadgeCheck, Puzzle } from 'lucide-react';
 
 interface ChangelogModalProps {
   isOpen: boolean;
@@ -158,7 +158,7 @@ const ChangelogModal: React.FC<ChangelogModalProps> = ({ isOpen, onClose, curren
         rel="noopener noreferrer"
         className="inline-flex items-center gap-2 px-4 py-2 bg-pink-600 hover:bg-pink-500 text-white text-sm font-medium rounded-full transition-colors"
       >
-        <Heart size={16} className="fill-current" />
+        <BadgeCheck size={16} />
         Get Pro License
       </a>
       <a

--- a/components/ChangelogModal.tsx
+++ b/components/ChangelogModal.tsx
@@ -132,23 +132,15 @@ const ChangelogModal: React.FC<ChangelogModalProps> = ({ isOpen, onClose, curren
 <div className="mb-6 p-4 bg-gradient-to-br from-blue-900/20 to-purple-900/20 border border-blue-500/30 rounded-lg">
   <h3 className="text-lg font-semibold text-blue-300 mb-3">Message from the Dev</h3>
   <div className="text-gray-300 space-y-3 text-sm leading-relaxed">
-    <p>Hey there, I'm Lucas - solo dev behind Image MetaHub.</p>
+    <p>Hi there, this is Lucas -- the solo dev behind Image MetaHub.</p>
 
-    <p>v0.14 is a big one. It adds some very substantial features, especially around ComfyUI workflow inspection/regeneration, improved analytics, improved comparison, and a lot more. Most of it is the result of trying to make the app more useful in the same way I use it myself.</p>
+    <p>v0.15 is here with some new and useful features for organizing your library, which include audio support, tag/collection automation rules, metadata editing, and more. Although they are functional, some of these features may feel a bit rough in this first implementation. I felt it was better to ship them as they are now tho, and proceed to polish them over time.</p>
 
-    <p>I started IMH last September, as a tool for my own use, to basically do what the core of the app still is today: search/filter by generation parameters, with support exclusive to InvokeAI. After it got some visibility, I started to expand on it by including support to other generators.</p>
+    <p>I also put a lot of focus on making the app more responsive, faster, and more intuitive, I hope you'll notice the difference! One note: during development I did run into a few memory crashes that were mostly fixed. If you do happen to come across one, it would be really helpful if you open an Issue with the console logs!</p>
 
-    <p>One thing hasn't changed, tho; I still develop this app for myself, as I'm just a normal mid-tier user who generates as a hobby and share a lot of the pains with people who deal with large libraries. This means that most features I add are things that are useful for myself which end up overlapping with many other users. This is also the reason a lot of things that may seem obvious are overlooked - which is why I thank everyone who help out on GitHub with Bug Reports/Feature Requests.</p>
+    <p>A genuine thank you to everyone who helped support development by purchasing a Pro license -- it truly makes a difference, your support is what will turn IMH into a reference point for everyone working with GenMedia. I also want to thank everyone who submitted bug reports and feature requests on GitHub, for actively helping shape the app into something genuinely useful.</p>
 
-    <p>Still tho, I'm glad this thing is useful to people. Building it alone means I end up doing development, support, bug fixing, communication, and whatever else needs doing. So if IMH has been useful to you and it ever makes sense to mention it to someone who might benefit from it, that helps a lot!</p>
-
-    <p>As a side note: I hate the term "vibe coding". Sounds like something you would do lounging in a beanbag chair, burning incense, and saying "Take that, bug" while debugging.</p>
-
-    <p>Anyway, make sure to join our Discord server: <a href="https://discord.gg/7XgrWCSxfJ" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 underline">https://discord.gg/7XgrWCSxfJ</a></p>
-
-    <p>And as usual, thanks to everyone who's helped development by downloading IMH, getting a pro license, or contributing on GitHub. Special thanks to nonplayer for their many relevant insights, Taruvi who helped building the base of what the app is today, mankochan11 for helping to test this build, and Silva and Camilo for funding the project.</p>
-
-    <p className="mt-4">Enjoy the update!</p>
+    <p>Make sure to join our Discord server! <a href="https://discord.gg/7XgrWCSxfJ" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 underline">https://discord.gg/7XgrWCSxfJ</a></p>
 
     <div className="flex flex-wrap gap-3 mt-6 pt-4 border-t border-gray-700/50">
       <a

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -23,6 +23,8 @@ import TagManagerModal from './TagManagerModal';
 import { useReparseMetadata } from '../hooks/useReparseMetadata';
 import Tooltip from './Tooltip';
 
+const OPEN_BATCH_EXPORT_EVENT = 'imagemetahub:open-batch-export';
+
 interface GridToolbarProps {
 
   selectedImages: Set<string>;
@@ -135,40 +137,18 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
     showInExplorer(`${directory.path}/${firstSelectedImage.name}`);
   };
 
-  const handleExport = async () => {
-    if (selectedCount > 1) {
-      onBatchExport();
-      return;
-    }
-    if (!firstSelectedImage) return;
-    const directory = directories.find(d => d.id === firstSelectedImage.directoryId);
-    if (!directory) return;
-
-    if (!window.electronAPI) {
-      showNotification('Export only available in desktop app', 'error');
+  const handleExport = () => {
+    if (selectedCount === 1 && firstSelectedImage) {
+      window.dispatchEvent(new CustomEvent(OPEN_BATCH_EXPORT_EVENT, {
+        detail: {
+          imageIds: [firstSelectedImage.id],
+          preferredSource: 'selected',
+        },
+      }));
       return;
     }
 
-    try {
-      const destResult = await window.electronAPI.showDirectoryDialog();
-      if (destResult.canceled || !destResult.path) return;
-
-      const sourcePathResult = await window.electronAPI.joinPaths(directory.path, firstSelectedImage.name);
-      if (!sourcePathResult.success || !sourcePathResult.path) throw new Error('Failed to construct source path');
-
-      const destPathResult = await window.electronAPI.joinPaths(destResult.path, firstSelectedImage.name);
-      if (!destPathResult.success || !destPathResult.path) throw new Error('Failed to construct destination path');
-
-      const readResult = await window.electronAPI.readFile(sourcePathResult.path);
-      if (!readResult.success || !readResult.data) throw new Error('Failed to read file');
-
-      const writeResult = await window.electronAPI.writeFile(destPathResult.path, readResult.data);
-      if (!writeResult.success) throw new Error('Failed to write file');
-
-      showNotification('Image exported successfully!');
-    } catch (error: any) {
-      showNotification(`Export failed: ${error.message}`, 'error');
-    }
+    onBatchExport();
   };
 
   const handleToggleFavorites = () => {

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -22,10 +22,14 @@ import { useSettingsStore } from '../store/useSettingsStore';
 import { getElectronAbsoluteMediaPath, mediaSourceCache } from '../services/mediaSourceCache';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 
+import { bulkSaveShadowMetadata } from '../services/imageAnnotationsStorage';
+import { copyEditableMetadata, readEditableMetadataClipboard } from '../services/metadataClipboard';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
+import { buildEffectiveMetadata, getEditableMetadataFields } from '../utils/editableMetadata';
 import { eventMatchesKeybinding, isTypingElement } from '../utils/hotkeyUtils';
 import { useShadowMetadata } from '../hooks/useShadowMetadata';
-import { MetadataEditorModal } from './MetadataEditorModal';
+import { MetadataEditorModal, type MetadataEditorDraft } from './MetadataEditorModal';
+import BatchExportModal from './BatchExportModal';
 import ImageLineageSection from './ImageLineageSection';
 import { getGenerationTypeLabel } from '../utils/imageLineage';
 import RatingStars from './RatingStars';
@@ -769,7 +773,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const { addImage, comparisonCount } = useImageComparison();
   const { isReparsing, reparseImages } = useReparseMetadata();
 
-  const { canUseA1111, canUseComfyUI, canUseComparison, showProModal, initialized } = useFeatureAccess();
+  const { canUseA1111, canUseComfyUI, canUseComparison, canUseBatchExport, showProModal, initialized } = useFeatureAccess();
   const { a1111Enabled, comfyUIEnabled, visibleProviders, singleVisibleProvider } = useGenerationProviderAvailability();
 
   const toggleFavorite = useImageStore((state) => state.toggleFavorite);
@@ -785,9 +789,16 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const collections = useImageStore((state) => state.collections);
   const createCollection = useImageStore((state) => state.createCollection);
   const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
+  const directories = useImageStore((state) => state.directories);
+  const filteredImages = useImageStore((state) => state.filteredImages);
+  const allImages = useImageStore((state) => state.images);
+  const selectedImages = useImageStore((state) => state.selectedImages);
+  const activeImageScope = useImageStore((state) => state.activeImageScope);
+  const clusterNavigationContext = useImageStore((state) => state.clusterNavigationContext);
 
   const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata, deleteMetadata: deleteShadowMetadata } = useShadowMetadata(image.id);
   const [isMetadataEditorOpen, setIsMetadataEditorOpen] = useState(false);
+  const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
   const [showOriginal, setShowOriginal] = useState(false);
 
   const imageFromStore = useImageStore(
@@ -818,6 +829,28 @@ const ImageModal: React.FC<ImageModalProps> = ({
     limit: recentTagChipLimit,
   }), [currentTags, recentTagChipLimit, recentTags]);
   const createdAtLabel = useMemo(() => new Date(image.lastModified).toLocaleString(), [image.lastModified]);
+  const exportScopeImages = useMemo(() => {
+    const candidateScopes = [
+      clusterNavigationContext,
+      activeImageScope,
+      filteredImages,
+    ].filter((scope): scope is IndexedImage[] => Array.isArray(scope) && scope.length > 0);
+
+    for (const scope of candidateScopes) {
+      if (scope.some((candidate) => candidate.id === liveImage.id)) {
+        return scope;
+      }
+    }
+
+    return [liveImage];
+  }, [activeImageScope, clusterNavigationContext, filteredImages, liveImage]);
+  const exportSelectionIds = useMemo(() => {
+    if (selectedImages.has(liveImage.id)) {
+      return new Set(selectedImages);
+    }
+
+    return new Set([liveImage.id]);
+  }, [liveImage.id, selectedImages]);
 
   const [tagInput, setTagInput] = useState('');
   const [isMediaOverlayVisible, setIsMediaOverlayVisible] = useState(false);
@@ -1180,29 +1213,29 @@ const ImageModal: React.FC<ImageModalProps> = ({
     };
   }, [applyModalWindowStyles, isFullscreen, modalInteraction, scheduleModalWindowPaint]);
 
-  const nMeta: BaseMetadata | undefined = image.metadata?.normalizedMetadata;
+  const nMeta: BaseMetadata | undefined = liveImage.metadata?.normalizedMetadata;
   const canFindSimilar = Boolean(nMeta?.prompt) && Boolean(onFindSimilar);
-  const effectiveMetadata: BaseMetadata | undefined = (nMeta && !showOriginal) ? {
-    ...nMeta,
-    prompt: shadowMetadata?.prompt ?? nMeta.prompt,
-    negativePrompt: shadowMetadata?.negativePrompt ?? nMeta.negativePrompt,
-    seed: shadowMetadata?.seed ?? nMeta.seed,
-    width: shadowMetadata?.width ?? nMeta.width,
-    height: shadowMetadata?.height ?? nMeta.height,
-    model: (shadowMetadata?.resources?.find(r => r.type === 'model')?.name) ?? nMeta.model,
-  } : (shadowMetadata && !showOriginal) ? {
-     prompt: shadowMetadata.prompt || '',
-     negativePrompt: shadowMetadata.negativePrompt,
-     seed: shadowMetadata.seed,
-     width: shadowMetadata.width || 0,
-     height: shadowMetadata.height || 0,
-     model: shadowMetadata.resources?.find(r => r.type === 'model')?.name || 'Unknown',
-     steps: 0,
-     scheduler: 'Unknown',
-     topics: [],
-  } as BaseMetadata : nMeta;
-
+  const effectiveMetadata = buildEffectiveMetadata(nMeta, shadowMetadata, showOriginal);
+  const generationImage = useMemo<IndexedImage>(() => (
+    effectiveMetadata
+      ? {
+          ...liveImage,
+          metadata: {
+            ...liveImage.metadata,
+            normalizedMetadata: effectiveMetadata,
+          },
+        }
+      : liveImage
+  ), [effectiveMetadata, liveImage]);
   const effectiveDuration = shadowMetadata?.duration ?? (nMeta as any)?.video?.duration_seconds ?? (nMeta as any)?.audio?.duration_seconds;
+  const editorInitialMetadata = useMemo<MetadataEditorDraft | null>(() => {
+    const editableFields = getEditableMetadataFields(nMeta, shadowMetadata);
+    return {
+      imageId: liveImage.id,
+      updatedAt: shadowMetadata?.updatedAt ?? Date.now(),
+      ...editableFields,
+    };
+  }, [liveImage.id, nMeta, shadowMetadata]);
 
 
   const videoInfo = (nMeta as any)?.video;
@@ -1417,7 +1450,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   };
 
   const copySeed = () => {
-    copyToClipboardElectron(String(nMeta?.seed || ''), 'Seed');
+    copyToClipboardElectron(String(effectiveMetadata?.seed || ''), 'Seed');
     hideContextMenu();
   };
 
@@ -1472,56 +1505,18 @@ const ImageModal: React.FC<ImageModalProps> = ({
     await reparseImages([liveImage]);
   };
 
-  const exportImage = async () => {
+  const openBatchExport = useCallback(() => {
+    if (exportSelectionIds.size > 1 && !canUseBatchExport) {
+      showProModal('batch_export');
+      return;
+    }
+
+    setIsBatchExportModalOpen(true);
+  }, [canUseBatchExport, exportSelectionIds.size, showProModal]);
+
+  const exportImage = () => {
     hideContextMenu();
-    
-    if (!window.electronAPI) {
-      alert('Export feature is only available in the desktop app version.');
-      return;
-    }
-    
-    if (!directoryPath) {
-      alert('Cannot export image: source directory path is missing.');
-      return;
-    }
-
-    try {
-      const destResult = await window.electronAPI.showDirectoryDialog();
-      if (destResult.canceled || !destResult.path) {
-        return;
-      }
-      const destDir = destResult.path;
-      const sourcePathResult = await window.electronAPI.joinPaths(directoryPath, image.name);
-      if (!sourcePathResult.success || !sourcePathResult.path) {
-        throw new Error(`Failed to construct source path: ${sourcePathResult.error}`);
-      }
-      const destPathResult = await window.electronAPI.joinPaths(destDir, image.name);
-      if (!destPathResult.success || !destPathResult.path) {
-        throw new Error(`Failed to construct destination path: ${destPathResult.error}`);
-      }
-
-      const sourcePath = sourcePathResult.path;
-      const destPath = destPathResult.path;
-
-      const readResult = await window.electronAPI.readFile(sourcePath);
-      if (!readResult.success || !readResult.data) {
-        alert(`Failed to read original file: ${readResult.error}`);
-        return;
-      }
-
-      const writeResult = await window.electronAPI.writeFile(destPath, readResult.data);
-      if (!writeResult.success) {
-        alert(`Failed to export image: ${writeResult.error}`);
-        return;
-      }
-
-      alert(`Image exported successfully to: ${destPath}`);
-
-    } catch (error) {
-      console.error('Export error:', error);
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      alert(`An unexpected error occurred during export: ${errorMessage}`);
-    }
+    openBatchExport();
   };
 
   useEffect(() => {
@@ -2724,8 +2719,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
                     {((nMeta as any).vae || (nMeta as any).vaes?.[0]?.name) && (
                       <MetadataItem label="VAE" value={(nMeta as any).vae || (nMeta as any).vaes?.[0]?.name} />
                     )}
-                    {nMeta.loras && nMeta.loras.length > 0 && (
-                      <MetadataItem label="LoRAs" value={nMeta.loras.map(formatLoRA).join(', ')} />
+                    {effectiveMetadata?.loras && effectiveMetadata.loras.length > 0 && (
+                      <MetadataItem label="LoRAs" value={effectiveMetadata.loras.map(formatLoRA).join(', ')} />
                     )}
                     <div className="grid grid-cols-2 gap-2">
                       <MetadataItem label="Steps" value={effectiveMetadata?.steps} />
@@ -2733,8 +2728,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
                       {nMeta.clip_skip && nMeta.clip_skip > 1 && (
                         <MetadataItem label="Clip Skip" value={nMeta.clip_skip} />
                       )}
-                      <MetadataItem label="Seed" value={nMeta.seed} onCopy={(v) => copyToClipboard(v, "Seed")} />
-                      <MetadataItem label="Sampler" value={nMeta.sampler} />
+                      <MetadataItem label="Seed" value={effectiveMetadata?.seed} onCopy={(v) => copyToClipboard(v, "Seed")} />
+                      <MetadataItem label="Sampler" value={effectiveMetadata?.sampler} />
                       <MetadataItem label="Scheduler" value={effectiveMetadata?.scheduler} />
                       <MetadataItem label="Dimensions" value={effectiveMetadata?.width && effectiveMetadata?.height ? `${effectiveMetadata.width}x${effectiveMetadata.height}` : undefined} />
                       {(nMeta as any).denoise != null && (nMeta as any).denoise < 1 && (
@@ -2913,7 +2908,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   }
                   setIsGenerateModalOpen(true);
                 }}
-                disabled={canUseA1111 && !nMeta.prompt}
+                disabled={canUseA1111 && !effectiveMetadata?.prompt}
                 className="w-full bg-blue-50 hover:bg-blue-100 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-blue-200 dark:border-blue-500/50 hover:border-blue-300 dark:hover:border-blue-400 text-blue-700 dark:text-blue-100 px-4 py-3 rounded-lg text-sm font-semibold flex items-center justify-center gap-2 transition-all duration-200"
               >
                 {isGenerating && canUseA1111 ? (
@@ -2940,9 +2935,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
                     showProModal('a1111');
                     return;
                   }
-                  copyToA1111(image);
+                  copyToA1111(generationImage, effectiveMetadata);
                 }}
-                disabled={canUseA1111 && (isCopying || !nMeta.prompt)}
+                disabled={canUseA1111 && (isCopying || !effectiveMetadata?.prompt)}
                 className="w-full bg-gray-50 hover:bg-gray-100 dark:bg-white/5 dark:hover:bg-white/10 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-lg text-xs font-medium flex items-center justify-center gap-2 transition-all duration-200"
               >
                 {isCopying && canUseA1111 ? (
@@ -2974,11 +2969,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
               )}
 
               {/* Generate Variation Modal */}
-              {showA1111Actions && isGenerateModalOpen && nMeta && (
+              {showA1111Actions && isGenerateModalOpen && effectiveMetadata && (
                 <A1111GenerateModal
                   isOpen={isGenerateModalOpen}
                   onClose={() => setIsGenerateModalOpen(false)}
-                  image={image}
+                  image={generationImage}
                   onGenerate={async (params: A1111GenerationParams) => {
                     const customMetadata: Partial<BaseMetadata> = {
                       prompt: params.prompt,
@@ -2988,10 +2983,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
                       seed: params.randomSeed ? -1 : params.seed,
                       width: params.width,
                       height: params.height,
-                      model: params.model || nMeta?.model,
+                      model: params.model || effectiveMetadata?.model,
                       ...(params.sampler ? { sampler: params.sampler } : {}),
                     };
-                    await generateWithA1111(image, customMetadata, params.numberOfImages);
+                    await generateWithA1111(generationImage, customMetadata, params.numberOfImages);
                     setIsGenerateModalOpen(false);
                   }}
                   isGenerating={isGenerating}
@@ -3001,7 +2996,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
           )}
 
           {/* ComfyUI Integration */}
-          {nMeta && showComfyUIActions && (
+          {effectiveMetadata && showComfyUIActions && (
             <div className={`mt-3 ${showComfyUIHeading ? 'pt-3 border-t border-gray-700' : ''}`}>
               {showComfyUIHeading && (
                 <h4 className="text-xs text-gray-400 uppercase tracking-wider mb-2">ComfyUI</h4>
@@ -3030,9 +3025,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
                     showProModal('comfyui');
                     return;
                   }
-                  copyToComfyUI(image);
+                  copyToComfyUI(generationImage, effectiveMetadata);
                 }}
-                disabled={canUseComfyUI && (isCopyingComfyUI || !nMeta.prompt)}
+                disabled={canUseComfyUI && (isCopyingComfyUI || !effectiveMetadata?.prompt)}
                 className="w-full bg-gray-50 hover:bg-gray-100 dark:bg-white/5 dark:hover:bg-white/10 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-lg text-xs font-medium flex items-center justify-center gap-2 transition-all duration-200"
               >
                 {isCopyingComfyUI && canUseComfyUI ? (
@@ -3108,6 +3103,13 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   <Pencil size={14} />
                 </button>
                 <button
+                  onClick={openBatchExport}
+                  className="p-1.5 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors text-gray-400 hover:text-white"
+                  title={exportSelectionIds.size > 1 && !canUseBatchExport && initialized ? 'Pro feature - start trial' : 'Open export flow'}
+                >
+                  <Download size={14} />
+                </button>
+                <button
                   onClick={() => setShowRawMetadata(!showRawMetadata)}
                   className="text-xs text-gray-400 hover:text-white underline"
                 >
@@ -3136,12 +3138,12 @@ const ImageModal: React.FC<ImageModalProps> = ({
                       width: params.width,
                       height: params.height,
                       batch_size: params.numberOfImages,
-                      model: params.model?.name || nMeta?.model,
+                      model: params.model?.name || effectiveMetadata?.model,
                       ...(params.sampler ? { sampler: params.sampler } : {}),
                       ...(params.scheduler ? { scheduler: params.scheduler } : {}),
                     };
 
-                    await generateWithComfyUI(image, {
+                    await generateWithComfyUI(generationImage, {
                       customMetadata,
                       overrides: {
                         model: params.model || undefined,
@@ -3228,9 +3230,50 @@ const ImageModal: React.FC<ImageModalProps> = ({
         <MetadataEditorModal
           isOpen={isMetadataEditorOpen}
           onClose={() => setIsMetadataEditorOpen(false)}
-          initialMetadata={shadowMetadata}
-          onSave={async (m) => { await saveShadowMetadata(m); }}
-          imageId={image.id}
+          initialMetadata={editorInitialMetadata}
+          onSave={async (metadata) => { await saveShadowMetadata(metadata); }}
+          onExportEditedCopy={openBatchExport}
+          onApplyToSelected={exportSelectionIds.size > 1 ? async (metadata) => {
+            await bulkSaveShadowMetadata(Array.from(exportSelectionIds).map((imageId) => ({
+              ...metadata,
+              imageId,
+              updatedAt: Date.now(),
+            })));
+          } : null}
+          selectedImageCount={exportSelectionIds.size}
+          onCopyEditableMetadata={(metadata) => {
+            copyEditableMetadata(metadata, liveImage.id);
+          }}
+          onPasteEditableMetadata={() => {
+            const clipboardMetadata = readEditableMetadataClipboard()?.metadata;
+            if (!clipboardMetadata) {
+              return null;
+            }
+
+            return {
+              ...(editorInitialMetadata ?? {
+                imageId: liveImage.id,
+                updatedAt: Date.now(),
+              }),
+              ...clipboardMetadata,
+              imageId: liveImage.id,
+              updatedAt: Date.now(),
+            };
+          }}
+          imageId={liveImage.id}
+        />
+      </div>
+
+      <div className="pointer-events-auto">
+        <BatchExportModal
+          isOpen={isBatchExportModalOpen}
+          onClose={() => setIsBatchExportModalOpen(false)}
+          selectedImageIds={exportSelectionIds}
+          filteredImages={exportScopeImages}
+          allImages={allImages}
+          directories={directories}
+          requestedImageIds={Array.from(exportSelectionIds)}
+          preferredSource="selected"
         />
       </div>
 
@@ -3424,9 +3467,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
               <button
                 onClick={exportImage}
                 className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+                title={exportSelectionIds.size > 1 && !canUseBatchExport && initialized ? 'Pro feature - start trial' : undefined}
               >
                 <Download className="w-4 h-4" />
-                Export Image
+                Export...
               </button>
             </>
           )}

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState, FC } from 'react';
-import { Clipboard, Sparkles, ChevronDown, ChevronRight, Heart, X, Zap, CheckCircle, ArrowUp, Copy, Search } from 'lucide-react';
+import { Clipboard, Sparkles, ChevronDown, ChevronRight, Heart, X, Zap, CheckCircle, ArrowUp, Copy, Search, Pencil, Download, Eye, EyeOff } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
-import { type BaseMetadata, type LoRAInfo } from '../types';
+import { type BaseMetadata, type IndexedImage, type LoRAInfo } from '../types';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
@@ -22,6 +22,12 @@ import { useSettingsStore } from '../store/useSettingsStore';
 import { getRecentTagChips } from '../utils/tagSuggestions';
 import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 import AudioPlayer from './AudioPlayer';
+import { useShadowMetadata } from '../hooks/useShadowMetadata';
+import { bulkSaveShadowMetadata } from '../services/imageAnnotationsStorage';
+import { copyEditableMetadata, readEditableMetadataClipboard } from '../services/metadataClipboard';
+import { buildEffectiveMetadata, getEditableMetadataFields } from '../utils/editableMetadata';
+import { MetadataEditorModal, type MetadataEditorDraft } from './MetadataEditorModal';
+import BatchExportModal from './BatchExportModal';
 
 const formatLoRA = (lora: string | LoRAInfo): string => {
   if (typeof lora === 'string') {
@@ -128,7 +134,6 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const {
     previewImage,
     setPreviewImage,
-    directories,
     toggleFavorite,
     setImageRating,
     addTagToImage,
@@ -139,6 +144,11 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     setSelectedImage,
   } = useImageStore();
   const recentTags = useImageStore((state) => state.recentTags);
+  const directories = useImageStore((state) => state.directories);
+  const filteredImages = useImageStore((state) => state.filteredImages);
+  const selectedImages = useImageStore((state) => state.selectedImages);
+  const activeImageScope = useImageStore((state) => state.activeImageScope);
+  const clusterNavigationContext = useImageStore((state) => state.clusterNavigationContext);
   const previewImageFromStore = useImageStore((state) => {
     if (!state.previewImage) return null;
     const id = state.previewImage.id;
@@ -152,6 +162,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const [tagInput, setTagInput] = useState('');
   const [showPerformance, setShowPerformance] = useState(true);
   const [showRawMetadata, setShowRawMetadata] = useState(false);
+  const [showOriginal, setShowOriginal] = useState(false);
+  const [isMetadataEditorOpen, setIsMetadataEditorOpen] = useState(false);
+  const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     x: 0,
     y: 0,
@@ -165,10 +178,12 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const { copyToComfyUI, isCopying: isCopyingComfyUI, copyStatus: copyStatusComfyUI } = useCopyToComfyUI();
   const { generateWithComfyUI, isGenerating: isGeneratingComfyUI, generateStatus: generateStatusComfyUI } = useGenerateWithComfyUI();
 
-  const { canUseA1111, canUseComfyUI, showProModal, initialized } = useFeatureAccess();
+  const { canUseA1111, canUseComfyUI, canUseBatchExport, showProModal, initialized } = useFeatureAccess();
   const { a1111Enabled, comfyUIEnabled, visibleProviders, singleVisibleProvider } = useGenerationProviderAvailability();
 
   const activeImage = previewImageFromStore || previewImage;
+  const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata } = useShadowMetadata(activeImage?.id);
+  const allImages = useImageStore((state) => state.images);
   const thumbnail = useResolvedThumbnail(activeImage);
   const isVideo = !!activeImage && isVideoFileName(activeImage.name, activeImage.fileType);
   const isAudio = !!activeImage && isAudioFileName(activeImage.name, activeImage.fileType);
@@ -253,9 +268,52 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   }
 
   const nMeta: BaseMetadata | undefined = activeImage.metadata?.normalizedMetadata;
+  const effectiveMetadata = buildEffectiveMetadata(nMeta, shadowMetadata, showOriginal);
+  const generationImage: IndexedImage = effectiveMetadata
+    ? {
+        ...activeImage,
+        metadata: {
+          ...activeImage.metadata,
+          normalizedMetadata: effectiveMetadata,
+        },
+      }
+    : activeImage;
+  const editorInitialMetadata: MetadataEditorDraft | null = {
+    imageId: activeImage.id,
+    updatedAt: shadowMetadata?.updatedAt ?? Date.now(),
+    ...getEditableMetadataFields(nMeta, shadowMetadata),
+  };
+  const effectiveDuration = shadowMetadata?.duration ?? (nMeta as any)?.video?.duration_seconds ?? (nMeta as any)?.audio?.duration_seconds;
+  const exportScopeImages = (() => {
+    const candidateScopes = [
+      clusterNavigationContext,
+      activeImageScope,
+      filteredImages,
+    ].filter((scope): scope is typeof filteredImages => Array.isArray(scope) && scope.length > 0);
+
+    for (const scope of candidateScopes) {
+      if (scope.some((candidate) => candidate.id === activeImage.id)) {
+        return scope;
+      }
+    }
+
+    return [activeImage];
+  })();
+  const exportSelectionIds = selectedImages.has(activeImage.id)
+    ? new Set(selectedImages)
+    : new Set([activeImage.id]);
   const videoInfo = (nMeta as any)?.video;
   const audioInfo = (nMeta as any)?.audio;
   const motionModel = (nMeta as any)?.motion_model;
+  const notesValue = shadowMetadata?.notes ?? effectiveMetadata?.notes ?? nMeta?.notes;
+  const openBatchExport = () => {
+    if (exportSelectionIds.size > 1 && !canUseBatchExport) {
+      showProModal('batch_export');
+      return;
+    }
+
+    setIsBatchExportModalOpen(true);
+  };
 
   const copyToClipboard = (text: string, type: string) => {
     if(!text) return;
@@ -521,7 +579,41 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
 
         {nMeta ? (
           <>
-            <h3 className="text-base font-semibold text-gray-700 dark:text-gray-300 border-b border-gray-200 dark:border-gray-600 pb-2">Metadata</h3>
+            <div className="flex items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-600 pb-2">
+              <div className="flex items-center gap-2">
+                <h3 className="text-base font-semibold text-gray-700 dark:text-gray-300">Metadata</h3>
+                {shadowMetadata && (
+                  <span className="text-[10px] bg-blue-900/50 text-blue-300 px-1.5 py-0.5 rounded border border-blue-800">
+                    EDITED
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-1.5">
+                {shadowMetadata && (
+                  <button
+                    onClick={() => setShowOriginal((current) => !current)}
+                    className={`p-1.5 rounded-md transition-colors ${showOriginal ? 'bg-blue-900/50 text-blue-300' : 'bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-900 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white'}`}
+                    title={showOriginal ? 'Show edited metadata' : 'Show original metadata'}
+                  >
+                    {showOriginal ? <EyeOff size={14} /> : <Eye size={14} />}
+                  </button>
+                )}
+                <button
+                  onClick={() => setIsMetadataEditorOpen(true)}
+                  className="p-1.5 rounded-md transition-colors bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-900 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+                  title="Edit metadata overrides"
+                >
+                  <Pencil size={14} />
+                </button>
+                <button
+                  onClick={openBatchExport}
+                  className="p-1.5 rounded-md transition-colors bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-900 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+                  title={exportSelectionIds.size > 1 && !canUseBatchExport && initialized ? 'Pro feature - start trial' : 'Open export flow'}
+                >
+                  <Download size={14} />
+                </button>
+              </div>
+            </div>
             <div className="space-y-3">
               <ImageLineageSection
                 image={activeImage}
@@ -532,21 +624,21 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 }}
               />
               <MetadataItem label="Format" value={nMeta.format} onCopy={(v) => copyToClipboard(v, "Format")} />
-              <MetadataItem label="Prompt" value={nMeta.prompt} isPrompt onCopy={(v) => copyToClipboard(v, "Prompt")} />
-              <MetadataItem label="Negative Prompt" value={nMeta.negativePrompt} isPrompt onCopy={(v) => copyToClipboard(v, "Negative Prompt")} />
-              <MetadataItem label="Model" value={nMeta.model} onCopy={(v) => copyToClipboard(v, "Model")} />
+              <MetadataItem label="Prompt" value={effectiveMetadata?.prompt} isPrompt onCopy={(v) => copyToClipboard(v, "Prompt")} />
+              <MetadataItem label="Negative Prompt" value={effectiveMetadata?.negativePrompt} isPrompt onCopy={(v) => copyToClipboard(v, "Negative Prompt")} />
+              <MetadataItem label="Model" value={effectiveMetadata?.model} onCopy={(v) => copyToClipboard(v, "Model")} />
               {((nMeta as any).vae || (nMeta as any).vaes?.[0]?.name) && (
                 <MetadataItem label="VAE" value={(nMeta as any).vae || (nMeta as any).vaes?.[0]?.name} />
               )}
 
               <div className="grid grid-cols-2 gap-2 text-sm">
                   <MetadataItem label="Generation Type" value={nMeta.generationType ? getGenerationTypeLabel(nMeta.generationType) : undefined} />
-                  <MetadataItem label="Steps" value={nMeta.steps} />
-                  <MetadataItem label="CFG Scale" value={nMeta.cfgScale ?? nMeta.cfg_scale} />
-                  <MetadataItem label="Seed" value={nMeta.seed} />
-                  <MetadataItem label="Dimensions" value={nMeta.width && nMeta.height ? `${nMeta.width}x${nMeta.height}` : undefined} />
-                  <MetadataItem label="Sampler" value={nMeta.sampler} />
-                  <MetadataItem label="Scheduler" value={nMeta.scheduler} />
+                  <MetadataItem label="Steps" value={effectiveMetadata?.steps} />
+                  <MetadataItem label="CFG Scale" value={effectiveMetadata?.cfg_scale ?? effectiveMetadata?.cfgScale} />
+                  <MetadataItem label="Seed" value={effectiveMetadata?.seed} />
+                  <MetadataItem label="Dimensions" value={effectiveMetadata?.width && effectiveMetadata?.height ? `${effectiveMetadata.width}x${effectiveMetadata.height}` : undefined} />
+                  <MetadataItem label="Sampler" value={effectiveMetadata?.sampler} />
+                  <MetadataItem label="Scheduler" value={effectiveMetadata?.scheduler} />
                   {(nMeta as any).denoise != null && (nMeta as any).denoise < 1 && (
                     <MetadataItem label="Denoise" value={(nMeta as any).denoise} />
                   )}
@@ -555,8 +647,8 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 <div className="grid grid-cols-2 gap-2 text-sm">
                   <MetadataItem label="Frames" value={videoInfo.frame_count} />
                   <MetadataItem label="FPS" value={videoInfo.frame_rate != null ? Number(videoInfo.frame_rate).toFixed(2) : undefined} />
-                  {videoInfo.duration_seconds != null && (
-                    <MetadataItem label="Duration" value={formatDurationSeconds(Number(videoInfo.duration_seconds))} />
+                  {effectiveDuration != null && (
+                    <MetadataItem label="Duration" value={formatDurationSeconds(Number(effectiveDuration))} />
                   )}
                   <MetadataItem label="Video Codec" value={videoInfo.codec} />
                   <MetadataItem label="Video Format" value={videoInfo.format} />
@@ -564,8 +656,8 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
               )}
               {audioInfo && (
                 <div className="grid grid-cols-2 gap-2 text-sm">
-                  {audioInfo.duration_seconds != null && (
-                    <MetadataItem label="Duration" value={formatDurationSeconds(Number(audioInfo.duration_seconds))} />
+                  {effectiveDuration != null && (
+                    <MetadataItem label="Duration" value={formatDurationSeconds(Number(effectiveDuration))} />
                   )}
                   <MetadataItem label="Audio Codec" value={audioInfo.codec} />
                   <MetadataItem label="Audio Format" value={audioInfo.format} />
@@ -585,18 +677,20 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
               )}
             </div>
 
-            {nMeta.loras && nMeta.loras.length > 0 && (
+            {effectiveMetadata?.loras && effectiveMetadata.loras.length > 0 && (
                <>
                   <h3 className="text-base font-semibold text-gray-700 dark:text-gray-300 pt-2 border-b border-gray-200 dark:border-gray-600 pb-2">LoRAs</h3>
-                  <MetadataItem label="LoRAs" value={nMeta.loras.map(formatLoRA).join(', ')} />
+                  <MetadataItem label="LoRAs" value={effectiveMetadata.loras.map(formatLoRA).join(', ')} />
                </>
             )}
 
             {/* MetaHub Save Node Notes */}
-            {nMeta.notes && (
+            {notesValue && (
               <div className="bg-gray-900/50 p-3 rounded-md border border-gray-700/50">
-                <p className="font-semibold text-purple-300 text-xs uppercase tracking-wider mb-2">Notes (MetaHub Save Node)</p>
-                <pre className="text-gray-200 whitespace-pre-wrap break-words font-mono text-sm bg-gray-800/50 p-2 rounded">{nMeta.notes}</pre>
+                <p className="font-semibold text-purple-300 text-xs uppercase tracking-wider mb-2">
+                  {shadowMetadata?.notes ? 'Notes (Edited)' : 'Notes (MetaHub Save Node)'}
+                </p>
+                <pre className="text-gray-200 whitespace-pre-wrap break-words font-mono text-sm bg-gray-800/50 p-2 rounded">{notesValue}</pre>
               </div>
             )}
 
@@ -673,7 +767,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                   }
                   setIsGenerateModalOpen(true);
                 }}
-                disabled={canUseA1111 && !nMeta.prompt}
+                disabled={canUseA1111 && !effectiveMetadata?.prompt}
                 className="w-full bg-blue-50 hover:bg-blue-100 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-blue-200 dark:border-blue-500/50 hover:border-blue-300 dark:hover:border-blue-400 text-blue-700 dark:text-blue-100 px-4 py-3 rounded-md text-sm font-semibold flex items-center justify-center gap-2 transition-all duration-200"
               >
                 {isGenerating && canUseA1111 ? (
@@ -700,9 +794,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                     showProModal('a1111');
                     return;
                   }
-                  copyToA1111(activeImage);
+                  copyToA1111(generationImage, effectiveMetadata);
                 }}
-                disabled={canUseA1111 && (isCopying || !nMeta.prompt)}
+                disabled={canUseA1111 && (isCopying || !effectiveMetadata?.prompt)}
                 className="w-full bg-gray-50 hover:bg-gray-100 dark:bg-white/5 dark:hover:bg-white/10 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-md text-xs font-medium flex items-center justify-center gap-2 transition-all duration-200"
               >
                 {isCopying && canUseA1111 ? (
@@ -734,11 +828,11 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
               )}
 
               {/* Generate Variation Modal */}
-              {showA1111Actions && isGenerateModalOpen && nMeta && (
+              {showA1111Actions && isGenerateModalOpen && effectiveMetadata && (
                 <A1111GenerateModal
                   isOpen={isGenerateModalOpen}
                   onClose={() => setIsGenerateModalOpen(false)}
-                  image={activeImage}
+                  image={generationImage}
                   onGenerate={async (params: A1111GenerationParams) => {
                     const customMetadata: Partial<BaseMetadata> = {
                       prompt: params.prompt,
@@ -748,10 +842,10 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                       seed: params.randomSeed ? -1 : params.seed,
                       width: params.width,
                       height: params.height,
-                      model: params.model || nMeta?.model,
+                      model: params.model || effectiveMetadata?.model,
                       ...(params.sampler ? { sampler: params.sampler } : {}),
                     };
-                    await generateWithA1111(activeImage, customMetadata, params.numberOfImages);
+                    await generateWithA1111(generationImage, customMetadata, params.numberOfImages);
                     setIsGenerateModalOpen(false);
                   }}
                   isGenerating={isGenerating}
@@ -776,7 +870,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                   }
                   setIsComfyUIGenerateModalOpen(true);
                 }}
-                disabled={canUseComfyUI && !nMeta.prompt}
+                disabled={canUseComfyUI && !effectiveMetadata?.prompt}
                 className="w-full bg-purple-50 hover:bg-purple-100 dark:bg-purple-500/10 dark:hover:bg-purple-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-purple-200 dark:border-purple-500/50 hover:border-purple-300 dark:hover:border-purple-400 text-purple-700 dark:text-purple-100 px-4 py-3 rounded-md text-sm font-semibold flex items-center justify-center gap-2 mb-2 transition-all duration-200"
               >
                 {isGeneratingComfyUI && canUseComfyUI ? (
@@ -803,9 +897,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                     showProModal('comfyui');
                     return;
                   }
-                  copyToComfyUI(activeImage);
+                  copyToComfyUI(generationImage, effectiveMetadata);
                 }}
-                disabled={canUseComfyUI && (isCopyingComfyUI || !nMeta.prompt)}
+                disabled={canUseComfyUI && (isCopyingComfyUI || !effectiveMetadata?.prompt)}
                 className="w-full bg-gray-50 hover:bg-gray-100 dark:bg-white/5 dark:hover:bg-white/10 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-md text-xs font-medium flex items-center justify-center gap-2 transition-all duration-200"
               >
                 {isCopyingComfyUI && canUseComfyUI ? (
@@ -837,11 +931,11 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
               )}
 
               {/* ComfyUI Generate Modal */}
-              {showComfyUIActions && isComfyUIGenerateModalOpen && nMeta && (
+              {showComfyUIActions && isComfyUIGenerateModalOpen && effectiveMetadata && (
                 <ComfyUIGenerateModal
                   isOpen={isComfyUIGenerateModalOpen}
                   onClose={() => setIsComfyUIGenerateModalOpen(false)}
-                  image={activeImage}
+                  image={generationImage}
                   onGenerate={async (params: ComfyUIGenerationParams) => {
                     const customMetadata: Partial<BaseMetadata> = {
                       prompt: params.prompt,
@@ -852,11 +946,11 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                       width: params.width,
                       height: params.height,
                       batch_size: params.numberOfImages,
-                      model: params.model?.name || nMeta?.model,
+                      model: params.model?.name || effectiveMetadata?.model,
                       ...(params.sampler ? { sampler: params.sampler } : {}),
                       ...(params.scheduler ? { scheduler: params.scheduler } : {}),
                     };
-                    await generateWithComfyUI(activeImage, {
+                    await generateWithComfyUI(generationImage, {
                       customMetadata,
                       overrides: {
                         model: params.model || undefined,
@@ -900,6 +994,53 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
           </div>
         )}
       </div>
+
+      <MetadataEditorModal
+        isOpen={isMetadataEditorOpen}
+        onClose={() => setIsMetadataEditorOpen(false)}
+        initialMetadata={editorInitialMetadata}
+        onSave={async (metadata) => { await saveShadowMetadata(metadata); }}
+        onExportEditedCopy={openBatchExport}
+        onApplyToSelected={exportSelectionIds.size > 1 ? async (metadata) => {
+          await bulkSaveShadowMetadata(Array.from(exportSelectionIds).map((imageId) => ({
+            ...metadata,
+            imageId,
+            updatedAt: Date.now(),
+          })));
+        } : null}
+        selectedImageCount={exportSelectionIds.size}
+        onCopyEditableMetadata={(metadata) => {
+          copyEditableMetadata(metadata, activeImage.id);
+        }}
+        onPasteEditableMetadata={() => {
+          const clipboardMetadata = readEditableMetadataClipboard()?.metadata;
+          if (!clipboardMetadata) {
+            return null;
+          }
+
+          return {
+            ...(editorInitialMetadata ?? {
+              imageId: activeImage.id,
+              updatedAt: Date.now(),
+            }),
+            ...clipboardMetadata,
+            imageId: activeImage.id,
+            updatedAt: Date.now(),
+          };
+        }}
+        imageId={activeImage.id}
+      />
+
+      <BatchExportModal
+        isOpen={isBatchExportModalOpen}
+        onClose={() => setIsBatchExportModalOpen(false)}
+        selectedImageIds={exportSelectionIds}
+        filteredImages={exportScopeImages}
+        allImages={allImages}
+        directories={directories}
+        requestedImageIds={Array.from(exportSelectionIds)}
+        preferredSource="selected"
+      />
 
       {contextMenu.visible && (
         <div

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -278,11 +278,11 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
         },
       }
     : activeImage;
-  const editorInitialMetadata: MetadataEditorDraft | null = {
+  const editorInitialMetadata = useMemo<MetadataEditorDraft | null>(() => ({
     imageId: activeImage.id,
     updatedAt: shadowMetadata?.updatedAt ?? Date.now(),
     ...getEditableMetadataFields(nMeta, shadowMetadata),
-  };
+  }), [activeImage.id, nMeta, shadowMetadata]);
   const effectiveDuration = shadowMetadata?.duration ?? (nMeta as any)?.video?.duration_seconds ?? (nMeta as any)?.audio?.duration_seconds;
   const exportScopeImages = (() => {
     const candidateScopes = [

--- a/components/MetadataEditorModal.tsx
+++ b/components/MetadataEditorModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { X, Plus, Trash2, Save, Copy, Clipboard, RefreshCw } from 'lucide-react';
 import { ShadowMetadata, ShadowResource } from '../types';
+import { applyShadowMetadataUpdates } from '../utils/editableMetadata';
 
 const EDITABLE_METADATA_SCHEMA = 'imagemetahub/editable-metadata';
 const EDITABLE_METADATA_VERSION = 1;
@@ -130,6 +131,27 @@ const normalizeTags = (value: unknown): string[] | undefined => {
 
 const formatTags = (tags?: string[]): string => (tags && tags.length > 0 ? tags.join(', ') : '');
 
+const EDITABLE_METADATA_KEYS: Array<keyof MetadataEditorDraft> = [
+  'prompt',
+  'negativePrompt',
+  'seed',
+  'width',
+  'height',
+  'duration',
+  'model',
+  'steps',
+  'cfg_scale',
+  'clip_skip',
+  'sampler',
+  'scheduler',
+  'generator',
+  'version',
+  'module',
+  'tags',
+  'notes',
+  'resources',
+];
+
 const syncPrimaryModelResource = (
   resources: ShadowResource[],
   modelName?: string
@@ -198,8 +220,10 @@ const coerceMetadataDraft = (
 
 const createPortableMetadata = (
   draft: MetadataEditorDraft,
-  tagsText: string
+  tagsText: string,
+  options?: { preserveCleared?: boolean }
 ): MetadataEditorDraft => {
+  const preserveCleared = options?.preserveCleared === true;
   const portableResources = syncPrimaryModelResource(
     sanitizeResources(draft.resources),
     normalizeOptionalText(draft.model)
@@ -229,25 +253,60 @@ const createPortableMetadata = (
     updatedAt: Date.now(),
   };
 
-  if (!normalizedDraft.prompt) delete normalizedDraft.prompt;
-  if (!normalizedDraft.negativePrompt) delete normalizedDraft.negativePrompt;
-  if (normalizedDraft.seed === undefined) delete normalizedDraft.seed;
-  if (normalizedDraft.width === undefined) delete normalizedDraft.width;
-  if (normalizedDraft.height === undefined) delete normalizedDraft.height;
-  if (normalizedDraft.duration === undefined) delete normalizedDraft.duration;
-  if (!normalizedDraft.model) delete normalizedDraft.model;
-  if (normalizedDraft.steps === undefined) delete normalizedDraft.steps;
-  if (normalizedDraft.cfg_scale === undefined) delete normalizedDraft.cfg_scale;
-  if (normalizedDraft.clip_skip === undefined) delete normalizedDraft.clip_skip;
-  if (!normalizedDraft.sampler) delete normalizedDraft.sampler;
-  if (!normalizedDraft.scheduler) delete normalizedDraft.scheduler;
-  if (!normalizedDraft.generator) delete normalizedDraft.generator;
-  if (!normalizedDraft.version) delete normalizedDraft.version;
-  if (!normalizedDraft.module) delete normalizedDraft.module;
-  if (!normalizedDraft.tags || normalizedDraft.tags.length === 0) delete normalizedDraft.tags;
-  if (!normalizedDraft.notes) delete normalizedDraft.notes;
+  if (!preserveCleared) {
+    if (!normalizedDraft.prompt) delete normalizedDraft.prompt;
+    if (!normalizedDraft.negativePrompt) delete normalizedDraft.negativePrompt;
+    if (normalizedDraft.seed === undefined) delete normalizedDraft.seed;
+    if (normalizedDraft.width === undefined) delete normalizedDraft.width;
+    if (normalizedDraft.height === undefined) delete normalizedDraft.height;
+    if (normalizedDraft.duration === undefined) delete normalizedDraft.duration;
+    if (!normalizedDraft.model) delete normalizedDraft.model;
+    if (normalizedDraft.steps === undefined) delete normalizedDraft.steps;
+    if (normalizedDraft.cfg_scale === undefined) delete normalizedDraft.cfg_scale;
+    if (normalizedDraft.clip_skip === undefined) delete normalizedDraft.clip_skip;
+    if (!normalizedDraft.sampler) delete normalizedDraft.sampler;
+    if (!normalizedDraft.scheduler) delete normalizedDraft.scheduler;
+    if (!normalizedDraft.generator) delete normalizedDraft.generator;
+    if (!normalizedDraft.version) delete normalizedDraft.version;
+    if (!normalizedDraft.module) delete normalizedDraft.module;
+    if (!normalizedDraft.tags || normalizedDraft.tags.length === 0) delete normalizedDraft.tags;
+    if (!normalizedDraft.notes) delete normalizedDraft.notes;
+  }
 
   return normalizedDraft;
+};
+
+const buildShadowMetadataReplacement = (
+  initialMetadata: MetadataEditorDraft | null,
+  draft: MetadataEditorDraft,
+  tagsText: string,
+): MetadataEditorDraft => {
+  const normalizedDraft = createPortableMetadata(draft, tagsText, { preserveCleared: true });
+  const initialDraft = coerceMetadataDraft(initialMetadata, draft.imageId);
+  const replacement: Record<string, unknown> = {
+    ...normalizedDraft,
+    imageId: draft.imageId,
+    updatedAt: Date.now(),
+  };
+
+  for (const key of EDITABLE_METADATA_KEYS) {
+    const currentValue = normalizedDraft[key];
+    const initialValue = initialDraft[key];
+    const hadInitialValue =
+      Array.isArray(initialValue)
+        ? initialValue.length > 0
+        : typeof initialValue === 'string'
+          ? initialValue.trim().length > 0
+          : typeof initialValue === 'number'
+            ? Number.isFinite(initialValue)
+            : Boolean(initialValue);
+
+    if (currentValue === undefined && hadInitialValue) {
+      replacement[key] = null;
+    }
+  }
+
+  return replacement as unknown as MetadataEditorDraft;
 };
 
 const serializeEditableMetadata = (draft: MetadataEditorDraft, tagsText: string): string => {
@@ -340,12 +399,7 @@ export const MetadataEditorModal: React.FC<MetadataEditorModalProps> = ({
     setStatus(null);
 
     try {
-      const normalizedDraft = createPortableMetadata(draft, tagsText);
-      const nextMetadata: MetadataEditorDraft = {
-        ...normalizedDraft,
-        imageId,
-        updatedAt: Date.now(),
-      };
+      const nextMetadata = buildShadowMetadataReplacement(initialMetadata, draft, tagsText);
 
       await onSave(nextMetadata);
       onClose();
@@ -500,12 +554,8 @@ export const MetadataEditorModal: React.FC<MetadataEditorModalProps> = ({
     setStatus(null);
 
     try {
-      const normalizedDraft = createPortableMetadata(draft, tagsText);
-      await onApplyToSelected({
-        ...normalizedDraft,
-        imageId,
-        updatedAt: Date.now(),
-      });
+      const nextMetadata = buildShadowMetadataReplacement(initialMetadata, draft, tagsText);
+      await onApplyToSelected(nextMetadata);
       setStatus({
         tone: 'success',
         text: `Applied editable metadata to ${selectedImageCount} selected image${selectedImageCount === 1 ? '' : 's'}.`,

--- a/components/MetadataEditorModal.tsx
+++ b/components/MetadataEditorModal.tsx
@@ -1,15 +1,293 @@
-
-import React, { useState, useEffect } from 'react';
-import { X, Plus, Trash2, Save } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { X, Plus, Trash2, Save, Copy, Clipboard, RefreshCw } from 'lucide-react';
 import { ShadowMetadata, ShadowResource } from '../types';
+
+const EDITABLE_METADATA_SCHEMA = 'imagemetahub/editable-metadata';
+const EDITABLE_METADATA_VERSION = 1;
+const FIELD_HELP_TEXT =
+  'These overrides stay local to Image MetaHub and are meant to mirror normalized metadata fields.';
+
+type StatusTone = 'success' | 'error' | 'info';
+
+const STATUS_STYLES: Record<StatusTone, string> = {
+  success: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200',
+  error: 'border-red-500/30 bg-red-500/10 text-red-200',
+  info: 'border-blue-500/30 bg-blue-500/10 text-blue-200',
+};
+
+export interface MetadataEditorDraft extends ShadowMetadata {
+  model?: string;
+  steps?: number;
+  cfg_scale?: number;
+  clip_skip?: number;
+  sampler?: string;
+  scheduler?: string;
+  generator?: string;
+  version?: string;
+  module?: string;
+  tags?: string[];
+}
 
 interface MetadataEditorModalProps {
   isOpen: boolean;
   onClose: () => void;
-  initialMetadata: ShadowMetadata | null;
-  onSave: (metadata: ShadowMetadata) => Promise<void>;
+  initialMetadata: MetadataEditorDraft | null;
+  onSave: (metadata: MetadataEditorDraft) => Promise<void>;
   imageId: string;
+  onExportEditedCopy?: (() => void) | null;
+  onApplyToSelected?: ((metadata: MetadataEditorDraft) => Promise<void> | void) | null;
+  selectedImageCount?: number;
+  onCopyEditableMetadata?: (
+    metadata: MetadataEditorDraft,
+    serialized: string
+  ) => Promise<void> | void;
+  onPasteEditableMetadata?: () =>
+    | Promise<MetadataEditorDraft | string | null | undefined>
+    | MetadataEditorDraft
+    | string
+    | null
+    | undefined;
 }
+
+interface EditableMetadataClipboardPayload {
+  schema: typeof EDITABLE_METADATA_SCHEMA;
+  version: typeof EDITABLE_METADATA_VERSION;
+  metadata: Partial<MetadataEditorDraft>;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizeOptionalText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const normalizeOptionalMultilineText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  return value.trim().length > 0 ? value : undefined;
+};
+
+const normalizeOptionalNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const sanitizeResource = (value: unknown, index: number): ShadowResource | null => {
+  if (!isRecord(value)) return null;
+
+  const type =
+    value.type === 'model' || value.type === 'lora' || value.type === 'embedding'
+      ? value.type
+      : 'model';
+
+  return {
+    id:
+      typeof value.id === 'string' && value.id.trim().length > 0
+        ? value.id
+        : `resource-${index}-${crypto.randomUUID()}`,
+    type,
+    name: typeof value.name === 'string' ? value.name : '',
+    weight: normalizeOptionalNumber(value.weight),
+  };
+};
+
+const sanitizeResources = (value: unknown): ShadowResource[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((resource, index) => sanitizeResource(resource, index))
+    .filter((resource): resource is ShadowResource => resource !== null);
+};
+
+const normalizeTags = (value: unknown): string[] | undefined => {
+  if (Array.isArray(value)) {
+    const normalized = value
+      .map((tag) => (typeof tag === 'string' ? tag.trim() : ''))
+      .filter(Boolean);
+
+    return normalized.length > 0 ? Array.from(new Set(normalized)) : undefined;
+  }
+
+  if (typeof value !== 'string') return undefined;
+
+  const normalized = value
+    .split(/[\n,]/)
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+
+  return normalized.length > 0 ? Array.from(new Set(normalized)) : undefined;
+};
+
+const formatTags = (tags?: string[]): string => (tags && tags.length > 0 ? tags.join(', ') : '');
+
+const syncPrimaryModelResource = (
+  resources: ShadowResource[],
+  modelName?: string
+): ShadowResource[] => {
+  const trimmedModelName = modelName?.trim();
+  const nextResources = [...resources];
+  const primaryModelIndex = nextResources.findIndex((resource) => resource.type === 'model');
+
+  if (!trimmedModelName) {
+    if (primaryModelIndex >= 0) {
+      nextResources.splice(primaryModelIndex, 1);
+    }
+
+    return nextResources;
+  }
+
+  if (primaryModelIndex >= 0) {
+    nextResources[primaryModelIndex] = {
+      ...nextResources[primaryModelIndex],
+      name: trimmedModelName,
+    };
+    return nextResources;
+  }
+
+  return [
+    {
+      id: crypto.randomUUID(),
+      type: 'model',
+      name: trimmedModelName,
+      weight: 1,
+    },
+    ...nextResources,
+  ];
+};
+
+const coerceMetadataDraft = (
+  value: MetadataEditorDraft | Partial<MetadataEditorDraft> | null | undefined,
+  imageId: string
+): MetadataEditorDraft => {
+  const record = isRecord(value) ? value : {};
+
+  return {
+    ...record,
+    imageId,
+    prompt: typeof record.prompt === 'string' ? record.prompt : '',
+    negativePrompt: typeof record.negativePrompt === 'string' ? record.negativePrompt : '',
+    seed: normalizeOptionalNumber(record.seed),
+    width: normalizeOptionalNumber(record.width),
+    height: normalizeOptionalNumber(record.height),
+    duration: normalizeOptionalNumber(record.duration),
+    model: typeof record.model === 'string' ? record.model : '',
+    steps: normalizeOptionalNumber(record.steps),
+    cfg_scale: normalizeOptionalNumber(record.cfg_scale),
+    clip_skip: normalizeOptionalNumber(record.clip_skip),
+    sampler: typeof record.sampler === 'string' ? record.sampler : '',
+    scheduler: typeof record.scheduler === 'string' ? record.scheduler : '',
+    generator: typeof record.generator === 'string' ? record.generator : '',
+    version: typeof record.version === 'string' ? record.version : '',
+    module: typeof record.module === 'string' ? record.module : '',
+    tags: normalizeTags(record.tags) ?? [],
+    notes: typeof record.notes === 'string' ? record.notes : '',
+    resources: sanitizeResources(record.resources),
+    updatedAt: normalizeOptionalNumber(record.updatedAt) ?? Date.now(),
+  };
+};
+
+const createPortableMetadata = (
+  draft: MetadataEditorDraft,
+  tagsText: string
+): MetadataEditorDraft => {
+  const portableResources = syncPrimaryModelResource(
+    sanitizeResources(draft.resources),
+    normalizeOptionalText(draft.model)
+  );
+
+  const normalizedDraft: MetadataEditorDraft = {
+    ...draft,
+    imageId: draft.imageId,
+    prompt: normalizeOptionalMultilineText(draft.prompt),
+    negativePrompt: normalizeOptionalMultilineText(draft.negativePrompt),
+    seed: normalizeOptionalNumber(draft.seed),
+    width: normalizeOptionalNumber(draft.width),
+    height: normalizeOptionalNumber(draft.height),
+    duration: normalizeOptionalNumber(draft.duration),
+    model: normalizeOptionalText(draft.model),
+    steps: normalizeOptionalNumber(draft.steps),
+    cfg_scale: normalizeOptionalNumber(draft.cfg_scale),
+    clip_skip: normalizeOptionalNumber(draft.clip_skip),
+    sampler: normalizeOptionalText(draft.sampler),
+    scheduler: normalizeOptionalText(draft.scheduler),
+    generator: normalizeOptionalText(draft.generator),
+    version: normalizeOptionalText(draft.version),
+    module: normalizeOptionalText(draft.module),
+    tags: normalizeTags(tagsText),
+    notes: normalizeOptionalMultilineText(draft.notes),
+    resources: portableResources.length > 0 ? portableResources : undefined,
+    updatedAt: Date.now(),
+  };
+
+  if (!normalizedDraft.prompt) delete normalizedDraft.prompt;
+  if (!normalizedDraft.negativePrompt) delete normalizedDraft.negativePrompt;
+  if (normalizedDraft.seed === undefined) delete normalizedDraft.seed;
+  if (normalizedDraft.width === undefined) delete normalizedDraft.width;
+  if (normalizedDraft.height === undefined) delete normalizedDraft.height;
+  if (normalizedDraft.duration === undefined) delete normalizedDraft.duration;
+  if (!normalizedDraft.model) delete normalizedDraft.model;
+  if (normalizedDraft.steps === undefined) delete normalizedDraft.steps;
+  if (normalizedDraft.cfg_scale === undefined) delete normalizedDraft.cfg_scale;
+  if (normalizedDraft.clip_skip === undefined) delete normalizedDraft.clip_skip;
+  if (!normalizedDraft.sampler) delete normalizedDraft.sampler;
+  if (!normalizedDraft.scheduler) delete normalizedDraft.scheduler;
+  if (!normalizedDraft.generator) delete normalizedDraft.generator;
+  if (!normalizedDraft.version) delete normalizedDraft.version;
+  if (!normalizedDraft.module) delete normalizedDraft.module;
+  if (!normalizedDraft.tags || normalizedDraft.tags.length === 0) delete normalizedDraft.tags;
+  if (!normalizedDraft.notes) delete normalizedDraft.notes;
+
+  return normalizedDraft;
+};
+
+const serializeEditableMetadata = (draft: MetadataEditorDraft, tagsText: string): string => {
+  const portableMetadata = createPortableMetadata(draft, tagsText);
+  const payload: EditableMetadataClipboardPayload = {
+    schema: EDITABLE_METADATA_SCHEMA,
+    version: EDITABLE_METADATA_VERSION,
+    metadata: Object.fromEntries(
+      Object.entries(portableMetadata).filter(([key]) => key !== 'imageId' && key !== 'updatedAt')
+    ),
+  };
+
+  return JSON.stringify(payload, null, 2);
+};
+
+const parseEditableMetadataInput = (
+  rawValue: unknown,
+  imageId: string
+): { draft: MetadataEditorDraft; source: 'wrapped' | 'plain' } => {
+  const value =
+    typeof rawValue === 'string'
+      ? JSON.parse(rawValue)
+      : rawValue;
+
+  if (!isRecord(value)) {
+    throw new Error('Expected a JSON object.');
+  }
+
+  if (value.schema === EDITABLE_METADATA_SCHEMA && isRecord(value.metadata)) {
+    return {
+      draft: coerceMetadataDraft(value.metadata as Partial<MetadataEditorDraft>, imageId),
+      source: 'wrapped',
+    };
+  }
+
+  return {
+    draft: coerceMetadataDraft(value as Partial<MetadataEditorDraft>, imageId),
+    source: 'plain',
+  };
+};
 
 export const MetadataEditorModal: React.FC<MetadataEditorModalProps> = ({
   isOpen,
@@ -17,53 +295,66 @@ export const MetadataEditorModal: React.FC<MetadataEditorModalProps> = ({
   initialMetadata,
   onSave,
   imageId,
+  onExportEditedCopy,
+  onApplyToSelected,
+  selectedImageCount = 0,
+  onCopyEditableMetadata,
+  onPasteEditableMetadata,
 }) => {
-  const [prompt, setPrompt] = useState('');
-  const [negativePrompt, setNegativePrompt] = useState('');
-  const [seed, setSeed] = useState<number | undefined>(undefined);
-  const [width, setWidth] = useState<number | undefined>(undefined);
-  const [height, setHeight] = useState<number | undefined>(undefined);
-  const [duration, setDuration] = useState<number | undefined>(undefined);
-  const [notes, setNotes] = useState('');
-  const [resources, setResources] = useState<ShadowResource[]>([]);
+  const [draft, setDraft] = useState<MetadataEditorDraft>(() => coerceMetadataDraft(null, imageId));
+  const [tagsText, setTagsText] = useState('');
+  const [jsonEditorText, setJsonEditorText] = useState('');
+  const [status, setStatus] = useState<{ tone: StatusTone; text: string } | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isCopying, setIsCopying] = useState(false);
+  const [isPasting, setIsPasting] = useState(false);
 
   useEffect(() => {
-    if (isOpen) {
-      setPrompt(initialMetadata?.prompt || '');
-      setNegativePrompt(initialMetadata?.negativePrompt || '');
-      setSeed(initialMetadata?.seed);
-      setWidth(initialMetadata?.width);
-      setHeight(initialMetadata?.height);
-      setDuration(initialMetadata?.duration);
-      setNotes(initialMetadata?.notes || '');
-      setResources(initialMetadata?.resources || []);
-    }
-  }, [isOpen, initialMetadata]);
+    if (!isOpen) return;
+
+    const nextDraft = coerceMetadataDraft(initialMetadata, imageId);
+    setDraft(nextDraft);
+    setTagsText(formatTags(nextDraft.tags));
+    setJsonEditorText(serializeEditableMetadata(nextDraft, formatTags(nextDraft.tags)));
+    setStatus(null);
+  }, [imageId, initialMetadata, isOpen]);
 
   if (!isOpen) return null;
 
+  const updateField = <K extends keyof MetadataEditorDraft>(
+    key: K,
+    value: MetadataEditorDraft[K]
+  ) => {
+    setDraft((currentDraft) => ({
+      ...currentDraft,
+      [key]: value,
+    }));
+  };
+
+  const updateNumericField = (key: keyof MetadataEditorDraft, value: string) => {
+    updateField(key, normalizeOptionalNumber(value) as MetadataEditorDraft[keyof MetadataEditorDraft]);
+  };
+
   const handleSave = async () => {
     setIsSaving(true);
+    setStatus(null);
+
     try {
-      const newMetadata: ShadowMetadata = {
+      const normalizedDraft = createPortableMetadata(draft, tagsText);
+      const nextMetadata: MetadataEditorDraft = {
+        ...normalizedDraft,
         imageId,
-        prompt: prompt || undefined,
-        negativePrompt: negativePrompt || undefined,
-        seed: seed,
-        width: width,
-        height: height,
-        duration: duration,
-        notes: notes || undefined,
-        resources: resources.length > 0 ? resources : undefined,
         updatedAt: Date.now(),
       };
 
-      await onSave(newMetadata);
+      await onSave(nextMetadata);
       onClose();
     } catch (error) {
       console.error('Failed to save metadata:', error);
-      alert('Failed to save metadata');
+      setStatus({
+        tone: 'error',
+        text: error instanceof Error ? error.message : 'Failed to save metadata.',
+      });
     } finally {
       setIsSaving(false);
     }
@@ -74,70 +365,233 @@ export const MetadataEditorModal: React.FC<MetadataEditorModalProps> = ({
       id: crypto.randomUUID(),
       type: 'model',
       name: '',
-      weight: 1.0,
+      weight: 1,
     };
-    setResources([...resources, newResource]);
+
+    updateField('resources', [...sanitizeResources(draft.resources), newResource]);
   };
 
   const removeResource = (id: string) => {
-    setResources(resources.filter((r) => r.id !== id));
+    const nextResources = sanitizeResources(draft.resources).filter((resource) => resource.id !== id);
+    updateField('resources', nextResources);
   };
 
-  const updateResource = (id: string, field: keyof ShadowResource, value: any) => {
-    setResources(
-      resources.map((r) => (r.id === id ? { ...r, [field]: value } : r))
+  const updateResource = <K extends keyof ShadowResource>(
+    id: string,
+    field: K,
+    value: ShadowResource[K]
+  ) => {
+    const nextResources = sanitizeResources(draft.resources).map((resource) =>
+      resource.id === id ? { ...resource, [field]: value } : resource
     );
+
+    updateField('resources', nextResources);
+  };
+
+  const handleSyncJsonFromForm = () => {
+    const serialized = serializeEditableMetadata(draft, tagsText);
+    setJsonEditorText(serialized);
+    setStatus({
+      tone: 'info',
+      text: 'Editable JSON refreshed from the current form fields.',
+    });
+  };
+
+  const handleApplyJsonText = () => {
+    try {
+      const { draft: nextDraft } = parseEditableMetadataInput(jsonEditorText, imageId);
+      setDraft(nextDraft);
+      setTagsText(formatTags(nextDraft.tags));
+      setJsonEditorText(serializeEditableMetadata(nextDraft, formatTags(nextDraft.tags)));
+      setStatus({
+        tone: 'success',
+        text: 'Editable metadata JSON applied to the form.',
+      });
+    } catch (error) {
+      setStatus({
+        tone: 'error',
+        text:
+          error instanceof Error
+            ? `Could not apply editable metadata JSON: ${error.message}`
+            : 'Could not apply editable metadata JSON.',
+      });
+    }
+  };
+
+  const handleCopyEditableMetadata = async () => {
+    const serialized = serializeEditableMetadata(draft, tagsText);
+    const portableMetadata = createPortableMetadata(draft, tagsText);
+
+    setIsCopying(true);
+    setStatus(null);
+
+    try {
+      if (onCopyEditableMetadata) {
+        await onCopyEditableMetadata(portableMetadata, serialized);
+      } else if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(serialized);
+      } else {
+        throw new Error('Clipboard access is not available in this context.');
+      }
+
+      setJsonEditorText(serialized);
+      setStatus({
+        tone: 'success',
+        text: 'Editable metadata copied. You can edit the JSON and paste it back later.',
+      });
+    } catch (error) {
+      setStatus({
+        tone: 'error',
+        text:
+          error instanceof Error
+            ? `Could not copy editable metadata: ${error.message}`
+            : 'Could not copy editable metadata.',
+      });
+    } finally {
+      setIsCopying(false);
+    }
+  };
+
+  const handlePasteEditableMetadata = async () => {
+    setIsPasting(true);
+    setStatus(null);
+
+    try {
+      const rawPastedValue = onPasteEditableMetadata
+        ? await onPasteEditableMetadata()
+        : navigator.clipboard && window.isSecureContext
+          ? await navigator.clipboard.readText()
+          : null;
+
+      if (!rawPastedValue) {
+        throw new Error('Clipboard did not return editable metadata.');
+      }
+
+      const { draft: pastedDraft, source } = parseEditableMetadataInput(rawPastedValue, imageId);
+      setDraft(pastedDraft);
+      setTagsText(formatTags(pastedDraft.tags));
+      setJsonEditorText(serializeEditableMetadata(pastedDraft, formatTags(pastedDraft.tags)));
+      setStatus({
+        tone: 'success',
+        text:
+          source === 'wrapped'
+            ? 'Editable metadata pasted from the portable Image MetaHub format.'
+            : 'Editable metadata pasted from plain JSON and applied to the form.',
+      });
+    } catch (error) {
+      setStatus({
+        tone: 'error',
+        text:
+          error instanceof Error
+            ? `Could not paste editable metadata: ${error.message}`
+            : 'Could not paste editable metadata.',
+      });
+    } finally {
+      setIsPasting(false);
+    }
+  };
+
+  const handleApplyToSelected = async () => {
+    if (!onApplyToSelected) {
+      return;
+    }
+
+    setIsSaving(true);
+    setStatus(null);
+
+    try {
+      const normalizedDraft = createPortableMetadata(draft, tagsText);
+      await onApplyToSelected({
+        ...normalizedDraft,
+        imageId,
+        updatedAt: Date.now(),
+      });
+      setStatus({
+        tone: 'success',
+        text: `Applied editable metadata to ${selectedImageCount} selected image${selectedImageCount === 1 ? '' : 's'}.`,
+      });
+    } catch (error) {
+      setStatus({
+        tone: 'error',
+        text:
+          error instanceof Error
+            ? `Could not apply metadata to selection: ${error.message}`
+            : 'Could not apply metadata to selection.',
+      });
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
-    <div 
+    <div
       className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
-      onClick={(e) => e.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
     >
-      <div className="bg-gray-900 border border-gray-700 rounded-xl w-full max-w-4xl max-h-[90vh] flex flex-col shadow-2xl">
-        {/* Header */}
+      <div className="bg-gray-900 border border-gray-700 rounded-xl w-full max-w-5xl max-h-[90vh] flex flex-col shadow-2xl">
         <div className="flex items-center justify-between p-4 border-b border-gray-800">
-          <h2 className="text-xl font-bold text-white flex items-center gap-2">
-            <span className="text-blue-400">Edit Metadata</span>
-            <span className="text-xs font-normal text-gray-500 bg-gray-800 px-2 py-1 rounded">
-              Overrides only
-            </span>
-          </h2>
+          <div className="space-y-1">
+            <h2 className="text-xl font-bold text-white flex items-center gap-2">
+              <span className="text-blue-400">Edit Metadata</span>
+              <span className="text-xs font-normal text-gray-500 bg-gray-800 px-2 py-1 rounded">
+                Overrides only
+              </span>
+            </h2>
+            <p className="text-xs text-gray-500">{FIELD_HELP_TEXT}</p>
+          </div>
+
           <button
             onClick={onClose}
             className="text-gray-400 hover:text-white transition-colors"
+            aria-label="Close metadata editor"
           >
             <X size={24} />
           </button>
         </div>
 
-        {/* Scrollable Content */}
         <div className="flex-1 overflow-y-auto p-6 space-y-8 custom-scrollbar">
-          
-          {/* Section 1: Essentials */}
           <section className="space-y-4">
             <h3 className="text-lg font-semibold text-gray-300 border-b border-gray-800 pb-2">
-              Essentials
+              Prompts
             </h3>
-            
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="col-span-1 md:col-span-2 space-y-2">
+
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
                 <label className="text-sm font-medium text-gray-400">Prompt</label>
                 <textarea
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value)}
-                  className="w-full bg-gray-800/50 border border-gray-700 rounded-lg p-3 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none text-sm min-h-[100px]"
+                  value={typeof draft.prompt === 'string' ? draft.prompt : ''}
+                  onChange={(event) => updateField('prompt', event.target.value)}
+                  className="w-full bg-gray-800/50 border border-gray-700 rounded-lg p-3 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none text-sm min-h-[120px]"
                   placeholder="Enter positive prompt..."
                 />
               </div>
 
-              <div className="col-span-1 md:col-span-2 space-y-2">
+              <div className="space-y-2">
                 <label className="text-sm font-medium text-gray-400">Negative Prompt</label>
                 <textarea
-                  value={negativePrompt}
-                  onChange={(e) => setNegativePrompt(e.target.value)}
-                  className="w-full bg-gray-800/50 border border-gray-700 rounded-lg p-3 text-red-200/80 focus:ring-2 focus:ring-red-500/50 focus:border-red-500 outline-none text-sm min-h-[80px]"
+                  value={typeof draft.negativePrompt === 'string' ? draft.negativePrompt : ''}
+                  onChange={(event) => updateField('negativePrompt', event.target.value)}
+                  className="w-full bg-gray-800/50 border border-gray-700 rounded-lg p-3 text-red-200/80 focus:ring-2 focus:ring-red-500/50 focus:border-red-500 outline-none text-sm min-h-[100px]"
                   placeholder="Enter negative prompt..."
+                />
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="text-lg font-semibold text-gray-300 border-b border-gray-800 pb-2">
+              Generation
+            </h3>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+              <div className="space-y-2 xl:col-span-2">
+                <label className="text-sm font-medium text-gray-400">Primary Model</label>
+                <input
+                  type="text"
+                  value={typeof draft.model === 'string' ? draft.model : ''}
+                  onChange={(event) => updateField('model', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="e.g. juggernautXL_v9"
                 />
               </div>
 
@@ -145,54 +599,155 @@ export const MetadataEditorModal: React.FC<MetadataEditorModalProps> = ({
                 <label className="text-sm font-medium text-gray-400">Seed</label>
                 <input
                   type="number"
-                  value={seed ?? ''}
-                  onChange={(e) => setSeed(e.target.value ? Number(e.target.value) : undefined)}
+                  value={draft.seed ?? ''}
+                  onChange={(event) => updateNumericField('seed', event.target.value)}
                   className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
                   placeholder="123456789"
                 />
               </div>
 
               <div className="space-y-2">
-                <label className="text-sm font-medium text-gray-400">Duration (sec)</label>
-                 <input
+                <label className="text-sm font-medium text-gray-400">Steps</label>
+                <input
                   type="number"
-                  value={duration ?? ''}
-                  onChange={(e) => setDuration(e.target.value ? Number(e.target.value) : undefined)}
+                  value={draft.steps ?? ''}
+                  onChange={(event) => updateNumericField('steps', event.target.value)}
                   className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
-                  placeholder="For videos (e.g. 5.5)"
+                  placeholder="28"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">CFG Scale</label>
+                <input
+                  type="number"
+                  value={draft.cfg_scale ?? ''}
+                  onChange={(event) => updateNumericField('cfg_scale', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="7"
                   step="0.1"
                 />
               </div>
 
-               <div className="grid grid-cols-2 gap-4">
-                 <div className="space-y-2">
-                    <label className="text-sm font-medium text-gray-400">Width</label>
-                    <input
-                      type="number"
-                      value={width ?? ''}
-                      onChange={(e) => setWidth(e.target.value ? Number(e.target.value) : undefined)}
-                      className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
-                      placeholder="1024"
-                    />
-                 </div>
-                 <div className="space-y-2">
-                    <label className="text-sm font-medium text-gray-400">Height</label>
-                    <input
-                      type="number"
-                      value={height ?? ''}
-                      onChange={(e) => setHeight(e.target.value ? Number(e.target.value) : undefined)}
-                      className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
-                      placeholder="1024"
-                    />
-                 </div>
-               </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Clip Skip</label>
+                <input
+                  type="number"
+                  value={draft.clip_skip ?? ''}
+                  onChange={(event) => updateNumericField('clip_skip', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="2"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Sampler</label>
+                <input
+                  type="text"
+                  value={typeof draft.sampler === 'string' ? draft.sampler : ''}
+                  onChange={(event) => updateField('sampler', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="Euler a"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Scheduler</label>
+                <input
+                  type="text"
+                  value={typeof draft.scheduler === 'string' ? draft.scheduler : ''}
+                  onChange={(event) => updateField('scheduler', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="normal"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Generator</label>
+                <input
+                  type="text"
+                  value={typeof draft.generator === 'string' ? draft.generator : ''}
+                  onChange={(event) => updateField('generator', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="ComfyUI / A1111 / InvokeAI..."
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Version</label>
+                <input
+                  type="text"
+                  value={typeof draft.version === 'string' ? draft.version : ''}
+                  onChange={(event) => updateField('version', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="Generator or model version"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Module</label>
+                <input
+                  type="text"
+                  value={typeof draft.module === 'string' ? draft.module : ''}
+                  onChange={(event) => updateField('module', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="Optional module or preset"
+                />
+              </div>
             </div>
           </section>
 
-          {/* Section 2: Resources */}
+          <section className="space-y-4">
+            <h3 className="text-lg font-semibold text-gray-300 border-b border-gray-800 pb-2">
+              Dimensions & Media
+            </h3>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Width</label>
+                <input
+                  type="number"
+                  value={draft.width ?? ''}
+                  onChange={(event) => updateNumericField('width', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="1024"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Height</label>
+                <input
+                  type="number"
+                  value={draft.height ?? ''}
+                  onChange={(event) => updateNumericField('height', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="1024"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Duration (sec)</label>
+                <input
+                  type="number"
+                  value={draft.duration ?? ''}
+                  onChange={(event) => updateNumericField('duration', event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg p-2 text-gray-200 focus:ring-2 focus:ring-blue-500 outline-none"
+                  placeholder="For video metadata"
+                  step="0.1"
+                />
+              </div>
+            </div>
+          </section>
+
           <section className="space-y-4">
             <div className="flex items-center justify-between border-b border-gray-800 pb-2">
-              <h3 className="text-lg font-semibold text-gray-300">Resources</h3>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-300">Resources</h3>
+                <p className="text-xs text-gray-500 mt-1">
+                  The first model resource remains the compatibility fallback for current viewers.
+                </p>
+              </div>
+
               <button
                 onClick={addResource}
                 className="flex items-center gap-1 text-xs bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded transition-colors"
@@ -200,97 +755,199 @@ export const MetadataEditorModal: React.FC<MetadataEditorModalProps> = ({
                 <Plus size={14} /> Add Resource
               </button>
             </div>
-            
+
             <div className="space-y-3">
-              {resources.length === 0 && (
+              {sanitizeResources(draft.resources).length === 0 && (
                 <div className="text-center py-6 text-gray-500 text-sm italic">
-                  No models or LoRAs added yet.
+                  No models, LoRAs, or embeddings added yet.
                 </div>
               )}
-              
-              {resources.map((res) => (
-                <div key={res.id} className="flex items-start gap-3 bg-gray-800/30 p-3 rounded-lg border border-gray-700/50 group">
-                   <div className="w-32 flex-shrink-0">
-                      <select
-                        value={res.type}
-                        onChange={(e) => updateResource(res.id, 'type', e.target.value)}
-                        className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-300 outline-none focus:border-blue-500"
-                      >
-                        <option value="model">Model</option>
-                        <option value="lora">LoRA</option>
-                        <option value="embedding">Embedding</option>
-                      </select>
-                   </div>
-                   
-                   <div className="flex-1 space-y-2">
-                      <input
-                        type="text"
-                        value={res.name}
-                        onChange={(e) => updateResource(res.id, 'name', e.target.value)}
-                        className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-200 outline-none focus:border-blue-500"
-                        placeholder="Resource Name (e.g. SDXL Base 1.0)"
-                      />
-                   </div>
 
-                   <div className="w-24 flex-shrink-0">
-                      <input
-                        type="number"
-                        value={res.weight ?? 1}
-                        onChange={(e) => updateResource(res.id, 'weight', parseFloat(e.target.value))}
-                        className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-200 outline-none focus:border-blue-500 text-center"
-                        step="0.1"
-                        placeholder="Weight"
-                      />
-                   </div>
+              {sanitizeResources(draft.resources).map((resource) => (
+                <div
+                  key={resource.id}
+                  className="flex items-start gap-3 bg-gray-800/30 p-3 rounded-lg border border-gray-700/50 group"
+                >
+                  <div className="w-32 flex-shrink-0">
+                    <select
+                      value={resource.type}
+                      onChange={(event) =>
+                        updateResource(resource.id, 'type', event.target.value as ShadowResource['type'])
+                      }
+                      className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-300 outline-none focus:border-blue-500"
+                    >
+                      <option value="model">Model</option>
+                      <option value="lora">LoRA</option>
+                      <option value="embedding">Embedding</option>
+                    </select>
+                  </div>
 
-                   <button
-                    onClick={() => removeResource(res.id)}
+                  <div className="flex-1 space-y-2">
+                    <input
+                      type="text"
+                      value={resource.name}
+                      onChange={(event) => updateResource(resource.id, 'name', event.target.value)}
+                      className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-200 outline-none focus:border-blue-500"
+                      placeholder="Resource name"
+                    />
+                  </div>
+
+                  <div className="w-24 flex-shrink-0">
+                    <input
+                      type="number"
+                      value={resource.weight ?? ''}
+                      onChange={(event) => updateResource(resource.id, 'weight', normalizeOptionalNumber(event.target.value))}
+                      className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-200 outline-none focus:border-blue-500 text-center"
+                      step="0.1"
+                      placeholder="Weight"
+                    />
+                  </div>
+
+                  <button
+                    onClick={() => removeResource(resource.id)}
                     className="text-gray-500 hover:text-red-400 p-1.5 transition-colors opacity-0 group-hover:opacity-100"
                     title="Remove resource"
-                   >
-                     <Trash2 size={16} />
-                   </button>
+                  >
+                    <Trash2 size={16} />
+                  </button>
                 </div>
               ))}
             </div>
           </section>
 
-          {/* Section 3: Workflow / Notes */}
           <section className="space-y-4">
             <h3 className="text-lg font-semibold text-gray-300 border-b border-gray-800 pb-2">
-              Workflow & Notes
+              Tags & Notes
             </h3>
-             <textarea
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                className="w-full bg-gray-800/50 border border-gray-700 rounded-lg p-3 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none text-sm min-h-[120px] font-mono"
-                placeholder="Describe your workflow, settings, or any other notes here..."
-              />
+
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Tags</label>
+                <textarea
+                  value={tagsText}
+                  onChange={(event) => setTagsText(event.target.value)}
+                  className="w-full bg-gray-800/50 border border-gray-700 rounded-lg p-3 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none text-sm min-h-[72px]"
+                  placeholder="Comma or line separated tags"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-400">Notes</label>
+                <textarea
+                  value={typeof draft.notes === 'string' ? draft.notes : ''}
+                  onChange={(event) => updateField('notes', event.target.value)}
+                  className="w-full bg-gray-800/50 border border-gray-700 rounded-lg p-3 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none text-sm min-h-[140px] font-mono"
+                  placeholder="Workflow notes, generation context, or anything else you want to keep locally..."
+                />
+              </div>
+            </div>
           </section>
 
+          <section className="space-y-4">
+            <div className="flex items-center justify-between border-b border-gray-800 pb-2">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-300">Editable JSON</h3>
+                <p className="text-xs text-gray-500 mt-1">
+                  Copy this block, tweak it elsewhere, then paste it back to replace the form.
+                </p>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  onClick={handleSyncJsonFromForm}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium text-gray-200 bg-gray-800 hover:bg-gray-700 transition-colors"
+                >
+                  <RefreshCw size={14} /> Refresh JSON
+                </button>
+
+                <button
+                  onClick={handleCopyEditableMetadata}
+                  disabled={isCopying}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium text-white bg-blue-600 hover:bg-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <Copy size={14} /> {isCopying ? 'Copying...' : 'Copy JSON'}
+                </button>
+
+                <button
+                  onClick={handlePasteEditableMetadata}
+                  disabled={isPasting}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium text-gray-200 bg-gray-800 hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <Clipboard size={14} /> {isPasting ? 'Pasting...' : 'Paste JSON'}
+                </button>
+              </div>
+            </div>
+
+            <textarea
+              value={jsonEditorText}
+              onChange={(event) => setJsonEditorText(event.target.value)}
+              className="w-full bg-gray-950 border border-gray-700 rounded-lg p-3 text-gray-200 focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 outline-none text-sm min-h-[280px] font-mono"
+              spellCheck={false}
+            />
+
+            <div className="flex justify-end">
+              <button
+                onClick={handleApplyJsonText}
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-500 transition-colors"
+              >
+                <Clipboard size={15} /> Apply JSON To Form
+              </button>
+            </div>
+          </section>
         </div>
 
-        {/* Footer */}
-        <div className="p-4 border-t border-gray-800 flex justify-end gap-3 bg-gray-900 rounded-b-xl">
-           <button
-            onClick={onClose}
-            className="px-4 py-2 rounded-lg text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={isSaving}
-            className="flex items-center gap-2 px-6 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isSaving ? (
-              'Saving...'
-            ) : (
-              <>
-                <Save size={16} /> Save Changes
-              </>
-            )}
-          </button>
+        <div className="p-4 border-t border-gray-800 bg-gray-900 rounded-b-xl">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="min-h-[40px]">
+              {status && (
+                <div className={`inline-flex items-start gap-2 px-3 py-2 rounded-lg border text-sm ${STATUS_STYLES[status.tone]}`}>
+                  <span>{status.text}</span>
+                </div>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-3">
+              {onExportEditedCopy && (
+                <button
+                  onClick={onExportEditedCopy}
+                  className="px-4 py-2 rounded-lg text-sm font-medium text-blue-200 hover:text-white hover:bg-blue-600/20 transition-colors"
+                >
+                  Export Edited Copy...
+                </button>
+              )}
+
+              {onApplyToSelected && selectedImageCount > 1 && (
+                <button
+                  onClick={handleApplyToSelected}
+                  disabled={isSaving}
+                  className="px-4 py-2 rounded-lg text-sm font-medium text-gray-200 hover:text-white hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Apply To Selected ({selectedImageCount})
+                </button>
+              )}
+
+              <button
+                onClick={onClose}
+                className="px-4 py-2 rounded-lg text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 transition-colors"
+              >
+                Cancel
+              </button>
+
+              <button
+                onClick={handleSave}
+                disabled={isSaving}
+                className="flex items-center gap-2 px-6 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSaving ? (
+                  'Saving...'
+                ) : (
+                  <>
+                    <Save size={16} /> Save Changes
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/electron.mjs
+++ b/electron.mjs
@@ -3482,15 +3482,22 @@ function setupFileOperationHandlers() {
             continue;
           }
 
-          const artifact = await createExportArtifact({
-            sourcePath,
-            relativePath: file.relativePath,
-            metadataPolicy,
-            targetFormat,
-            effectiveMetadata: file.effectiveMetadata,
-          });
-          const uniqueName = getUniqueName(artifact.fileName, usedNames);
-          archive.append(artifact.buffer, { name: uniqueName });
+          const uniqueName = getUniqueName(path.basename(file.relativePath), usedNames);
+          
+          // For preserved files, stream directly from disk to avoid buffering entire file in memory
+          if (metadataPolicy === 'preserve') {
+            archive.file(sourcePath, { name: uniqueName });
+          } else {
+            // For rewritten artifacts (strip, metahub_standard), process through createExportArtifact
+            const artifact = await createExportArtifact({
+              sourcePath,
+              relativePath: file.relativePath,
+              metadataPolicy,
+              targetFormat,
+              effectiveMetadata: file.effectiveMetadata,
+            });
+            archive.append(artifact.buffer, { name: uniqueName });
+          }
           exportedCount += 1;
         } catch (error) {
           console.warn('[Electron] Failed to export file to ZIP:', file?.relativePath, error);

--- a/electron.mjs
+++ b/electron.mjs
@@ -1396,6 +1396,241 @@ function setupFileOperationHandlers() {
     }
   };
 
+  const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const PNG_EXPORTABLE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+
+  const createCrc32Table = () => {
+    const table = new Uint32Array(256);
+    for (let index = 0; index < 256; index += 1) {
+      let value = index;
+      for (let bit = 0; bit < 8; bit += 1) {
+        value = (value & 1) !== 0 ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+      }
+      table[index] = value >>> 0;
+    }
+    return table;
+  };
+
+  const CRC32_TABLE = createCrc32Table();
+
+  const computeCrc32 = (buffer) => {
+    let crc = 0xffffffff;
+    for (const byte of buffer) {
+      crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+  };
+
+  const createPngChunk = (type, data) => {
+    const typeBuffer = Buffer.from(type, 'ascii');
+    const dataBuffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
+    const lengthBuffer = Buffer.alloc(4);
+    lengthBuffer.writeUInt32BE(dataBuffer.length, 0);
+    const crcBuffer = Buffer.alloc(4);
+    crcBuffer.writeUInt32BE(computeCrc32(Buffer.concat([typeBuffer, dataBuffer])), 0);
+    return Buffer.concat([lengthBuffer, typeBuffer, dataBuffer, crcBuffer]);
+  };
+
+  const createPngTextChunk = (keyword, text) => {
+    const keywordBuffer = Buffer.from(keyword, 'utf8');
+    const textBuffer = Buffer.from(text, 'utf8');
+    return createPngChunk('tEXt', Buffer.concat([keywordBuffer, Buffer.from([0]), textBuffer]));
+  };
+
+  const createPngInternationalTextChunk = (keyword, text) => {
+    const keywordBuffer = Buffer.from(keyword, 'utf8');
+    const textBuffer = Buffer.from(text, 'utf8');
+    return createPngChunk(
+      'iTXt',
+      Buffer.concat([
+        keywordBuffer,
+        Buffer.from([0, 0, 0, 0, 0]),
+        textBuffer,
+      ]),
+    );
+  };
+
+  const appendChunksToPng = (pngBuffer, chunks) => {
+    if (!Buffer.isBuffer(pngBuffer) || pngBuffer.length < PNG_SIGNATURE.length + 12) {
+      throw new Error('Invalid PNG buffer.');
+    }
+
+    if (!pngBuffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
+      throw new Error('PNG signature missing.');
+    }
+
+    let offset = PNG_SIGNATURE.length;
+    while (offset + 12 <= pngBuffer.length) {
+      const chunkLength = pngBuffer.readUInt32BE(offset);
+      const chunkType = pngBuffer.subarray(offset + 4, offset + 8).toString('ascii');
+      const chunkTotalLength = chunkLength + 12;
+      if (offset + chunkTotalLength > pngBuffer.length) {
+        break;
+      }
+
+      if (chunkType === 'IEND') {
+        return Buffer.concat([
+          pngBuffer.subarray(0, offset),
+          ...chunks,
+          pngBuffer.subarray(offset),
+        ]);
+      }
+
+      offset += chunkTotalLength;
+    }
+
+    throw new Error('PNG IEND chunk not found.');
+  };
+
+  const toLoraPayload = (loras) => {
+    if (!Array.isArray(loras)) {
+      return [];
+    }
+
+    return loras
+      .map((entry) => {
+        if (typeof entry === 'string') {
+          const name = entry.trim();
+          return name ? { name } : null;
+        }
+
+        if (!entry || typeof entry !== 'object') {
+          return null;
+        }
+
+        const name = typeof entry.name === 'string' && entry.name.trim()
+          ? entry.name.trim()
+          : (typeof entry.model_name === 'string' ? entry.model_name.trim() : '');
+        if (!name) {
+          return null;
+        }
+
+        const weight = Number.isFinite(entry.weight)
+          ? entry.weight
+          : Number.isFinite(entry.model_weight)
+            ? entry.model_weight
+            : undefined;
+
+        return weight !== undefined ? { name, weight } : { name };
+      })
+      .filter(Boolean);
+  };
+
+  const formatMetadataForA1111Compat = (metadata) => {
+    if (!metadata || typeof metadata.prompt !== 'string' || !metadata.prompt.trim()) {
+      throw new Error('Prompt is required to generate A1111-compatible metadata.');
+    }
+
+    const lines = [metadata.prompt.trim()];
+    if (typeof metadata.negativePrompt === 'string' && metadata.negativePrompt.trim()) {
+      lines.push(`Negative prompt: ${metadata.negativePrompt.trim()}`);
+    }
+
+    const params = [];
+    if (Number.isFinite(metadata.steps)) {
+      params.push(`Steps: ${metadata.steps}`);
+    }
+
+    const sampler = metadata.sampler || metadata.scheduler;
+    if (typeof sampler === 'string' && sampler.trim()) {
+      params.push(`Sampler: ${sampler.trim()}`);
+    }
+
+    if (Number.isFinite(metadata.cfg_scale)) {
+      params.push(`CFG scale: ${metadata.cfg_scale}`);
+    }
+
+    if (Number.isFinite(metadata.seed)) {
+      params.push(`Seed: ${metadata.seed}`);
+    }
+
+    if (Number.isFinite(metadata.width) && Number.isFinite(metadata.height) && metadata.width > 0 && metadata.height > 0) {
+      params.push(`Size: ${metadata.width}x${metadata.height}`);
+    }
+
+    if (typeof metadata.model === 'string' && metadata.model.trim()) {
+      params.push(`Model: ${metadata.model.trim()}`);
+    }
+
+    if (params.length > 0) {
+      lines.push(params.join(', '));
+    }
+
+    return lines.join('\n');
+  };
+
+  const buildMetaHubExportPayload = (metadata) => ({
+    generator: 'Image MetaHub',
+    source_generator: typeof metadata?.generator === 'string' ? metadata.generator : null,
+    exported_at: new Date().toISOString(),
+    prompt: typeof metadata?.prompt === 'string' ? metadata.prompt : '',
+    negativePrompt: typeof metadata?.negativePrompt === 'string' ? metadata.negativePrompt : '',
+    seed: Number.isFinite(metadata?.seed) ? metadata.seed : undefined,
+    steps: Number.isFinite(metadata?.steps) ? metadata.steps : undefined,
+    cfg: Number.isFinite(metadata?.cfg_scale) ? metadata.cfg_scale : undefined,
+    sampler_name: typeof metadata?.sampler === 'string' ? metadata.sampler : '',
+    scheduler: typeof metadata?.scheduler === 'string' ? metadata.scheduler : '',
+    model: typeof metadata?.model === 'string' ? metadata.model : '',
+    width: Number.isFinite(metadata?.width) ? metadata.width : 0,
+    height: Number.isFinite(metadata?.height) ? metadata.height : 0,
+    loras: toLoraPayload(metadata?.loras),
+    imh_pro: {
+      notes: typeof metadata?.notes === 'string' ? metadata.notes : '',
+      user_tags: Array.isArray(metadata?.tags) ? metadata.tags.join(', ') : '',
+    },
+  });
+
+  const buildPngExportBuffer = (pngBuffer, metadataPolicy, effectiveMetadata) => {
+    if (metadataPolicy === 'strip') {
+      return pngBuffer;
+    }
+
+    if (metadataPolicy !== 'metahub_standard') {
+      throw new Error(`Unsupported metadata export policy: ${metadataPolicy}`);
+    }
+
+    if (!effectiveMetadata) {
+      throw new Error('Edited metadata is required for MetaHub export.');
+    }
+
+    const metaHubPayload = buildMetaHubExportPayload(effectiveMetadata);
+    const parametersText = formatMetadataForA1111Compat(effectiveMetadata);
+    return appendChunksToPng(pngBuffer, [
+      createPngTextChunk('parameters', parametersText),
+      createPngInternationalTextChunk('imagemetahub_data', JSON.stringify(metaHubPayload)),
+    ]);
+  };
+
+  const createExportArtifact = async ({ sourcePath, relativePath, metadataPolicy = 'preserve', targetFormat = 'original', effectiveMetadata }) => {
+    if (metadataPolicy === 'preserve') {
+      const buffer = await fs.readFile(sourcePath);
+      return {
+        buffer,
+        fileName: path.basename(relativePath),
+      };
+    }
+
+    const sourceExtension = path.extname(relativePath).toLowerCase();
+    if (!PNG_EXPORTABLE_EXTENSIONS.has(sourceExtension)) {
+      throw new Error('This file format can only be exported with metadata preserved in v1.');
+    }
+
+    const image = nativeImage.createFromPath(sourcePath);
+    if (image.isEmpty()) {
+      throw new Error('Failed to decode source image for metadata export.');
+    }
+
+    const pngBuffer = image.toPNG();
+    const exportedBuffer = buildPngExportBuffer(pngBuffer, metadataPolicy, effectiveMetadata);
+    const targetExtension = targetFormat === 'original' && sourceExtension === '.png' ? '.png' : '.png';
+    const fileName = `${path.parse(relativePath).name}${targetExtension}`;
+
+    return {
+      buffer: exportedBuffer,
+      fileName,
+    };
+  };
+
   // --- Settings IPC ---
   ipcMain.handle('get-settings', async () => {
     const settings = await readSettings();
@@ -2829,7 +3064,13 @@ function setupFileOperationHandlers() {
     }
   });
 
-  ipcMain.handle('export-images-batch', async (event, { files, destDir, exportId } = {}) => {
+  ipcMain.handle('export-images-batch', async (event, {
+    files,
+    destDir,
+    exportId,
+    metadataPolicy = 'preserve',
+    targetFormat = 'original',
+  } = {}) => {
     try {
       if (!Array.isArray(files) || files.length === 0) {
         return { success: false, error: 'No files provided for export.', exportedCount: 0, failedCount: 0 };
@@ -2882,12 +3123,19 @@ function setupFileOperationHandlers() {
             continue;
           }
 
-          const baseName = path.basename(file.relativePath);
-          const uniqueName = getUniqueName(baseName, usedNames);
+          const artifact = await createExportArtifact({
+            sourcePath,
+            relativePath: file.relativePath,
+            metadataPolicy,
+            targetFormat,
+            effectiveMetadata: file.effectiveMetadata,
+          });
+          const uniqueName = getUniqueName(artifact.fileName, usedNames);
           const destPath = path.resolve(destDir, uniqueName);
-          await fs.copyFile(sourcePath, destPath);
+          await fs.writeFile(destPath, artifact.buffer);
           exportedCount += 1;
         } catch (error) {
+          console.warn('[Electron] Failed to export file to folder:', file?.relativePath, error);
           failedCount += 1;
         } finally {
           processedCount += 1;
@@ -2911,7 +3159,13 @@ function setupFileOperationHandlers() {
     }
   });
 
-  ipcMain.handle('export-images-zip', async (event, { files, destZipPath, exportId } = {}) => {
+  ipcMain.handle('export-images-zip', async (event, {
+    files,
+    destZipPath,
+    exportId,
+    metadataPolicy = 'preserve',
+    targetFormat = 'original',
+  } = {}) => {
     try {
       if (!Array.isArray(files) || files.length === 0) {
         return { success: false, error: 'No files provided for export.', exportedCount: 0, failedCount: 0 };
@@ -2975,12 +3229,18 @@ function setupFileOperationHandlers() {
             continue;
           }
 
-          await fs.access(sourcePath);
-          const baseName = path.basename(file.relativePath);
-          const uniqueName = getUniqueName(baseName, usedNames);
-          archive.file(sourcePath, { name: uniqueName });
+          const artifact = await createExportArtifact({
+            sourcePath,
+            relativePath: file.relativePath,
+            metadataPolicy,
+            targetFormat,
+            effectiveMetadata: file.effectiveMetadata,
+          });
+          const uniqueName = getUniqueName(artifact.fileName, usedNames);
+          archive.append(artifact.buffer, { name: uniqueName });
           exportedCount += 1;
         } catch (error) {
+          console.warn('[Electron] Failed to export file to ZIP:', file?.relativePath, error);
           failedCount += 1;
         } finally {
           processedCount += 1;

--- a/electron.mjs
+++ b/electron.mjs
@@ -1398,6 +1398,11 @@ function setupFileOperationHandlers() {
 
   const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
   const PNG_EXPORTABLE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+  const PNG_METADATA_CHUNKS = new Set(['tEXt', 'iTXt', 'zTXt', 'eXIf', 'tIME']);
+  const WEBP_METADATA_CHUNKS = new Set(['EXIF', 'XMP ']);
+  const WEBP_VP8X_EXIF_FLAG = 0x08;
+  const WEBP_VP8X_XMP_FLAG = 0x04;
+  const activeCanceledExportIds = new Set();
 
   const createCrc32Table = () => {
     const table = new Uint32Array(256);
@@ -1480,6 +1485,205 @@ function setupFileOperationHandlers() {
     }
 
     throw new Error('PNG IEND chunk not found.');
+  };
+
+  const stripMetadataFromPngBuffer = (pngBuffer) => {
+    if (!Buffer.isBuffer(pngBuffer) || pngBuffer.length < PNG_SIGNATURE.length + 12) {
+      throw new Error('Invalid PNG buffer.');
+    }
+
+    if (!pngBuffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
+      throw new Error('PNG signature missing.');
+    }
+
+    const outputChunks = [PNG_SIGNATURE];
+    let offset = PNG_SIGNATURE.length;
+
+    while (offset + 12 <= pngBuffer.length) {
+      const chunkLength = pngBuffer.readUInt32BE(offset);
+      const chunkTotalLength = chunkLength + 12;
+      if (offset + chunkTotalLength > pngBuffer.length) {
+        throw new Error('Corrupted PNG chunk layout.');
+      }
+
+      const chunkType = pngBuffer.subarray(offset + 4, offset + 8).toString('ascii');
+      const chunkBuffer = pngBuffer.subarray(offset, offset + chunkTotalLength);
+
+      if (!PNG_METADATA_CHUNKS.has(chunkType)) {
+        outputChunks.push(chunkBuffer);
+      }
+
+      offset += chunkTotalLength;
+
+      if (chunkType === 'IEND') {
+        return Buffer.concat(outputChunks);
+      }
+    }
+
+    throw new Error('PNG IEND chunk not found.');
+  };
+
+  const isJpegMarkerStandalone = (marker) => marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7);
+
+  const shouldKeepJpegAppSegment = (marker, segmentData) => {
+    if (marker === 0xe0) {
+      return (
+        segmentData.subarray(0, 5).equals(Buffer.from('JFIF\0', 'binary')) ||
+        segmentData.subarray(0, 5).equals(Buffer.from('JFXX\0', 'binary'))
+      );
+    }
+
+    if (marker === 0xe2) {
+      return segmentData.subarray(0, 12).equals(Buffer.from('ICC_PROFILE\0', 'binary'));
+    }
+
+    if (marker === 0xee) {
+      return segmentData.subarray(0, 5).equals(Buffer.from('Adobe', 'binary'));
+    }
+
+    return false;
+  };
+
+  const stripMetadataFromJpegBuffer = (jpegBuffer) => {
+    if (!Buffer.isBuffer(jpegBuffer) || jpegBuffer.length < 4) {
+      throw new Error('Invalid JPEG buffer.');
+    }
+
+    if (jpegBuffer[0] !== 0xff || jpegBuffer[1] !== 0xd8) {
+      throw new Error('JPEG SOI marker missing.');
+    }
+
+    const outputChunks = [jpegBuffer.subarray(0, 2)];
+    let offset = 2;
+
+    while (offset < jpegBuffer.length) {
+      if (jpegBuffer[offset] !== 0xff) {
+        outputChunks.push(jpegBuffer.subarray(offset));
+        break;
+      }
+
+      let markerOffset = offset + 1;
+      while (markerOffset < jpegBuffer.length && jpegBuffer[markerOffset] === 0xff) {
+        markerOffset += 1;
+      }
+
+      if (markerOffset >= jpegBuffer.length) {
+        break;
+      }
+
+      const marker = jpegBuffer[markerOffset];
+      const segmentStart = markerOffset - 1;
+
+      if (marker === 0xd9) {
+        outputChunks.push(jpegBuffer.subarray(segmentStart, markerOffset + 1));
+        break;
+      }
+
+      if (marker === 0xda) {
+        outputChunks.push(jpegBuffer.subarray(segmentStart));
+        break;
+      }
+
+      if (isJpegMarkerStandalone(marker)) {
+        outputChunks.push(jpegBuffer.subarray(segmentStart, markerOffset + 1));
+        offset = markerOffset + 1;
+        continue;
+      }
+
+      if (markerOffset + 2 >= jpegBuffer.length) {
+        throw new Error('Corrupted JPEG segment length.');
+      }
+
+      const segmentLength = jpegBuffer.readUInt16BE(markerOffset + 1);
+      const segmentEnd = markerOffset + 1 + segmentLength;
+      if (segmentLength < 2 || segmentEnd > jpegBuffer.length) {
+        throw new Error('Corrupted JPEG segment bounds.');
+      }
+
+      const fullSegment = jpegBuffer.subarray(segmentStart, segmentEnd);
+      const segmentData = jpegBuffer.subarray(markerOffset + 3, segmentEnd);
+      const isAppMarker = marker >= 0xe0 && marker <= 0xef;
+      const shouldDrop =
+        marker === 0xfe ||
+        (isAppMarker && !shouldKeepJpegAppSegment(marker, segmentData));
+
+      if (!shouldDrop) {
+        outputChunks.push(fullSegment);
+      }
+
+      offset = segmentEnd;
+    }
+
+    return Buffer.concat(outputChunks);
+  };
+
+  const createRiffChunk = (type, data) => {
+    const typeBuffer = Buffer.from(type, 'ascii');
+    const dataBuffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
+    const header = Buffer.alloc(8);
+    typeBuffer.copy(header, 0);
+    header.writeUInt32LE(dataBuffer.length, 4);
+    const padding = dataBuffer.length % 2 === 1 ? Buffer.from([0]) : Buffer.alloc(0);
+    return Buffer.concat([header, dataBuffer, padding]);
+  };
+
+  const stripMetadataFromWebpBuffer = (webpBuffer) => {
+    if (!Buffer.isBuffer(webpBuffer) || webpBuffer.length < 12) {
+      throw new Error('Invalid WebP buffer.');
+    }
+
+    if (webpBuffer.subarray(0, 4).toString('ascii') !== 'RIFF' || webpBuffer.subarray(8, 12).toString('ascii') !== 'WEBP') {
+      throw new Error('WEBP RIFF header missing.');
+    }
+
+    const outputChunks = [];
+    let offset = 12;
+
+    while (offset + 8 <= webpBuffer.length) {
+      const chunkType = webpBuffer.subarray(offset, offset + 4).toString('ascii');
+      const chunkSize = webpBuffer.readUInt32LE(offset + 4);
+      const paddedChunkSize = chunkSize + (chunkSize % 2);
+      const chunkEnd = offset + 8 + paddedChunkSize;
+
+      if (chunkEnd > webpBuffer.length) {
+        throw new Error('Corrupted WebP chunk bounds.');
+      }
+
+      if (!WEBP_METADATA_CHUNKS.has(chunkType)) {
+        if (chunkType === 'VP8X' && chunkSize >= 10) {
+          const vp8xData = Buffer.from(webpBuffer.subarray(offset + 8, offset + 8 + chunkSize));
+          vp8xData[0] &= ~(WEBP_VP8X_EXIF_FLAG | WEBP_VP8X_XMP_FLAG);
+          outputChunks.push(createRiffChunk('VP8X', vp8xData));
+        } else {
+          outputChunks.push(webpBuffer.subarray(offset, chunkEnd));
+        }
+      }
+
+      offset = chunkEnd;
+    }
+
+    const body = Buffer.concat(outputChunks);
+    const header = Buffer.alloc(12);
+    header.write('RIFF', 0, 'ascii');
+    header.writeUInt32LE(body.length + 4, 4);
+    header.write('WEBP', 8, 'ascii');
+    return Buffer.concat([header, body]);
+  };
+
+  const stripMetadataFromImageBuffer = (buffer, sourceExtension) => {
+    if (sourceExtension === '.png') {
+      return stripMetadataFromPngBuffer(buffer);
+    }
+
+    if (sourceExtension === '.jpg' || sourceExtension === '.jpeg') {
+      return stripMetadataFromJpegBuffer(buffer);
+    }
+
+    if (sourceExtension === '.webp') {
+      return stripMetadataFromWebpBuffer(buffer);
+    }
+
+    throw new Error('This file format can only be exported with metadata preserved in v1.');
   };
 
   const toLoraPayload = (loras) => {
@@ -1613,6 +1817,14 @@ function setupFileOperationHandlers() {
     const sourceExtension = path.extname(relativePath).toLowerCase();
     if (!PNG_EXPORTABLE_EXTENSIONS.has(sourceExtension)) {
       throw new Error('This file format can only be exported with metadata preserved in v1.');
+    }
+
+    if (metadataPolicy === 'strip' && targetFormat === 'original') {
+      const sourceBuffer = await fs.readFile(sourcePath);
+      return {
+        buffer: stripMetadataFromImageBuffer(sourceBuffer, sourceExtension),
+        fileName: path.basename(relativePath),
+      };
     }
 
     const image = nativeImage.createFromPath(sourcePath);
@@ -3064,6 +3276,15 @@ function setupFileOperationHandlers() {
     }
   });
 
+  ipcMain.handle('cancel-export-batch', async (event, { exportId } = {}) => {
+    if (!exportId) {
+      return { success: false, error: 'No export ID provided.' };
+    }
+
+    activeCanceledExportIds.add(String(exportId));
+    return { success: true };
+  });
+
   ipcMain.handle('export-images-batch', async (event, {
     files,
     destDir,
@@ -3112,10 +3333,17 @@ function setupFileOperationHandlers() {
           console.warn('[Electron] Failed to send export progress update', error);
         }
       };
+      const isCanceled = () => progressId ? activeCanceledExportIds.has(progressId) : false;
 
       sendProgress(true);
 
       for (const file of files) {
+        if (isCanceled()) {
+          stage = 'canceled';
+          sendProgress(true);
+          break;
+        }
+
         try {
           const sourcePath = path.resolve(file.directoryPath, file.relativePath);
           if (!isPathAllowed(sourcePath)) {
@@ -3143,8 +3371,21 @@ function setupFileOperationHandlers() {
         }
       }
 
-      stage = 'done';
+      const wasCanceled = isCanceled();
+      stage = wasCanceled ? 'canceled' : 'done';
       sendProgress(true);
+      if (progressId) {
+        activeCanceledExportIds.delete(progressId);
+      }
+
+      if (wasCanceled) {
+        return {
+          success: false,
+          exportedCount,
+          failedCount,
+          error: 'Export canceled.',
+        };
+      }
 
       const success = exportedCount > 0;
       return {
@@ -3154,6 +3395,9 @@ function setupFileOperationHandlers() {
         error: success ? undefined : 'No files were exported.',
       };
     } catch (error) {
+      if (exportId) {
+        activeCanceledExportIds.delete(String(exportId));
+      }
       console.error('Error exporting images in batch:', error);
       return { success: false, error: error.message, exportedCount: 0, failedCount: 0 };
     }
@@ -3207,6 +3451,7 @@ function setupFileOperationHandlers() {
           console.warn('[Electron] Failed to send export progress update', error);
         }
       };
+      const isCanceled = () => progressId ? activeCanceledExportIds.has(progressId) : false;
 
       const output = fsSync.createWriteStream(destZipPath);
       const archive = archiver('zip', { zlib: { level: 9 } });
@@ -3222,6 +3467,14 @@ function setupFileOperationHandlers() {
       sendProgress(true);
 
       for (const file of files) {
+        if (isCanceled()) {
+          stage = 'canceled';
+          sendProgress(true);
+          archive.abort();
+          output.destroy();
+          break;
+        }
+
         try {
           const sourcePath = path.resolve(file.directoryPath, file.relativePath);
           if (!isPathAllowed(sourcePath)) {
@@ -3248,6 +3501,22 @@ function setupFileOperationHandlers() {
         }
       }
 
+      const wasCanceled = isCanceled();
+      if (wasCanceled) {
+        try {
+          await fs.rm(destZipPath, { force: true });
+        } catch {}
+        if (progressId) {
+          activeCanceledExportIds.delete(progressId);
+        }
+        return {
+          success: false,
+          exportedCount,
+          failedCount,
+          error: 'Export canceled.',
+        };
+      }
+
       stage = 'finalizing';
       sendProgress(true);
 
@@ -3256,6 +3525,9 @@ function setupFileOperationHandlers() {
 
       stage = 'done';
       sendProgress(true);
+      if (progressId) {
+        activeCanceledExportIds.delete(progressId);
+      }
 
       const success = exportedCount > 0;
       return {
@@ -3265,6 +3537,9 @@ function setupFileOperationHandlers() {
         error: success ? undefined : 'No files were exported.',
       };
     } catch (error) {
+      if (exportId) {
+        activeCanceledExportIds.delete(String(exportId));
+      }
       console.error('Error exporting images to ZIP:', error);
       return { success: false, error: error.message, exportedCount: 0, failedCount: 0 };
     }

--- a/hooks/useContextMenu.ts
+++ b/hooks/useContextMenu.ts
@@ -3,6 +3,7 @@ import { type IndexedImage } from '../types';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
 import { A1111ApiClient } from '../services/a1111ApiClient';
 import { useSettingsStore } from '../store/useSettingsStore';
+import { useImageStore } from '../store/useImageStore';
 import { formatMetadataForA1111 } from '../utils/a1111Formatter';
 import { useA1111ProgressContext } from '../contexts/A1111ProgressContext';
 import { useFeatureAccess } from './useFeatureAccess';
@@ -42,6 +43,7 @@ const showNotification = (message: string) => {
 
 export const useContextMenu = () => {
   const contextMenuRef = useRef<HTMLDivElement | null>(null);
+  const selectedImages = useImageStore((state) => state.selectedImages);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     x: 0,
     y: 0,
@@ -227,13 +229,30 @@ export const useContextMenu = () => {
     showInExplorer(`${contextMenu.directoryPath}/${contextMenu.image.name}`);
   };
 
+  const getContextTargetImageIds = () => {
+    if (!contextMenu.image) {
+      return [];
+    }
+
+    if (selectedImages.has(contextMenu.image.id)) {
+      return Array.from(selectedImages);
+    }
+
+    return [contextMenu.image.id];
+  };
+
   const exportImage = () => {
     if (!contextMenu.image) return;
     hideContextMenu();
 
+    const imageIds = getContextTargetImageIds();
+    if (imageIds.length === 0) {
+      return;
+    }
+
     window.dispatchEvent(new CustomEvent(OPEN_BATCH_EXPORT_EVENT, {
       detail: {
-        imageIds: [contextMenu.image.id],
+        imageIds,
         preferredSource: 'selected',
       },
     }));

--- a/hooks/useContextMenu.ts
+++ b/hooks/useContextMenu.ts
@@ -26,6 +26,7 @@ interface ContextMenuState {
 }
 
 const CONTEXT_MENU_MARGIN = 8;
+const OPEN_BATCH_EXPORT_EVENT = 'imagemetahub:open-batch-export';
 
 const showNotification = (message: string) => {
   const notification = document.createElement('div');
@@ -226,62 +227,16 @@ export const useContextMenu = () => {
     showInExplorer(`${contextMenu.directoryPath}/${contextMenu.image.name}`);
   };
 
-  const exportImage = async () => {
-    if (!contextMenu.image || !contextMenu.directoryPath) return;
+  const exportImage = () => {
+    if (!contextMenu.image) return;
     hideContextMenu();
 
-    if (!window.electronAPI) {
-      alert('Export feature is only available in the desktop app version.');
-      return;
-    }
-
-    try {
-      // 1. Ask user for destination directory
-      const destResult = await window.electronAPI.showDirectoryDialog();
-      if (destResult.canceled || !destResult.path) {
-        return; // User cancelled
-      }
-      const destDir = destResult.path;
-
-      // Get safe paths using joinPaths
-      const sourcePathResult = await window.electronAPI.joinPaths(contextMenu.directoryPath, contextMenu.image.name);
-      if (!sourcePathResult.success || !sourcePathResult.path) {
-        throw new Error(`Failed to construct source path: ${sourcePathResult.error}`);
-      }
-
-      // Fix: Extract just the filename from the relative path to flatten the export structure
-      // image.name might be "subfolder/image.png", we just want "image.png" for the destination
-      const fileName = contextMenu.image.name.split(/[/\\]/).pop() || contextMenu.image.name;
-      
-      const destPathResult = await window.electronAPI.joinPaths(destDir, fileName);
-      if (!destPathResult.success || !destPathResult.path) {
-        throw new Error(`Failed to construct destination path: ${destPathResult.error}`);
-      }
-
-      const sourcePath = sourcePathResult.path;
-      const destPath = destPathResult.path;
-
-      // 2. Read the source file
-      const readResult = await window.electronAPI.readFile(sourcePath);
-      if (!readResult.success || !readResult.data) {
-        alert(`Failed to read original file: ${readResult.error}`);
-        return;
-      }
-
-      // 3. Write the new file
-      const writeResult = await window.electronAPI.writeFile(destPath, readResult.data);
-      if (!writeResult.success) {
-        alert(`Failed to export image: ${writeResult.error}`);
-        return;
-      }
-
-      // 4. Success!
-      alert(`Image exported successfully to: ${destPath}`);
-
-    } catch (error: unknown) {
-      console.error('Export error:', error);
-      alert(`An unexpected error occurred during export: ${error instanceof Error ? error.message : String(error)}`);
-    }
+    window.dispatchEvent(new CustomEvent(OPEN_BATCH_EXPORT_EVENT, {
+      detail: {
+        imageIds: [contextMenu.image.id],
+        preferredSource: 'selected',
+      },
+    }));
   };
 
   const copyMetadataToA1111 = async () => {

--- a/hooks/useCopyToA1111.ts
+++ b/hooks/useCopyToA1111.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { IndexedImage } from '../types';
+import { BaseMetadata, IndexedImage } from '../types';
 import { formatMetadataForA1111 } from '../utils/a1111Formatter';
 import {
   getClipboardErrorMessage,
@@ -18,8 +18,8 @@ export function useCopyToA1111() {
   const [isCopying, setIsCopying] = useState(false);
   const [copyStatus, setCopyStatus] = useState<CopyStatus | null>(null);
 
-  const copyToA1111 = useCallback(async (image: IndexedImage) => {
-    const metadata = getNormalizedMetadata(image);
+  const copyToA1111 = useCallback(async (image: IndexedImage, metadataOverride?: BaseMetadata) => {
+    const metadata = metadataOverride ?? getNormalizedMetadata(image);
 
     if (!hasPromptMetadata(metadata)) {
       setCopyStatus({

--- a/hooks/useCopyToComfyUI.ts
+++ b/hooks/useCopyToComfyUI.ts
@@ -4,8 +4,8 @@
  */
 
 import { useState, useCallback } from 'react';
-import { IndexedImage } from '../types';
-import { formatImageForComfyUI } from '../utils/comfyUIFormatter';
+import { BaseMetadata, IndexedImage } from '../types';
+import { formatImageForComfyUI, formatMetadataForComfyUI } from '../utils/comfyUIFormatter';
 import {
   getClipboardErrorMessage,
   getNormalizedMetadata,
@@ -23,8 +23,8 @@ export function useCopyToComfyUI() {
   const [isCopying, setIsCopying] = useState(false);
   const [copyStatus, setCopyStatus] = useState<CopyStatus | null>(null);
 
-  const copyToComfyUI = useCallback(async (image: IndexedImage) => {
-    const metadata = getNormalizedMetadata(image);
+  const copyToComfyUI = useCallback(async (image: IndexedImage, metadataOverride?: BaseMetadata) => {
+    const metadata = metadataOverride ?? getNormalizedMetadata(image);
     if (!hasPromptMetadata(metadata)) {
       setCopyStatus({
         success: false,
@@ -38,7 +38,9 @@ export function useCopyToComfyUI() {
     setCopyStatus(null);
 
     try {
-      const workflowJSON = formatImageForComfyUI(image);
+      const workflowJSON = metadataOverride
+        ? formatMetadataForComfyUI(metadataOverride)
+        : formatImageForComfyUI(image);
 
       // Copy to clipboard
       await navigator.clipboard.writeText(workflowJSON);

--- a/hooks/useShadowMetadata.ts
+++ b/hooks/useShadowMetadata.ts
@@ -6,6 +6,7 @@ import {
   saveShadowMetadata as saveToStorage,
   deleteShadowMetadata as deleteFromStorage,
 } from '../services/imageAnnotationsStorage';
+import { applyShadowMetadataUpdates } from '../utils/editableMetadata';
 
 export function useShadowMetadata(imageId?: string) {
   const [metadata, setMetadata] = useState<ShadowMetadata | null>(null);
@@ -54,13 +55,11 @@ export function useShadowMetadata(imageId?: string) {
       if (!imageId) return;
 
       try {
-        // Merge existing with updates
-        const newMetadata: ShadowMetadata = {
+        const newMetadata = applyShadowMetadataUpdates(metadata, {
+          ...updates,
           imageId,
           updatedAt: Date.now(),
-          ...(metadata || {}),
-          ...updates,
-        };
+        });
 
         await saveToStorage(newMetadata);
         setMetadata(newMetadata);

--- a/preload.js
+++ b/preload.js
@@ -142,6 +142,7 @@ const electronAPI = {
   writeFile: (filePath, data) => ipcRenderer.invoke('write-file', filePath, data),
   exportBatchToFolder: (args) => ipcRenderer.invoke('export-images-batch', args),
   exportBatchToZip: (args) => ipcRenderer.invoke('export-images-zip', args),
+  cancelBatchExport: (args) => ipcRenderer.invoke('cancel-export-batch', args),
   transferIndexedImages: (args) => ipcRenderer.invoke('transfer-indexed-images', args),
   deleteFile: (filePath) => ipcRenderer.invoke('delete-file', filePath),
   ensureDirectory: (dirPath) => ipcRenderer.invoke('ensure-directory', dirPath),

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+
+
+### Improved
+
+- **Viewer Metadata Actions**: Image Modal and Image Preview Sidebar now share clearer entry points for editing metadata, exporting edited copies, exporting without metadata, and switching between original and edited metadata views.
+- **Export Pipeline Consistency**: Unified desktop export handling behind a single request model so regular export, batch export, metadata stripping, and metadata rewrite all follow the same scope-aware workflow.
+- **MetaHub Standard Metadata Compatibility**: Standardized exported metadata payloads so files saved from edited metadata remain parseable by the app and keep compatibility with A1111-style generation parameter import.
+
 ## [0.15.0] - 2026-04-22
 
 ### Added
@@ -13,8 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Find Similar + Compare Flow**: Added a new `Find similar...` workflow in the grid, table, Image Modal, and Model View for finding prompt matches and related images across checkpoints, then sending the results directly into Compare Mode.
 - **Slideshow Mode**: Added fullscreen slideshow playback for the current selection or active browse scope, with keyboard controls plus configurable interval and filename overlay settings.
 - **Audio Library Support**: Added indexing, metadata extraction, filtering, library views, and in-app playback for common audio formats including MP3, WAV, FLAC, OGG/OGA, M4A, AAC, OPUS, AIFF/AIF, and WMA.
-- **Image Rename Workflows**: Added inline rename in the grid plus rename actions in grid/table context menus and the Image Modal, while preserving subfolders and original extensions.
-- **Indexed Subfolder Transfers**: Bulk copy/move actions can now target indexed subfolders, including nested folders and symlinked or aliased destinations.
+- **Editable Metadata Workflow**: Added a metadata editor for normalized generation fields in the viewer, including prompt, negative prompt, model, resources/LoRAs, seed, steps, CFG, sampler, scheduler, dimensions, and notes, while keeping edits local and reversible through shadow metadata.
 
 ### Improved
 
@@ -23,7 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Windowed Viewer UX**: Floating image windows are more reliable around focus, activation, dragging, offscreen recovery, footer layering, sidebar resizing, and optional minimize/restore motion.
 - **Selection and Navigation Scope**: Opening images from the grid, table, stacks, collections, or background-open actions now preserves multi-selection and keeps navigation tied to the active scope.
 - **Tagging and Filtering Workflow**: Added clear buttons to facet searches, kept mixed-selection tags available in batch tagging, and allowed clicking existing batch-tag chips to apply that tag to the full selection.
-- **Large Library Responsiveness**: Improved worst-case Smart Library clustering behavior and added optional performance diagnostics for troubleshooting search, grid, thumbnail, and viewer responsiveness.
+- **Image Rename Workflows**: Added inline rename in the grid plus rename actions in grid/table context menus and the Image Modal, while preserving subfolders and original extensions.
+- **Indexed Subfolder Transfers**: Bulk copy/move actions can now target indexed subfolders, including nested folders and symlinked or aliased destinations.
+- **Unified Export Metadata Policies**: Added a shared export flow for single-image and batch export with metadata policies to preserve original metadata, strip metadata entirely, or save a standardized `Image MetaHub + A1111` compatible PNG copy.
+- **Large Library Responsiveness**: Improved Smart Library clustering behavior and added optional performance diagnostics for troubleshooting search, grid, thumbnail, and viewer responsiveness.
 
 ### Fixed
 

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -1327,8 +1327,12 @@ export async function bulkSaveShadowMetadata(metadataRecords: ShadowMetadata[]):
     const store = transaction.objectStore(SHADOW_METADATA_STORE_NAME);
 
     for (const record of metadataRecords) {
+      const cleanedRecord = Object.fromEntries(
+        Object.entries(record).filter(([, value]) => value !== null && value !== undefined),
+      ) as ShadowMetadata;
+
       store.put({
-        ...record,
+        ...cleanedRecord,
         updatedAt: Date.now(),
       });
     }

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -1311,6 +1311,37 @@ export async function saveShadowMetadata(metadata: ShadowMetadata): Promise<void
 }
 
 /**
+ * Save shadow metadata for multiple images in a single transaction.
+ */
+export async function bulkSaveShadowMetadata(metadataRecords: ShadowMetadata[]): Promise<void> {
+  const db = await openDatabase();
+  if (!db || metadataRecords.length === 0) return;
+
+  return new Promise((resolve, reject) => {
+    if (!db.objectStoreNames.contains(SHADOW_METADATA_STORE_NAME)) {
+      reject(new Error('Shadow metadata store not found'));
+      return;
+    }
+
+    const transaction = db.transaction([SHADOW_METADATA_STORE_NAME], 'readwrite');
+    const store = transaction.objectStore(SHADOW_METADATA_STORE_NAME);
+
+    for (const record of metadataRecords) {
+      store.put({
+        ...record,
+        updatedAt: Date.now(),
+      });
+    }
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => {
+      console.error('Error bulk saving shadow metadata:', transaction.error);
+      reject(transaction.error);
+    };
+  });
+}
+
+/**
  * Delete shadow metadata for an image
  */
 export async function deleteShadowMetadata(imageId: string): Promise<void> {

--- a/services/metadataClipboard.ts
+++ b/services/metadataClipboard.ts
@@ -1,0 +1,63 @@
+import type { MetadataClipboardPayload } from '../types';
+import { buildMetadataClipboardPayload, sanitizeEditableMetadataFields } from '../utils/editableMetadata';
+
+const STORAGE_KEY = 'image-metahub-editable-metadata-clipboard';
+
+let memoryClipboard: MetadataClipboardPayload | null = null;
+
+const canUseStorage = (): boolean => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+export const copyEditableMetadata = (
+  metadata: MetadataClipboardPayload['metadata'],
+  sourceImageId?: string | null,
+): MetadataClipboardPayload => {
+  const payload = buildMetadataClipboardPayload(sourceImageId, metadata);
+  memoryClipboard = payload;
+
+  if (canUseStorage()) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  }
+
+  return payload;
+};
+
+export const readEditableMetadataClipboard = (): MetadataClipboardPayload | null => {
+  if (memoryClipboard) {
+    return memoryClipboard;
+  }
+
+  if (!canUseStorage()) {
+    return null;
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as MetadataClipboardPayload;
+    if (parsed?.schemaVersion !== 1 || !parsed.metadata) {
+      return null;
+    }
+
+    const payload: MetadataClipboardPayload = {
+      schemaVersion: 1,
+      copiedAt: typeof parsed.copiedAt === 'number' ? parsed.copiedAt : Date.now(),
+      sourceImageId: typeof parsed.sourceImageId === 'string' ? parsed.sourceImageId : null,
+      metadata: sanitizeEditableMetadataFields(parsed.metadata),
+    };
+    memoryClipboard = payload;
+    return payload;
+  } catch (error) {
+    console.warn('Failed to read editable metadata clipboard:', error);
+    return null;
+  }
+};
+
+export const clearEditableMetadataClipboard = (): void => {
+  memoryClipboard = null;
+  if (canUseStorage()) {
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+};

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -790,8 +790,9 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
     if (typeof rawData === 'object' && rawData !== null && rawData.imagemetahub_data) {
       const metahubData = rawData.imagemetahub_data;
 
-      // Verify it's valid MetaHub data (must have generator: "ComfyUI")
-      if (metahubData.generator === 'ComfyUI') {
+      // Support both the native MetaHub Save Node payload and Image MetaHub's
+      // normalized export payload written during Save As / strip workflows.
+      if (metahubData.generator === 'ComfyUI' || metahubData.generator === 'Image MetaHub') {
         // Extract tags from imh_pro.user_tags (comma-separated string)
         const userTags = metahubData.imh_pro?.user_tags
           ? metahubData.imh_pro.user_tags.split(',').map((tag: string) => tag.trim()).filter((tag: string) => tag)
@@ -858,7 +859,7 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
           lora: metahubData.loras?.map((l: any) => l.name) || [], // Backward compatibility
           tags: userTags,
           notes: userNotes,
-          generator: 'ComfyUI',
+          generator: metahubData.generator === 'ComfyUI' ? 'ComfyUI' : 'Image MetaHub',
           generationType,
           lineage,
           _detection_method: 'metahub_chunk',

--- a/services/parsers/metadataParserFactory.ts
+++ b/services/parsers/metadataParserFactory.ts
@@ -89,7 +89,11 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
     // MetaHub Save Node detection (PRIORITY: before generic ComfyUI)
     // Check for imagemetahub_data chunk (iTXt format from MetaHub Save Node)
     if ('imagemetahub_data' in metadata) {
-        console.log('🎯 Selected parser: ComfyUI (MetaHub Save Node)');
+        const metaHubGenerator = typeof (metadata as Record<string, any>).imagemetahub_data?.generator === 'string'
+            ? (metadata as Record<string, any>).imagemetahub_data.generator
+            : 'Image MetaHub';
+        const parserGenerator = metaHubGenerator === 'ComfyUI' ? 'ComfyUI' : 'Image MetaHub';
+        console.log(`🎯 Selected parser: ${parserGenerator} (MetaHub payload)`);
         return {
             parse: async (data: ComfyUIMetadata) => {
                 const result = await parseComfyUIMetadataEnhanced(data);
@@ -114,7 +118,7 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
                     _detection_method: result._detection_method,
                 } as BaseMetadata;
             },
-            generator: 'ComfyUI'
+            generator: parserGenerator
         };
     }
 

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -644,11 +644,11 @@ const createRenamedFileHandle = (
     nextFileName: string,
 ): FileSystemFileHandle => {
     const nextHandle = {
-        ...(handle as Record<string, unknown>),
+        ...(handle as unknown as Record<string, unknown>),
         name: nextFileName,
     } as ElectronFileHandleLike;
 
-    const electronAPI = typeof window !== 'undefined' ? (window as Window & { electronAPI?: { readFile?: (filePath: string) => Promise<{ success: boolean; data?: ArrayBuffer; error?: string }> } }).electronAPI : undefined;
+    const electronAPI = typeof window !== 'undefined' ? (window as unknown as Window & { electronAPI?: { readFile?: (filePath: string) => Promise<{ success: boolean; data?: Buffer; error?: string }> } }).electronAPI : undefined;
     const currentFilePath = typeof nextHandle._filePath === 'string' ? nextHandle._filePath : null;
 
     if (!currentFilePath || typeof electronAPI?.readFile !== 'function') {

--- a/types.ts
+++ b/types.ts
@@ -33,7 +33,7 @@ export interface ExportBatchProgress {
   processed: number;
   exportedCount: number;
   failedCount: number;
-  stage: 'copying' | 'finalizing' | 'done';
+  stage: 'copying' | 'finalizing' | 'done' | 'canceled';
 }
 
 export type MetadataExportPolicy = 'preserve' | 'strip' | 'metahub_standard';
@@ -154,6 +154,7 @@ export interface ElectronAPI {
   writeFile: (filePath: string, data: any) => Promise<{ success: boolean; error?: string }>;
   exportBatchToFolder: (args: ExportBatchRequest & { destDir: string }) => Promise<{ success: boolean; exportedCount: number; failedCount: number; error?: string }>;
   exportBatchToZip: (args: ExportBatchRequest & { destZipPath: string }) => Promise<{ success: boolean; exportedCount: number; failedCount: number; error?: string }>;
+  cancelBatchExport: (args: { exportId: string }) => Promise<{ success: boolean; error?: string }>;
   transferIndexedImages: (args: {
     files: { directoryPath: string; relativePath: string }[];
     destDir: string;

--- a/types.ts
+++ b/types.ts
@@ -36,6 +36,26 @@ export interface ExportBatchProgress {
   stage: 'copying' | 'finalizing' | 'done';
 }
 
+export type MetadataExportPolicy = 'preserve' | 'strip' | 'metahub_standard';
+export type ExportScope = 'single' | 'selected' | 'filtered' | 'folder';
+export type ExportTargetFormat = 'original' | 'png';
+
+export interface ExportFileDescriptor {
+  imageId?: string;
+  directoryPath: string;
+  relativePath: string;
+  effectiveMetadata?: BaseMetadata | null;
+}
+
+export interface ExportBatchRequest {
+  files: ExportFileDescriptor[];
+  exportId?: string;
+  metadataPolicy?: MetadataExportPolicy;
+  applyShadowEdits?: boolean;
+  scope?: ExportScope;
+  targetFormat?: ExportTargetFormat;
+}
+
 export type IndexedImageTransferMode = 'copy' | 'move';
 
 export interface IndexedImageTransferProgress {
@@ -132,8 +152,8 @@ export interface ElectronAPI {
   readVideoMetadata: (args: { filePath: string }) => Promise<{ success: boolean; comment?: string; description?: string; title?: string; video?: VideoInfo | null; audio?: AudioInfo | null; error?: string }>;
   getFileStats: (filePath: string) => Promise<{ success: boolean; stats?: any; error?: string }>;
   writeFile: (filePath: string, data: any) => Promise<{ success: boolean; error?: string }>;
-  exportBatchToFolder: (args: { files: { directoryPath: string; relativePath: string }[]; destDir: string; exportId?: string }) => Promise<{ success: boolean; exportedCount: number; failedCount: number; error?: string }>;
-  exportBatchToZip: (args: { files: { directoryPath: string; relativePath: string }[]; destZipPath: string; exportId?: string }) => Promise<{ success: boolean; exportedCount: number; failedCount: number; error?: string }>;
+  exportBatchToFolder: (args: ExportBatchRequest & { destDir: string }) => Promise<{ success: boolean; exportedCount: number; failedCount: number; error?: string }>;
+  exportBatchToZip: (args: ExportBatchRequest & { destZipPath: string }) => Promise<{ success: boolean; exportedCount: number; failedCount: number; error?: string }>;
   transferIndexedImages: (args: {
     files: { directoryPath: string; relativePath: string }[];
     destDir: string;
@@ -222,20 +242,37 @@ export interface ShadowResource {
   weight?: number;
 }
 
-export interface ShadowMetadata {
-  imageId: string; // Key, links to IndexedImage.id
-  // Essentials
+export interface EditableMetadataFields {
   prompt?: string;
   negativePrompt?: string;
+  model?: string;
   seed?: number;
+  steps?: number;
+  cfg_scale?: number;
+  clip_skip?: number;
+  sampler?: string;
+  scheduler?: string;
+  generator?: string;
+  version?: string;
+  module?: string;
   width?: number;
   height?: number;
   duration?: number;
-  // Resources
   resources?: ShadowResource[];
-  // Workflow
+  tags?: string[];
   notes?: string;
+}
+
+export interface ShadowMetadata extends EditableMetadataFields {
+  imageId: string; // Key, links to IndexedImage.id
   updatedAt: number;
+}
+
+export interface MetadataClipboardPayload {
+  schemaVersion: 1;
+  copiedAt: number;
+  sourceImageId?: string | null;
+  metadata: EditableMetadataFields;
 }
 
 export type Automatic1111Metadata = Omit<SharedAutomatic1111Metadata, 'normalizedMetadata'> & {

--- a/utils/editableMetadata.ts
+++ b/utils/editableMetadata.ts
@@ -146,6 +146,33 @@ export const sanitizeEditableMetadataFields = (
   };
 };
 
+export const applyShadowMetadataUpdates = (
+  existing: ShadowMetadata | null | undefined,
+  updates: Partial<EditableMetadataFields> & { imageId?: string; updatedAt?: number },
+): ShadowMetadata => {
+  const nextMetadata: Record<string, unknown> = {
+    ...(existing ?? {}),
+  };
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (key === 'imageId' || key === 'updatedAt') {
+      continue;
+    }
+
+    if (value === null || value === undefined) {
+      delete nextMetadata[key];
+      continue;
+    }
+
+    nextMetadata[key] = value;
+  }
+
+  nextMetadata.imageId = typeof updates.imageId === 'string' && updates.imageId ? updates.imageId : (existing?.imageId ?? '');
+  nextMetadata.updatedAt = Number.isFinite(updates.updatedAt) ? updates.updatedAt : Date.now();
+
+  return nextMetadata as unknown as ShadowMetadata;
+};
+
 const getMetadataNotes = (metadata?: BaseMetadata | null): string | undefined => {
   if (!metadata) {
     return undefined;

--- a/utils/editableMetadata.ts
+++ b/utils/editableMetadata.ts
@@ -1,0 +1,280 @@
+import type {
+  BaseMetadata,
+  EditableMetadataFields,
+  LoRAInfo,
+  MetadataClipboardPayload,
+  ShadowMetadata,
+  ShadowResource,
+} from '../types';
+
+type BaseMetadataWithNotes = BaseMetadata & {
+  notes?: string;
+  tags?: string[];
+  clip_skip?: number;
+  _metahub_pro?: {
+    notes?: string;
+  } | null;
+};
+
+const DEFAULT_BASE_METADATA: BaseMetadata = {
+  prompt: '',
+  model: '',
+  width: 0,
+  height: 0,
+  steps: 0,
+  scheduler: '',
+};
+
+const coerceFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+};
+
+const toResourceName = (lora: string | LoRAInfo): string => {
+  if (typeof lora === 'string') {
+    return lora;
+  }
+
+  return lora.name || lora.model_name || 'Unknown resource';
+};
+
+const toResourceWeight = (lora: string | LoRAInfo): number | undefined => {
+  if (typeof lora === 'string') {
+    return undefined;
+  }
+
+  return coerceFiniteNumber(lora.weight ?? lora.model_weight ?? lora.clip_weight);
+};
+
+export const buildResourcesFromMetadata = (metadata?: BaseMetadata | null): ShadowResource[] => {
+  if (!metadata) {
+    return [];
+  }
+
+  const resources: ShadowResource[] = [];
+
+  if (metadata.model) {
+    resources.push({
+      id: crypto.randomUUID(),
+      type: 'model',
+      name: metadata.model,
+    });
+  }
+
+  for (const lora of metadata.loras ?? []) {
+    resources.push({
+      id: crypto.randomUUID(),
+      type: 'lora',
+      name: toResourceName(lora),
+      weight: toResourceWeight(lora),
+    });
+  }
+
+  return resources;
+};
+
+export const sanitizeEditableMetadataFields = (
+  fields?: Partial<EditableMetadataFields> | null,
+): EditableMetadataFields => {
+  if (!fields) {
+    return {};
+  }
+
+  const resources = Array.isArray(fields.resources)
+    ? fields.resources
+        .map((resource) => {
+          const name = typeof resource?.name === 'string' ? resource.name.trim() : '';
+          if (!name) {
+            return null;
+          }
+
+          const type = resource.type === 'embedding' || resource.type === 'model' ? resource.type : 'lora';
+          const weight = coerceFiniteNumber(resource.weight);
+
+          return {
+            id: resource.id || crypto.randomUUID(),
+            type,
+            name,
+            ...(weight !== undefined ? { weight } : {}),
+          } satisfies ShadowResource;
+        })
+        .filter((resource): resource is ShadowResource => Boolean(resource))
+    : undefined;
+
+  const prompt = typeof fields.prompt === 'string' ? fields.prompt : undefined;
+  const negativePrompt = typeof fields.negativePrompt === 'string' ? fields.negativePrompt : undefined;
+  const model = typeof fields.model === 'string' && fields.model.trim() ? fields.model.trim() : undefined;
+  const sampler = typeof fields.sampler === 'string' && fields.sampler.trim() ? fields.sampler.trim() : undefined;
+  const scheduler = typeof fields.scheduler === 'string' && fields.scheduler.trim() ? fields.scheduler.trim() : undefined;
+  const notes = typeof fields.notes === 'string' ? fields.notes : undefined;
+  const generator = typeof fields.generator === 'string' && fields.generator.trim() ? fields.generator.trim() : undefined;
+  const version = typeof fields.version === 'string' && fields.version.trim() ? fields.version.trim() : undefined;
+  const module = typeof fields.module === 'string' && fields.module.trim() ? fields.module.trim() : undefined;
+  const tags = Array.isArray(fields.tags)
+    ? fields.tags.map((tag) => String(tag).trim()).filter(Boolean)
+    : undefined;
+
+  return {
+    ...(prompt !== undefined ? { prompt } : {}),
+    ...(negativePrompt !== undefined ? { negativePrompt } : {}),
+    ...(model !== undefined ? { model } : {}),
+    ...(coerceFiniteNumber(fields.seed) !== undefined ? { seed: coerceFiniteNumber(fields.seed) } : {}),
+    ...(coerceFiniteNumber(fields.steps) !== undefined ? { steps: coerceFiniteNumber(fields.steps) } : {}),
+    ...(coerceFiniteNumber(fields.cfg_scale) !== undefined ? { cfg_scale: coerceFiniteNumber(fields.cfg_scale) } : {}),
+    ...(coerceFiniteNumber(fields.clip_skip) !== undefined ? { clip_skip: coerceFiniteNumber(fields.clip_skip) } : {}),
+    ...(sampler !== undefined ? { sampler } : {}),
+    ...(scheduler !== undefined ? { scheduler } : {}),
+    ...(generator !== undefined ? { generator } : {}),
+    ...(version !== undefined ? { version } : {}),
+    ...(module !== undefined ? { module } : {}),
+    ...(coerceFiniteNumber(fields.width) !== undefined ? { width: coerceFiniteNumber(fields.width) } : {}),
+    ...(coerceFiniteNumber(fields.height) !== undefined ? { height: coerceFiniteNumber(fields.height) } : {}),
+    ...(coerceFiniteNumber(fields.duration) !== undefined ? { duration: coerceFiniteNumber(fields.duration) } : {}),
+    ...(resources && resources.length > 0 ? { resources } : {}),
+    ...(tags && tags.length > 0 ? { tags } : {}),
+    ...(notes !== undefined ? { notes } : {}),
+  };
+};
+
+const getMetadataNotes = (metadata?: BaseMetadata | null): string | undefined => {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const meta = metadata as BaseMetadataWithNotes;
+  return meta.notes ?? meta._metahub_pro?.notes;
+};
+
+const getShadowModel = (shadow?: ShadowMetadata | null): string | undefined =>
+  shadow?.model ?? shadow?.resources?.find((resource) => resource.type === 'model')?.name;
+
+const getShadowLoraResources = (shadow?: ShadowMetadata | null): ShadowResource[] | undefined => {
+  if (!shadow?.resources?.length) {
+    return undefined;
+  }
+
+  return shadow.resources.filter((resource) => resource.type !== 'model');
+};
+
+export const getEditableMetadataFields = (
+  metadata?: BaseMetadata | null,
+  shadowMetadata?: ShadowMetadata | null,
+): EditableMetadataFields => {
+  const shadowResources = shadowMetadata?.resources;
+  const baseResources = buildResourcesFromMetadata(metadata);
+
+  return sanitizeEditableMetadataFields({
+    prompt: shadowMetadata?.prompt ?? metadata?.prompt,
+    negativePrompt: shadowMetadata?.negativePrompt ?? metadata?.negativePrompt,
+    model: getShadowModel(shadowMetadata) ?? metadata?.model,
+    seed: shadowMetadata?.seed ?? metadata?.seed,
+    steps: shadowMetadata?.steps ?? metadata?.steps,
+    cfg_scale: shadowMetadata?.cfg_scale ?? metadata?.cfg_scale,
+    clip_skip: shadowMetadata?.clip_skip ?? (metadata as BaseMetadataWithNotes | undefined)?.clip_skip,
+    sampler: shadowMetadata?.sampler ?? metadata?.sampler,
+    scheduler: shadowMetadata?.scheduler ?? metadata?.scheduler,
+    generator: shadowMetadata?.generator ?? metadata?.generator,
+    version: shadowMetadata?.version ?? metadata?.version,
+    module: shadowMetadata?.module ?? metadata?.module,
+    width: shadowMetadata?.width ?? metadata?.width,
+    height: shadowMetadata?.height ?? metadata?.height,
+    duration: shadowMetadata?.duration,
+    resources: shadowResources && shadowResources.length > 0 ? shadowResources : baseResources,
+    tags: shadowMetadata?.tags ?? (metadata as BaseMetadataWithNotes | undefined)?.tags,
+    notes: shadowMetadata?.notes ?? getMetadataNotes(metadata),
+  });
+};
+
+const mapResourcesToLoras = (resources?: ShadowResource[]): Array<string | LoRAInfo> | undefined => {
+  if (!resources?.length) {
+    return undefined;
+  }
+
+  const loras = resources
+    .filter((resource) => resource.type !== 'model')
+    .map((resource) => (
+      resource.weight !== undefined
+        ? { name: resource.name, weight: resource.weight }
+        : resource.name
+    ));
+
+  return loras.length > 0 ? loras : [];
+};
+
+export const buildEffectiveMetadata = (
+  metadata?: BaseMetadata | null,
+  shadowMetadata?: ShadowMetadata | null,
+  showOriginal = false,
+): BaseMetadata | undefined => {
+  if (showOriginal) {
+    return metadata ?? undefined;
+  }
+
+  if (!metadata && !shadowMetadata) {
+    return undefined;
+  }
+
+  const editable = getEditableMetadataFields(metadata, shadowMetadata);
+  const base: BaseMetadata = metadata ? { ...metadata } : { ...DEFAULT_BASE_METADATA };
+  const shadowModel = getShadowModel(shadowMetadata);
+  const shadowLoras = getShadowLoraResources(shadowMetadata);
+
+  const nextMetadata: BaseMetadataWithNotes = {
+    ...base,
+    prompt: editable.prompt ?? base.prompt,
+    negativePrompt: editable.negativePrompt ?? base.negativePrompt,
+    model: shadowModel ?? editable.model ?? base.model,
+    width: editable.width ?? base.width,
+    height: editable.height ?? base.height,
+    seed: editable.seed ?? base.seed,
+    steps: editable.steps ?? base.steps,
+    cfg_scale: editable.cfg_scale ?? base.cfg_scale,
+    clip_skip: editable.clip_skip ?? (base as BaseMetadataWithNotes).clip_skip,
+    sampler: editable.sampler ?? base.sampler,
+    scheduler: editable.scheduler ?? base.scheduler,
+    generator: editable.generator ?? base.generator,
+    version: editable.version ?? base.version,
+    module: editable.module ?? base.module,
+    tags: editable.tags ?? (base as BaseMetadataWithNotes).tags,
+    notes: editable.notes ?? getMetadataNotes(base),
+  };
+
+  if (nextMetadata.model) {
+    nextMetadata.models = [nextMetadata.model];
+  }
+
+  if (shadowMetadata?.resources) {
+    nextMetadata.loras = mapResourcesToLoras(shadowLoras);
+  }
+
+  return nextMetadata;
+};
+
+export const buildShadowMetadata = (
+  imageId: string,
+  fields: Partial<EditableMetadataFields>,
+): ShadowMetadata => ({
+  imageId,
+  ...sanitizeEditableMetadataFields(fields),
+  updatedAt: Date.now(),
+});
+
+export const buildMetadataClipboardPayload = (
+  imageId: string | null | undefined,
+  fields: Partial<EditableMetadataFields>,
+): MetadataClipboardPayload => ({
+  schemaVersion: 1,
+  copiedAt: Date.now(),
+  sourceImageId: imageId ?? null,
+  metadata: sanitizeEditableMetadataFields(fields),
+});


### PR DESCRIPTION
## Summary
- Adds a richer local metadata editor with shadow metadata and editable clipboard support.
- Unifies export flows with metadata policies for preserve, strip, and MetaHub+A1111 exports.
- Improves viewer/sidebar entry points and adds cancelable export handling.

## Verification
- `npx tsc --noEmit`
- `npm run build`
- targeted Vitest runs for the new metadata and context menu flows.