### PR TITLE
Add advanced folder management

### DIFF
--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Directory } from '../types';
+import { Directory, IndexedImage } from '../types';
 import { FolderOpen, RotateCcw, Trash2, ChevronDown, Folder, FolderTree, X, EyeOff, Eye, FolderPlus, Edit2, Clipboard } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { transferIndexedImages } from '../services/fileTransferService';
@@ -106,6 +106,14 @@ const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: str
   const replaceImageId = (imageId: string) => (
     imageId.startsWith(`${oldPath}::`) ? `${newPath}::${imageId.slice(oldPath.length + 2)}` : imageId
   );
+  const remapImage = (image: IndexedImage | null): IndexedImage | null => (
+    image && normalizePath(image.directoryId ?? '') === normalizePath(oldPath)
+      ? { ...image, id: replaceImageId(image.id), directoryId: newPath }
+      : image
+  );
+  const remapImageList = (images: IndexedImage[] | null): IndexedImage[] | null => (
+    images ? images.map((image) => remapImage(image) ?? image) : null
+  );
 
   const nextDirectories = store.directories.map((directory) =>
     normalizePath(directory.path) === normalizePath(oldPath)
@@ -124,6 +132,9 @@ const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: str
   );
 
   const nextSelectedImages = new Set(Array.from(store.selectedImages).map(replaceImageId));
+  const nextClipboard = store.clipboard
+    ? { ...store.clipboard, imageIds: store.clipboard.imageIds.map(replaceImageId) }
+    : null;
   const nextSelectedFolders = new Set(Array.from(store.selectedFolders).map((folderPath) =>
     normalizePath(folderPath) === normalizePath(oldPath) ||
     normalizePath(folderPath).startsWith(`${normalizePath(oldPath)}/`)
@@ -136,21 +147,53 @@ const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: str
     const nextImageId = replaceImageId(imageId);
     nextAnnotations.set(nextImageId, { ...annotation, imageId: nextImageId });
   });
+  const nextFilteredImages = remapImageList(store.filteredImages) ?? [];
+  const nextActiveImageScope = remapImageList(store.activeImageScope);
+  const nextClusterNavigationContext = remapImageList(store.clusterNavigationContext);
+  const nextComparisonImages = remapImageList(store.comparisonImages) ?? [];
 
   useImageStore.setState({
     directories: nextDirectories,
     images: nextImages,
-    filteredImages: store.filteredImages.map((image) =>
-      normalizePath(image.directoryId ?? '') === normalizePath(oldPath)
-        ? { ...image, id: replaceImageId(image.id), directoryId: newPath }
-        : image
-    ),
+    filteredImages: nextFilteredImages,
+    selectedImage: remapImage(store.selectedImage),
+    previewImage: remapImage(store.previewImage),
+    activeImageScope: nextActiveImageScope,
+    clusterNavigationContext: nextClusterNavigationContext,
+    comparisonImages: nextComparisonImages,
     selectedImages: nextSelectedImages,
+    clipboard: nextClipboard,
     selectedFolders: nextSelectedFolders,
     annotations: nextAnnotations,
   });
 
   localStorage.setItem('image-metahub-directories', JSON.stringify(nextDirectories.map((directory) => directory.path)));
