### PR TITLE
Hotfix macOS media memory safety and diagnostics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ### Current Stack
 
-* **Version:** 0.15.0
+* **Version:** 0.15.1
 * **Renderer:** React 18 + TypeScript
 * **Desktop shell:** Electron 38
 * **State management:** Zustand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Video Thumbnail Guardrails**: Reduced thumbnail generation concurrency, capped active thumbnail object URLs, reused legacy thumbnail cache entries where possible, and skipped renderer-side video thumbnail generation for videos with unknown size or over 80 MB to avoid memory spikes during cache refresh.
 
 
-## [0.15.1] - 2026-04-23
+## [0.15.0] - 2026-04-23
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.15.1] - 2026-04-23
 
-### Added
+### Fixed
+
+- **Desktop Media Memory Safety**: Fixed a v0.15.0 regression where large video or audio files could be read fully into renderer memory when the desktop streaming media URL path failed, potentially causing black screens or renderer crashes on macOS.
+- **Video Thumbnail Guardrails**: Reduced thumbnail generation concurrency, capped active thumbnail object URLs, reused legacy thumbnail cache entries where possible, and skipped renderer-side video thumbnail generation for videos with unknown size or over 80 MB to avoid memory spikes during cache refresh.
 
 
-
-### Improved
-
-- **Viewer Metadata Actions**: Image Modal and Image Preview Sidebar now share clearer entry points for editing metadata, exporting edited copies, exporting without metadata, and switching between original and edited metadata views.
-- **Export Pipeline Consistency**: Unified desktop export handling behind a single request model so regular export, batch export, metadata stripping, and metadata rewrite all follow the same scope-aware workflow.
-- **MetaHub Standard Metadata Compatibility**: Standardized exported metadata payloads so files saved from edited metadata remain parseable by the app and keep compatibility with A1111-style generation parameter import.
-
-## [0.15.0] - 2026-04-22
+## [0.15.1] - 2026-04-23
 
 ### Added
 
@@ -38,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Indexed Subfolder Transfers**: Bulk copy/move actions can now target indexed subfolders, including nested folders and symlinked or aliased destinations.
 - **Unified Export Metadata Policies**: Added a shared export flow for single-image and batch export with metadata policies to preserve original metadata, strip metadata entirely, or save a standardized `Image MetaHub + A1111` compatible PNG copy.
 - **Large Library Responsiveness**: Improved Smart Library clustering behavior and added optional performance diagnostics for troubleshooting search, grid, thumbnail, and viewer responsiveness.
+- **Viewer Metadata Actions**: Image Modal and Image Preview Sidebar now share clearer entry points for editing metadata, exporting edited copies, exporting without metadata, and switching between original and edited metadata views.
+- **Export Pipeline Consistency**: Unified desktop export handling behind a single request model so regular export, batch export, metadata stripping, and metadata rewrite all follow the same scope-aware workflow.
 
 ### Fixed
 

--- a/cli.ts
+++ b/cli.ts
@@ -13,7 +13,7 @@ const program = new Command();
 program
   .name('imagemetahub-cli')
   .description('Image MetaHub CLI - Parse AI-generated image metadata')
-  .version('0.15.0');
+  .version('0.15.1');
 
 type ParseOptions = { json: boolean; pretty: boolean; raw?: boolean; quiet?: boolean };
 type IndexOptions = { out: string; recursive: boolean; raw?: boolean; quiet?: boolean; concurrency?: string };

