### PR TITLE
Improve generation queue and generated output preview

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1661,18 +1661,8 @@ export default function App() {
       return output.imageId;
     }
 
-    if (!output.name) {
-      return undefined;
-    }
-
-    const normalizedOutputName = output.name.toLowerCase();
-    const match = [...images, ...filteredImages].find((candidate) => {
-      const candidateName = candidate.name.toLowerCase();
-      return candidateName === normalizedOutputName || candidate.id.toLowerCase().endsWith(`::${normalizedOutputName}`);
-    });
-
-    return match?.id;
-  }, [filteredImages, getImageByIdFromStore, images]);
+    return undefined;
+  }, [getImageByIdFromStore]);
 
   const enrichGeneratedOutputs = useCallback((outputs: GeneratedQueueOutput[]): GeneratedQueueOutput[] =>
     outputs.map((output) => ({

--- a/App.tsx
+++ b/App.tsx
@@ -1605,6 +1605,82 @@ export default function App() {
     });
   }, [beginModalOpenFlow, safeActiveImageScope, safeClusterNavigationContext, safeFilteredImages]);
 
+  const handleOpenImageModalFromGeneratedOutput = useCallback((imageId: string) => {
+    const image = getImageByIdFromStore(imageId);
+    if (!image) {
+      return;
+    }
+
+    const navigationSource = safeActiveImageScope ?? safeFilteredImages;
+    const navigationImageIds = navigationSource.map((entry) => entry.id);
+    const modalId = `image-modal-${Date.now()}-${image.id}`;
+    const existingModalForImage = openImageModals.find((modal) => modal.imageId === image.id);
+    const activeModalId = existingModalForImage?.modalId ?? modalId;
+
+    setOpenImageModals((current) => {
+      const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;
+      const nextZIndex = highestZIndex + 1;
+      const existingModal = current.find((modal) => modal.imageId === image.id);
+
+      if (existingModal) {
+        return current.map((modal) =>
+          modal.modalId === existingModal.modalId
+            ? {
+                ...modal,
+                navigationImageIds,
+                navigationSource: safeActiveImageScope ? 'scope' : 'filtered',
+                zIndex: nextZIndex,
+                isMinimized: false,
+              }
+            : modal
+        );
+      }
+
+      return [
+        ...current,
+        {
+          modalId,
+          imageId: image.id,
+          navigationImageIds,
+          navigationSource: safeActiveImageScope ? 'scope' : 'filtered',
+          zIndex: nextZIndex,
+          initialWindowOffset: current.length * 28,
+          isMinimized: false,
+          diagnosticsFlowId: beginModalOpenFlow(image.id, 'generated-output'),
+        },
+      ];
+    });
+
+    setActiveImageModalId(activeModalId);
+    setSelectedImage(image);
+    setGeneratedOutputPreview(null);
+  }, [beginModalOpenFlow, getImageByIdFromStore, openImageModals, safeActiveImageScope, safeFilteredImages, setSelectedImage]);
+
+  const resolveGeneratedOutputImageId = useCallback((output: GeneratedQueueOutput): string | undefined => {
+    if (output.imageId && getImageByIdFromStore(output.imageId)) {
+      return output.imageId;
+    }
+
+    if (!output.name) {
+      return undefined;
+    }
+
+    const normalizedOutputName = output.name.toLowerCase();
+    const match = [...images, ...filteredImages].find((candidate) => {
+      const candidateName = candidate.name.toLowerCase();
+      return candidateName === normalizedOutputName || candidate.id.toLowerCase().endsWith(`::${normalizedOutputName}`);
+    });
+
+    return match?.id;
+  }, [filteredImages, getImageByIdFromStore, images]);
+
+  const enrichGeneratedOutputs = useCallback((outputs: GeneratedQueueOutput[]): GeneratedQueueOutput[] =>
+    outputs.map((output) => ({
+      ...output,
+      imageId: resolveGeneratedOutputImageId(output),
+    })),
+  [resolveGeneratedOutputImageId]);
+
   const handleGridImageClick = useCallback((image: IndexedImage, event: React.MouseEvent) => {
     if (event.button === 1) {
       event.preventDefault();
@@ -2095,9 +2171,10 @@ export default function App() {
           isResizing={isRightSidebarResizing}
           onResizeStart={handleRightSidebarResizeStart}
           onOpenGeneratedOutputs={(item) => {
+            const outputs = enrichGeneratedOutputs(item.generatedOutputs || []);
             setGeneratedOutputPreview({
               itemId: item.id,
-              outputs: item.generatedOutputs || [],
+              outputs,
               initialIndex: 0,
               jobName: item.imageName,
             });
@@ -2116,6 +2193,7 @@ export default function App() {
           outputs={generatedOutputPreview.outputs}
           initialIndex={generatedOutputPreview.initialIndex}
           jobName={generatedOutputPreview.jobName}
+          onOpenIndexedImage={handleOpenImageModalFromGeneratedOutput}
           onClose={() => setGeneratedOutputPreview(null)}
         />
       )}

--- a/App.tsx
+++ b/App.tsx
@@ -1661,8 +1661,23 @@ export default function App() {
       return output.imageId;
     }
 
-    return undefined;
-  }, [getImageByIdFromStore]);
+    if (!output.relativePath) {
+      return undefined;
+    }
+
+    const normalizeRelativePath = (value: string) => value.replace(/\\/g, '/').replace(/^\/+/, '').toLowerCase();
+    const targetRelativePath = normalizeRelativePath(output.relativePath);
+    const matchedIds = new Set<string>();
+
+    for (const candidate of [...images, ...filteredImages]) {
+      const candidateRelativePath = normalizeRelativePath(candidate.id.split('::').slice(1).join('::') || candidate.name);
+      if (candidateRelativePath === targetRelativePath) {
+        matchedIds.add(candidate.id);
+      }
+    }
+
+    return matchedIds.size === 1 ? Array.from(matchedIds)[0] : undefined;
+  }, [filteredImages, getImageByIdFromStore, images]);
 
   const enrichGeneratedOutputs = useCallback((outputs: GeneratedQueueOutput[]): GeneratedQueueOutput[] =>
     outputs.map((output) => ({

--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,7 @@ import cacheManager from './services/cacheManager';
 import DirectoryList from './components/DirectoryList';
 import ImagePreviewSidebar from './components/ImagePreviewSidebar';
 import GenerationQueueSidebar from './components/GenerationQueueSidebar';
+import GeneratedOutputModal from './components/GeneratedOutputModal';
 import CommandPalette from './components/CommandPalette';
 import HotkeyHelp from './components/HotkeyHelp';
 import Analytics from './components/Analytics';
@@ -40,13 +41,14 @@ import BatchExportModal from './components/BatchExportModal';
 import CollectionFormModal, { CollectionFormValues } from './components/CollectionFormModal';
 import { useA1111ProgressContext } from './contexts/A1111ProgressContext';
 import { useGenerationQueueSync } from './hooks/useGenerationQueueSync';
+import { useGenerationQueueRunner } from './hooks/useGenerationQueueRunner';
 import {
   beginPerformanceFlow,
   createProfilerOnRender,
   finishPerformanceFlowAfterNextPaint,
   markPerformanceFlow,
 } from './utils/performanceDiagnostics';
-import { useGenerationQueueStore } from './store/useGenerationQueueStore';
+import { GeneratedQueueOutput, useGenerationQueueStore } from './store/useGenerationQueueStore';
 // Ensure the correct path to ImageTable
 import ImageTable from './components/ImageTable'; // Verify this file exists or adjust the path
 import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } from './components/A1111GenerateModal';
@@ -186,6 +188,7 @@ export default function App() {
   // Data selectors
   const images = useImageStore((state) => state.images);
   const filteredImages = useImageStore((state) => state.filteredImages);
+  useGenerationQueueRunner({ images, filteredImages });
   const selectionTotalImages = useImageStore((state) => state.selectionTotalImages);
   const selectionDirectoryCount = useImageStore((state) => state.selectionDirectoryCount);
   const directories = useImageStore((state) => state.directories);
@@ -390,6 +393,12 @@ export default function App() {
   const [modelPromptPickerState, setModelPromptPickerState] = useState<{
     modelName: string;
     groups: ModelPromptOverlapGroup[];
+  } | null>(null);
+  const [generatedOutputPreview, setGeneratedOutputPreview] = useState<{
+    itemId: string;
+    outputs: GeneratedQueueOutput[];
+    initialIndex: number;
+    jobName?: string;
   } | null>(null);
   const lastOpenedModalImageIdRef = useRef<string | null>(null);
   const suppressSelectedImageModalOpenRef = useRef<string | null>(null);
@@ -2085,12 +2094,29 @@ export default function App() {
           width={rightSidebarWidth}
           isResizing={isRightSidebarResizing}
           onResizeStart={handleRightSidebarResizeStart}
+          onOpenGeneratedOutputs={(item) => {
+            setGeneratedOutputPreview({
+              itemId: item.id,
+              outputs: item.generatedOutputs || [],
+              initialIndex: 0,
+              jobName: item.imageName,
+            });
+          }}
         />
       ) : (
         <ImagePreviewSidebar
           width={rightSidebarWidth}
           isResizing={isRightSidebarResizing}
           onResizeStart={handleRightSidebarResizeStart}
+        />
+      )}
+
+      {generatedOutputPreview && (
+        <GeneratedOutputModal
+          outputs={generatedOutputPreview.outputs}
+          initialIndex={generatedOutputPreview.initialIndex}
+          jobName={generatedOutputPreview.jobName}
+          onClose={() => setGeneratedOutputPreview(null)}
         />
       )}
 

--- a/__tests__/generationQueueProgress.test.ts
+++ b/__tests__/generationQueueProgress.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { GenerationQueueItem } from '../store/useGenerationQueueStore';
+import { getDisplayCurrentImage } from '../utils/generationQueueProgress';
+
+const createItem = (progress: number): GenerationQueueItem => ({
+  id: 'job',
+  provider: 'a1111',
+  imageId: 'image',
+  imageName: 'image.png',
+  status: 'processing',
+  progress,
+  totalImages: 4,
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+describe('getDisplayCurrentImage', () => {
+  it.each([
+    [0, 1],
+    [0.26, 2],
+    [0.51, 3],
+    [0.76, 4],
+    [1, 4],
+  ])('maps progress %s to image %s/4', (progress, expectedImage) => {
+    expect(getDisplayCurrentImage(createItem(progress))).toBe(expectedImage);
+  });
+});

--- a/__tests__/useGenerationQueueStore.test.ts
+++ b/__tests__/useGenerationQueueStore.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGenerationQueueStore } from '../store/useGenerationQueueStore';
+
+const resetQueueStore = () => {
+  useGenerationQueueStore.setState({
+    items: [],
+    activeJobs: {
+      a1111: null,
+      comfyui: null,
+    },
+  });
+};
+
+const createA1111Job = (imageName: string) =>
+  useGenerationQueueStore.getState().createJob({
+    provider: 'a1111',
+    imageId: imageName,
+    imageName,
+    prompt: 'prompt',
+    totalImages: 1,
+    payload: {
+      provider: 'a1111',
+      numberOfImages: 1,
+    },
+  });
+
+describe('useGenerationQueueStore', () => {
+  beforeEach(() => {
+    resetQueueStore();
+    vi.useRealTimers();
+  });
+
+  it('creates the first job as processing when there is no active provider job', () => {
+    const id = createA1111Job('first.png');
+    const state = useGenerationQueueStore.getState();
+
+    expect(state.items.find((item) => item.id === id)?.status).toBe('processing');
+    expect(state.activeJobs.a1111).toBe(id);
+  });
+
+  it('creates the second provider job as waiting when one is already active', () => {
+    const firstId = createA1111Job('first.png');
+    const secondId = createA1111Job('second.png');
+    const state = useGenerationQueueStore.getState();
+
+    expect(state.activeJobs.a1111).toBe(firstId);
+    expect(state.items.find((item) => item.id === secondId)?.status).toBe('waiting');
+  });
+
+  it('returns the oldest waiting job for FIFO processing', () => {
+    vi.useFakeTimers();
+    createA1111Job('active.png');
+
+    vi.setSystemTime(1000);
+    const olderId = createA1111Job('older.png');
+    vi.setSystemTime(2000);
+    const newerId = createA1111Job('newer.png');
+
+    expect(useGenerationQueueStore.getState().getNextWaitingJobId('a1111')).toBe(olderId);
+    expect(useGenerationQueueStore.getState().getNextWaitingJobId('a1111')).not.toBe(newerId);
+  });
+
+  it('clears activeJobs when removing the active job', () => {
+    const id = createA1111Job('active.png');
+
+    useGenerationQueueStore.getState().removeJob(id);
+
+    expect(useGenerationQueueStore.getState().activeJobs.a1111).toBeNull();
+  });
+
+  it('does not leave activeJobs pointing to an item removed by clearByStatus', () => {
+    const id = createA1111Job('active.png');
+    expect(useGenerationQueueStore.getState().activeJobs.a1111).toBe(id);
+
+    useGenerationQueueStore.getState().clearByStatus(['processing']);
+
+    expect(useGenerationQueueStore.getState().items).toHaveLength(0);
+    expect(useGenerationQueueStore.getState().activeJobs.a1111).toBeNull();
+  });
+});

--- a/components/ComfyUIWorkflowWorkspace.tsx
+++ b/components/ComfyUIWorkflowWorkspace.tsx
@@ -745,12 +745,11 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
       }
     }
 
-    const shouldUseWorkingWorkflowJson = activeTab === 'visual' || showAdvancedEditor;
     const resolvedAdvancedPromptJson = params.workflowMode === 'original'
-      ? (manualPromptJson || (shouldUseWorkingWorkflowJson && workingPromptGraph ? JSON.stringify(workingPromptGraph) : undefined))
+      ? (manualPromptJson || (workingPromptGraph ? JSON.stringify(workingPromptGraph) : ''))
       : undefined;
     const resolvedAdvancedWorkflowJson = params.workflowMode === 'original'
-      ? (manualWorkflowJson || (shouldUseWorkingWorkflowJson && workingWorkflowUi ? JSON.stringify(workingWorkflowUi) : undefined))
+      ? (manualWorkflowJson || (workingWorkflowUi ? JSON.stringify(workingWorkflowUi) : undefined))
       : undefined;
 
     await onGenerate({

--- a/components/ComfyUIWorkflowWorkspace.tsx
+++ b/components/ComfyUIWorkflowWorkspace.tsx
@@ -1216,20 +1216,6 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
         </div>
       )}
 
-      <div className="min-h-[38px]">
-        {(status || validationError) && (
-          <div
-            className={`rounded-lg border px-3 py-2 text-sm ${
-              status?.success && !validationError
-                ? 'border-green-700/40 bg-green-500/10 text-green-200'
-                : 'border-red-700/40 bg-red-500/10 text-red-200'
-            }`}
-          >
-            {validationError || status?.message}
-          </div>
-        )}
-      </div>
-
       <div className="flex items-center justify-end gap-3">
         {showCancelButton && onCancel && (
           <button
@@ -1247,6 +1233,18 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
           {isGenerating ? 'Generating...' : 'Generate'}
         </button>
       </div>
+
+      {(status || validationError) && (
+        <div
+          className={`rounded-lg border px-3 py-2 text-sm ${
+            status?.success && !validationError
+              ? 'border-green-700/40 bg-green-500/10 text-green-200'
+              : 'border-red-700/40 bg-red-500/10 text-red-200'
+          }`}
+        >
+          {validationError || status?.message}
+        </div>
+      )}
     </div>
   );
 };

--- a/components/ComfyUIWorkflowWorkspace.tsx
+++ b/components/ComfyUIWorkflowWorkspace.tsx
@@ -42,6 +42,7 @@ export interface GenerationParams {
 }
 
 type WorkspaceTab = 'parameters' | 'visual';
+const WORKSPACE_TAB_STORAGE_KEY = 'IMH_COMFYUI_LAST_WORKSPACE_TAB';
 
 interface ComfyUIWorkflowWorkspaceProps {
   image: IndexedImage;
@@ -357,6 +358,17 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
     }
   };
 
+  const persistActiveTab = (tab: WorkspaceTab) => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(WORKSPACE_TAB_STORAGE_KEY, tab);
+    }
+  };
+
+  const changeActiveTab = (tab: WorkspaceTab) => {
+    setActiveTab(tab);
+    persistActiveTab(tab);
+  };
+
   useEffect(() => {
     if (!normalizedMetadata) {
       return;
@@ -371,6 +383,9 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
     const storedModel = typeof window !== 'undefined' ? localStorage.getItem('IMH_COMFYUI_LAST_MODEL_OBJECT') : null;
     const storedLoras = typeof window !== 'undefined' ? localStorage.getItem('IMH_COMFYUI_LAST_LORAS') : null;
     const storedRandomSeed = typeof window !== 'undefined' ? localStorage.getItem('IMH_COMFYUI_LAST_RANDOM_SEED') : null;
+    const storedWorkspaceTab = typeof window !== 'undefined'
+      ? localStorage.getItem(WORKSPACE_TAB_STORAGE_KEY) as WorkspaceTab | null
+      : null;
 
     const parsedModel = parseStoredJson<ComfyUIModelResource>(storedModel, 'stored ComfyUI model');
     const parsedLoras = parseStoredJson<ComfyUILoRAConfig[]>(storedLoras, 'stored ComfyUI LoRAs') ?? [];
@@ -415,7 +430,8 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
     setValidationError('');
     setModelSearch('');
     setLoraSearch('');
-    setActiveTab(defaultTab === 'visual' && workflowAnalysis.originalAvailable ? 'visual' : 'parameters');
+    const preferredTab = storedWorkspaceTab || defaultTab;
+    setActiveTab(preferredTab === 'visual' && workflowAnalysis.originalAvailable ? 'visual' : 'parameters');
     setSelectedVisualNodeId(null);
   }, [
     defaultTab,
@@ -429,6 +445,7 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
   useEffect(() => {
     if (params.workflowMode !== 'original' && activeTab === 'visual') {
       setActiveTab('parameters');
+      persistActiveTab('parameters');
     }
   }, [activeTab, params.workflowMode]);
 
@@ -715,6 +732,7 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
       localStorage.setItem('IMH_COMFYUI_LAST_MODE', params.workflowMode);
       localStorage.setItem('IMH_COMFYUI_LAST_SOURCE_POLICY', params.sourceImagePolicy);
       localStorage.setItem('IMH_COMFYUI_LAST_RANDOM_SEED', String(params.randomSeed));
+      localStorage.setItem(WORKSPACE_TAB_STORAGE_KEY, activeTab);
       if (params.model) {
         localStorage.setItem('IMH_COMFYUI_LAST_MODEL_OBJECT', JSON.stringify(params.model));
       } else {
@@ -813,7 +831,7 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
         <div className="flex flex-wrap gap-2">
           <button
             type="button"
-            onClick={() => setActiveTab('parameters')}
+            onClick={() => changeActiveTab('parameters')}
             className={`inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
               activeTab === 'parameters'
                 ? 'bg-purple-500/15 text-purple-100 ring-1 ring-purple-400/40'
@@ -826,7 +844,7 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
           <button
             type="button"
             disabled={visualTabDisabled}
-            onClick={() => !visualTabDisabled && setActiveTab('visual')}
+            onClick={() => !visualTabDisabled && changeActiveTab('visual')}
             className={`inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
               activeTab === 'visual'
                 ? 'bg-blue-500/15 text-blue-100 ring-1 ring-blue-400/40'

--- a/components/ComfyUIWorkflowWorkspace.tsx
+++ b/components/ComfyUIWorkflowWorkspace.tsx
@@ -745,11 +745,12 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
       }
     }
 
+    const shouldUseWorkingWorkflowJson = activeTab === 'visual' || showAdvancedEditor;
     const resolvedAdvancedPromptJson = params.workflowMode === 'original'
-      ? (manualPromptJson || (workingPromptGraph ? JSON.stringify(workingPromptGraph) : ''))
+      ? (manualPromptJson || (shouldUseWorkingWorkflowJson && workingPromptGraph ? JSON.stringify(workingPromptGraph) : undefined))
       : undefined;
     const resolvedAdvancedWorkflowJson = params.workflowMode === 'original'
-      ? (manualWorkflowJson || (workingWorkflowUi ? JSON.stringify(workingWorkflowUi) : undefined))
+      ? (manualWorkflowJson || (shouldUseWorkingWorkflowJson && workingWorkflowUi ? JSON.stringify(workingWorkflowUi) : undefined))
       : undefined;
 
     await onGenerate({
@@ -1215,17 +1216,19 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
         </div>
       )}
 
-      {(status || validationError) && (
-        <div
-          className={`rounded-lg border px-3 py-2 text-sm ${
-            status?.success && !validationError
-              ? 'border-green-700/40 bg-green-500/10 text-green-200'
-              : 'border-red-700/40 bg-red-500/10 text-red-200'
-          }`}
-        >
-          {validationError || status?.message}
-        </div>
-      )}
+      <div className="min-h-[38px]">
+        {(status || validationError) && (
+          <div
+            className={`rounded-lg border px-3 py-2 text-sm ${
+              status?.success && !validationError
+                ? 'border-green-700/40 bg-green-500/10 text-green-200'
+                : 'border-red-700/40 bg-red-500/10 text-red-200'
+            }`}
+          >
+            {validationError || status?.message}
+          </div>
+        )}
+      </div>
 
       <div className="flex items-center justify-end gap-3">
         {showCancelButton && onCancel && (

--- a/components/GeneratedOutputModal.tsx
+++ b/components/GeneratedOutputModal.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react';
+import { ChevronLeft, ChevronRight, ExternalLink, X } from 'lucide-react';
+import { GeneratedQueueOutput } from '../store/useGenerationQueueStore';
+
+interface GeneratedOutputModalProps {
+  outputs: GeneratedQueueOutput[];
+  initialIndex?: number;
+  jobName?: string;
+  onClose: () => void;
+}
+
+const GeneratedOutputModal: React.FC<GeneratedOutputModalProps> = ({
+  outputs,
+  initialIndex = 0,
+  jobName,
+  onClose,
+}) => {
+  const [index, setIndex] = useState(() => Math.min(initialIndex, Math.max(outputs.length - 1, 0)));
+  const current = outputs[index];
+  const hasMultiple = outputs.length > 1;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+      if (event.key === 'ArrowLeft') {
+        setIndex((currentIndex) => Math.max(0, currentIndex - 1));
+      }
+      if (event.key === 'ArrowRight') {
+        setIndex((currentIndex) => Math.min(outputs.length - 1, currentIndex + 1));
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, outputs.length]);
+
+  if (!current) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-4">
+      <div className="flex max-h-[92vh] w-full max-w-6xl flex-col overflow-hidden rounded-lg border border-gray-700 bg-gray-900 shadow-2xl">
+        <div className="flex items-center justify-between gap-3 border-b border-gray-700 px-4 py-3">
+          <div className="min-w-0">
+            <h2 className="truncate text-base font-semibold text-gray-100">
+              {current.name || jobName || 'Generated output'}
+            </h2>
+            {jobName && current.name !== jobName && (
+              <p className="truncate text-xs text-gray-500">{jobName}</p>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {hasMultiple && (
+              <span className="text-xs text-gray-400">
+                {index + 1}/{outputs.length}
+              </span>
+            )}
+            {current.kind === 'remote-url' && current.url && (
+              <a
+                href={current.url}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-800 hover:text-gray-100"
+                aria-label="Open image in browser"
+                title="Open image in browser"
+              >
+                <ExternalLink size={18} />
+              </a>
+            )}
+            <button
+              onClick={onClose}
+              className="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-800 hover:text-gray-100"
+              aria-label="Close generated output preview"
+              title="Close"
+            >
+              <X size={20} />
+            </button>
+          </div>
+        </div>
+
+        <div className="relative flex min-h-0 flex-1 items-center justify-center bg-black">
+          {hasMultiple && (
+            <button
+              onClick={() => setIndex((currentIndex) => Math.max(0, currentIndex - 1))}
+              disabled={index === 0}
+              className="absolute left-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-gray-900/80 p-2 text-gray-100 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+              aria-label="Previous generated image"
+              title="Previous"
+            >
+              <ChevronLeft size={24} />
+            </button>
+          )}
+          {current.url ? (
+            <img
+              src={current.url}
+              alt={current.name || 'Generated output'}
+              className="max-h-[78vh] max-w-full object-contain"
+            />
+          ) : (
+            <div className="p-8 text-sm text-gray-400">Generated output is not available for preview.</div>
+          )}
+          {hasMultiple && (
+            <button
+              onClick={() => setIndex((currentIndex) => Math.min(outputs.length - 1, currentIndex + 1))}
+              disabled={index === outputs.length - 1}
+              className="absolute right-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-gray-900/80 p-2 text-gray-100 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+              aria-label="Next generated image"
+              title="Next"
+            >
+              <ChevronRight size={24} />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GeneratedOutputModal;

--- a/components/GeneratedOutputModal.tsx
+++ b/components/GeneratedOutputModal.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { ChevronLeft, ChevronRight, ExternalLink, X } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ExternalLink, FileText, X } from 'lucide-react';
 import { GeneratedQueueOutput } from '../store/useGenerationQueueStore';
 
 interface GeneratedOutputModalProps {
   outputs: GeneratedQueueOutput[];
   initialIndex?: number;
   jobName?: string;
+  onOpenIndexedImage?: (imageId: string) => void;
   onClose: () => void;
 }
 
@@ -13,6 +14,7 @@ const GeneratedOutputModal: React.FC<GeneratedOutputModalProps> = ({
   outputs,
   initialIndex = 0,
   jobName,
+  onOpenIndexedImage,
   onClose,
 }) => {
   const [index, setIndex] = useState(() => Math.min(initialIndex, Math.max(outputs.length - 1, 0)));
@@ -69,6 +71,17 @@ const GeneratedOutputModal: React.FC<GeneratedOutputModalProps> = ({
               >
                 <ExternalLink size={18} />
               </a>
+            )}
+            {current.imageId && onOpenIndexedImage && (
+              <button
+                onClick={() => onOpenIndexedImage(current.imageId!)}
+                className="inline-flex items-center gap-2 rounded bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-500"
+                aria-label="View full metadata"
+                title="View full metadata"
+              >
+                <FileText size={16} />
+                <span>View full metadata</span>
+              </button>
             )}
             <button
               onClick={onClose}

--- a/components/GenerationQueueSidebar.tsx
+++ b/components/GenerationQueueSidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { X, RefreshCw, Ban, Trash2 } from 'lucide-react';
+import { X, RefreshCw, CircleX, CircleStop, ArchiveX } from 'lucide-react';
 import { useGenerationQueueStore, GenerationQueueItem } from '../store/useGenerationQueueStore';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
@@ -9,12 +9,14 @@ import { A1111ApiClient } from '../services/a1111ApiClient';
 import { ComfyUIApiClient } from '../services/comfyUIApiClient';
 import { useA1111ProgressContext } from '../contexts/A1111ProgressContext';
 import { useComfyUIProgressContext } from '../contexts/ComfyUIProgressContext';
+import { getDisplayCurrentImage } from '../utils/generationQueueProgress';
 
 interface GenerationQueueSidebarProps {
   onClose: () => void;
   width: number;
   isResizing: boolean;
   onResizeStart: (event: React.PointerEvent<HTMLDivElement>) => void;
+  onOpenGeneratedOutputs?: (item: GenerationQueueItem) => void;
 }
 
 const statusStyles: Record<string, string> = {
@@ -48,6 +50,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
   width,
   isResizing,
   onResizeStart,
+  onOpenGeneratedOutputs,
 }) => {
   const items = useGenerationQueueStore((state) => state.items);
   const removeJob = useGenerationQueueStore((state) => state.removeJob);
@@ -120,8 +123,19 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
     });
   };
 
-  const handleCancel = async (item: GenerationQueueItem) => {
+  const handleCancel = async (item: GenerationQueueItem, event?: React.MouseEvent<HTMLButtonElement>) => {
+    event?.stopPropagation();
     if (item.status !== 'processing' && item.status !== 'waiting') {
+      return;
+    }
+
+    if (item.status === 'waiting') {
+      setJobStatus(item.id, 'canceled', { error: undefined });
+      return;
+    }
+
+    if (activeJobs[item.provider] !== item.id) {
+      setJobStatus(item.id, 'canceled', { error: undefined });
       return;
     }
 
@@ -138,7 +152,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
         stopPolling();
         setActiveJob('a1111', null);
       }
-      setJobStatus(item.id, 'canceled');
+      setJobStatus(item.id, 'canceled', { error: undefined });
       return;
     }
 
@@ -155,7 +169,29 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
       stopTracking();
       setActiveJob('comfyui', null);
     }
-    setJobStatus(item.id, 'canceled');
+    setJobStatus(item.id, 'canceled', { error: undefined });
+  };
+
+  const handleRemove = (item: GenerationQueueItem, event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    removeJob(item.id);
+  };
+
+  const handleRetryClick = async (item: GenerationQueueItem, event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    await handleRetry(item);
+  };
+
+  const handleCardKeyDown = (item: GenerationQueueItem, event: React.KeyboardEvent<HTMLDivElement>) => {
+    const canOpenResult = item.status === 'done' && Boolean(item.generatedOutputs?.length);
+    if (!canOpenResult || !onOpenGeneratedOutputs) {
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onOpenGeneratedOutputs(item);
+    }
   };
 
   return (
@@ -186,6 +222,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
           onClick={onClose}
           className="text-gray-400 hover:text-gray-50 transition-colors"
           title="Close queue"
+          aria-label="Close queue"
         >
           <X className="w-5 h-5" />
         </button>
@@ -209,12 +246,6 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
           >
             Clear finished
           </button>
-          <button
-            onClick={() => clearByStatus(['waiting', 'processing', 'done', 'failed', 'canceled'])}
-            className="px-2 py-1 rounded bg-gray-700/60 hover:bg-gray-700 text-gray-200 transition-colors"
-          >
-            Clear all
-          </button>
         </div>
       </div>
 
@@ -224,10 +255,24 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
             No generations queued yet.
           </div>
         ) : (
-          items.map((item) => (
-            <div key={item.id} className="bg-gray-900/60 border border-gray-700/60 rounded-lg p-3 space-y-2">
+          items.map((item) => {
+            const canOpenResult = item.status === 'done' && Boolean(item.generatedOutputs?.length);
+            const firstOutput = item.generatedOutputs?.[0];
+            const displayCurrentImage = getDisplayCurrentImage(item);
+
+            return (
+            <div
+              key={item.id}
+              role={canOpenResult ? 'button' : undefined}
+              tabIndex={canOpenResult ? 0 : undefined}
+              onClick={canOpenResult && onOpenGeneratedOutputs ? () => onOpenGeneratedOutputs(item) : undefined}
+              onKeyDown={(event) => handleCardKeyDown(item, event)}
+              className={`bg-gray-900/60 border border-gray-700/60 rounded-lg p-3 space-y-2 transition-colors ${
+                canOpenResult ? 'cursor-pointer hover:border-blue-400/60 hover:bg-gray-900/80' : ''
+              }`}
+            >
               <div className="flex items-start justify-between gap-2">
-                <div>
+                <div className="min-w-0">
                   <div className="flex items-center gap-2">
                     <span className={`text-xs font-semibold ${statusStyles[item.status]}`}>
                       {statusLabel[item.status]}
@@ -242,31 +287,50 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
                 <div className="flex items-center gap-2">
                   {(item.status === 'processing' || item.status === 'waiting') && (
                     <button
-                      onClick={() => handleCancel(item)}
+                      onClick={(event) => handleCancel(item, event)}
                       className="text-gray-400 hover:text-red-300 transition-colors"
-                      title="Cancel"
+                      title={item.status === 'waiting' ? 'Cancel queued job' : 'Stop generation'}
+                      aria-label={item.status === 'waiting' ? 'Cancel queued job' : 'Stop generation'}
                     >
-                      <Ban size={16} />
+                      {item.status === 'waiting' ? <CircleX size={16} /> : <CircleStop size={16} />}
                     </button>
                   )}
                   {(item.status === 'failed' || item.status === 'canceled') && (
                     <button
-                      onClick={() => handleRetry(item)}
+                      onClick={(event) => handleRetryClick(item, event)}
                       className="text-gray-400 hover:text-blue-300 transition-colors"
                       title="Retry"
+                      aria-label="Retry generation"
                     >
                       <RefreshCw size={16} />
                     </button>
                   )}
                   <button
-                    onClick={() => removeJob(item.id)}
+                    onClick={(event) => handleRemove(item, event)}
                     className="text-gray-400 hover:text-gray-200 transition-colors"
-                    title="Remove"
+                    title="Remove from queue"
+                    aria-label="Remove from queue"
                   >
-                    <Trash2 size={16} />
+                    <ArchiveX size={16} />
                   </button>
                 </div>
               </div>
+
+              {firstOutput?.url && (
+                <div className="relative overflow-hidden rounded border border-gray-700/60 bg-black">
+                  <img
+                    src={firstOutput.url}
+                    alt={firstOutput.name || 'Generated output'}
+                    className="h-24 w-full object-cover"
+                    loading="lazy"
+                  />
+                  {(item.generatedOutputs?.length || 0) > 1 && (
+                    <span className="absolute right-2 top-2 rounded-full bg-black/70 px-2 py-0.5 text-xs font-semibold text-gray-100">
+                      +{(item.generatedOutputs?.length || 1) - 1}
+                    </span>
+                  )}
+                </div>
+              )}
 
               <p className="text-xs text-gray-400 break-words">
                 {formatPromptPreview(item.prompt)}
@@ -276,9 +340,9 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
                 <div className="space-y-1">
                   <div className="flex items-center justify-between text-xs text-gray-500">
                     <span>{Math.round(item.progress * 100)}%</span>
-                    {item.totalImages && item.totalImages > 1 && (
+                    {displayCurrentImage && (
                       <span>
-                        Image {item.currentImage || 1}/{item.totalImages}
+                        Image {displayCurrentImage}/{item.totalImages}
                       </span>
                     )}
                     {item.totalSteps ? (
@@ -316,7 +380,8 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
                 <p className="text-xs text-red-300 break-words">{item.error}</p>
               )}
             </div>
-          ))
+            );
+          })
         )}
       </div>
     </div>

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2963,15 +2963,17 @@ const ImageModal: React.FC<ImageModalProps> = ({
               </button>
 
               {/* Status messages */}
-              {(copyStatus || generateStatus) && (
-                <div className={`mt-2 p-2 rounded text-xs ${
-                  (copyStatus?.success || generateStatus?.success)
-                    ? 'bg-green-900/50 border border-green-700 text-green-300'
-                    : 'bg-red-900/50 border border-red-700 text-red-300'
-                }`}>
-                  {copyStatus?.message || generateStatus?.message}
-                </div>
-              )}
+              <div className="mt-2 min-h-[34px]">
+                {(copyStatus || generateStatus) && (
+                  <div className={`p-2 rounded text-xs ${
+                    (copyStatus?.success || generateStatus?.success)
+                      ? 'bg-green-900/50 border border-green-700 text-green-300'
+                      : 'bg-red-900/50 border border-red-700 text-red-300'
+                  }`}>
+                    {copyStatus?.message || generateStatus?.message}
+                  </div>
+                )}
+              </div>
 
               {/* Generate Variation Modal */}
               {showA1111Actions && isGenerateModalOpen && effectiveMetadata && (
@@ -3053,15 +3055,17 @@ const ImageModal: React.FC<ImageModalProps> = ({
               </button>
 
               {/* Status messages */}
-              {(copyStatusComfyUI || generateStatusComfyUI) && (
-                <div className={`mt-2 p-2 rounded text-xs ${
-                  (copyStatusComfyUI?.success || generateStatusComfyUI?.success)
-                    ? 'bg-green-900/50 border border-green-700 text-green-300'
-                    : 'bg-red-900/50 border border-red-700 text-red-300'
-                }`}>
-                  {copyStatusComfyUI?.message || generateStatusComfyUI?.message}
-                </div>
-              )}
+              <div className="mt-2 min-h-[34px]">
+                {(copyStatusComfyUI || generateStatusComfyUI) && (
+                  <div className={`p-2 rounded text-xs ${
+                    (copyStatusComfyUI?.success || generateStatusComfyUI?.success)
+                      ? 'bg-green-900/50 border border-green-700 text-green-300'
+                      : 'bg-red-900/50 border border-red-700 text-red-300'
+                  }`}>
+                    {copyStatusComfyUI?.message || generateStatusComfyUI?.message}
+                  </div>
+                )}
+              </div>
 
             </div>
           )}
@@ -3163,7 +3167,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   }}
                   isGenerating={isGeneratingComfyUI}
                   status={generateStatusComfyUI}
-                  defaultTab="visual"
+                  defaultTab="parameters"
                   viewportHeight={showSidebarOnBottom ? 420 : 520}
                   showCancelButton={false}
                 />

--- a/hooks/useA1111Progress.ts
+++ b/hooks/useA1111Progress.ts
@@ -54,10 +54,19 @@ export function useA1111Progress() {
       const overallProgress = totalImagesInBatch > 1
         ? (completedImages + currentImageProgress) / totalImagesInBatch
         : currentImageProgress;
+      const fallbackCurrentImage = totalImagesInBatch > 1
+        ? Math.min(
+            totalImagesInBatch,
+            Math.max(1, Math.floor(overallProgress * totalImagesInBatch) + 1)
+          )
+        : 1;
+      const displayCurrentImage = currentImageInBatch > 0
+        ? Math.min(currentImageInBatch + 1, totalImagesInBatch)
+        : fallbackCurrentImage;
 
       setProgressState({
         isGenerating: data.progress > 0 && data.progress < 1,
-        currentImage: currentImageInBatch + 1, // 1-indexed for display
+        currentImage: displayCurrentImage,
         totalImages: totalImagesInBatch,
         progress: overallProgress,
         currentStep: data.state.sampling_step || 0,

--- a/hooks/useA1111Progress.ts
+++ b/hooks/useA1111Progress.ts
@@ -25,6 +25,7 @@ interface A1111ProgressResponse {
 export function useA1111Progress() {
   const [progressState, setProgressState] = useState<A1111ProgressState | null>(null);
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const clearProgressTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const serverUrlRef = useRef<string>('');
   const totalImagesRef = useRef<number>(0);
 
@@ -87,6 +88,10 @@ export function useA1111Progress() {
     if (pollingIntervalRef.current) {
       clearInterval(pollingIntervalRef.current);
     }
+    if (clearProgressTimeoutRef.current) {
+      clearTimeout(clearProgressTimeoutRef.current);
+      clearProgressTimeoutRef.current = null;
+    }
 
     serverUrlRef.current = serverUrl;
     totalImagesRef.current = numberOfImages;
@@ -110,10 +115,14 @@ export function useA1111Progress() {
       clearInterval(pollingIntervalRef.current);
       pollingIntervalRef.current = null;
     }
+    if (clearProgressTimeoutRef.current) {
+      clearTimeout(clearProgressTimeoutRef.current);
+    }
 
     // Keep the final state visible for 2 seconds before clearing
-    setTimeout(() => {
+    clearProgressTimeoutRef.current = setTimeout(() => {
       setProgressState(null);
+      clearProgressTimeoutRef.current = null;
     }, 2000);
   }, []);
 

--- a/hooks/useGenerateWithA1111.ts
+++ b/hooks/useGenerateWithA1111.ts
@@ -1,8 +1,6 @@
 import { useState, useCallback } from 'react';
 import { IndexedImage, BaseMetadata } from '../types';
-import { A1111ApiClient } from '../services/a1111ApiClient';
 import { useSettingsStore } from '../store/useSettingsStore';
-import { useA1111ProgressContext } from '../contexts/A1111ProgressContext';
 import { useGenerationQueueStore } from '../store/useGenerationQueueStore';
 import {
   hasPromptMetadata,
@@ -21,16 +19,15 @@ export function useGenerateWithA1111() {
   const [generateStatus, setGenerateStatus] = useState<GenerateStatus | null>(null);
 
   const a1111ServerUrl = useSettingsStore((state) => state.a1111ServerUrl);
-  const { startPolling, stopPolling } = useA1111ProgressContext();
   const createJob = useGenerationQueueStore((state) => state.createJob);
-  const setJobStatus = useGenerationQueueStore((state) => state.setJobStatus);
-  const setActiveJob = useGenerationQueueStore((state) => state.setActiveJob);
 
   const generateWithA1111 = useCallback(
     async (image: IndexedImage, customParams?: Partial<BaseMetadata>, numberOfImages?: number) => {
+      setIsGenerating(true);
       const metadata = mergeNormalizedMetadata(image, customParams);
 
       if (!hasPromptMetadata(metadata)) {
+        setIsGenerating(false);
         setGenerateStatus({
           success: false,
           message: NO_METADATA_MESSAGE,
@@ -40,6 +37,7 @@ export function useGenerateWithA1111() {
       }
 
       if (!a1111ServerUrl) {
+        setIsGenerating(false);
         setGenerateStatus({
           success: false,
           message: 'A1111 server URL not configured. Please check Settings.',
@@ -62,6 +60,7 @@ export function useGenerateWithA1111() {
       });
       const { activeJobs } = useGenerationQueueStore.getState();
       if (activeJobs.a1111 && activeJobs.a1111 !== jobId) {
+        setIsGenerating(false);
         setGenerateStatus({
           success: true,
           message: 'Generation queued. Waiting for current A1111 job to finish.',
@@ -69,66 +68,15 @@ export function useGenerateWithA1111() {
         setTimeout(() => setGenerateStatus(null), TEMPORARY_STATUS_TIMEOUT_MS);
         return;
       }
-      setActiveJob('a1111', jobId);
-      setJobStatus(jobId, 'processing');
 
-      setIsGenerating(true);
-      setGenerateStatus(null);
-
-      try {
-        const client = new A1111ApiClient({ serverUrl: a1111ServerUrl });
-
-        // Start progress polling
-        startPolling(a1111ServerUrl, numberOfImages || 1);
-
-        // ALWAYS start generation (autoStart: true)
-        const result = await client.sendToTxt2Img(metadata, {
-          autoStart: true,
-          numberOfImages: numberOfImages || 1,
-        });
-
-        setGenerateStatus({
-          success: result.success,
-          message: result.success
-            ? 'Generated successfully!'
-            : (result.error || 'Generation failed'),
-        });
-
-        if (!result.success) {
-          setJobStatus(jobId, 'failed', { error: result.error || 'Generation failed' });
-          const { activeJobs } = useGenerationQueueStore.getState();
-          if (activeJobs.a1111 === jobId) {
-            setActiveJob('a1111', null);
-          }
-        }
-
-        // Stop progress polling
-        stopPolling();
-
-        // Clear status after 5 seconds
-        setTimeout(() => setGenerateStatus(null), TEMPORARY_STATUS_TIMEOUT_MS);
-      } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        setGenerateStatus({
-          success: false,
-          message: `Error: ${errorMessage}`,
-        });
-
-        setJobStatus(jobId, 'failed', { error: errorMessage });
-        const { activeJobs } = useGenerationQueueStore.getState();
-        if (activeJobs.a1111 === jobId) {
-          setActiveJob('a1111', null);
-        }
-
-        // Stop progress polling on error
-        stopPolling();
-
-        setTimeout(() => setGenerateStatus(null), TEMPORARY_STATUS_TIMEOUT_MS);
-      } finally {
-        setIsGenerating(false);
-      }
+      setIsGenerating(false);
+      setGenerateStatus({
+        success: true,
+        message: 'Generation queued.',
+      });
+      setTimeout(() => setGenerateStatus(null), TEMPORARY_STATUS_TIMEOUT_MS);
     },
-    [a1111ServerUrl, createJob, setActiveJob, setJobStatus, startPolling, stopPolling]
+    [a1111ServerUrl, createJob]
   );
 
   return {

--- a/hooks/useGenerateWithComfyUI.ts
+++ b/hooks/useGenerateWithComfyUI.ts
@@ -5,9 +5,8 @@
 
 import { useState, useCallback } from 'react';
 import { IndexedImage, BaseMetadata } from '../types';
-import { ComfyUIApiClient, WorkflowOverrides } from '../services/comfyUIApiClient';
+import { WorkflowOverrides } from '../services/comfyUIApiClient';
 import { useSettingsStore } from '../store/useSettingsStore';
-import { useComfyUIProgressContext } from '../contexts/ComfyUIProgressContext';
 import { useGenerationQueueStore } from '../store/useGenerationQueueStore';
 import { ComfyUISourceImagePolicy, ComfyUIWorkflowMode } from '../services/comfyUIWorkflowBuilder';
 import {
@@ -38,20 +37,15 @@ export function useGenerateWithComfyUI() {
   const [generateStatus, setGenerateStatus] = useState<GenerateStatus | null>(null);
 
   const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
-  const { startTracking, stopTracking } = useComfyUIProgressContext();
   const createJob = useGenerationQueueStore((state) => state.createJob);
-  const setJobStatus = useGenerationQueueStore((state) => state.setJobStatus);
-  const setActiveJob = useGenerationQueueStore((state) => state.setActiveJob);
-
-  const updateQueueJob = useCallback((jobId: string, promptId: string) => {
-    useGenerationQueueStore.getState().updateJob(jobId, { providerJobId: promptId });
-  }, []);
 
   const generateWithComfyUI = useCallback(
     async (image: IndexedImage, params?: GenerateParams) => {
+      setIsGenerating(true);
       const metadata = mergeNormalizedMetadata(image, params?.customMetadata);
 
       if (!hasPromptMetadata(metadata)) {
+        setIsGenerating(false);
         setGenerateStatus({
           success: false,
           message: NO_METADATA_MESSAGE,
@@ -61,6 +55,7 @@ export function useGenerateWithComfyUI() {
       }
 
       if (!comfyUIServerUrl) {
+        setIsGenerating(false);
         setGenerateStatus({
           success: false,
           message: 'ComfyUI server URL not configured. Please check Settings.',
@@ -90,6 +85,7 @@ export function useGenerateWithComfyUI() {
       });
       const { activeJobs } = useGenerationQueueStore.getState();
       if (activeJobs.comfyui && activeJobs.comfyui !== jobId) {
+        setIsGenerating(false);
         setGenerateStatus({
           success: true,
           message: 'Generation queued. Waiting for current ComfyUI job to finish.',
@@ -97,77 +93,15 @@ export function useGenerateWithComfyUI() {
         setTimeout(() => setGenerateStatus(null), TEMPORARY_STATUS_TIMEOUT_MS);
         return;
       }
-      setActiveJob('comfyui', jobId);
-      setJobStatus(jobId, 'processing');
 
-      setIsGenerating(true);
-      setGenerateStatus(null);
-
-      try {
-        const client = new ComfyUIApiClient({ serverUrl: comfyUIServerUrl });
-
-        const prepared = await client.prepareWorkflow({
-          image,
-          metadata,
-          overrides: params?.overrides,
-          workflowMode: params?.workflowMode,
-          sourceImagePolicy: params?.sourceImagePolicy,
-          advancedPromptJson: params?.advancedPromptJson,
-          advancedWorkflowJson: params?.advancedWorkflowJson,
-          maskFile: params?.maskFile || null,
-        });
-        const workflow = prepared.workflow;
-
-        // Queue prompt
-        const result = await client.queuePrompt(workflow);
-
-        if (result.success && result.prompt_id) {
-          updateQueueJob(jobId, result.prompt_id);
-          // Start WebSocket progress tracking with matching client id
-          startTracking(comfyUIServerUrl, result.prompt_id, workflow.client_id);
-
-          setGenerateStatus({
-            success: true,
-            message: prepared.warnings.length > 0
-              ? `Workflow queued in ${prepared.modeUsed} mode. ${prepared.warnings[0]}`
-              : `Workflow queued in ${prepared.modeUsed} mode.`,
-          });
-        } else {
-          setGenerateStatus({
-            success: false,
-            message: result.error || 'Failed to queue workflow',
-          });
-          setJobStatus(jobId, 'failed', { error: result.error || 'Failed to queue workflow' });
-          const { activeJobs } = useGenerationQueueStore.getState();
-          if (activeJobs.comfyui === jobId) {
-            setActiveJob('comfyui', null);
-          }
-        }
-
-        // Clear status after 5 seconds
-        setTimeout(() => setGenerateStatus(null), TEMPORARY_STATUS_TIMEOUT_MS);
-      } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        setGenerateStatus({
-          success: false,
-          message: `Error: ${errorMessage}`,
-        });
-
-        setJobStatus(jobId, 'failed', { error: errorMessage });
-        const { activeJobs } = useGenerationQueueStore.getState();
-        if (activeJobs.comfyui === jobId) {
-          setActiveJob('comfyui', null);
-        }
-
-        // Stop progress tracking on error
-        stopTracking();
-
-        setTimeout(() => setGenerateStatus(null), TEMPORARY_STATUS_TIMEOUT_MS);
-      } finally {
-        setIsGenerating(false);
-      }
+      setIsGenerating(false);
+      setGenerateStatus({
+        success: true,
+        message: 'Generation queued.',
+      });
+      setTimeout(() => setGenerateStatus(null), TEMPORARY_STATUS_TIMEOUT_MS);
     },
-    [comfyUIServerUrl, createJob, setActiveJob, setJobStatus, startTracking, stopTracking, updateQueueJob]
+    [comfyUIServerUrl, createJob]
   );
 
   return {

--- a/hooks/useGenerationQueueRunner.ts
+++ b/hooks/useGenerationQueueRunner.ts
@@ -1,0 +1,135 @@
+import { useEffect, useRef } from 'react';
+import { IndexedImage } from '../types';
+import { useA1111ProgressContext } from '../contexts/A1111ProgressContext';
+import { useComfyUIProgressContext } from '../contexts/ComfyUIProgressContext';
+import { useGenerationQueueStore, GenerationProvider, GenerationQueueItem } from '../store/useGenerationQueueStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+import {
+  executeA1111QueueJob,
+  executeComfyUIQueueJob,
+} from '../services/generationQueueExecutors';
+
+type ImageLookup = {
+  images: IndexedImage[];
+  filteredImages: IndexedImage[];
+};
+
+const terminalStatuses = new Set(['done', 'failed', 'canceled']);
+
+const findImage = ({ images, filteredImages }: ImageLookup, imageId: string) =>
+  images.find((img) => img.id === imageId) ||
+  filteredImages.find((img) => img.id === imageId) ||
+  null;
+
+export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup) {
+  const items = useGenerationQueueStore((state) => state.items);
+  const activeJobs = useGenerationQueueStore((state) => state.activeJobs);
+  const a1111ServerUrl = useSettingsStore((state) => state.a1111ServerUrl);
+  const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
+  const { startPolling, stopPolling } = useA1111ProgressContext();
+  const { startTracking, stopTracking } = useComfyUIProgressContext();
+  const runningJobsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const startProvider = (provider: GenerationProvider) => {
+      const state = useGenerationQueueStore.getState();
+      const activeJobId = state.activeJobs[provider];
+
+      if (!activeJobId) {
+        const nextJobId = state.getNextWaitingJobId(provider);
+        if (nextJobId) {
+          state.setActiveJob(provider, nextJobId);
+          state.setJobStatus(nextJobId, 'processing', { error: undefined });
+        }
+        return;
+      }
+
+      const activeItem = state.items.find((item) => item.id === activeJobId);
+      if (!activeItem) {
+        state.setActiveJob(provider, null);
+        return;
+      }
+
+      if (terminalStatuses.has(activeItem.status)) {
+        state.setActiveJob(provider, null);
+        return;
+      }
+
+      if (activeItem.status !== 'processing' || runningJobsRef.current.has(activeItem.id)) {
+        return;
+      }
+
+      void executeProviderJob(activeItem);
+    };
+
+    const executeProviderJob = async (job: GenerationQueueItem) => {
+      runningJobsRef.current.add(job.id);
+      const state = useGenerationQueueStore.getState();
+      const image = findImage({ images, filteredImages }, job.imageId);
+
+      if (!image) {
+        state.setJobStatus(job.id, 'failed', { error: 'Source image no longer available.' });
+        if (state.activeJobs[job.provider] === job.id) {
+          state.setActiveJob(job.provider, null);
+        }
+        runningJobsRef.current.delete(job.id);
+        return;
+      }
+
+      try {
+        const result = job.provider === 'a1111'
+          ? await executeA1111QueueJob(job, {
+              image,
+              serverUrl: a1111ServerUrl,
+              startPolling,
+              stopPolling,
+            })
+          : await executeComfyUIQueueJob(job, {
+              image,
+              serverUrl: comfyUIServerUrl,
+              startTracking,
+              stopTracking,
+            });
+
+        const latest = useGenerationQueueStore.getState().items.find((item) => item.id === job.id);
+        if (latest && latest.status !== 'canceled') {
+          useGenerationQueueStore.getState().setJobStatus(job.id, 'done', {
+            progress: 1,
+            currentImage: job.totalImages,
+            completedAt: Date.now(),
+            generatedOutputs: result.generatedOutputs,
+            providerJobId: result.providerJobId || latest.providerJobId,
+            error: undefined,
+          });
+        }
+      } catch (error) {
+        const latest = useGenerationQueueStore.getState().items.find((item) => item.id === job.id);
+        if (latest && latest.status !== 'canceled') {
+          useGenerationQueueStore.getState().setJobStatus(job.id, 'failed', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      } finally {
+        runningJobsRef.current.delete(job.id);
+        const latestState = useGenerationQueueStore.getState();
+        if (latestState.activeJobs[job.provider] === job.id) {
+          latestState.setActiveJob(job.provider, null);
+        }
+      }
+    };
+
+    startProvider('a1111');
+    startProvider('comfyui');
+  }, [
+    activeJobs,
+    a1111ServerUrl,
+    comfyUIServerUrl,
+    filteredImages,
+    images,
+    items,
+    startPolling,
+    startTracking,
+    stopPolling,
+    stopTracking,
+  ]);
+}

--- a/hooks/useGenerationQueueRunner.ts
+++ b/hooks/useGenerationQueueRunner.ts
@@ -120,7 +120,12 @@ export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup
         runningJobsRef.current.delete(job.id);
         runningProvidersRef.current.delete(job.provider);
         const latestState = useGenerationQueueStore.getState();
-        if (latestState.activeJobs[job.provider] === job.id) {
+        const activeJobId = latestState.activeJobs[job.provider];
+        if (activeJobId === job.id) {
+          latestState.setActiveJob(job.provider, null);
+        } else if (activeJobId) {
+          latestState.updateJob(activeJobId, {});
+        } else {
           latestState.setActiveJob(job.provider, null);
         }
       }

--- a/hooks/useGenerationQueueRunner.ts
+++ b/hooks/useGenerationQueueRunner.ts
@@ -29,11 +29,16 @@ export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup
   const { startPolling, stopPolling } = useA1111ProgressContext();
   const { startTracking, stopTracking } = useComfyUIProgressContext();
   const runningJobsRef = useRef<Set<string>>(new Set());
+  const runningProvidersRef = useRef<Set<GenerationProvider>>(new Set());
 
   useEffect(() => {
     const startProvider = (provider: GenerationProvider) => {
       const state = useGenerationQueueStore.getState();
       const activeJobId = state.activeJobs[provider];
+
+      if (runningProvidersRef.current.has(provider)) {
+        return;
+      }
 
       if (!activeJobId) {
         const nextJobId = state.getNextWaitingJobId(provider);
@@ -64,6 +69,7 @@ export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup
 
     const executeProviderJob = async (job: GenerationQueueItem) => {
       runningJobsRef.current.add(job.id);
+      runningProvidersRef.current.add(job.provider);
       const state = useGenerationQueueStore.getState();
       const image = findImage({ images, filteredImages }, job.imageId);
 
@@ -73,6 +79,7 @@ export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup
           state.setActiveJob(job.provider, null);
         }
         runningJobsRef.current.delete(job.id);
+        runningProvidersRef.current.delete(job.provider);
         return;
       }
 
@@ -111,6 +118,7 @@ export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup
         }
       } finally {
         runningJobsRef.current.delete(job.id);
+        runningProvidersRef.current.delete(job.provider);
         const latestState = useGenerationQueueStore.getState();
         if (latestState.activeJobs[job.provider] === job.id) {
           latestState.setActiveJob(job.provider, null);

--- a/hooks/useGenerationQueueSync.ts
+++ b/hooks/useGenerationQueueSync.ts
@@ -7,79 +7,35 @@ export function useGenerationQueueSync() {
   const { progressState: a1111Progress } = useA1111ProgressContext();
   const { progressState: comfyUIProgress } = useComfyUIProgressContext();
   const updateJob = useGenerationQueueStore((state) => state.updateJob);
-  const setJobStatus = useGenerationQueueStore((state) => state.setJobStatus);
-  const setActiveJob = useGenerationQueueStore((state) => state.setActiveJob);
 
   useEffect(() => {
-    const { activeJobs, items, getNextWaitingJobId } = useGenerationQueueStore.getState();
-    const activeJobId = activeJobs.a1111;
+    const { activeJobs } = useGenerationQueueStore.getState();
+    const jobId = activeJobs.a1111;
 
-    if (a1111Progress) {
-      let jobId = activeJobId;
-      if (!jobId) {
-        const nextId = getNextWaitingJobId('a1111');
-        if (nextId) {
-          setActiveJob('a1111', nextId);
-          setJobStatus(nextId, 'processing');
-          jobId = nextId;
-        }
-      }
-
-      if (jobId) {
-        updateJob(jobId, {
-          progress: a1111Progress.progress,
-          currentImage: a1111Progress.currentImage,
-          totalImages: a1111Progress.totalImages,
-          currentStep: a1111Progress.currentStep,
-          totalSteps: a1111Progress.totalSteps,
-          status: 'processing',
-        });
-      }
-      return;
+    if (a1111Progress && jobId) {
+      updateJob(jobId, {
+        progress: a1111Progress.progress,
+        currentImage: a1111Progress.currentImage,
+        totalImages: a1111Progress.totalImages,
+        currentStep: a1111Progress.currentStep,
+        totalSteps: a1111Progress.totalSteps,
+        status: 'processing',
+      });
     }
-
-    if (activeJobId) {
-      const activeItem = items.find((item) => item.id === activeJobId);
-      if (activeItem && activeItem.status === 'processing') {
-        setJobStatus(activeJobId, 'done', { progress: 1 });
-      }
-      setActiveJob('a1111', null);
-    }
-  }, [a1111Progress, setActiveJob, setJobStatus, updateJob]);
+  }, [a1111Progress, updateJob]);
 
   useEffect(() => {
-    const { activeJobs, items, getNextWaitingJobId } = useGenerationQueueStore.getState();
-    const activeJobId = activeJobs.comfyui;
+    const { activeJobs } = useGenerationQueueStore.getState();
+    const jobId = activeJobs.comfyui;
 
-    if (comfyUIProgress) {
-      let jobId = activeJobId;
-      if (!jobId) {
-        const nextId = getNextWaitingJobId('comfyui');
-        if (nextId) {
-          setActiveJob('comfyui', nextId);
-          setJobStatus(nextId, 'processing');
-          jobId = nextId;
-        }
-      }
-
-      if (jobId) {
-        updateJob(jobId, {
-          progress: comfyUIProgress.progress,
-          currentStep: comfyUIProgress.currentStep,
-          totalSteps: comfyUIProgress.totalSteps,
-          currentNode: comfyUIProgress.currentNode,
-          status: 'processing',
-        });
-      }
-      return;
+    if (comfyUIProgress && jobId) {
+      updateJob(jobId, {
+        progress: comfyUIProgress.progress,
+        currentStep: comfyUIProgress.currentStep,
+        totalSteps: comfyUIProgress.totalSteps,
+        currentNode: comfyUIProgress.currentNode,
+        status: 'processing',
+      });
     }
-
-    if (activeJobId) {
-      const activeItem = items.find((item) => item.id === activeJobId);
-      if (activeItem && activeItem.status === 'processing') {
-        setJobStatus(activeJobId, 'done', { progress: 1 });
-      }
-      setActiveJob('comfyui', null);
-    }
-  }, [comfyUIProgress, setActiveJob, setJobStatus, updateJob]);
+  }, [comfyUIProgress, updateJob]);
 }

--- a/services/comfyUIApiClient.ts
+++ b/services/comfyUIApiClient.ts
@@ -575,6 +575,15 @@ export class ComfyUIApiClient {
     }
   }
 
+  getViewUrl(image: { filename: string; subfolder?: string; type?: string }): string {
+    const params = new URLSearchParams({
+      filename: image.filename,
+      subfolder: image.subfolder || '',
+      type: image.type || 'output',
+    });
+    return `${this.config.serverUrl}/view?${params.toString()}`;
+  }
+
   /**
    * Get current queue status
    */

--- a/services/comfyUIWorkflowBuilder.ts
+++ b/services/comfyUIWorkflowBuilder.ts
@@ -707,13 +707,11 @@ export function analyzeComfyWorkflow(source: IndexedImage | UnknownRecord, norma
       timerNodeIds.push(nodeId);
     }
 
-    if (typeof node.inputs?.width === 'number' || typeof node.inputs?.height === 'number') {
-      if ('width' in (node.inputs || {})) {
-        dimensionTargets.push({ nodeId, inputKey: 'width' });
-      }
-      if ('height' in (node.inputs || {})) {
-        dimensionTargets.push({ nodeId, inputKey: 'height' });
-      }
+    if ('width' in (node.inputs || {})) {
+      dimensionTargets.push({ nodeId, inputKey: 'width' });
+    }
+    if ('height' in (node.inputs || {})) {
+      dimensionTargets.push({ nodeId, inputKey: 'height' });
     }
 
     if ('batch_size' in (node.inputs || {})) {

--- a/services/comfyUIWorkflowBuilder.ts
+++ b/services/comfyUIWorkflowBuilder.ts
@@ -707,11 +707,13 @@ export function analyzeComfyWorkflow(source: IndexedImage | UnknownRecord, norma
       timerNodeIds.push(nodeId);
     }
 
-    if ('width' in (node.inputs || {})) {
-      dimensionTargets.push({ nodeId, inputKey: 'width' });
-    }
-    if ('height' in (node.inputs || {})) {
-      dimensionTargets.push({ nodeId, inputKey: 'height' });
+    if (typeof node.inputs?.width === 'number' || typeof node.inputs?.height === 'number') {
+      if ('width' in (node.inputs || {})) {
+        dimensionTargets.push({ nodeId, inputKey: 'width' });
+      }
+      if ('height' in (node.inputs || {})) {
+        dimensionTargets.push({ nodeId, inputKey: 'height' });
+      }
     }
 
     if ('batch_size' in (node.inputs || {})) {

--- a/services/generationQueueExecutors.ts
+++ b/services/generationQueueExecutors.ts
@@ -31,6 +31,23 @@ const getErrorMessage = (error: unknown): string =>
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const base64PngToObjectUrl = (base64: string): string => {
+  const binary = atob(base64);
+  const chunks: BlobPart[] = [];
+  const chunkSize = 8192;
+
+  for (let offset = 0; offset < binary.length; offset += chunkSize) {
+    const slice = binary.slice(offset, offset + chunkSize);
+    const bytes = new Uint8Array(slice.length);
+    for (let index = 0; index < slice.length; index += 1) {
+      bytes[index] = slice.charCodeAt(index);
+    }
+    chunks.push(bytes);
+  }
+
+  return URL.createObjectURL(new Blob(chunks, { type: 'image/png' }));
+};
+
 const assertRunnableMetadata = (metadata: BaseMetadata) => {
   if (!hasPromptMetadata(metadata)) {
     throw new Error(NO_METADATA_MESSAGE);
@@ -69,8 +86,8 @@ export async function executeA1111QueueJob(
     return {
       generatedOutputs: (result.images || []).map((base64, index) => ({
         id: `${job.id}_a1111_${index}`,
-        kind: 'data-url',
-        url: `data:image/png;base64,${base64}`,
+        kind: 'object-url',
+        url: base64PngToObjectUrl(base64),
         name: `${job.imageName} result ${index + 1}`,
       })),
     };

--- a/services/generationQueueExecutors.ts
+++ b/services/generationQueueExecutors.ts
@@ -118,6 +118,7 @@ function extractComfyUIOutputs(
 
       const subfolder = typeof image.subfolder === 'string' ? image.subfolder : '';
       const type = typeof image.type === 'string' ? image.type : 'output';
+      const relativePath = subfolder ? `${subfolder}/${image.filename}` : image.filename;
       images.push({
         id: `${job.id}_comfyui_${nodeIndex}_${imageIndex}`,
         kind: 'remote-url',
@@ -126,6 +127,7 @@ function extractComfyUIOutputs(
           subfolder,
           type,
         }),
+        relativePath,
         name: image.filename,
       });
     });

--- a/services/generationQueueExecutors.ts
+++ b/services/generationQueueExecutors.ts
@@ -1,0 +1,205 @@
+import { A1111ApiClient } from './a1111ApiClient';
+import { ComfyUIApiClient } from './comfyUIApiClient';
+import { BaseMetadata, IndexedImage } from '../types';
+import {
+  GeneratedQueueOutput,
+  GenerationQueueItem,
+} from '../store/useGenerationQueueStore';
+import {
+  hasPromptMetadata,
+  mergeNormalizedMetadata,
+  NO_METADATA_MESSAGE,
+} from '../utils/imageMetadata';
+
+type ProgressPollingControls = {
+  startPolling: (serverUrl: string, numberOfImages?: number) => void;
+  stopPolling: () => void;
+};
+
+type ProgressTrackingControls = {
+  startTracking: (serverUrl: string, promptId: string, clientId?: string) => void;
+  stopTracking: () => void;
+};
+
+export type QueueExecutionResult = {
+  generatedOutputs?: GeneratedQueueOutput[];
+  providerJobId?: string;
+};
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const assertRunnableMetadata = (metadata: BaseMetadata) => {
+  if (!hasPromptMetadata(metadata)) {
+    throw new Error(NO_METADATA_MESSAGE);
+  }
+};
+
+export async function executeA1111QueueJob(
+  job: GenerationQueueItem,
+  context: {
+    image: IndexedImage;
+    serverUrl: string;
+  } & ProgressPollingControls
+): Promise<QueueExecutionResult> {
+  if (!context.serverUrl) {
+    throw new Error('A1111 server URL not configured. Please check Settings.');
+  }
+
+  const payload = job.payload?.provider === 'a1111' ? job.payload : undefined;
+  const metadata = mergeNormalizedMetadata(context.image, payload?.customMetadata);
+  assertRunnableMetadata(metadata);
+
+  const numberOfImages = payload?.numberOfImages || job.totalImages || 1;
+  const client = new A1111ApiClient({ serverUrl: context.serverUrl });
+
+  context.startPolling(context.serverUrl, numberOfImages);
+  try {
+    const result = await client.sendToTxt2Img(metadata, {
+      autoStart: true,
+      numberOfImages,
+    });
+
+    if (!result.success) {
+      throw new Error(result.error || 'Generation failed');
+    }
+
+    return {
+      generatedOutputs: (result.images || []).map((base64, index) => ({
+        id: `${job.id}_a1111_${index}`,
+        kind: 'data-url',
+        url: `data:image/png;base64,${base64}`,
+        name: `${job.imageName} result ${index + 1}`,
+      })),
+    };
+  } finally {
+    context.stopPolling();
+  }
+}
+
+type ComfyUIHistoryImage = {
+  filename?: unknown;
+  subfolder?: unknown;
+  type?: unknown;
+};
+
+const isHistoryImage = (value: unknown): value is ComfyUIHistoryImage =>
+  Boolean(value && typeof value === 'object' && 'filename' in value);
+
+function extractComfyUIOutputs(
+  history: Record<string, unknown>,
+  promptId: string,
+  client: ComfyUIApiClient,
+  job: GenerationQueueItem
+): GeneratedQueueOutput[] {
+  const promptHistory = history[promptId];
+  if (!promptHistory || typeof promptHistory !== 'object') {
+    return [];
+  }
+
+  const outputs = (promptHistory as { outputs?: unknown }).outputs;
+  if (!outputs || typeof outputs !== 'object') {
+    return [];
+  }
+
+  const images: GeneratedQueueOutput[] = [];
+  Object.values(outputs as Record<string, unknown>).forEach((nodeOutput, nodeIndex) => {
+    const nodeImages = (nodeOutput as { images?: unknown }).images;
+    if (!Array.isArray(nodeImages)) {
+      return;
+    }
+
+    nodeImages.filter(isHistoryImage).forEach((image, imageIndex) => {
+      if (typeof image.filename !== 'string') {
+        return;
+      }
+
+      const subfolder = typeof image.subfolder === 'string' ? image.subfolder : '';
+      const type = typeof image.type === 'string' ? image.type : 'output';
+      images.push({
+        id: `${job.id}_comfyui_${nodeIndex}_${imageIndex}`,
+        kind: 'remote-url',
+        url: client.getViewUrl({
+          filename: image.filename,
+          subfolder,
+          type,
+        }),
+        name: image.filename,
+      });
+    });
+  });
+
+  return images;
+}
+
+async function waitForComfyUIOutputs(
+  client: ComfyUIApiClient,
+  promptId: string,
+  job: GenerationQueueItem
+): Promise<GeneratedQueueOutput[]> {
+  const startedAt = Date.now();
+  const timeoutMs = 5 * 60 * 1000;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const history = await client.getHistory(promptId) as Record<string, unknown>;
+    const outputs = extractComfyUIOutputs(history, promptId, client, job);
+    if (outputs.length > 0) {
+      return outputs;
+    }
+
+    if (history[promptId]) {
+      return [];
+    }
+
+    await sleep(1000);
+  }
+
+  throw new Error('Timed out waiting for ComfyUI generation to finish.');
+}
+
+export async function executeComfyUIQueueJob(
+  job: GenerationQueueItem,
+  context: {
+    image: IndexedImage;
+    serverUrl: string;
+  } & ProgressTrackingControls
+): Promise<QueueExecutionResult> {
+  if (!context.serverUrl) {
+    throw new Error('ComfyUI server URL not configured. Please check Settings.');
+  }
+
+  const payload = job.payload?.provider === 'comfyui' ? job.payload : undefined;
+  const metadata = mergeNormalizedMetadata(context.image, payload?.customMetadata);
+  assertRunnableMetadata(metadata);
+
+  const client = new ComfyUIApiClient({ serverUrl: context.serverUrl });
+  const prepared = await client.prepareWorkflow({
+    image: context.image,
+    metadata,
+    overrides: payload?.overrides,
+    workflowMode: payload?.workflowMode,
+    sourceImagePolicy: payload?.sourceImagePolicy,
+    advancedPromptJson: payload?.advancedPromptJson,
+    advancedWorkflowJson: payload?.advancedWorkflowJson,
+    maskFile: payload?.maskFile || null,
+  });
+
+  const result = await client.queuePrompt(prepared.workflow);
+  if (!result.success || !result.prompt_id) {
+    throw new Error(result.error || 'Failed to queue workflow');
+  }
+
+  context.startTracking(context.serverUrl, result.prompt_id, prepared.workflow.client_id);
+  try {
+    return {
+      providerJobId: result.prompt_id,
+      generatedOutputs: await waitForComfyUIOutputs(client, result.prompt_id, job),
+    };
+  } catch (error) {
+    throw new Error(getErrorMessage(error));
+  } finally {
+    context.stopTracking();
+  }
+}

--- a/store/useGenerationQueueStore.ts
+++ b/store/useGenerationQueueStore.ts
@@ -30,6 +30,7 @@ export interface GeneratedQueueOutput {
   kind: 'data-url' | 'remote-url' | 'indexed-image';
   url?: string;
   imageId?: string;
+  relativePath?: string;
   name?: string;
   width?: number;
   height?: number;

--- a/store/useGenerationQueueStore.ts
+++ b/store/useGenerationQueueStore.ts
@@ -25,6 +25,16 @@ export type ComfyUIQueuePayload = {
 
 export type GenerationQueuePayload = A1111QueuePayload | ComfyUIQueuePayload;
 
+export interface GeneratedQueueOutput {
+  id: string;
+  kind: 'data-url' | 'remote-url' | 'indexed-image';
+  url?: string;
+  imageId?: string;
+  name?: string;
+  width?: number;
+  height?: number;
+}
+
 export interface GenerationQueueItem {
   id: string;
   provider: GenerationProvider;
@@ -41,6 +51,8 @@ export interface GenerationQueueItem {
   providerJobId?: string;
   error?: string;
   payload?: GenerationQueuePayload;
+  generatedOutputs?: GeneratedQueueOutput[];
+  completedAt?: number;
   createdAt: number;
   updatedAt: number;
 }
@@ -128,9 +140,9 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
     })),
   getNextWaitingJobId: (provider) => {
     const { items } = get();
-    const next = items.find(
-      (item) => item.provider === provider && item.status === 'waiting'
-    );
+    const next = items
+      .filter((item) => item.provider === provider && item.status === 'waiting')
+      .sort((a, b) => a.createdAt - b.createdAt)[0];
     return next?.id ?? null;
   },
   removeJob: (id) => {

--- a/store/useGenerationQueueStore.ts
+++ b/store/useGenerationQueueStore.ts
@@ -27,7 +27,7 @@ export type GenerationQueuePayload = A1111QueuePayload | ComfyUIQueuePayload;
 
 export interface GeneratedQueueOutput {
   id: string;
-  kind: 'data-url' | 'remote-url' | 'indexed-image';
+  kind: 'data-url' | 'object-url' | 'remote-url' | 'indexed-image';
   url?: string;
   imageId?: string;
   relativePath?: string;
@@ -83,6 +83,20 @@ const MAX_ITEMS = 200;
 
 const createQueueId = () =>
   `job_${Date.now()}_${Math.random().toString(16).slice(2, 10)}`;
+
+const revokeGeneratedOutputUrls = (items: GenerationQueueItem[]) => {
+  if (typeof URL === 'undefined' || typeof URL.revokeObjectURL !== 'function') {
+    return;
+  }
+
+  items.forEach((item) => {
+    item.generatedOutputs?.forEach((output) => {
+      if (output.kind === 'object-url' && output.url) {
+        URL.revokeObjectURL(output.url);
+      }
+    });
+  });
+};
 
 export const useGenerationQueueStore = create<GenerationQueueState>((set, get) => ({
   items: [],
@@ -148,6 +162,7 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
   },
   removeJob: (id) => {
     set((state) => {
+      revokeGeneratedOutputUrls(state.items.filter((item) => item.id === id));
       const activeJobs = { ...state.activeJobs };
       if (activeJobs.a1111 === id) {
         activeJobs.a1111 = null;
@@ -165,7 +180,9 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
     const statusSet = new Set(statuses);
     set((state) => {
       const activeJobs = { ...state.activeJobs };
+      const removedItems = state.items.filter((item) => statusSet.has(item.status));
       const nextItems = state.items.filter((item) => !statusSet.has(item.status));
+      revokeGeneratedOutputUrls(removedItems);
       if (activeJobs.a1111 && !nextItems.some((item) => item.id === activeJobs.a1111)) {
         activeJobs.a1111 = null;
       }

--- a/utils/generationQueueProgress.ts
+++ b/utils/generationQueueProgress.ts
@@ -1,0 +1,20 @@
+import { GenerationQueueItem } from '../store/useGenerationQueueStore';
+
+export const getDisplayCurrentImage = (item: GenerationQueueItem): number | null => {
+  if (!item.totalImages || item.totalImages <= 1) {
+    return null;
+  }
+
+  if (item.currentImage && item.currentImage > 1) {
+    return Math.min(item.currentImage, item.totalImages);
+  }
+
+  if (item.progress >= 1) {
+    return item.totalImages;
+  }
+
+  return Math.min(
+    item.totalImages,
+    Math.max(1, Math.floor(item.progress * item.totalImages) + 1)
+  );
+};


### PR DESCRIPTION
## Summary

- Reworks the generation queue so waiting A1111 and ComfyUI jobs are picked up by a real runner and processed FIFO.
- Separates queue creation from job execution to avoid duplicate jobs and lets each provider drain independently.
- Improves queue card actions, cancel behavior, progress display, and generated output previews.
- Adds a generated output preview modal and links indexed outputs back to the full metadata modal when available.
- Remembers the last ComfyUI workflow workspace tab and prevents status messages from moving the Generate button.

## Notes

- The ComfyUI width/height parameter issue is intentionally left as-is for a later fix.

## Validation

- Not run during PR creation per request.