+  localStorage.setItem(
+    'image-metahub-directory-watchers',
+    JSON.stringify(Object.fromEntries(nextDirectories.map((directory) => [
+      directory.id,
+      { enabled: !!directory.autoWatch, path: directory.path },
+    ]))),
+  );
+};
+
+const rebindRootWatcher = async (oldDirectoryId: string, newDirectoryId: string, newPath: string) => {
+  if (typeof window === 'undefined' || !window.electronAPI) {
+    return;
+  }
+
+  const stopResult = await window.electronAPI.stopWatchingDirectory?.({ directoryId: oldDirectoryId });
+  if (stopResult && !stopResult.success) {
+    console.warn('Failed to stop watcher for renamed folder:', (stopResult as { error?: string }).error);
+  }
+
+  const startResult = await window.electronAPI.startWatchingDirectory?.({
+    directoryId: newDirectoryId,
+    dirPath: newPath,
+  });
+  if (startResult && !startResult.success) {
+    useImageStore.getState().setError(startResult.error || 'Folder renamed, but auto-watch could not be restarted.');
+  }
 };
 
 export default function DirectoryList({
@@ -1105,6 +1148,9 @@ export default function DirectoryList({
                         const isRootRename = normalizePath(rootDir.path) === normalizePath(targetPath);
                         if (isRootRename) {
                           renameIndexedRootInStore(targetPath, newPath, newName.trim());
+                          if (rootDir.autoWatch) {
+                            await rebindRootWatcher(targetPath, newPath, newPath);
+                          }
                           onUpdateDirectory(newPath);
                           return;
                         }

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -82,6 +82,7 @@ export default function DirectoryList({
   const [loadingNodes, setLoadingNodes] = useState<Set<string>>(new Set());
   const [autoMarkedNodes, setAutoMarkedNodes] = useState<Set<string>>(new Set());
   const [isExpanded, setIsExpanded] = useState(true);
+  const [autoExpandedDirs, setAutoExpandedDirs] = useState<Set<string>>(new Set());
   const [dragOverPath, setDragOverPath] = useState<string | null>(null);
   const [isTransferring, setIsTransferring] = useState(false);
   const clipboard = useImageStore(state => state.clipboard);
@@ -262,11 +263,12 @@ export default function DirectoryList({
         const { imageIds } = payload;
         if (imageIds && Array.isArray(imageIds)) {
           const imagesToTransfer = useImageStore.getState().images.filter(img => imageIds.includes(img.id));
-          if (imagesToTransfer.length > 0) {
+          const rootDir = directories.find(d => destPath.startsWith(d.path));
+          if (imagesToTransfer.length > 0 && rootDir) {
             setIsTransferring(true);
             await transferIndexedImages({
               images: imagesToTransfer,
-              destinationDirectory: { path: destPath },
+              destinationDirectory: { ...rootDir, path: destPath },
               mode: e.ctrlKey || e.altKey ? 'copy' : 'move',
             });
             // refresh dest dir
@@ -859,19 +861,19 @@ export default function DirectoryList({
                   return;
                 }
                 const destPath = contextMenu.path;
+                const rootDir = directories.find(d => destPath.startsWith(d.path));
                 const imagesToTransfer = useImageStore.getState().images.filter(img => clipboard.imageIds.includes(img.id));
-                if (imagesToTransfer.length > 0) {
+                if (imagesToTransfer.length > 0 && rootDir) {
                   setIsTransferring(true);
                   try {
                     await transferIndexedImages({
                       images: imagesToTransfer,
-                      destinationDirectory: { path: destPath },
+                      destinationDirectory: { ...rootDir, path: destPath },
                       mode: clipboard.mode,
                     });
                     if (clipboard.mode === 'move') {
                       useImageStore.getState().setClipboard(null);
                     }
-                    const rootDir = directories.find(d => destPath.startsWith(d.path));
                     if (rootDir) {
                       onUpdateDirectory(rootDir.id, destPath);
                     }

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -112,18 +112,34 @@ const getElectronDirname = async (filePath: string): Promise<string | null> => {
 
 const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: string) => {
   const store = useImageStore.getState();
-  const remapPathPrefix = (targetPath: string) => (
-    normalizePath(targetPath) === normalizePath(oldPath) ||
-    normalizePath(targetPath).startsWith(`${normalizePath(oldPath)}/`)
-      ? normalizePath(`${newPath}${targetPath.slice(oldPath.length)}`)
-      : targetPath
-  );
-  const replaceImageId = (imageId: string) => (
-    imageId.startsWith(`${oldPath}::`) ? `${newPath}::${imageId.slice(oldPath.length + 2)}` : imageId
-  );
+  const normalizedOldPath = normalizePath(oldPath);
+  const normalizedNewPath = normalizePath(newPath);
+  const isSameOrNestedPath = (targetPath: string) => {
+    const normalizedTarget = normalizePath(targetPath);
+    return normalizedTarget === normalizedOldPath || normalizedTarget.startsWith(`${normalizedOldPath}/`);
+  };
+  const remapPathPrefix = (targetPath: string) => {
+    const normalizedTarget = normalizePath(targetPath);
+    if (!isSameOrNestedPath(normalizedTarget)) {
+      return targetPath;
+    }
+    return `${normalizedNewPath}${normalizedTarget.slice(normalizedOldPath.length)}`;
+  };
+  const replaceImageId = (imageId: string) => {
+    const separatorIndex = imageId.indexOf('::');
+    if (separatorIndex < 0) {
+      return imageId;
+    }
+
+    const directoryId = imageId.slice(0, separatorIndex);
+    const remappedDirectoryId = remapPathPrefix(directoryId);
+    return remappedDirectoryId === directoryId
+      ? imageId
+      : `${remappedDirectoryId}${imageId.slice(separatorIndex)}`;
+  };
   const remapImage = (image: IndexedImage | null): IndexedImage | null => (
-    image && normalizePath(image.directoryId ?? '') === normalizePath(oldPath)
-      ? { ...image, id: replaceImageId(image.id), directoryId: newPath }
+    image?.directoryId && isSameOrNestedPath(image.directoryId)
+      ? { ...image, id: replaceImageId(image.id), directoryId: remapPathPrefix(image.directoryId) }
       : image
   );
   const remapImageList = (images: IndexedImage[] | null): IndexedImage[] | null => (
@@ -131,19 +147,18 @@ const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: str
   );
 
   const nextDirectories = store.directories.map((directory) =>
-    normalizePath(directory.path) === normalizePath(oldPath)
-      ? { ...directory, id: newPath, path: newPath, name: newName }
+    isSameOrNestedPath(directory.path)
+      ? {
+          ...directory,
+          id: remapPathPrefix(directory.id),
+          path: remapPathPrefix(directory.path),
+          name: normalizePath(directory.path) === normalizedOldPath ? newName : directory.name,
+        }
       : directory
   );
 
   const nextImages = store.images.map((image) =>
-    normalizePath(image.directoryId ?? '') === normalizePath(oldPath)
-      ? {
-          ...image,
-          id: replaceImageId(image.id),
-          directoryId: newPath,
-        }
-      : image
+    remapImage(image) ?? image
   );
 
   const nextSelectedImages = new Set(Array.from(store.selectedImages).map(replaceImageId));
@@ -187,24 +202,28 @@ const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: str
       { enabled: !!directory.autoWatch, path: directory.path },
     ]))),
   );
+
+  return nextDirectories;
 };
 
-const rebindRootWatcher = async (oldDirectoryId: string, newDirectoryId: string, newPath: string) => {
+const rebindRootWatchers = async (watchers: Array<{ oldDirectoryId: string; newDirectoryId: string; newPath: string }>) => {
   if (typeof window === 'undefined' || !window.electronAPI) {
     return;
   }
 
-  const stopResult = await window.electronAPI.stopWatchingDirectory?.({ directoryId: oldDirectoryId });
-  if (stopResult && !stopResult.success) {
-    console.warn('Failed to stop watcher for renamed folder:', (stopResult as { error?: string }).error);
-  }
+  for (const watcher of watchers) {
+    const stopResult = await window.electronAPI.stopWatchingDirectory?.({ directoryId: watcher.oldDirectoryId });
+    if (stopResult && !stopResult.success) {
+      console.warn('Failed to stop watcher for renamed folder:', (stopResult as { error?: string }).error);
+    }
 
-  const startResult = await window.electronAPI.startWatchingDirectory?.({
-    directoryId: newDirectoryId,
-    dirPath: newPath,
-  });
-  if (startResult && !startResult.success) {
-    useImageStore.getState().setError(startResult.error || 'Folder renamed, but auto-watch could not be restarted.');
+    const startResult = await window.electronAPI.startWatchingDirectory?.({
+      directoryId: watcher.newDirectoryId,
+      dirPath: watcher.newPath,
+    });
+    if (startResult && !startResult.success) {
+      useImageStore.getState().setError(startResult.error || 'Folder renamed, but auto-watch could not be restarted.');
+    }
   }
 };
 
@@ -1164,9 +1183,26 @@ export default function DirectoryList({
                       if (rootDir) {
                         const isRootRename = normalizePath(rootDir.path) === normalizePath(targetPath);
                         if (isRootRename) {
-                          renameIndexedRootInStore(targetPath, newPath, newName.trim());
-                          if (rootDir.autoWatch) {
-                            await rebindRootWatcher(targetPath, newPath, newPath);
+                          const affectedDirectories = useImageStore.getState().directories
+                            .filter((directory) => {
+                              const normalizedPath = normalizePath(directory.path);
+                              const normalizedTarget = normalizePath(targetPath);
+                              return normalizedPath === normalizedTarget || normalizedPath.startsWith(`${normalizedTarget}/`);
+                            })
+                            .map((directory) => {
+                              const remappedPath = `${normalizePath(newPath)}${normalizePath(directory.path).slice(normalizePath(targetPath).length)}`;
+                              return {
+                                oldDirectoryId: directory.id,
+                                newDirectoryId: remappedPath,
+                                newPath: remappedPath,
+                                autoWatch: directory.autoWatch,
+                              };
+                            });
+                          const nextDirectories = renameIndexedRootInStore(targetPath, newPath, newName.trim());
+                          await window.electronAPI?.updateAllowedPaths(nextDirectories.map((directory) => directory.path));
+                          const watcherRebinds = affectedDirectories.filter((directory) => directory.autoWatch);
+                          if (watcherRebinds.length > 0) {
+                            await rebindRootWatchers(watcherRebinds);
                           }
                           onUpdateDirectory(newPath);
                           return;

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -115,7 +115,7 @@ const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: str
   const remapPathPrefix = (targetPath: string) => (
     normalizePath(targetPath) === normalizePath(oldPath) ||
     normalizePath(targetPath).startsWith(`${normalizePath(oldPath)}/`)
-      ? `${newPath}${targetPath.slice(oldPath.length)}`
+      ? normalizePath(`${newPath}${targetPath.slice(oldPath.length)}`)
       : targetPath
   );
   const replaceImageId = (imageId: string) => (
@@ -444,12 +444,14 @@ export default function DirectoryList({
       const destinationDirectory = createTransferDestination(directories, destPath);
       if (imagesToTransfer.length > 0 && destinationDirectory) {
         setIsTransferring(true);
-        await transferIndexedImages({
+        const result = await transferIndexedImages({
           images: imagesToTransfer,
           destinationDirectory,
           mode: e.ctrlKey || e.altKey ? 'copy' : 'move',
         });
-        onUpdateDirectory(destinationDirectory.id, destPath);
+        if (result.success) {
+          onUpdateDirectory(destinationDirectory.id, destPath);
+        }
       }
     } catch (err) {
       console.error('Drop transfer failed:', err);
@@ -1059,15 +1061,17 @@ export default function DirectoryList({
                 if (imagesToTransfer.length > 0 && destinationDirectory) {
                   setIsTransferring(true);
                   try {
-                    await transferIndexedImages({
+                    const result = await transferIndexedImages({
                       images: imagesToTransfer,
                       destinationDirectory,
                       mode: clipboard.mode,
                     });
-                    if (clipboard.mode === 'move') {
+                    if (result.success && clipboard.mode === 'move') {
                       useImageStore.getState().setClipboard(null);
                     }
-                    onUpdateDirectory(destinationDirectory.id, destPath);
+                    if (result.success) {
+                      onUpdateDirectory(destinationDirectory.id, destPath);
+                    }
                   } catch (err) {
                     console.error('Paste failed:', err);
                   } finally {

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -101,8 +101,23 @@ const joinElectronPath = async (...paths: string[]): Promise<string | null> => {
   return null;
 };
 
+const getElectronDirname = async (filePath: string): Promise<string | null> => {
+  const result = await window.electronAPI?.dirname(filePath);
+  if (result?.success && typeof result.path === 'string') {
+    return result.path;
+  }
+  useImageStore.getState().setError(result?.error || 'Failed to resolve parent folder.');
+  return null;
+};
+
 const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: string) => {
   const store = useImageStore.getState();
+  const remapPathPrefix = (targetPath: string) => (
+    normalizePath(targetPath) === normalizePath(oldPath) ||
+    normalizePath(targetPath).startsWith(`${normalizePath(oldPath)}/`)
+      ? `${newPath}${targetPath.slice(oldPath.length)}`
+      : targetPath
+  );
   const replaceImageId = (imageId: string) => (
     imageId.startsWith(`${oldPath}::`) ? `${newPath}::${imageId.slice(oldPath.length + 2)}` : imageId
   );
@@ -135,12 +150,8 @@ const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: str
   const nextClipboard = store.clipboard
     ? { ...store.clipboard, imageIds: store.clipboard.imageIds.map(replaceImageId) }
     : null;
-  const nextSelectedFolders = new Set(Array.from(store.selectedFolders).map((folderPath) =>
-    normalizePath(folderPath) === normalizePath(oldPath) ||
-    normalizePath(folderPath).startsWith(`${normalizePath(oldPath)}/`)
-      ? `${newPath}${folderPath.slice(oldPath.length)}`
-      : folderPath
-  ));
+  const nextSelectedFolders = new Set(Array.from(store.selectedFolders).map(remapPathPrefix));
+  const nextExcludedFolders = new Set(Array.from(store.excludedFolders).map(remapPathPrefix));
 
   const nextAnnotations = new Map<string, any>();
   store.annotations.forEach((annotation, imageId) => {
@@ -164,6 +175,7 @@ const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: str
     selectedImages: nextSelectedImages,
     clipboard: nextClipboard,
     selectedFolders: nextSelectedFolders,
+    excludedFolders: nextExcludedFolders,
     annotations: nextAnnotations,
   });
 
@@ -1135,7 +1147,8 @@ export default function DirectoryList({
                   if (newName.trim() && newName.trim() !== folderName) {
                     const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
                     if (isElectron) {
-                      const parentPath = targetPath.substring(0, targetPath.length - folderName.length - 1);
+                      const parentPath = await getElectronDirname(targetPath);
+                      if (!parentPath) return;
                       const newPath = await joinElectronPath(parentPath, newName.trim());
                       if (!newPath) return;
                       const result = await (window as any).electronAPI.renameFile(targetPath, newPath);

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -101,6 +101,58 @@ const joinElectronPath = async (...paths: string[]): Promise<string | null> => {
   return null;
 };
 
+const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: string) => {
+  const store = useImageStore.getState();
+  const replaceImageId = (imageId: string) => (
+    imageId.startsWith(`${oldPath}::`) ? `${newPath}::${imageId.slice(oldPath.length + 2)}` : imageId
+  );
+
+  const nextDirectories = store.directories.map((directory) =>
+    normalizePath(directory.path) === normalizePath(oldPath)
+      ? { ...directory, id: newPath, path: newPath, name: newName }
+      : directory
+  );
+
+  const nextImages = store.images.map((image) =>
+    normalizePath(image.directoryId ?? '') === normalizePath(oldPath)
+      ? {
+          ...image,
+          id: replaceImageId(image.id),
+          directoryId: newPath,
+        }
+      : image
+  );
+
+  const nextSelectedImages = new Set(Array.from(store.selectedImages).map(replaceImageId));
+  const nextSelectedFolders = new Set(Array.from(store.selectedFolders).map((folderPath) =>
+    normalizePath(folderPath) === normalizePath(oldPath) ||
+    normalizePath(folderPath).startsWith(`${normalizePath(oldPath)}/`)
+      ? `${newPath}${folderPath.slice(oldPath.length)}`
+      : folderPath
+  ));
+
+  const nextAnnotations = new Map<string, any>();
+  store.annotations.forEach((annotation, imageId) => {
+    const nextImageId = replaceImageId(imageId);
+    nextAnnotations.set(nextImageId, { ...annotation, imageId: nextImageId });
+  });
+
+  useImageStore.setState({
+    directories: nextDirectories,
+    images: nextImages,
+    filteredImages: store.filteredImages.map((image) =>
+      normalizePath(image.directoryId ?? '') === normalizePath(oldPath)
+        ? { ...image, id: replaceImageId(image.id), directoryId: newPath }
+        : image
+    ),
+    selectedImages: nextSelectedImages,
+    selectedFolders: nextSelectedFolders,
+    annotations: nextAnnotations,
+  });
+
+  localStorage.setItem('image-metahub-directories', JSON.stringify(nextDirectories.map((directory) => directory.path)));
+};
+
 export default function DirectoryList({
   directories,
   onRemoveDirectory,
@@ -1000,7 +1052,17 @@ export default function DirectoryList({
                       return;
                     }
                     const rootDir = findRootDirectoryForPath(directories, targetPath);
-                    if (rootDir) onUpdateDirectory(rootDir.id, targetPath);
+                    if (rootDir) {
+                      const nodeKey = makeNodeKey(rootDir.id, getRelativePath(rootDir.path, targetPath));
+                      setSubfolderCache(prev => {
+                        const next = new Map(prev);
+                        next.delete(nodeKey);
+                        return next;
+                      });
+                      setExpandedNodes(prev => new Set(prev).add(nodeKey));
+                      await loadSubfolders(nodeKey, targetPath, rootDir);
+                      onUpdateDirectory(rootDir.id, targetPath);
+                    }
                   }
                 },
               });
@@ -1039,7 +1101,25 @@ export default function DirectoryList({
                         return;
                       }
                       const rootDir = findRootDirectoryForPath(directories, targetPath);
-                      if (rootDir) onUpdateDirectory(rootDir.id);
+                      if (rootDir) {
+                        const isRootRename = normalizePath(rootDir.path) === normalizePath(targetPath);
+                        if (isRootRename) {
+                          renameIndexedRootInStore(targetPath, newPath, newName.trim());
+                          onUpdateDirectory(newPath);
+                          return;
+                        }
+
+                        const parentKey = makeNodeKey(rootDir.id, getRelativePath(rootDir.path, parentPath));
+                        setSubfolderCache(prev => {
+                          const next = new Map(prev);
+                          next.delete(parentKey);
+                          next.delete(makeNodeKey(rootDir.id, getRelativePath(rootDir.path, targetPath)));
+                          return next;
+                        });
+                        setExpandedNodes(prev => new Set(prev).add(parentKey));
+                        await loadSubfolders(parentKey, parentPath, rootDir);
+                        onUpdateDirectory(rootDir.id);
+                      }
                     }
                   }
                 },

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -4,6 +4,7 @@ import { FolderOpen, RotateCcw, Trash2, ChevronDown, Folder, FolderTree, X, EyeO
 import { useImageStore } from '../store/useImageStore';
 import { transferIndexedImages } from '../services/fileTransferService';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
+import { getActiveDragImageIds, clearActiveDragImageIds } from './ImageGrid';
 
 interface DirectoryListProps {
   directories: Directory[];
@@ -59,6 +60,47 @@ const getRelativePath = (rootPath: string, targetPath: string) => {
   return normalizedTarget;
 };
 
+const findRootDirectoryForPath = (directories: Directory[], targetPath: string): Directory | undefined => {
+  const normalizedTarget = toForwardSlashes(targetPath).toLowerCase();
+
+  return directories
+    .filter((directory) => {
+      const normalizedRoot = toForwardSlashes(directory.path).toLowerCase();
+      return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}/`);
+    })
+    .sort((a, b) => b.path.length - a.path.length)[0];
+};
+
+const createTransferDestination = (directories: Directory[], destinationPath: string) => {
+  const rootDirectory = findRootDirectoryForPath(directories, destinationPath);
+  if (!rootDirectory) {
+    return null;
+  }
+
+  const relativePath = getRelativePath(rootDirectory.path, destinationPath);
+
+  return {
+    ...rootDirectory,
+    path: destinationPath,
+    name: relativePath || rootDirectory.name,
+    rootDirectoryPath: rootDirectory.path,
+    destinationRelativePath: relativePath,
+    displayName: relativePath ? `${rootDirectory.name}/${relativePath}` : rootDirectory.name,
+  };
+};
+
+const joinElectronPath = async (...paths: string[]): Promise<string | null> => {
+  const result = await (window as any).electronAPI.joinPaths(...paths);
+  if (typeof result === 'string') {
+    return result;
+  }
+  if (result?.success && typeof result.path === 'string') {
+    return result.path;
+  }
+  useImageStore.getState().setError(result?.error || 'Failed to resolve folder path.');
+  return null;
+};
+
 export default function DirectoryList({
   directories,
   onRemoveDirectory,
@@ -87,6 +129,14 @@ export default function DirectoryList({
   const [isTransferring, setIsTransferring] = useState(false);
   const clipboard = useImageStore(state => state.clipboard);
   const { canUseFileManagement, showProModal } = useFeatureAccess();
+  const [folderPrompt, setFolderPrompt] = useState<{
+    mode: 'new' | 'rename';
+    targetPath: string;
+    defaultValue: string;
+    onConfirm: (value: string) => void;
+  } | null>(null);
+  const [folderPromptValue, setFolderPromptValue] = useState('');
+  const folderPromptInputRef = useRef<HTMLInputElement>(null);
   const [contextMenu, setContextMenu] = useState<{
     visible: boolean;
     x: number;
@@ -95,6 +145,14 @@ export default function DirectoryList({
   } | null>(null);
   const treeRef = useRef<HTMLDivElement>(null);
   const treeKeyboardActiveRef = useRef(false);
+
+  // Focus input when prompt opens
+  useEffect(() => {
+    if (folderPrompt) {
+      setFolderPromptValue(folderPrompt.defaultValue);
+      setTimeout(() => folderPromptInputRef.current?.focus(), 50);
+    }
+  }, [folderPrompt]);
 
   const loadSubfolders = useCallback(async (
     nodeKey: string,
@@ -226,8 +284,9 @@ export default function DirectoryList({
   useEffect(() => {
     const handleClickOutside = () => setContextMenu(null);
     if (contextMenu) {
-      window.addEventListener('click', handleClickOutside, true);
-      return () => window.removeEventListener('click', handleClickOutside, true);
+      // Use bubble phase (not capture) so stopPropagation on the menu container works
+      window.addEventListener('click', handleClickOutside);
+      return () => window.removeEventListener('click', handleClickOutside);
     }
   }, [contextMenu]);
 
@@ -256,32 +315,41 @@ export default function DirectoryList({
       return;
     }
 
-    try {
-      const data = e.dataTransfer.getData('application/x-image-metahub-drag');
-      if (data) {
-        const payload = JSON.parse(data);
-        const { imageIds } = payload;
-        if (imageIds && Array.isArray(imageIds)) {
-          const imagesToTransfer = useImageStore.getState().images.filter(img => imageIds.includes(img.id));
-          const rootDir = directories.find(d => destPath.startsWith(d.path));
-          if (imagesToTransfer.length > 0 && rootDir) {
-            setIsTransferring(true);
-            await transferIndexedImages({
-              images: imagesToTransfer,
-              destinationDirectory: { ...rootDir, path: destPath },
-              mode: e.ctrlKey || e.altKey ? 'copy' : 'move',
-            });
-            // refresh dest dir
-            onUpdateDirectory(rootDirId, destPath);
-          }
+    // Prefer module-level variable (works in Electron native drag)
+    // Fall back to dataTransfer for browser env
+    let imageIds: string[] = getActiveDragImageIds();
+    clearActiveDragImageIds();
+
+    if (imageIds.length === 0) {
+      try {
+        const data = e.dataTransfer.getData('application/x-image-metahub-drag');
+        if (data) {
+          const payload = JSON.parse(data);
+          imageIds = payload.imageIds || [];
         }
+      } catch (_) { /* ignore */ }
+    }
+
+    if (imageIds.length === 0) return;
+
+    try {
+      const imagesToTransfer = useImageStore.getState().images.filter(img => imageIds.includes(img.id));
+      const destinationDirectory = createTransferDestination(directories, destPath);
+      if (imagesToTransfer.length > 0 && destinationDirectory) {
+        setIsTransferring(true);
+        await transferIndexedImages({
+          images: imagesToTransfer,
+          destinationDirectory,
+          mode: e.ctrlKey || e.altKey ? 'copy' : 'move',
+        });
+        onUpdateDirectory(destinationDirectory.id, destPath);
       }
     } catch (err) {
-      console.error('Failed to parse internal drag data or transfer files:', err);
+      console.error('Drop transfer failed:', err);
     } finally {
       setIsTransferring(false);
     }
-  }, [canUseFileManagement, showProModal, onUpdateDirectory]);
+  }, [canUseFileManagement, showProModal, onUpdateDirectory, directories]);
 
   const renderSubfolderList = useCallback((rootDirectory: Directory, parentKey: string): React.ReactNode => {
     const children = subfolderCache.get(parentKey) || [];
@@ -406,7 +474,25 @@ export default function DirectoryList({
         </li>
       );
     });
-  }, [expandedNodes, handleFolderClick, handleContextMenu, handleToggleNode, isFolderSelected, loadingNodes, subfolderCache, excludedFolders]);
+  }, [
+    dragOverPath,
+    expandedNodes,
+    handleDragLeave,
+    handleDragOver,
+    handleDrop,
+    handleFolderClick,
+    handleContextMenu,
+    handleToggleNode,
+    isFolderSelected,
+    loadingNodes,
+    subfolderCache,
+    excludedFolders,
+    onIncludeFolder,
+    onExcludeFolder,
+    isIndexing,
+    onUpdateDirectory,
+    loadSubfolders,
+  ]);
 
   const visibleNodes = useMemo<VisibleDirectoryNode[]>(() => {
     const nodes: VisibleDirectoryNode[] = [];
@@ -861,22 +947,20 @@ export default function DirectoryList({
                   return;
                 }
                 const destPath = contextMenu.path;
-                const rootDir = directories.find(d => destPath.startsWith(d.path));
+                const destinationDirectory = createTransferDestination(directories, destPath);
                 const imagesToTransfer = useImageStore.getState().images.filter(img => clipboard.imageIds.includes(img.id));
-                if (imagesToTransfer.length > 0 && rootDir) {
+                if (imagesToTransfer.length > 0 && destinationDirectory) {
                   setIsTransferring(true);
                   try {
                     await transferIndexedImages({
                       images: imagesToTransfer,
-                      destinationDirectory: { ...rootDir, path: destPath },
+                      destinationDirectory,
                       mode: clipboard.mode,
                     });
                     if (clipboard.mode === 'move') {
                       useImageStore.getState().setClipboard(null);
                     }
-                    if (rootDir) {
-                      onUpdateDirectory(rootDir.id, destPath);
-                    }
+                    onUpdateDirectory(destinationDirectory.id, destPath);
                   } catch (err) {
                     console.error('Paste failed:', err);
                   } finally {
@@ -893,25 +977,33 @@ export default function DirectoryList({
 
           <button
             className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-gray-700 flex items-center gap-2"
-            onClick={async () => {
+            onClick={() => {
               if (!canUseFileManagement) {
                 showProModal('file_management');
                 setContextMenu(null);
                 return;
               }
-              const newName = window.prompt("New folder name:");
-              if (newName) {
-                const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
-                if (isElectron) {
-                  const newPath = await (window as any).electronAPI.joinPaths(contextMenu.path, newName);
-                  await (window as any).electronAPI.ensureDirectory(newPath);
-                  const rootDir = directories.find(d => contextMenu.path.startsWith(d.path));
-                  if (rootDir) {
-                    onUpdateDirectory(rootDir.id, contextMenu.path);
-                  }
-                }
-              }
+              const targetPath = contextMenu.path;
               setContextMenu(null);
+              setFolderPrompt({
+                mode: 'new',
+                targetPath,
+                defaultValue: '',
+                onConfirm: async (newName) => {
+                  const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
+                  if (isElectron && newName.trim()) {
+                    const newPath = await joinElectronPath(targetPath, newName.trim());
+                    if (!newPath) return;
+                    const result = await (window as any).electronAPI.ensureDirectory(newPath);
+                    if (!result?.success) {
+                      useImageStore.getState().setError(result?.error || 'Failed to create folder.');
+                      return;
+                    }
+                    const rootDir = findRootDirectoryForPath(directories, targetPath);
+                    if (rootDir) onUpdateDirectory(rootDir.id, targetPath);
+                  }
+                },
+              });
             }}
           >
             <FolderPlus className="w-4 h-4 text-green-400" />
@@ -920,31 +1012,38 @@ export default function DirectoryList({
 
           <button
             className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-gray-700 flex items-center gap-2"
-            onClick={async () => {
+            onClick={() => {
               if (!canUseFileManagement) {
                 showProModal('file_management');
                 setContextMenu(null);
                 return;
               }
-              const folderName = contextMenu.path.split(/[\\/]/).pop();
-              if (!folderName) {
-                setContextMenu(null);
-                return;
-              }
-              const newName = window.prompt("Rename folder:", folderName);
-              if (newName && newName !== folderName) {
-                const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
-                if (isElectron) {
-                  const parentPath = contextMenu.path.substring(0, contextMenu.path.length - folderName.length - 1);
-                  const newPath = await (window as any).electronAPI.joinPaths(parentPath, newName);
-                  await (window as any).electronAPI.renameFile(contextMenu.path, newPath);
-                  const rootDir = directories.find(d => contextMenu.path.startsWith(d.path));
-                  if (rootDir) {
-                    onUpdateDirectory(rootDir.id); // Refresh root safely
-                  }
-                }
-              }
+              const folderName = contextMenu.path.split(/[\\/]/).pop() ?? '';
+              if (!folderName) { setContextMenu(null); return; }
+              const targetPath = contextMenu.path;
               setContextMenu(null);
+              setFolderPrompt({
+                mode: 'rename',
+                targetPath,
+                defaultValue: folderName,
+                onConfirm: async (newName) => {
+                  if (newName.trim() && newName.trim() !== folderName) {
+                    const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
+                    if (isElectron) {
+                      const parentPath = targetPath.substring(0, targetPath.length - folderName.length - 1);
+                      const newPath = await joinElectronPath(parentPath, newName.trim());
+                      if (!newPath) return;
+                      const result = await (window as any).electronAPI.renameFile(targetPath, newPath);
+                      if (!result?.success) {
+                        useImageStore.getState().setError(result?.error || 'Failed to rename folder.');
+                        return;
+                      }
+                      const rootDir = findRootDirectoryForPath(directories, targetPath);
+                      if (rootDir) onUpdateDirectory(rootDir.id);
+                    }
+                  }
+                },
+              });
             }}
           >
             <Edit2 className="w-4 h-4 text-yellow-400" />
@@ -981,6 +1080,58 @@ export default function DirectoryList({
               </button>
             )
           )}
+        </div>
+      )}
+
+      {/* Custom folder prompt modal (replaces window.prompt which is unsupported in Electron) */}
+      {folderPrompt && (
+        <div
+          className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          onClick={() => setFolderPrompt(null)}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div
+            className="bg-gray-800 border border-gray-600 rounded-lg shadow-2xl p-5 w-80 flex flex-col gap-3"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-sm font-semibold text-white">
+              {folderPrompt.mode === 'new' ? 'New Folder' : 'Rename Folder'}
+            </h3>
+            <input
+              ref={folderPromptInputRef}
+              type="text"
+              value={folderPromptValue}
+              onChange={(e) => setFolderPromptValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  folderPrompt.onConfirm(folderPromptValue);
+                  setFolderPrompt(null);
+                } else if (e.key === 'Escape') {
+                  setFolderPrompt(null);
+                }
+              }}
+              placeholder={folderPrompt.mode === 'new' ? 'Folder name…' : 'New name…'}
+              className="bg-gray-700 border border-gray-500 rounded px-3 py-2 text-sm text-white outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                className="px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded hover:bg-gray-700 transition-colors"
+                onClick={() => setFolderPrompt(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors"
+                onClick={() => {
+                  folderPrompt.onConfirm(folderPromptValue);
+                  setFolderPrompt(null);
+                }}
+              >
+                {folderPrompt.mode === 'new' ? 'Create' : 'Rename'}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Directory } from '../types';
-import { FolderOpen, RotateCcw, Trash2, ChevronDown, Folder, FolderTree, X, EyeOff, Eye } from 'lucide-react';
+import { FolderOpen, RotateCcw, Trash2, ChevronDown, Folder, FolderTree, X, EyeOff, Eye, FolderPlus, Edit2, Clipboard } from 'lucide-react';
+import { useImageStore } from '../store/useImageStore';
+import { transferIndexedImages } from '../services/fileTransferService';
+import { useFeatureAccess } from '../hooks/useFeatureAccess';
 
 interface DirectoryListProps {
   directories: Directory[];
@@ -79,7 +82,10 @@ export default function DirectoryList({
   const [loadingNodes, setLoadingNodes] = useState<Set<string>>(new Set());
   const [autoMarkedNodes, setAutoMarkedNodes] = useState<Set<string>>(new Set());
   const [isExpanded, setIsExpanded] = useState(true);
-  const [autoExpandedDirs, setAutoExpandedDirs] = useState<Set<string>>(new Set());
+  const [dragOverPath, setDragOverPath] = useState<string | null>(null);
+  const [isTransferring, setIsTransferring] = useState(false);
+  const clipboard = useImageStore(state => state.clipboard);
+  const { canUseFileManagement, showProModal } = useFeatureAccess();
   const [contextMenu, setContextMenu] = useState<{
     visible: boolean;
     x: number;
@@ -224,6 +230,57 @@ export default function DirectoryList({
     }
   }, [contextMenu]);
 
+  const handleDragOver = useCallback((e: React.DragEvent, path: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.dataTransfer) {
+      e.dataTransfer.dropEffect = e.ctrlKey || e.altKey ? 'copy' : 'move';
+    }
+    setDragOverPath(normalizePath(path));
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOverPath(null);
+  }, []);
+
+  const handleDrop = useCallback(async (e: React.DragEvent, destPath: string, rootDirId: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOverPath(null);
+
+    if (!canUseFileManagement) {
+      showProModal('file_management');
+      return;
+    }
+
+    try {
+      const data = e.dataTransfer.getData('application/x-image-metahub-drag');
+      if (data) {
+        const payload = JSON.parse(data);
+        const { imageIds } = payload;
+        if (imageIds && Array.isArray(imageIds)) {
+          const imagesToTransfer = useImageStore.getState().images.filter(img => imageIds.includes(img.id));
+          if (imagesToTransfer.length > 0) {
+            setIsTransferring(true);
+            await transferIndexedImages({
+              images: imagesToTransfer,
+              destinationDirectory: { path: destPath },
+              mode: e.ctrlKey || e.altKey ? 'copy' : 'move',
+            });
+            // refresh dest dir
+            onUpdateDirectory(rootDirId, destPath);
+          }
+        }
+      }
+    } catch (err) {
+      console.error('Failed to parse internal drag data or transfer files:', err);
+    } finally {
+      setIsTransferring(false);
+    }
+  }, [canUseFileManagement, showProModal, onUpdateDirectory]);
+
   const renderSubfolderList = useCallback((rootDirectory: Directory, parentKey: string): React.ReactNode => {
     const children = subfolderCache.get(parentKey) || [];
 
@@ -245,9 +302,12 @@ export default function DirectoryList({
               isSelected
                 ? 'bg-blue-500/15 ring-1 ring-blue-500/30 hover:bg-blue-500/20'
                 : 'hover:bg-gray-700/50'
-            }`}
+            } ${dragOverPath === normalizePath(child.path) ? 'ring-2 ring-blue-400 bg-blue-500/20' : ''}`}
             onClick={(e) => handleFolderClick(child.path, e)}
             onContextMenu={(e) => handleContextMenu(e, child.path)}
+            onDragOver={(e) => handleDragOver(e, child.path)}
+            onDragLeave={handleDragLeave}
+            onDrop={(e) => handleDrop(e, child.path, rootDirectory.id)}
           >
             {hasSubfolders ? (
               <button
@@ -620,7 +680,10 @@ export default function DirectoryList({
                       isRootSelected
                         ? 'bg-blue-500/15 ring-1 ring-blue-500/30 hover:bg-blue-500/20'
                         : 'bg-gray-800 hover:bg-gray-700/50'
-                    }`}
+                    } ${dragOverPath === normalizePath(dir.path) ? 'ring-2 ring-blue-400 bg-blue-500/20' : ''}`}
+                    onDragOver={(e) => handleDragOver(e, dir.path)}
+                    onDragLeave={handleDragLeave}
+                    onDrop={(e) => handleDrop(e, dir.path, dir.id)}
                   >
                     {progressEntry && (
                       <div className="absolute inset-0 pointer-events-none">
@@ -783,6 +846,110 @@ export default function DirectoryList({
             <RotateCcw className={`w-4 h-4 ${isIndexing ? 'text-gray-600' : ''}`} />
             Refresh Folder
           </button>
+
+          <div className="h-px bg-gray-700 my-1" />
+
+          {clipboard && clipboard.imageIds.length > 0 && (
+            <button
+              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-gray-700 flex items-center gap-2"
+              onClick={async () => {
+                if (!canUseFileManagement) {
+                  showProModal('file_management');
+                  setContextMenu(null);
+                  return;
+                }
+                const destPath = contextMenu.path;
+                const imagesToTransfer = useImageStore.getState().images.filter(img => clipboard.imageIds.includes(img.id));
+                if (imagesToTransfer.length > 0) {
+                  setIsTransferring(true);
+                  try {
+                    await transferIndexedImages({
+                      images: imagesToTransfer,
+                      destinationDirectory: { path: destPath },
+                      mode: clipboard.mode,
+                    });
+                    if (clipboard.mode === 'move') {
+                      useImageStore.getState().setClipboard(null);
+                    }
+                    const rootDir = directories.find(d => destPath.startsWith(d.path));
+                    if (rootDir) {
+                      onUpdateDirectory(rootDir.id, destPath);
+                    }
+                  } catch (err) {
+                    console.error('Paste failed:', err);
+                  } finally {
+                    setIsTransferring(false);
+                  }
+                }
+                setContextMenu(null);
+              }}
+            >
+              <Clipboard className="w-4 h-4 text-blue-400" />
+              Paste {clipboard.imageIds.length} image(s)
+            </button>
+          )}
+
+          <button
+            className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-gray-700 flex items-center gap-2"
+            onClick={async () => {
+              if (!canUseFileManagement) {
+                showProModal('file_management');
+                setContextMenu(null);
+                return;
+              }
+              const newName = window.prompt("New folder name:");
+              if (newName) {
+                const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
+                if (isElectron) {
+                  const newPath = await (window as any).electronAPI.joinPaths(contextMenu.path, newName);
+                  await (window as any).electronAPI.ensureDirectory(newPath);
+                  const rootDir = directories.find(d => contextMenu.path.startsWith(d.path));
+                  if (rootDir) {
+                    onUpdateDirectory(rootDir.id, contextMenu.path);
+                  }
+                }
+              }
+              setContextMenu(null);
+            }}
+          >
+            <FolderPlus className="w-4 h-4 text-green-400" />
+            New Folder
+          </button>
+
+          <button
+            className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-gray-700 flex items-center gap-2"
+            onClick={async () => {
+              if (!canUseFileManagement) {
+                showProModal('file_management');
+                setContextMenu(null);
+                return;
+              }
+              const folderName = contextMenu.path.split(/[\\/]/).pop();
+              if (!folderName) {
+                setContextMenu(null);
+                return;
+              }
+              const newName = window.prompt("Rename folder:", folderName);
+              if (newName && newName !== folderName) {
+                const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
+                if (isElectron) {
+                  const parentPath = contextMenu.path.substring(0, contextMenu.path.length - folderName.length - 1);
+                  const newPath = await (window as any).electronAPI.joinPaths(parentPath, newName);
+                  await (window as any).electronAPI.renameFile(contextMenu.path, newPath);
+                  const rootDir = directories.find(d => contextMenu.path.startsWith(d.path));
+                  if (rootDir) {
+                    onUpdateDirectory(rootDir.id); // Refresh root safely
+                  }
+                }
+              }
+              setContextMenu(null);
+            }}
+          >
+            <Edit2 className="w-4 h-4 text-yellow-400" />
+            Rename Folder
+          </button>
+
+          <div className="h-px bg-gray-700 my-1" />
 
           {excludedFolders?.has(normalizePath(contextMenu.path)) ? (
             onIncludeFolder && (

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -346,7 +346,8 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
     e.preventDefault();
     if (e.dataTransfer) {
       e.dataTransfer.effectAllowed = 'copyMove';
-      const imageIds = selectedImages.has(image.id) ? Array.from(selectedImages) : [image.id];
+      const currentSelectedImages = useImageStore.getState().selectedImages;
+      const imageIds = currentSelectedImages.has(image.id) ? Array.from(currentSelectedImages) : [image.id];
       e.dataTransfer.setData('application/x-image-metahub-drag', JSON.stringify({
         imageIds,
       }));

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -345,7 +345,11 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
     suppressNextClickRef.current = true;
     e.preventDefault();
     if (e.dataTransfer) {
-      e.dataTransfer.effectAllowed = 'copy';
+      e.dataTransfer.effectAllowed = 'copyMove';
+      const imageIds = selectedImages.has(image.id) ? Array.from(selectedImages) : [image.id];
+      e.dataTransfer.setData('application/x-image-metahub-drag', JSON.stringify({
+        imageIds,
+      }));
     }
     window.electronAPI?.startFileDrag({ directoryPath, relativePath });
   };

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -49,6 +49,13 @@ import {
   recordPerformanceDuration,
 } from '../utils/performanceDiagnostics';
 
+// Module-level variable to track internal image drag state (survives native file drag)
+let _activeDragImageIds: string[] = [];
+let _activeExternalDragPayload: { directoryPath: string; relativePath: string } | null = null;
+let _nativeDragStarted = false;
+export const getActiveDragImageIds = () => _activeDragImageIds;
+export const clearActiveDragImageIds = () => { _activeDragImageIds = []; };
+
 interface ImageRenameResult {
   oldImageId: string;
   newImageId: string;
@@ -343,16 +350,40 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
     const relativePath = relativeFromId || image.name;
 
     suppressNextClickRef.current = true;
-    e.preventDefault();
-    if (e.dataTransfer) {
-      e.dataTransfer.effectAllowed = 'copyMove';
-      const currentSelectedImages = useImageStore.getState().selectedImages;
-      const imageIds = currentSelectedImages.has(image.id) ? Array.from(currentSelectedImages) : [image.id];
-      e.dataTransfer.setData('application/x-image-metahub-drag', JSON.stringify({
-        imageIds,
-      }));
+    // Do NOT call e.preventDefault() — that kills HTML5 dragover/drop on page elements.
+    // Suppress the browser ghost image with a transparent pixel so the OS cursor
+    // from startFileDrag is the only visible indicator.
+    const transparentPixel = document.createElement('canvas');
+    transparentPixel.width = 1;
+    transparentPixel.height = 1;
+    e.dataTransfer.setDragImage(transparentPixel, 0, 0);
+    const currentSelectedImages = useImageStore.getState().selectedImages;
+    const imageIds = currentSelectedImages.has(image.id) ? Array.from(currentSelectedImages) : [image.id];
+    // Store in module-level variables so DirectoryList can consume internal drops.
+    _activeDragImageIds = imageIds;
+    _activeExternalDragPayload = { directoryPath, relativePath };
+    _nativeDragStarted = false;
+    e.dataTransfer.effectAllowed = 'copyMove';
+    try {
+      e.dataTransfer.setData('application/x-image-metahub-drag', JSON.stringify({ imageIds }));
+    } catch (_) { /* ignore in Electron native drag context */ }
+  };
+
+  const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!_activeExternalDragPayload || _nativeDragStarted || !window.electronAPI?.startFileDrag) {
+      return;
     }
-    window.electronAPI?.startFileDrag({ directoryPath, relativePath });
+
+    const hasLeftWindow =
+      e.clientX <= 0 ||
+      e.clientY <= 0 ||
+      e.clientX >= window.innerWidth - 1 ||
+      e.clientY >= window.innerHeight - 1;
+
+    if (hasLeftWindow) {
+      _nativeDragStarted = true;
+      window.electronAPI.startFileDrag(_activeExternalDragPayload);
+    }
   };
 
   const handleDragEnd = () => {
@@ -363,7 +394,11 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
     dragResetTimeoutRef.current = window.setTimeout(() => {
       suppressNextClickRef.current = false;
       dragResetTimeoutRef.current = null;
-    }, 0);
+      // Clear drag IDs if not consumed by a drop handler
+      clearActiveDragImageIds();
+      _activeExternalDragPayload = null;
+      _nativeDragStarted = false;
+    }, 100);
   };
 
   const handlePointerLikeDown = (clientX: number, clientY: number, button: number) => {
@@ -450,6 +485,7 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
 
         onContextMenu={(e) => onContextMenu && onContextMenu(image, e)}
         onDragStart={handleDragStart}
+        onDrag={handleDrag}
         onDragEnd={handleDragEnd}
         draggable={canDragExternally}
       >

--- a/electron.mjs
+++ b/electron.mjs
@@ -4282,9 +4282,9 @@ function setupFileOperationHandlers() {
 
   ipcMain.handle('ensure-directory', async (event, dirPath) => {
     try {
-      if (!isInternalPath(dirPath)) {
-        console.error('SECURITY VIOLATION: Attempted to create directory outside userData.');
-        return { success: false, error: 'Access denied: Cannot create directories outside userData.' };
+      if (!isAllowedOrInternal(dirPath)) {
+        console.error('SECURITY VIOLATION: Attempted to create directory outside allowed paths.');
+        return { success: false, error: 'Access denied: Cannot create directories outside allowed paths.' };
       }
       await fs.mkdir(dirPath, { recursive: true });
       return { success: true };

--- a/electron.mjs
+++ b/electron.mjs
@@ -3786,6 +3786,18 @@ function setupFileOperationHandlers() {
     }
   });
 
+  ipcMain.handle('dirname', async (event, filePath) => {
+    try {
+      if (!filePath) {
+        return { success: false, error: 'No path provided' };
+      }
+      return { success: true, path: path.dirname(String(filePath)) };
+    } catch (error) {
+      console.error('Error getting dirname:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
   // Handle batch path joining - optimized for processing multiple paths at once
   ipcMain.handle('join-paths-batch', async (event, { basePath, fileNames }) => {
     try {

--- a/electron.mjs
+++ b/electron.mjs
@@ -1776,6 +1776,19 @@ function setupFileOperationHandlers() {
     return normalized === userDataPath || normalized.startsWith(userDataPath + path.sep);
   };
   const isAllowedOrInternal = (filePath) => isPathAllowed(filePath) || isInternalPath(filePath);
+  const isRenameTargetAllowed = (oldPath, newPath) => {
+    if (isAllowedOrInternal(newPath)) {
+      return true;
+    }
+
+    if (!isPathAllowed(oldPath) || !newPath) {
+      return false;
+    }
+
+    const normalizedOldPath = normalizeAllowedPath(oldPath);
+    const normalizedNewPath = normalizeAllowedPath(newPath);
+    return path.dirname(normalizedOldPath) === path.dirname(normalizedNewPath);
+  };
   const normalizeNameKey = (name) => name.toLowerCase();
   const getUniqueName = (name, usedNames) => {
     const parsed = path.parse(name);
@@ -2972,7 +2985,7 @@ function setupFileOperationHandlers() {
   // Handle file renaming
   ipcMain.handle('rename-file', async (event, oldPath, newPath) => {
     try {
-      if (!isAllowedOrInternal(oldPath) || !isAllowedOrInternal(newPath)) {
+      if (!isAllowedOrInternal(oldPath) || !isRenameTargetAllowed(oldPath, newPath)) {
         console.error('SECURITY VIOLATION: Attempted to rename file outside of allowed directories.');
         return { success: false, error: 'Access denied: Cannot rename files outside of the allowed directories.' };
       }
@@ -2992,6 +3005,13 @@ function setupFileOperationHandlers() {
       }
 
       await fs.rename(oldPath, newPath);
+
+      const normalizedOldAllowedPath = normalizeAllowedPath(oldPath);
+      if (allowedDirectoryPaths.has(normalizedOldAllowedPath)) {
+        allowedDirectoryPaths.delete(normalizedOldAllowedPath);
+        allowedDirectoryPaths.add(normalizeAllowedPath(newPath));
+      }
+
       return { success: true };
     } catch (error) {
       console.error('Error renaming file:', error);

--- a/hooks/useHotkeys.ts
+++ b/hooks/useHotkeys.ts
@@ -136,45 +136,41 @@ export const useHotkeys = ({
       }
     });
 
-    hotkeyManager.registerAction('pasteImages', async () => {
-      if (!canUseFileManagement) {
-        showProModal('file_management');
-        return;
-      }
-      const state = useImageStore.getState();
-      const clipboard = state.clipboard;
-      if (!clipboard || clipboard.imageIds.length === 0) return;
+    hotkeyManager.registerAction('pasteImages', () => {
+      (async () => {
+        if (!canUseFileManagement) {
+          showProModal('file_management');
+          return;
+        }
+        const state = useImageStore.getState();
+        const clipboard = state.clipboard;
+        if (!clipboard || clipboard.imageIds.length === 0) return;
 
-      const destPath = Array.from(state.selectedFolders)[0];
-      if (!destPath) return;
+        const destPath = Array.from(state.selectedFolders)[0];
+        if (!destPath) return;
 
-      const imagesToTransfer = state.images.filter(img => clipboard.imageIds.includes(img.id));
-      if (imagesToTransfer.length > 0) {
-        try {
-          await transferIndexedImages({
-            images: imagesToTransfer,
-            destinationDirectory: { path: destPath },
-            mode: clipboard.mode,
-          });
-          if (clipboard.mode === 'move') {
-            state.setClipboard(null);
-          }
-          // Request reload of the destination directory
-          const rootDir = state.directories.find(d => destPath.startsWith(d.path));
-          if (rootDir) {
-            // How to call onUpdateDirectory?
-            // Since useImageLoader handles this, we might need a way to refresh it.
-            // But we don't have onUpdateDirectory here.
-            // For now, doing it via rescanFolders or just let auto-watch pick it up.
+        const rootDir = state.directories.find(d => destPath.startsWith(d.path));
+        const imagesToTransfer = state.images.filter(img => clipboard.imageIds.includes(img.id));
+        if (imagesToTransfer.length > 0 && rootDir) {
+          try {
+            await transferIndexedImages({
+              images: imagesToTransfer,
+              destinationDirectory: { ...rootDir, path: destPath },
+              mode: clipboard.mode,
+            });
+            if (clipboard.mode === 'move') {
+              state.setClipboard(null);
+            }
+            // Request reload of the destination directory
             if (!rootDir.autoWatch) {
                // Fallback: trigger rescan manually
                handleLoadFromStorage().catch(console.error);
             }
+          } catch (err) {
+            console.error('Paste failed:', err);
           }
-        } catch (err) {
-          console.error('Paste failed:', err);
         }
-      }
+      })();
     });
 
     hotkeyManager.registerAction('closeModalsOrClearSelection', () => {

--- a/hooks/useHotkeys.ts
+++ b/hooks/useHotkeys.ts
@@ -6,6 +6,7 @@ import { useImageSelection } from './useImageSelection';
 import { useImageLoader } from './useImageLoader';
 import { useFeatureAccess } from './useFeatureAccess';
 import { transferIndexedImages } from '../services/fileTransferService';
+import type { Directory } from '../types';
 
 interface HotkeyProps {
   isCommandPaletteOpen: boolean;
@@ -15,6 +16,39 @@ interface HotkeyProps {
   isSettingsModalOpen: boolean;
   setIsSettingsModalOpen: (isOpen: boolean) => void;
 }
+
+const normalizePath = (path: string) => path.replace(/\\/g, '/').replace(/\/+$/, '');
+
+const getRelativePath = (rootPath: string, targetPath: string) => {
+  const normalizedRoot = normalizePath(rootPath);
+  const normalizedTarget = normalizePath(targetPath);
+  if (normalizedRoot === normalizedTarget) return '';
+  return normalizedTarget.startsWith(`${normalizedRoot}/`)
+    ? normalizedTarget.slice(normalizedRoot.length + 1)
+    : '';
+};
+
+const createTransferDestination = (directories: Directory[], destinationPath: string) => {
+  const normalizedDestination = normalizePath(destinationPath).toLowerCase();
+  const rootDirectory = directories
+    .filter((directory) => {
+      const normalizedRoot = normalizePath(directory.path).toLowerCase();
+      return normalizedDestination === normalizedRoot || normalizedDestination.startsWith(`${normalizedRoot}/`);
+    })
+    .sort((a, b) => b.path.length - a.path.length)[0];
+
+  if (!rootDirectory) return null;
+
+  const relativePath = getRelativePath(rootDirectory.path, destinationPath);
+  return {
+    ...rootDirectory,
+    path: destinationPath,
+    name: relativePath || rootDirectory.name,
+    rootDirectoryPath: rootDirectory.path,
+    destinationRelativePath: relativePath,
+    displayName: relativePath ? `${rootDirectory.name}/${relativePath}` : rootDirectory.name,
+  };
+};
 
 export const useHotkeys = ({
   isCommandPaletteOpen,
@@ -113,27 +147,40 @@ export const useHotkeys = ({
 
     hotkeyManager.registerAction('copyImages', () => {
       const state = useImageStore.getState();
-      if (state.selectedImages.size > 0 && canUseFileManagement) {
-        state.setClipboard({
-          imageIds: Array.from(state.selectedImages),
-          mode: 'copy',
-        });
-        // Optional: show a toast
-      } else if (!canUseFileManagement && state.selectedImages.size > 0) {
+      const imageIds = state.selectedImages.size > 0
+        ? Array.from(state.selectedImages)
+        : state.selectedImage
+          ? [state.selectedImage.id]
+          : [];
+      if (imageIds.length === 0) return;
+      if (!canUseFileManagement) {
         showProModal('file_management');
+        return;
       }
+      state.setClipboard({
+        imageIds,
+        mode: 'copy',
+      });
+      state.setSuccess(`${imageIds.length} image${imageIds.length === 1 ? '' : 's'} copied.`);
     });
 
     hotkeyManager.registerAction('cutImages', () => {
       const state = useImageStore.getState();
-      if (state.selectedImages.size > 0 && canUseFileManagement) {
-        state.setClipboard({
-          imageIds: Array.from(state.selectedImages),
-          mode: 'move',
-        });
-      } else if (!canUseFileManagement && state.selectedImages.size > 0) {
+      const imageIds = state.selectedImages.size > 0
+        ? Array.from(state.selectedImages)
+        : state.selectedImage
+          ? [state.selectedImage.id]
+          : [];
+      if (imageIds.length === 0) return;
+      if (!canUseFileManagement) {
         showProModal('file_management');
+        return;
       }
+      state.setClipboard({
+        imageIds,
+        mode: 'move',
+      });
+      state.setSuccess(`${imageIds.length} image${imageIds.length === 1 ? '' : 's'} ready to move.`);
     });
 
     hotkeyManager.registerAction('pasteImages', () => {
@@ -147,23 +194,24 @@ export const useHotkeys = ({
         if (!clipboard || clipboard.imageIds.length === 0) return;
 
         const destPath = Array.from(state.selectedFolders)[0];
-        if (!destPath) return;
+        if (!destPath) {
+          state.setError('Select a destination folder before pasting images.');
+          return;
+        }
 
-        const rootDir = state.directories.find(d => destPath.startsWith(d.path));
+        const destinationDirectory = createTransferDestination(state.directories, destPath);
         const imagesToTransfer = state.images.filter(img => clipboard.imageIds.includes(img.id));
-        if (imagesToTransfer.length > 0 && rootDir) {
+        if (imagesToTransfer.length > 0 && destinationDirectory) {
           try {
             await transferIndexedImages({
               images: imagesToTransfer,
-              destinationDirectory: { ...rootDir, path: destPath },
+              destinationDirectory,
               mode: clipboard.mode,
             });
             if (clipboard.mode === 'move') {
               state.setClipboard(null);
             }
-            // Request reload of the destination directory
-            if (!rootDir.autoWatch) {
-               // Fallback: trigger rescan manually
+            if (!destinationDirectory.autoWatch) {
                handleLoadFromStorage().catch(console.error);
             }
           } catch (err) {
@@ -223,6 +271,8 @@ export const useHotkeys = ({
     setSelectedImage,
     handleNavigatePrevious,
     handleNavigateNext,
+    canUseFileManagement,
+    showProModal,
     isCommandPaletteOpen,
     isHotkeyHelpOpen,
     isSettingsModalOpen,

--- a/hooks/useHotkeys.ts
+++ b/hooks/useHotkeys.ts
@@ -203,15 +203,15 @@ export const useHotkeys = ({
         const imagesToTransfer = state.images.filter(img => clipboard.imageIds.includes(img.id));
         if (imagesToTransfer.length > 0 && destinationDirectory) {
           try {
-            await transferIndexedImages({
+            const result = await transferIndexedImages({
               images: imagesToTransfer,
               destinationDirectory,
               mode: clipboard.mode,
             });
-            if (clipboard.mode === 'move') {
+            if (result.success && clipboard.mode === 'move') {
               state.setClipboard(null);
             }
-            if (!destinationDirectory.autoWatch) {
+            if (result.success && !destinationDirectory.autoWatch) {
                handleLoadFromStorage().catch(console.error);
             }
           } catch (err) {

--- a/hooks/useHotkeys.ts
+++ b/hooks/useHotkeys.ts
@@ -4,6 +4,8 @@ import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageSelection } from './useImageSelection';
 import { useImageLoader } from './useImageLoader';
+import { useFeatureAccess } from './useFeatureAccess';
+import { transferIndexedImages } from '../services/fileTransferService';
 
 interface HotkeyProps {
   isCommandPaletteOpen: boolean;
@@ -38,6 +40,7 @@ export const useHotkeys = ({
   const { handleDeleteSelectedImages } = useImageSelection();
   const { handleSelectFolder, handleLoadFromStorage } = useImageLoader();
   const { toggleViewMode, theme, setTheme, keymap } = useSettingsStore();
+  const { canUseFileManagement, showProModal } = useFeatureAccess();
 
   const focusArea = (area: 'sidebar' | 'grid' | 'preview') => {
     const selector = area === 'sidebar'
@@ -107,6 +110,73 @@ export const useHotkeys = ({
     hotkeyManager.registerAction('toggleListGridView', toggleViewMode);
     hotkeyManager.registerAction('navigatePrevious', handleNavigatePrevious);
     hotkeyManager.registerAction('navigateNext', handleNavigateNext);
+
+    hotkeyManager.registerAction('copyImages', () => {
+      const state = useImageStore.getState();
+      if (state.selectedImages.size > 0 && canUseFileManagement) {
+        state.setClipboard({
+          imageIds: Array.from(state.selectedImages),
+          mode: 'copy',
+        });
+        // Optional: show a toast
+      } else if (!canUseFileManagement && state.selectedImages.size > 0) {
+        showProModal('file_management');
+      }
+    });
+
+    hotkeyManager.registerAction('cutImages', () => {
+      const state = useImageStore.getState();
+      if (state.selectedImages.size > 0 && canUseFileManagement) {
+        state.setClipboard({
+          imageIds: Array.from(state.selectedImages),
+          mode: 'move',
+        });
+      } else if (!canUseFileManagement && state.selectedImages.size > 0) {
+        showProModal('file_management');
+      }
+    });
+
+    hotkeyManager.registerAction('pasteImages', async () => {
+      if (!canUseFileManagement) {
+        showProModal('file_management');
+        return;
+      }
+      const state = useImageStore.getState();
+      const clipboard = state.clipboard;
+      if (!clipboard || clipboard.imageIds.length === 0) return;
+
+      const destPath = Array.from(state.selectedFolders)[0];
+      if (!destPath) return;
+
+      const imagesToTransfer = state.images.filter(img => clipboard.imageIds.includes(img.id));
+      if (imagesToTransfer.length > 0) {
+        try {
+          await transferIndexedImages({
+            images: imagesToTransfer,
+            destinationDirectory: { path: destPath },
+            mode: clipboard.mode,
+          });
+          if (clipboard.mode === 'move') {
+            state.setClipboard(null);
+          }
+          // Request reload of the destination directory
+          const rootDir = state.directories.find(d => destPath.startsWith(d.path));
+          if (rootDir) {
+            // How to call onUpdateDirectory?
+            // Since useImageLoader handles this, we might need a way to refresh it.
+            // But we don't have onUpdateDirectory here.
+            // For now, doing it via rescanFolders or just let auto-watch pick it up.
+            if (!rootDir.autoWatch) {
+               // Fallback: trigger rescan manually
+               handleLoadFromStorage().catch(console.error);
+            }
+          }
+        } catch (err) {
+          console.error('Paste failed:', err);
+        }
+      }
+    });
+
     hotkeyManager.registerAction('closeModalsOrClearSelection', () => {
       if (isCommandPaletteOpen) setIsCommandPaletteOpen(false);
       else if (isHotkeyHelpOpen) setIsHotkeyHelpOpen(false);

--- a/preload.js
+++ b/preload.js
@@ -155,6 +155,7 @@ const electronAPI = {
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
   joinPaths: (...paths) => ipcRenderer.invoke('join-paths', ...paths),
   joinPathsBatch: (args) => ipcRenderer.invoke('join-paths-batch', args),
+  dirname: (filePath) => ipcRenderer.invoke('dirname', filePath),
   toggleFullscreen: () => ipcRenderer.invoke('toggle-fullscreen'),
   getFullscreenState: () => ipcRenderer.invoke('get-fullscreen-state'),
   setFullscreen: (isFullscreen) => ipcRenderer.invoke('set-fullscreen', isFullscreen),

--- a/services/hotkeyConfig.ts
+++ b/services/hotkeyConfig.ts
@@ -25,6 +25,9 @@ export const hotkeyConfig: HotkeyDefinition[] = [
   { id: 'toggleQuickPreview', name: 'Toggle Quick Preview', scope: 'global', defaultKey: 'space' },
   { id: 'openFullscreen', name: 'Open Fullscreen', scope: 'global', defaultKey: 'enter' },
   { id: 'toggleListGridView', name: 'Toggle List/Grid View', scope: 'global', defaultKey: 'ctrl+l, cmd+l' },
+  { id: 'copyImages', name: 'Copy Images', scope: 'global', defaultKey: 'ctrl+c, cmd+c' },
+  { id: 'cutImages', name: 'Cut Images', scope: 'global', defaultKey: 'ctrl+x, cmd+x' },
+  { id: 'pasteImages', name: 'Paste Images', scope: 'global', defaultKey: 'ctrl+v, cmd+v' },
   { id: 'closeModalsOrClearSelection', name: 'Close Modals / Clear Selection', scope: 'global', defaultKey: 'esc' },
 
   // Preview Scope

--- a/services/hotkeyManager.ts
+++ b/services/hotkeyManager.ts
@@ -26,6 +26,9 @@ const hotkeysAllowedInTypingContext = new Set([
   'openQuickSettings',
   'openKeyboardShortcuts',
 ]);
+const hotkeysAllowedWithTextSelection = new Set([
+  'copyImages',
+]);
 
 // Track nested pause requests so overlapping modals do not resume hotkeys too early.
 let hotkeysPauseCount = 0;
@@ -68,6 +71,11 @@ const bindAllActions = () => {
       const isTypingContext = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 
       if (isTypingContext && !hotkeysAllowedInTypingContext.has(action.id)) {
+        return;
+      }
+
+      const selectedText = window.getSelection()?.toString() ?? '';
+      if (!isTypingContext && selectedText.length > 0 && hotkeysAllowedWithTextSelection.has(action.id)) {
         return;
       }
 

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -3648,7 +3648,6 @@ export const useImageStore = create<ImageState>((set, get) => {
         },
         setFocusedImageIndex: (index) => set({ focusedImageIndex: index }),
         setClipboard: (clipboard) => set({ clipboard }),
-        setViewingStackPrompt: (prompt) => set({ viewingStackPrompt: prompt }),
         setFullscreenMode: (isFullscreen) => set({ isFullscreenMode: isFullscreen }),
 
         // Clustering Actions (Phase 2)

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -773,6 +773,7 @@ interface ImageState {
   isAutomationRulesLoaded: boolean;
   activeCollectionId: string | null;
   previewImage: IndexedImage | null;
+  clipboard: { mode: 'copy' | 'move'; imageIds: string[] } | null;
   focusedImageIndex: number | null;
   isStackingEnabled: boolean;
   scanSubfolders: boolean;
@@ -931,6 +932,7 @@ interface ImageState {
   deleteSelectedImages: () => Promise<void>; // This will require file operations logic
   setScanSubfolders: (scan: boolean) => void;
   setFocusedImageIndex: (index: number | null) => void;
+  setClipboard: (clipboard: { mode: 'copy' | 'move'; imageIds: string[] } | null) => void;
   setViewingStackPrompt: (prompt: string | null) => void;
   setFullscreenMode: (isFullscreen: boolean) => void;
 
@@ -2484,6 +2486,7 @@ export const useImageStore = create<ImageState>((set, get) => {
         transferProgress: null,
         selectedImage: null,
         previewImage: null,
+        clipboard: null,
         selectedImages: new Set(),
         activeImageScope: null,
         collections: [],
@@ -3644,6 +3647,8 @@ export const useImageStore = create<ImageState>((set, get) => {
             return resolveSmartCollectionImageIds(collection, state.images).length;
         },
         setFocusedImageIndex: (index) => set({ focusedImageIndex: index }),
+        setClipboard: (clipboard) => set({ clipboard }),
+        setViewingStackPrompt: (prompt) => set({ viewingStackPrompt: prompt }),
         setFullscreenMode: (isFullscreen) => set({ isFullscreenMode: isFullscreen }),
 
         // Clustering Actions (Phase 2)

--- a/types.ts
+++ b/types.ts
@@ -211,6 +211,7 @@ export interface ElectronAPI {
   getAppVersion: () => Promise<string>;
   joinPaths: (...paths: string[]) => Promise<{ success: boolean; path?: string; error?: string }>;
   joinPathsBatch: (args: { basePath: string; fileNames: string[] }) => Promise<{ success: boolean; paths?: string[]; error?: string }>;
+  dirname: (filePath: string) => Promise<{ success: boolean; path?: string; error?: string }>;
   resolveMediaUrl: (filePath: string) => Promise<{ success: boolean; url?: string; error?: string; errorType?: string; errorCode?: string }>;
   startFileDrag: (args: { directoryPath: string; relativePath: string }) => void;
   copyImageToClipboard: (filePath: string) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## Summary

Adds advanced folder management workflows for indexed folders:

- drag and drop images from the grid into indexed folders/subfolders
- copy, cut, and paste selected images with keyboard shortcuts and folder context-menu paste
- create and rename folders from the directory list context menu
- keep Electron allowed-path checks compatible with folder creation and root folder renames
- refresh affected subfolder trees after create/rename operations

## Root Cause / Notes

The existing Copy To / Move To path only worked through explicit modal/context-menu transfer flows. This adds direct folder-oriented interactions while preserving native drag-out behavior for moving files outside the app.

## Validation

- `npx tsc --noEmit`
- `npm test -- --run __tests__/hotkeyManager.test.ts __tests__/hotkey-utils.test.ts`