--- a/components/FolderSelector.tsx
+++ b/components/FolderSelector.tsx
@@ -18,7 +18,7 @@ const FolderSelector: React.FC<FolderSelectorProps> = ({ onSelectFolder }) => {
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center p-8 border-2 border-dashed border-gray-700 rounded-xl bg-gray-800/50">
       <img src="logo1.png" alt="Image MetaHub Logo" className="h-64 w-64 mb-4 rounded-lg shadow-lg" />
   <h2 className="text-2xl font-semibold mb-2 text-gray-100">Welcome to Image MetaHub v0.15</h2>
-  <p className="text-xs text-gray-500 mb-4">v0.15.0</p>
+  <p className="text-xs text-gray-500 mb-4">v0.15.1</p>
       <p className="text-gray-400 max-w-md mb-6">
         Select a folder to get started. The app will automatically scan <strong className="text-gray-200">all subfolders</strong> and display images from the entire directory tree.
       </p>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -266,7 +266,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           <img src="logo1.png" alt="Image MetaHub" className="h-11 w-11 flex-shrink-0 rounded-xl object-contain" />
           <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
             <h1 className="truncate text-lg font-semibold tracking-tight text-white">Image MetaHub</h1>
-            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.15.0</span>
+            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.15.1</span>
           </div>
           <button
             onClick={onToggleCollapse}

--- a/electron.mjs
+++ b/electron.mjs
@@ -1092,7 +1092,7 @@ async function createWindow(startupDirectory = null) {
     mainWindow.setTitle(`Image MetaHub v${appVersion}`);
   } catch (e) {
     // Fallback if app.getVersion is not available
-    mainWindow.setTitle('Image MetaHub v0.15.0');
+    mainWindow.setTitle('Image MetaHub v0.15.1');
   }
 
   // Load the app

--- a/electron.mjs
+++ b/electron.mjs
@@ -419,18 +419,120 @@ async function getCacheRootPath() {
   return app.getPath('userData');
 }
 
-function logRendererCrash(details = {}) {
+function getDiagnosticsLogPaths() {
+  const paths = [];
+
   try {
-    const crashLogPath = path.join(app.getPath('userData'), 'renderer-crashes.log');
+    paths.push(path.join(app.getPath('userData'), 'logs', 'process-events.log'));
+  } catch (error) {
+    console.error('Failed to resolve userData diagnostics log path:', error);
+  }
+
+  try {
+    paths.push(path.join(app.getPath('logs'), 'process-events.log'));
+  } catch (error) {
+    console.error('Failed to resolve app logs diagnostics path:', error);
+  }
+
+  return [...new Set(paths)];
+}
+
+function logProcessEvent(details = {}) {
+  try {
     const payload = {
       timestamp: new Date().toISOString(),
+      appVersion: app.getVersion(),
+      platform: process.platform,
+      arch: process.arch,
+      isPackaged: app.isPackaged,
+      electronVersion: process.versions.electron,
+      chromeVersion: process.versions.chrome,
+      memoryUsage: process.memoryUsage(),
       ...details,
     };
+    const line = `${JSON.stringify(payload)}\n`;
 
-    fsSync.appendFileSync(crashLogPath, `${JSON.stringify(payload)}\n`, 'utf8');
+    for (const logPath of getDiagnosticsLogPaths()) {
+      fsSync.mkdirSync(path.dirname(logPath), { recursive: true });
+      fsSync.appendFileSync(logPath, line, 'utf8');
+    }
+
+    const legacyCrashLogPath = path.join(app.getPath('userData'), 'renderer-crashes.log');
+    fsSync.appendFileSync(legacyCrashLogPath, line, 'utf8');
   } catch (error) {
-    console.error('Failed to write renderer crash log:', error);
+    console.error('Failed to write process diagnostics log:', error);
   }
+}
+
+function registerProcessDiagnostics() {
+  logProcessEvent({
+    kind: 'app-startup',
+    logs: getDiagnosticsLogPaths(),
+    gpuMitigationEnabled,
+    gpuFeatureStatus: app.getGPUFeatureStatus?.() ?? null,
+  });
+
+  app.on('child-process-gone', (_event, details) => {
+    console.error('Child process gone:', details);
+    logProcessEvent({
+      kind: 'child-process-gone',
+      type: details?.type ?? null,
+      reason: details?.reason ?? null,
+      exitCode: details?.exitCode ?? null,
+      serviceName: details?.serviceName ?? null,
+      name: details?.name ?? null,
+    });
+  });
+
+  app.on('gpu-process-crashed', (_event, killed) => {
+    console.error('GPU process crashed:', { killed });
+    logProcessEvent({
+      kind: 'gpu-process-crashed',
+      killed: Boolean(killed),
+    });
+  });
+
+  app.on('render-process-gone', (_event, webContents, details) => {
+    console.error('App render process gone:', details);
+    logProcessEvent({
+      kind: 'app-render-process-gone',
+      reason: details?.reason ?? null,
+      exitCode: details?.exitCode ?? null,
+      url: webContents?.getURL?.() ?? null,
+    });
+  });
+}
+
+function attachWindowProcessDiagnostics(window) {
+  const webContents = window?.webContents;
+  if (!webContents) {
+    return;
+  }
+
+  webContents.on('render-process-gone', (_event, details) => {
+    console.error('Renderer process gone:', details);
+    logProcessEvent({
+      kind: 'webcontents-render-process-gone',
+      reason: details?.reason ?? null,
+      exitCode: details?.exitCode ?? null,
+      url: webContents.getURL(),
+    });
+  });
+
+  webContents.on('unresponsive', () => {
+    console.error('Renderer became unresponsive');
+    logProcessEvent({
+      kind: 'webcontents-unresponsive',
+      url: webContents.getURL(),
+    });
+  });
+
+  webContents.on('responsive', () => {
+    logProcessEvent({
+      kind: 'webcontents-responsive',
+      url: webContents.getURL(),
+    });
+  });
 }
 // --- End Settings Management ---
 
@@ -1136,25 +1238,12 @@ async function createWindow(startupDirectory = null) {
     }
   });
 
