### PR TITLE
Fix search OOM by compacting worker sync payload

### DIFF
--- a/__tests__/useImageStore.filters.test.ts
+++ b/__tests__/useImageStore.filters.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Directory, IndexedImage } from '../types';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -106,6 +106,78 @@ const imageI = createImage({
   lastModified: new Date(2026, 3, 3, 22, 0, 0, 0).getTime(),
 });
 
+const mockWorkerInstances: MockSearchWorker[] = [];
+
+class MockSearchWorker {
+  onmessage: ((event: MessageEvent<any>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readonly postMessage = vi.fn((message: any) => {
+    if (message?.type === 'syncDataset') {
+      this.dataset = message.payload.images;
+      return;
+    }
+
+    if (message?.type === 'compute') {
+      const filteredIds = this.computeFilteredIds(message.payload.criteria.searchQuery);
+      queueMicrotask(() => {
+        this.onmessage?.({
+          data: {
+            type: 'complete',
+            payload: {
+              criteriaKey: message.payload.criteriaKey,
+              filteredIds,
+              facets: {
+                availableModels: [],
+                availableLoras: [],
+                availableSamplers: [],
+                availableSchedulers: [],
+                availableGenerators: [],
+                availableGpuDevices: [],
+                availableDimensions: [],
+                modelFacetCounts: [],
+                loraFacetCounts: [],
+                samplerFacetCounts: [],
+                schedulerFacetCounts: [],
+              },
+            },
+          },
+        } as MessageEvent);
+      });
+    }
+  });
+  readonly terminate = vi.fn();
+  private dataset: Array<{ id: string; catalogText: string; searchText: string }> = [];
+
+  constructor() {
+    mockWorkerInstances.push(this);
+  }
+
+  private computeFilteredIds(searchQuery: string): string[] {
+    const terms = searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+    if (terms.length === 0) {
+      return this.dataset.map((image) => image.id);
+    }
+
+    return this.dataset
+      .filter((image) => {
+        const catalogMatch = terms.every((term) => image.catalogText.includes(term));
+        if (catalogMatch) {
+          return true;
+        }
+        if (!image.searchText) {
+          return false;
+        }
+        return terms.every((term) => image.searchText.includes(term));
+      })
+      .map((image) => image.id);
+  }
+}
+
+const flushSearchWorker = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
 const seedStore = () => {
   useSettingsStore.setState({
     enableSafeMode: false,
@@ -125,7 +197,15 @@ const seedStore = () => {
 
 describe('useImageStore tri-state filters', () => {
   beforeEach(() => {
+    vi.stubGlobal('Worker', MockSearchWorker as unknown as typeof Worker);
+    mockWorkerInstances.length = 0;
     seedStore();
+  });
+
+  afterEach(() => {
+    useImageStore.getState().resetState();
+    vi.unstubAllGlobals();
+    mockWorkerInstances.length = 0;
   });
 
   it('filters favorites with include and exclude modes', () => {
@@ -172,6 +252,80 @@ describe('useImageStore tri-state filters', () => {
     });
 
     expect(useImageStore.getState().filteredImages.map((image) => image.name)).toEqual(['a.png']);
+  });
+
+  it('searches prompt, model, lora, scheduler, and workflow node terms through the compact worker corpus', async () => {
+    const searchable = createImage({
+      id: 'dir-1::searchable.png',
+      name: 'searchable.png',
+      prompt: 'Galactic cat portrait',
+      models: ['NovaXL'],
+      loras: ['detailer'],
+      scheduler: 'karras',
+      workflowNodes: ['KSampler', 'CLIPTextEncode'],
+      metadataString: '{"workflow":{"huge":"blob"}}',
+      enrichmentState: 'enriched',
+    });
+    const plain = createImage({
+      id: 'dir-1::plain.png',
+      name: 'plain.png',
+      prompt: 'forest landscape',
+      models: ['OtherModel'],
+      loras: ['other-lora'],
+      scheduler: 'normal',
+      workflowNodes: ['LoadImage'],
+      enrichmentState: 'enriched',
+    });
+
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      directories: [directory],
+      images: [searchable, plain],
+      filteredImages: [searchable, plain],
+      sortOrder: 'asc',
+    });
+
+    useImageStore.getState().setSearchQuery('galactic');
+    await flushSearchWorker();
+    expect(useImageStore.getState().filteredImages.map((image) => image.name)).toEqual(['searchable.png']);
+
+    useImageStore.getState().setSearchQuery('novaxl');
+    await flushSearchWorker();
+    expect(useImageStore.getState().filteredImages.map((image) => image.name)).toEqual(['searchable.png']);
+
+    useImageStore.getState().setSearchQuery('detailer');
+    await flushSearchWorker();
+    expect(useImageStore.getState().filteredImages.map((image) => image.name)).toEqual(['searchable.png']);
+
+    useImageStore.getState().setSearchQuery('karras');
+    await flushSearchWorker();
+    expect(useImageStore.getState().filteredImages.map((image) => image.name)).toEqual(['searchable.png']);
+
+    useImageStore.getState().setSearchQuery('ksampler');
+    await flushSearchWorker();
+    expect(useImageStore.getState().filteredImages.map((image) => image.name)).toEqual(['searchable.png']);
+  });
+
+  it('does not match search terms that exist only inside raw metadata JSON blobs', async () => {
+    const rawOnly = createImage({
+      id: 'dir-1::raw-only.png',
+      name: 'raw-only.png',
+      metadataString: '{"workflow":{"secret_token":"raw-json-only-marker"}}',
+      enrichmentState: 'enriched',
+    });
+
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      directories: [directory],
+      images: [rawOnly],
+      filteredImages: [rawOnly],
+      sortOrder: 'asc',
+    });
+
+    useImageStore.getState().setSearchQuery('raw-json-only-marker');
+    await flushSearchWorker();
+
+    expect(useImageStore.getState().filteredImages).toEqual([]);
   });
 
   it('matches LoRA filters when metadata only provides model_name', () => {

--- a/__tests__/useImageStore.search-worker.test.ts
+++ b/__tests__/useImageStore.search-worker.test.ts
@@ -44,7 +44,7 @@ class MockSearchWorker {
             type: 'complete',
             payload: {
               criteriaKey: message.payload.criteriaKey,
-              filteredIds: this.dataset.map((image) => image.id),
+              filteredIds: this.computeFilteredIds(message.payload.criteria.searchQuery),
               facets: {
                 availableModels: [],
                 availableLoras: [],
@@ -65,10 +65,34 @@ class MockSearchWorker {
     }
   });
   readonly terminate = vi.fn();
-  private dataset: Array<Record<string, unknown>> = [];
+  private dataset: Array<{ id: string; catalogText?: string; searchText?: string }> = [];
 
   constructor() {
     mockWorkerInstances.push(this);
+  }
+
+  private computeFilteredIds(searchQuery: string): string[] {
+    const terms = searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+    if (terms.length === 0) {
+      return this.dataset.map((image) => image.id);
+    }
+
+    return this.dataset
+      .filter((image) => {
+        const catalogText = image.catalogText ?? '';
+        const searchText = image.searchText ?? '';
+        const catalogMatch = terms.every((term) => catalogText.includes(term));
+        if (catalogMatch) {
+          return true;
+        }
+
+        if (!searchText) {
+          return false;
+        }
+
+        return terms.every((term) => searchText.includes(term));
+      })
+      .map((image) => image.id);
   }
 }
 
@@ -154,6 +178,21 @@ describe('useImageStore search worker sync', () => {
 
     expect(worker.postMessage.mock.calls.filter(([message]) => message.type === 'syncDataset')).toHaveLength(2);
     expect(worker.postMessage.mock.calls.filter(([message]) => message.type === 'compute')).toHaveLength(2);
+  });
+
+  it('re-syncs after direct image mutations so the next search sees fresh fields', async () => {
+    useImageStore.getState().setSearchQuery('cat');
+    await flushWorker();
+
+    const worker = mockWorkerInstances[0];
+    expect(worker.postMessage.mock.calls.filter(([message]) => message.type === 'syncDataset')).toHaveLength(1);
+
+    await useImageStore.getState().addTagToImage('dir-1::cat.png', 'fresh-tag');
+    useImageStore.getState().setSearchQuery('fresh-tag');
+    await flushWorker();
+
+    expect(worker.postMessage.mock.calls.filter(([message]) => message.type === 'syncDataset')).toHaveLength(2);
+    expect(useImageStore.getState().filteredImages.map((image) => image.name)).toEqual(['cat.png']);
   });
 
   it('sends a compact capped search payload without raw metadata blobs', async () => {

--- a/__tests__/useImageStore.search-worker.test.ts
+++ b/__tests__/useImageStore.search-worker.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Directory, IndexedImage } from '../types';
+import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+
+const directory: Directory = {
+  id: 'dir-1',
+  name: 'Library',
+  path: 'D:/library',
+  handle: {} as FileSystemDirectoryHandle,
+  visible: true,
+};
+
+const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
+  id: `dir-1::${overrides.name ?? 'image.png'}`,
+  name: overrides.name ?? 'image.png',
+  handle: {} as FileSystemFileHandle,
+  metadata: {} as any,
+  metadataString: '',
+  lastModified: 1,
+  models: [],
+  loras: [],
+  sampler: '',
+  scheduler: '',
+  directoryId: 'dir-1',
+  ...overrides,
+});
+
+const mockWorkerInstances: MockSearchWorker[] = [];
+
+class MockSearchWorker {
+  onmessage: ((event: MessageEvent<any>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readonly postMessage = vi.fn((message: any) => {
+    if (message?.type === 'syncDataset') {
+      this.dataset = message.payload.images;
+      return;
+    }
+
+    if (message?.type === 'compute') {
+      queueMicrotask(() => {
+        this.onmessage?.({
+          data: {
+            type: 'complete',
+            payload: {
+              criteriaKey: message.payload.criteriaKey,
+              filteredIds: this.dataset.map((image) => image.id),
+              facets: {
+                availableModels: [],
+                availableLoras: [],
+                availableSamplers: [],
+                availableSchedulers: [],
+                availableGenerators: [],
+                availableGpuDevices: [],
+                availableDimensions: [],
+                modelFacetCounts: [],
+                loraFacetCounts: [],
+                samplerFacetCounts: [],
+                schedulerFacetCounts: [],
+              },
+            },
+          },
+        } as MessageEvent);
+      });
+    }
+  });
+  readonly terminate = vi.fn();
+  private dataset: Array<Record<string, unknown>> = [];
+
+  constructor() {
+    mockWorkerInstances.push(this);
+  }
+}
+
+const flushWorker = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('useImageStore search worker sync', () => {
+  beforeEach(() => {
+    vi.stubGlobal('Worker', MockSearchWorker as unknown as typeof Worker);
+    mockWorkerInstances.length = 0;
+    useSettingsStore.setState({
+      enableSafeMode: false,
+      blurSensitiveImages: true,
+      sensitiveTags: [],
+    });
+
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      directories: [directory],
+      images: [
+        createImage({
+          id: 'dir-1::cat.png',
+          name: 'cat.png',
+          prompt: 'cat portrait',
+          models: ['NovaXL'],
+          loras: ['detailer'],
+          scheduler: 'karras',
+          workflowNodes: ['KSampler'],
+          metadataString: '{"workflow":{"secret":"should-not-sync"}}',
+          enrichmentState: 'enriched',
+        }),
+      ],
+      filteredImages: [],
+      sortOrder: 'asc',
+    });
+  });
+
+  afterEach(() => {
+    useImageStore.getState().resetState();
+    vi.unstubAllGlobals();
+    mockWorkerInstances.length = 0;
+  });
+
+  it('syncs the dataset once and only recomputes on subsequent query edits', async () => {
+    useImageStore.getState().setSearchQuery('cat');
+    await flushWorker();
+
+    const worker = mockWorkerInstances[0];
+    expect(worker).toBeTruthy();
+    expect(worker.postMessage.mock.calls.map(([message]) => message.type)).toEqual(['syncDataset', 'compute']);
+
+    useImageStore.getState().setSearchQuery('portrait');
+    await flushWorker();
+
+    expect(worker.postMessage.mock.calls.map(([message]) => message.type)).toEqual([
+      'syncDataset',
+      'compute',
+      'compute',
+    ]);
+  });
+
+  it('forces exactly one dataset re-sync after image data changes', async () => {
+    useImageStore.getState().setSearchQuery('cat');
+    await flushWorker();
+
+    const worker = mockWorkerInstances[0];
+    expect(worker.postMessage.mock.calls.filter(([message]) => message.type === 'syncDataset')).toHaveLength(1);
+
+    useImageStore.getState().setImages([
+      ...useImageStore.getState().images,
+      createImage({
+        id: 'dir-1::dog.png',
+        name: 'dog.png',
+        prompt: 'dog portrait',
+        enrichmentState: 'enriched',
+      }),
+    ]);
+
+    useImageStore.getState().setSearchQuery('dog');
+    await flushWorker();
+
+    expect(worker.postMessage.mock.calls.filter(([message]) => message.type === 'syncDataset')).toHaveLength(2);
+    expect(worker.postMessage.mock.calls.filter(([message]) => message.type === 'compute')).toHaveLength(2);
+  });
+
+  it('sends a compact capped search payload without raw metadata blobs', async () => {
+    const hugeMarker = 'raw-json-only-marker';
+    const giantMetadata = `{"workflow":"${hugeMarker.repeat(2000)}"}`;
+    useImageStore.getState().setImages([
+      createImage({
+        id: 'dir-1::huge.png',
+        name: 'huge.png',
+        prompt: 'sunset vista',
+        metadataString: giantMetadata,
+        models: ['NovaXL'],
+        loras: ['detailer'],
+        workflowNodes: ['KSampler'],
+        enrichmentState: 'enriched',
+      }),
+    ]);
+
+    useImageStore.getState().setSearchQuery('sunset');
+    await flushWorker();
+
+    const worker = mockWorkerInstances[0];
+    const syncMessage = worker.postMessage.mock.calls.find(([message]) => message.type === 'syncDataset')?.[0];
+    const syncedImage = syncMessage?.payload?.images?.[0];
+
+    expect(syncedImage).toBeTruthy();
+    expect('metadataString' in syncedImage).toBe(false);
+    expect(syncedImage.searchText).toContain('sunset vista');
+    expect(syncedImage.searchText).toContain('novaxl');
+    expect(syncedImage.searchText).not.toContain(hugeMarker);
+    expect(syncedImage.searchText.length).toBeLessThanOrEqual(8192);
+  });
+});

--- a/services/workers/searchFilterWorker.ts
+++ b/services/workers/searchFilterWorker.ts
@@ -4,13 +4,11 @@ import { parseLocalDateFilterEndExclusive, parseLocalDateFilterStart } from '../
 type SearchWorkerImage = {
   id: string;
   name: string;
+  catalogText: string;
+  searchText: string;
   relativePath: string;
   directoryId: string;
   directoryName: string;
-  metadataString: string;
-  prompt: string;
-  negativePrompt: string;
-  enrichmentState: 'catalog' | 'enriched' | '';
   models: string[];
   loraNames: string[];
   sampler: string;
@@ -87,11 +85,6 @@ type WorkerMessage =
       };
     };
 
-type PreparedSearchWorkerImage = SearchWorkerImage & {
-  catalogText: string;
-  enrichedText: string;
-};
-
 type WorkerResponse =
   | {
       type: 'complete';
@@ -123,7 +116,7 @@ type WorkerResponse =
 type CompletePayload = Extract<WorkerResponse, { type: 'complete' }>['payload'];
 
 let datasetVersion = -1;
-let preparedImages: PreparedSearchWorkerImage[] = [];
+let workerImages: SearchWorkerImage[] = [];
 
 const normalizePath = (path: string): string => path.replace(/\\/g, '/');
 
@@ -150,33 +143,6 @@ const getFolderPath = (image: SearchWorkerImage, parentDirectory: string) => {
   return joinPath(parentDirectory, segments.slice(0, -1).join('/'));
 };
 
-const buildCatalogSearchText = (image: SearchWorkerImage): string => {
-  const relativePath = image.relativePath.replace(/\\/g, '/').toLowerCase();
-  const name = (image.name || '').toLowerCase();
-  const directory = (image.directoryName || '').replace(/\\/g, '/').toLowerCase();
-  return [name, relativePath, directory].filter(Boolean).join(' ');
-};
-
-const buildEnrichedSearchText = (image: SearchWorkerImage): string => {
-  if (image.enrichmentState !== 'enriched') {
-    return '';
-  }
-
-  const segments = [
-    image.metadataString,
-    image.prompt,
-    image.negativePrompt,
-    image.models.join(' '),
-    image.loraNames.join(' '),
-    image.scheduler,
-    image.board,
-  ]
-    .filter(Boolean)
-    .map(value => value.toLowerCase());
-
-  return segments.join(' ');
-};
-
 const caseInsensitiveSort = (a: string, b: string) =>
   a.localeCompare(b, undefined, { sensitivity: 'accent' });
 
@@ -190,18 +156,12 @@ const stringHash = (str: string) => {
   return hash;
 };
 
-const buildPreparedImage = (image: SearchWorkerImage): PreparedSearchWorkerImage => ({
-  ...image,
-  catalogText: buildCatalogSearchText(image),
-  enrichedText: buildEnrichedSearchText(image),
-});
-
 self.onmessage = (event: MessageEvent<WorkerMessage>) => {
   const message = event.data;
 
   try {
     if (message.type === 'syncDataset') {
-      preparedImages = message.payload.images.map(buildPreparedImage);
+      workerImages = message.payload.images;
       datasetVersion = message.payload.datasetVersion;
       return;
     }
@@ -249,7 +209,7 @@ function computeResults(criteria: SearchWorkerCriteria): Omit<CompletePayload, '
     .split(/\s+/)
     .filter(Boolean);
 
-  let results = preparedImages.filter((image) => {
+  let results = workerImages.filter((image) => {
     if (!visibleDirectoryIds.has(image.directoryId)) {
       return false;
     }
@@ -337,11 +297,11 @@ function computeResults(criteria: SearchWorkerCriteria): Omit<CompletePayload, '
         return true;
       }
 
-      if (!image.enrichedText) {
+      if (!image.searchText) {
         return false;
       }
 
-      return searchTerms.every(term => image.enrichedText.includes(term));
+      return searchTerms.every(term => image.searchText.includes(term));
     });
   }
 
@@ -512,29 +472,29 @@ function numericRangeMatch(
 }
 
 function compareImages(
-  left: PreparedSearchWorkerImage,
-  right: PreparedSearchWorkerImage,
+  left: SearchWorkerImage,
+  right: SearchWorkerImage,
   sortOrder: SearchWorkerCriteria['sortOrder'],
   randomSeed: number
 ): number {
-  const compareById = (a: PreparedSearchWorkerImage, b: PreparedSearchWorkerImage) => a.id.localeCompare(b.id);
-  const compareByNameAsc = (a: PreparedSearchWorkerImage, b: PreparedSearchWorkerImage) => {
+  const compareById = (a: SearchWorkerImage, b: SearchWorkerImage) => a.id.localeCompare(b.id);
+  const compareByNameAsc = (a: SearchWorkerImage, b: SearchWorkerImage) => {
     const nameComparison = (a.name || '').localeCompare(b.name || '');
     return nameComparison !== 0 ? nameComparison : compareById(a, b);
   };
-  const compareByNameDesc = (a: PreparedSearchWorkerImage, b: PreparedSearchWorkerImage) => {
+  const compareByNameDesc = (a: SearchWorkerImage, b: SearchWorkerImage) => {
     const nameComparison = (b.name || '').localeCompare(a.name || '');
     return nameComparison !== 0 ? nameComparison : compareById(a, b);
   };
-  const compareByDateAsc = (a: PreparedSearchWorkerImage, b: PreparedSearchWorkerImage) => {
+  const compareByDateAsc = (a: SearchWorkerImage, b: SearchWorkerImage) => {
     const dateComparison = a.lastModified - b.lastModified;
     return dateComparison !== 0 ? dateComparison : compareByNameAsc(a, b);
   };
-  const compareByDateDesc = (a: PreparedSearchWorkerImage, b: PreparedSearchWorkerImage) => {
+  const compareByDateDesc = (a: SearchWorkerImage, b: SearchWorkerImage) => {
     const dateComparison = b.lastModified - a.lastModified;
     return dateComparison !== 0 ? dateComparison : compareByNameAsc(a, b);
   };
-  const compareRandom = (a: PreparedSearchWorkerImage, b: PreparedSearchWorkerImage) => {
+  const compareRandom = (a: SearchWorkerImage, b: SearchWorkerImage) => {
     const hashA = stringHash(`${a.id}${randomSeed}`);
     const hashB = stringHash(`${b.id}${randomSeed}`);
     return hashA !== hashB ? hashA - hashB : a.id.localeCompare(b.id);
@@ -548,7 +508,7 @@ function compareImages(
   return compareById(left, right);
 }
 
-function collectFacets(images: PreparedSearchWorkerImage[]) {
+function collectFacets(images: SearchWorkerImage[]) {
   const models = new Set<string>();
   const loras = new Set<string>();
   const samplers = new Set<string>();

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -94,13 +94,11 @@ type DerivedFacetState = {
 type SearchWorkerImage = {
     id: string;
     name: string;
+    catalogText: string;
+    searchText: string;
     relativePath: string;
     directoryId: string;
     directoryName: string;
-    metadataString: string;
-    prompt: string;
-    negativePrompt: string;
-    enrichmentState: 'catalog' | 'enriched' | '';
     models: string[];
     loraNames: string[];
     sampler: string;
@@ -570,50 +568,60 @@ const buildCatalogSearchText = (image: IndexedImage): string => {
     return [name, relativePath, directory].filter(Boolean).join(' ');
 };
 
-const buildEnrichedSearchText = (image: IndexedImage): string => {
-    if (image.enrichmentState !== 'enriched') {
-        return '';
-    }
+const MAX_SEARCH_TEXT_LENGTH = 8192;
 
+const buildCompactSearchText = (image: IndexedImage): string => {
     const segments: string[] = [];
-    if (image.metadataString) {
-        segments.push(String(image.metadataString).toLowerCase());
-    }
-    if (image.prompt) {
-        segments.push(String(image.prompt).toLowerCase());
-    }
-    if (image.negativePrompt) {
-        segments.push(String(image.negativePrompt).toLowerCase());
-    }
-    if (image.models?.length) {
-        segments.push(
-            image.models
-                .map(model => normalizeFacetValue(model))
-                .filter((model): model is string => Boolean(model))
-                .map(model => model.toLowerCase())
-                .join(' ')
-        );
-    }
-    if (image.loras?.length) {
-        const loraNames = image.loras.map(lora => {
-            const normalized = normalizeLoraName(typeof lora === 'string' ? lora : lora);
-            return normalized ? normalized.toLowerCase() : '';
-        }).filter(Boolean);
-        if (loraNames.length > 0) {
-            segments.push(loraNames.join(' '));
+    const pushValue = (value: unknown) => {
+        if (typeof value === 'number') {
+            segments.push(String(value));
+            return;
         }
-    }
-    if (image.scheduler) {
-        const normalized = normalizeFacetValue(image.scheduler);
+
+        if (typeof value !== 'string') {
+            return;
+        }
+
+        const normalized = value.trim().toLowerCase();
         if (normalized) {
-            segments.push(normalized.toLowerCase());
+            segments.push(normalized);
         }
+    };
+
+    pushValue(image.prompt);
+    pushValue(image.negativePrompt);
+
+    image.models?.forEach(model => pushValue(normalizeFacetValue(model)));
+    image.loras?.forEach(lora => pushValue(normalizeLoraName(typeof lora === 'string' ? lora : lora)));
+
+    pushValue(normalizeFacetValue(image.sampler));
+    pushValue(normalizeFacetValue(image.scheduler));
+    pushValue(image.board);
+    pushValue(getImageGenerator(image));
+    pushValue(normalizeFacetValue(image.dimensions));
+
+    if (typeof image.seed === 'number') {
+        pushValue(image.seed);
     }
-    if (image.board) {
-        segments.push(String(image.board).toLowerCase());
+    if (typeof image.steps === 'number') {
+        pushValue(image.steps);
+    }
+    if (typeof image.cfgScale === 'number') {
+        pushValue(image.cfgScale);
     }
 
-    return segments.join(' ');
+    image.tags?.forEach(tag => pushValue(tag));
+    image.autoTags?.forEach(tag => pushValue(tag));
+    image.workflowNodes?.forEach(nodeType => pushValue(nodeType));
+
+    pushValue(getImageGpuDevice(image));
+
+    const searchText = segments.join(' ');
+    if (searchText.length <= MAX_SEARCH_TEXT_LENGTH) {
+        return searchText;
+    }
+
+    return searchText.slice(0, MAX_SEARCH_TEXT_LENGTH);
 };
 
 const getImageAnalyticsSnapshot = (image: IndexedImage) => {
@@ -697,13 +705,11 @@ const toSearchWorkerImage = (image: IndexedImage): SearchWorkerImage => {
     return {
         id: image.id,
         name: image.name || '',
+        catalogText: buildCatalogSearchText(image),
+        searchText: buildCompactSearchText(image),
         relativePath,
         directoryId: image.directoryId || '',
         directoryName: image.directoryName || '',
-        metadataString: image.metadataString ? String(image.metadataString) : '',
-        prompt: image.prompt ? String(image.prompt) : '',
-        negativePrompt: image.negativePrompt ? String(image.negativePrompt) : '',
-        enrichmentState: image.enrichmentState ?? '',
         models: (image.models || [])
             .map(model => normalizeFacetValue(model))
             .filter((model): model is string => Boolean(model)),
@@ -1025,10 +1031,8 @@ export const useImageStore = create<ImageState>((set, get) => {
     const MERGE_FLUSH_LARGE_THRESHOLD = 8000;
     const FILTER_RECOMPUTE_INDEXING_MS = 5000;
     let searchWorker: Worker | null = null;
-    let cachedSearchWorkerImages: IndexedImage[] | null = null;
-    let cachedSearchWorkerDirectories: Directory[] | null = null;
-    let cachedSearchWorkerDataset: SearchWorkerImage[] | null = null;
     let searchDatasetVersion = 0;
+    let searchWorkerSyncedDatasetVersion = -1;
     let latestSearchCriteriaKey = '';
 
     const clearPendingQueue = () => {
@@ -1049,15 +1053,13 @@ export const useImageStore = create<ImageState>((set, get) => {
     };
 
     const invalidateSearchWorkerDataset = () => {
-        cachedSearchWorkerImages = null;
-        cachedSearchWorkerDirectories = null;
-        cachedSearchWorkerDataset = null;
         searchDatasetVersion += 1;
     };
 
     const terminateSearchWorker = () => {
         searchWorker?.terminate();
         searchWorker = null;
+        searchWorkerSyncedDatasetVersion = -1;
     };
 
     const purgePendingDirectoryEntries = (directoryId: string) => {
@@ -1272,21 +1274,8 @@ export const useImageStore = create<ImageState>((set, get) => {
         return false;
     };
 
-    const getSearchWorkerDataset = (state: ImageState): SearchWorkerImage[] => {
-        if (
-            cachedSearchWorkerDataset &&
-            cachedSearchWorkerImages === state.images &&
-            cachedSearchWorkerDirectories === state.directories
-        ) {
-            return cachedSearchWorkerDataset;
-        }
-
-        const dataset = state.images.map(toSearchWorkerImage);
-        cachedSearchWorkerImages = state.images;
-        cachedSearchWorkerDirectories = state.directories;
-        cachedSearchWorkerDataset = dataset;
-
-        return dataset;
+    const buildSearchWorkerDataset = (state: ImageState): SearchWorkerImage[] => {
+        return state.images.map(toSearchWorkerImage);
     };
 
     const buildSearchWorkerCriteria = (state: ImageState): SearchWorkerCriteria => {
@@ -1410,7 +1399,6 @@ export const useImageStore = create<ImageState>((set, get) => {
 
     const runAsyncSearchRecompute = (state: ImageState) => {
         const worker = ensureSearchWorker();
-        const dataset = getSearchWorkerDataset(state);
         const criteria = buildSearchWorkerCriteria(state);
         const criteriaKey = JSON.stringify({
             datasetVersion: searchDatasetVersion,
@@ -1418,13 +1406,16 @@ export const useImageStore = create<ImageState>((set, get) => {
         });
 
         latestSearchCriteriaKey = criteriaKey;
-        worker.postMessage({
-            type: 'syncDataset',
-            payload: {
-                datasetVersion: searchDatasetVersion,
-                images: dataset,
-            },
-        });
+        if (searchWorkerSyncedDatasetVersion !== searchDatasetVersion) {
+            worker.postMessage({
+                type: 'syncDataset',
+                payload: {
+                    datasetVersion: searchDatasetVersion,
+                    images: buildSearchWorkerDataset(state),
+                },
+            });
+            searchWorkerSyncedDatasetVersion = searchDatasetVersion;
+        }
         worker.postMessage({
             type: 'compute',
             payload: {
@@ -2101,11 +2092,11 @@ export const useImageStore = create<ImageState>((set, get) => {
                     let enrichedText = '';
                     if (perfEnabled) {
                         const enrichedStartedAt = perfNow();
-                        enrichedText = buildEnrichedSearchText(image);
+                        enrichedText = buildCompactSearchText(image);
                         searchMetrics.enrichedBuildMs += perfNow() - enrichedStartedAt;
                         searchMetrics.enrichedChars += enrichedText.length;
                     } else {
-                        enrichedText = buildEnrichedSearchText(image);
+                        enrichedText = buildCompactSearchText(image);
                     }
                     if (!enrichedText) {
                         if (perfEnabled) {

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -1032,6 +1032,7 @@ export const useImageStore = create<ImageState>((set, get) => {
     const FILTER_RECOMPUTE_INDEXING_MS = 5000;
     let searchWorker: Worker | null = null;
     let searchDatasetVersion = 0;
+    let searchDatasetSourceImages: IndexedImage[] | null = null;
     let searchWorkerSyncedDatasetVersion = -1;
     let latestSearchCriteriaKey = '';
 
@@ -1054,12 +1055,25 @@ export const useImageStore = create<ImageState>((set, get) => {
 
     const invalidateSearchWorkerDataset = () => {
         searchDatasetVersion += 1;
+        searchDatasetSourceImages = null;
+        searchWorkerSyncedDatasetVersion = -1;
+    };
+
+    const getSearchDatasetVersion = (state: ImageState) => {
+        if (searchDatasetSourceImages !== state.images) {
+            searchDatasetVersion += 1;
+            searchDatasetSourceImages = state.images;
+            searchWorkerSyncedDatasetVersion = -1;
+        }
+
+        return searchDatasetVersion;
     };
 
     const terminateSearchWorker = () => {
         searchWorker?.terminate();
         searchWorker = null;
         searchWorkerSyncedDatasetVersion = -1;
+        searchDatasetSourceImages = null;
     };
 
     const purgePendingDirectoryEntries = (directoryId: string) => {
@@ -1322,7 +1336,7 @@ export const useImageStore = create<ImageState>((set, get) => {
     };
 
     const buildSearchCriteriaKey = (state: ImageState) => JSON.stringify({
-        datasetVersion: searchDatasetVersion,
+        datasetVersion: getSearchDatasetVersion(state),
         criteria: buildSearchWorkerCriteria(state),
     });
 
@@ -1399,28 +1413,29 @@ export const useImageStore = create<ImageState>((set, get) => {
 
     const runAsyncSearchRecompute = (state: ImageState) => {
         const worker = ensureSearchWorker();
+        const datasetVersion = getSearchDatasetVersion(state);
         const criteria = buildSearchWorkerCriteria(state);
         const criteriaKey = JSON.stringify({
-            datasetVersion: searchDatasetVersion,
+            datasetVersion,
             criteria,
         });
 
         latestSearchCriteriaKey = criteriaKey;
-        if (searchWorkerSyncedDatasetVersion !== searchDatasetVersion) {
+        if (searchWorkerSyncedDatasetVersion !== datasetVersion) {
             worker.postMessage({
                 type: 'syncDataset',
                 payload: {
-                    datasetVersion: searchDatasetVersion,
+                    datasetVersion,
                     images: buildSearchWorkerDataset(state),
                 },
             });
-            searchWorkerSyncedDatasetVersion = searchDatasetVersion;
+            searchWorkerSyncedDatasetVersion = datasetVersion;
         }
         worker.postMessage({
             type: 'compute',
             payload: {
                 criteriaKey,
-                datasetVersion: searchDatasetVersion,
+                datasetVersion,
                 criteria,
             },
         });


### PR DESCRIPTION
## Summary
- compact the search worker dataset to send only `catalogText`, a capped `searchText`, and the existing filter/facet fields
- stop re-syncing the full dataset on every query edit by versioning worker dataset syncs
- simplify the worker to operate directly on the compact corpus instead of rebuilding large search strings from raw metadata blobs
- add regressions covering compact search behavior, worker sync behavior, and large metadata payload protection

## Why
Search was cloning large metadata-heavy image datasets into the worker on every keystroke. For ComfyUI-heavy libraries, embedded workflow JSON could create multiple live copies of very large strings in memory and trigger OOMs.

## Impact
- preserves practical global search across prompts, models, LoRAs, schedulers, workflow nodes, tags, and related user-facing fields
- intentionally stops relying on arbitrary raw metadata/workflow JSON blobs as searchable text for this release
- reduces peak memory pressure during repeated search updates

## Validation
- `npm test -- useImageStore.filters useImageStore.search-worker`
- `npx tsc -p tsconfig.json --noEmit`