-  mainWindow.webContents.on('render-process-gone', (_event, details) => {
-    console.error('Renderer process gone:', details);
-    logRendererCrash({
-      kind: 'render-process-gone',
-      reason: details?.reason ?? null,
-      exitCode: details?.exitCode ?? null,
-    });
-  });
-
-  mainWindow.webContents.on('unresponsive', () => {
-    console.error('Renderer became unresponsive');
-    logRendererCrash({
-      kind: 'unresponsive',
-    });
-  });
+  attachWindowProcessDiagnostics(mainWindow);
 }
 
 // App event handlers
 app.whenReady().then(async () => {
+  registerProcessDiagnostics();
   registerMediaProtocol();
 
   // Listen for theme changes and notify renderer

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Image MetaHub v0.15.0</title>
+  <title>Image MetaHub v0.15.1</title>
   </head>
   <body class="bg-gray-900 text-gray-100">
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-metahub",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-metahub",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "archiver": "^7.0.1",
         "cbor-js": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Image MetaHub",
   "author": "LuqP2 <github.com/LuqP2>",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "main": "electron.mjs",
   "homepage": "./",

--- a/services/mediaSourceCache.ts
+++ b/services/mediaSourceCache.ts
@@ -244,27 +244,6 @@ class MediaSourceCache {
 
       if (absolutePath) {
         if (isLargeStreamingMedia) {
-          if (fileHandle) {
-            const getFileStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
-            const file = await fileHandle.getFile();
-            const objectUrlStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
-            const url = URL.createObjectURL(file);
-            return {
-              url,
-              revoke: true,
-              detail: {
-                urlKind: 'object-url',
-                sourceMode: 'file-handle-large-media-fallback',
-                fileSize: file.size,
-                usedHandlePath: Boolean(electronAbsoluteMediaPath),
-                joinPathMs,
-                getFileMs: Math.round(((typeof performance !== 'undefined' ? performance.now() : Date.now()) - getFileStartedAt) * 100) / 100,
-                objectUrlMs: Math.round(((typeof performance !== 'undefined' ? performance.now() : Date.now()) - objectUrlStartedAt) * 100) / 100,
-                totalLoadMs: Math.round(((typeof performance !== 'undefined' ? performance.now() : Date.now()) - loadStartedAt) * 100) / 100,
-              },
-            };
-          }
-
           throw new Error('Could not create streaming media URL; refusing to read full media file into renderer memory.');
         }
 
@@ -295,6 +274,10 @@ class MediaSourceCache {
           },
         };
       }
+    }
+
+    if (window.electronAPI && isLargeStreamingMedia) {
+      throw new Error('Could not create streaming media URL; refusing to read full media file into renderer memory.');
     }
 
     if (fileHandle) {

--- a/services/mediaSourceCache.ts
+++ b/services/mediaSourceCache.ts
@@ -1,6 +1,6 @@
 import { IndexedImage } from '../types';
 import { thumbnailManager } from './thumbnailManager';
-import { inferMimeTypeFromName } from '../utils/mediaTypes.js';
+import { inferMimeTypeFromName, isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 import {
   recordPerformanceCounter,
   recordPerformanceDuration,
@@ -20,7 +20,28 @@ type MediaSourceLoadOptions = {
 
 const MAX_STREAM_URL_CACHE_ENTRIES = 64;
 const MAX_OBJECT_URL_CACHE_ENTRIES = 16;
+const MAX_RENDERER_READ_BYTES = 200 * 1024 * 1024;
 type ElectronFileHandle = FileSystemFileHandle & { _filePath?: string };
+
+const getFileDataByteLength = (data: unknown): number | undefined => {
+  if (typeof data === 'string') {
+    return Math.ceil((data.length * 3) / 4);
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return data.byteLength;
+  }
+
+  if (data && typeof data === 'object' && 'data' in data && Array.isArray((data as { data: unknown }).data)) {
+    return (data as { data: number[] }).data.length;
+  }
+
+  return undefined;
+};
 
 const createImageUrlFromFileData = (data: unknown, fileName: string): { url: string; revoke: boolean } => {
   const mimeType = inferMimeTypeFromName(fileName, 'image/png');
@@ -178,6 +199,8 @@ class MediaSourceCache {
         : fallbackHandle && typeof fallbackHandle.getFile === 'function'
           ? fallbackHandle
           : null;
+    const isLargeStreamingMedia =
+      isVideoFileName(image.name, image.fileType) || isAudioFileName(image.name, image.fileType);
 
     if (window.electronAPI) {
       let absolutePath = electronAbsoluteMediaPath;
@@ -220,10 +243,40 @@ class MediaSourceCache {
       }
 
       if (absolutePath) {
+        if (isLargeStreamingMedia) {
+          if (fileHandle) {
+            const getFileStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
+            const file = await fileHandle.getFile();
+            const objectUrlStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
+            const url = URL.createObjectURL(file);
+            return {
+              url,
+              revoke: true,
+              detail: {
+                urlKind: 'object-url',
+                sourceMode: 'file-handle-large-media-fallback',
+                fileSize: file.size,
+                usedHandlePath: Boolean(electronAbsoluteMediaPath),
+                joinPathMs,
+                getFileMs: Math.round(((typeof performance !== 'undefined' ? performance.now() : Date.now()) - getFileStartedAt) * 100) / 100,
+                objectUrlMs: Math.round(((typeof performance !== 'undefined' ? performance.now() : Date.now()) - objectUrlStartedAt) * 100) / 100,
+                totalLoadMs: Math.round(((typeof performance !== 'undefined' ? performance.now() : Date.now()) - loadStartedAt) * 100) / 100,
+              },
+            };
+          }
+
+          throw new Error('Could not create streaming media URL; refusing to read full media file into renderer memory.');
+        }
+
         const readStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
         const fileResult = await window.electronAPI.readFile(absolutePath);
         if (!fileResult.success || !fileResult.data) {
           throw new Error(fileResult.error || 'Failed to read file via Electron API.');
+        }
+
+        const byteLength = getFileDataByteLength(fileResult.data);
+        if (byteLength !== undefined && byteLength > MAX_RENDERER_READ_BYTES) {
+          throw new Error(`Refusing to load ${Math.round(byteLength / 1024 / 1024)}MB file into renderer memory.`);
         }
 
         const createUrlStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -233,7 +286,7 @@ class MediaSourceCache {
           detail: {
             urlKind: 'object-url',
             sourceMode: 'electron-read-file',
-            fileSize: fileResult.data instanceof Uint8Array ? fileResult.data.byteLength : ('byteLength' in (fileResult.data as object) ? (fileResult.data as ArrayBuffer).byteLength : undefined),
+            fileSize: byteLength,
             usedHandlePath: Boolean(electronAbsoluteMediaPath),
             joinPathMs,
             readFileMs: Math.round(((typeof performance !== 'undefined' ? performance.now() : Date.now()) - readStartedAt) * 100) / 100,

--- a/services/thumbnailManager.ts
+++ b/services/thumbnailManager.ts
@@ -8,6 +8,7 @@ const MAX_CONCURRENT_THUMBNAILS = 3;
 const MAX_CONCURRENT_HIGH_PRIORITY_THUMBNAILS = 2;
 const MAX_CONCURRENT_BACKGROUND_THUMBNAILS = 1;
 const MAX_ACTIVE_THUMBNAIL_URLS = 200;
+const MAX_RENDERER_VIDEO_THUMBNAIL_BYTES = 80 * 1024 * 1024;
 
 type ElectronFileHandle = FileSystemFileHandle & { _filePath?: string };
 
@@ -688,8 +689,16 @@ class ThumbnailManager {
       }
 
       let blob: Blob | null = null;
+      const isElectron = typeof window !== 'undefined' && Boolean(window.electronAPI);
+      const isVideo = isVideoAsset(image);
+      const fileSize = image.fileSize;
 
-      if (typeof window !== 'undefined' && window.electronAPI && !isVideoAsset(image)) {
+      if (isElectron && isVideo && (!fileSize || fileSize > MAX_RENDERER_VIDEO_THUMBNAIL_BYTES)) {
+        setSafe({ thumbnailStatus: 'ready', thumbnailUrl: null, thumbnailError: null });
+        return;
+      }
+
+      if (isElectron && !isVideo) {
         blob = await generateElectronThumbnailBlob(image);
       }
 

--- a/services/thumbnailManager.ts
+++ b/services/thumbnailManager.ts
@@ -4,10 +4,10 @@ import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 
 const MAX_THUMBNAIL_EDGE = 320;
 const THUMBNAIL_CACHE_VERSION = 2;
-const MAX_CONCURRENT_THUMBNAILS = 12;
-const MAX_CONCURRENT_HIGH_PRIORITY_THUMBNAILS = 10;
-const MAX_CONCURRENT_BACKGROUND_THUMBNAILS = 2;
-const MAX_ACTIVE_THUMBNAIL_URLS = 800;
+const MAX_CONCURRENT_THUMBNAILS = 3;
+const MAX_CONCURRENT_HIGH_PRIORITY_THUMBNAILS = 2;
+const MAX_CONCURRENT_BACKGROUND_THUMBNAILS = 1;
+const MAX_ACTIVE_THUMBNAIL_URLS = 200;
 
 type ElectronFileHandle = FileSystemFileHandle & { _filePath?: string };
 
@@ -673,9 +673,15 @@ class ThumbnailManager {
         return;
       }
 
-      const thumbnailKey = `v${THUMBNAIL_CACHE_VERSION}:${image.id}-${image.lastModified}`;
-      const cachedBlob = await cacheManager.getCachedThumbnail(thumbnailKey);
+      const legacyThumbnailKey = `${image.id}-${image.lastModified}`;
+      const thumbnailKey = `v${THUMBNAIL_CACHE_VERSION}:${legacyThumbnailKey}`;
+      let cachedBlob = await cacheManager.getCachedThumbnail(thumbnailKey);
+      const isLegacyCacheHit = !cachedBlob;
+      cachedBlob = cachedBlob || (await cacheManager.getCachedThumbnail(legacyThumbnailKey));
       if (cachedBlob) {
+        if (isLegacyCacheHit) {
+          void cacheManager.cacheThumbnail(thumbnailKey, cachedBlob).catch(() => {});
+        }
         const url = this.updateObjectUrl(image.id, cachedBlob);
         setSafe({ thumbnailStatus: 'ready', thumbnailUrl: url, thumbnailError: null });
         return;


### PR DESCRIPTION
## Summary

- Prevent Electron media fallbacks from reading full video/audio files into the renderer when streaming URL resolution fails.
- Add defensive renderer read limits and reduce thumbnail memory pressure while preserving video thumbnails for small, known-size files.
- Add main-process diagnostics for renderer, child process, and GPU process exits, writing `process-events.log` to easy-to-find log locations.
- Bump the app to `0.15.1` and update release notes for the hotfix.
- #240 

## Root Cause

The v0.15.0 media loading path could fall back from `resolveMediaUrl` to renderer-side full-file reads. In Electron, some `FileSystemFileHandle` mocks also implement `getFile()` via `electronAPI.readFile`, so video/audio fallbacks and thumbnail generation could still pull large MP4/MOV files into renderer memory and trigger the black-window failure mode on macOS.

## Validation

- Not run per maintainer request. Maintainer will run local validation before release.