### PR TITLE
Fix ImageGrid keyboard navigation

### DIFF
--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -5,9 +5,10 @@ import ImageGrid from '../components/ImageGrid';
 import { useImageSelection } from '../hooks/useImageSelection';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
-import type { IndexedImage } from '../types';
+import type { ImageStack, IndexedImage } from '../types';
 
 const renameIndexedImageMock = vi.hoisted(() => vi.fn());
+const stackedItemsMock = vi.hoisted(() => ({ value: null as (IndexedImage | ImageStack)[] | null }));
 const showContextMenuMock = vi.fn();
 const hideContextMenuMock = vi.fn();
 const contextMenuStateMock = {
@@ -102,7 +103,7 @@ vi.mock('../hooks/useFeatureAccess', () => ({
 
 vi.mock('../hooks/useImageStacking', () => ({
   useImageStacking: (images: IndexedImage[]) => ({
-    stackedItems: images,
+    stackedItems: stackedItemsMock.value ?? images,
   }),
 }));
 
@@ -213,6 +214,7 @@ describe('ImageGrid context menu', () => {
   beforeEach(() => {
     vi.useRealTimers();
     showContextMenuMock.mockReset();
+    stackedItemsMock.value = null;
     hideContextMenuMock.mockReset();
     renameIndexedImageMock.mockReset();
     renameIndexedImageMock.mockResolvedValue({
@@ -377,6 +379,54 @@ describe('ImageGrid context menu', () => {
     fireEvent.keyUp(document, { key: 'ArrowDown' });
 
     expect(useImageStore.getState().previewImage?.id).toBe('img-4');
+  });
+
+  it('navigates stack cards by rendered position while storing the stack cover image index', () => {
+    const images = createImages(5);
+    const onImageClick = vi.fn();
+    const firstStack: ImageStack = {
+      id: 'stack-img-0',
+      coverImage: images[0],
+      images: [images[0], images[1]],
+      count: 2,
+    };
+    const secondStack: ImageStack = {
+      id: 'stack-img-3',
+      coverImage: images[3],
+      images: [images[3], images[4]],
+      count: 2,
+    };
+    stackedItemsMock.value = [firstStack, images[2], secondStack];
+    useSettingsStore.setState({ itemsPerPage: -1 } as any);
+    setupImageGridState(images, 0);
+    useImageStore.setState({ isStackingEnabled: true } as any);
+
+    const { container } = render(
+      <ImageGrid
+        images={images}
+        onImageClick={onImageClick}
+        selectedImages={useImageStore.getState().selectedImages}
+        currentPage={1}
+        totalPages={1}
+        onPageChange={vi.fn()}
+        onBatchExport={vi.fn()}
+      />,
+    );
+
+    focusGridAndPress(container, 'ArrowRight');
+    expect(useImageStore.getState().focusedImageIndex).toBe(2);
+    expect(useImageStore.getState().previewImage?.id).toBe('img-2');
+
+    focusGridAndPress(container, 'ArrowRight');
+    expect(useImageStore.getState().focusedImageIndex).toBe(3);
+    expect(useImageStore.getState().previewImage?.id).toBe('img-3');
+    expect(
+      Array.from(container.querySelectorAll<HTMLElement>('[data-image-id="img-3"]'))
+        .some((element) => element.className.includes('outline-blue-400')),
+    ).toBe(true);
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(onImageClick).toHaveBeenCalledWith(images[3], expect.any(Object));
   });
 
   it('renames a thumbnail inline after double-clicking the filename', async () => {

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -36,6 +36,11 @@ vi.mock('../hooks/useContextMenu', () => ({
   }),
 }));
 
+vi.mock('react-virtualized-auto-sizer', () => ({
+  default: ({ children }: { children: (size: { height: number; width: number }) => React.ReactNode }) =>
+    children({ height: 600, width: 408 }),
+}));
+
 vi.mock('../services/imageRenameService', () => ({
   getRenameBasename: (image: IndexedImage) => {
     const fileName = image.name.replace(/\\/g, '/').split('/').pop() || image.name;
@@ -140,6 +145,14 @@ const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
   ...overrides,
 });
 
+const createImages = (count: number): IndexedImage[] =>
+  Array.from({ length: count }, (_, index) =>
+    createImage({
+      id: `img-${index}`,
+      name: `image-${index}.png`,
+    }),
+  );
+
 const Harness = ({ images, onFindSimilar }: { images: IndexedImage[]; onFindSimilar?: (image: IndexedImage) => void }) => {
   const selectedImages = useImageStore((state) => state.selectedImages);
 
@@ -155,6 +168,28 @@ const Harness = ({ images, onFindSimilar }: { images: IndexedImage[]; onFindSimi
       onFindSimilar={onFindSimilar}
     />
   );
+};
+
+const setupImageGridState = (images: IndexedImage[], focusedImageIndex: number | null = null) => {
+  useImageStore.setState({
+    images,
+    filteredImages: images,
+    directories: [{ id: 'dir-1', path: 'D:/library' }],
+    selectedImages: new Set(),
+    isStackingEnabled: false,
+    focusedImageIndex,
+    previewImage: focusedImageIndex != null && focusedImageIndex >= 0 ? images[focusedImageIndex] : null,
+    transferProgress: null,
+    filterAndSortImages: vi.fn(),
+  } as any);
+};
+
+const focusGridAndPress = (container: HTMLElement, key: string) => {
+  const grid = container.querySelector<HTMLElement>('[data-area="grid"]');
+  expect(grid).toBeTruthy();
+
+  fireEvent.focus(grid!);
+  fireEvent.keyDown(document, { key });
 };
 
 const SelectionHarness = ({ images }: { images: IndexedImage[] }) => {
@@ -258,6 +293,64 @@ describe('ImageGrid context menu', () => {
 
     expect(useImageStore.getState().focusedImageIndex).toBe(0);
     expect(useImageStore.getState().previewImage?.id).toBe('img-1');
+  });
+
+  it('establishes focus on the first rendered image when pressing ArrowDown without current focus', () => {
+    const images = createImages(6);
+    useSettingsStore.setState({ itemsPerPage: -1 } as any);
+    setupImageGridState(images);
+
+    const { container } = render(<Harness images={images} />);
+
+    focusGridAndPress(container, 'ArrowDown');
+
+    expect(useImageStore.getState().focusedImageIndex).toBe(0);
+    expect(useImageStore.getState().previewImage?.id).toBe('img-0');
+  });
+
+  it('moves down and up by the rendered column count', () => {
+    const images = createImages(7);
+    useSettingsStore.setState({ itemsPerPage: -1 } as any);
+    setupImageGridState(images, 1);
+
+    const { container } = render(<Harness images={images} />);
+
+    focusGridAndPress(container, 'ArrowDown');
+    expect(useImageStore.getState().focusedImageIndex).toBe(4);
+    expect(useImageStore.getState().previewImage?.id).toBe('img-4');
+
+    focusGridAndPress(container, 'ArrowUp');
+    expect(useImageStore.getState().focusedImageIndex).toBe(1);
+    expect(useImageStore.getState().previewImage?.id).toBe('img-1');
+  });
+
+  it('moves Home to the first image and End to the last rendered image', () => {
+    const images = createImages(6);
+    useSettingsStore.setState({ itemsPerPage: -1 } as any);
+    setupImageGridState(images, 3);
+
+    const { container } = render(<Harness images={images} />);
+
+    focusGridAndPress(container, 'Home');
+    expect(useImageStore.getState().focusedImageIndex).toBe(0);
+    expect(useImageStore.getState().previewImage?.id).toBe('img-0');
+
+    focusGridAndPress(container, 'End');
+    expect(useImageStore.getState().focusedImageIndex).toBe(5);
+    expect(useImageStore.getState().previewImage?.id).toBe('img-5');
+  });
+
+  it('clamps ArrowDown to the last image when navigating from the last partial row', () => {
+    const images = createImages(8);
+    useSettingsStore.setState({ itemsPerPage: -1 } as any);
+    setupImageGridState(images, 5);
+
+    const { container } = render(<Harness images={images} />);
+
+    focusGridAndPress(container, 'ArrowDown');
+
+    expect(useImageStore.getState().focusedImageIndex).toBe(7);
+    expect(useImageStore.getState().previewImage?.id).toBe('img-7');
   });
 
   it('renames a thumbnail inline after double-clicking the filename', async () => {

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ImageGrid from '../components/ImageGrid';
 import { useImageSelection } from '../hooks/useImageSelection';
@@ -211,6 +211,7 @@ const SelectionHarness = ({ images }: { images: IndexedImage[] }) => {
 
 describe('ImageGrid context menu', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     showContextMenuMock.mockReset();
     hideContextMenuMock.mockReset();
     renameIndexedImageMock.mockReset();
@@ -234,6 +235,10 @@ describe('ImageGrid context menu', () => {
       blurSensitiveImages: false,
       enableSafeMode: false,
     } as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('keeps multi-selection when right-clicking an image and opens the context menu', () => {
@@ -351,6 +356,27 @@ describe('ImageGrid context menu', () => {
 
     expect(useImageStore.getState().focusedImageIndex).toBe(7);
     expect(useImageStore.getState().previewImage?.id).toBe('img-7');
+  });
+
+  it('defers preview updates during repeated keyboard navigation and flushes on keyup', () => {
+    vi.useFakeTimers();
+    const images = createImages(7);
+    useSettingsStore.setState({ itemsPerPage: -1 } as any);
+    setupImageGridState(images, 1);
+
+    const { container } = render(<Harness images={images} />);
+    const grid = container.querySelector<HTMLElement>('[data-area="grid"]');
+    expect(grid).toBeTruthy();
+
+    fireEvent.focus(grid!);
+    fireEvent.keyDown(document, { key: 'ArrowDown', repeat: true });
+
+    expect(useImageStore.getState().focusedImageIndex).toBe(4);
+    expect(useImageStore.getState().previewImage?.id).toBe('img-1');
+
+    fireEvent.keyUp(document, { key: 'ArrowDown' });
+
+    expect(useImageStore.getState().previewImage?.id).toBe('img-4');
   });
 
   it('renames a thumbnail inline after double-clicking the filename', async () => {

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -435,7 +435,7 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
       <div
         ref={mergedRef}
         data-image-id={image.id}
-        className={`relative group flex items-center justify-center bg-gray-800 rounded-xl overflow-hidden cursor-pointer transition-all duration-300 ease-out border border-gray-700/50 ${
+        className={`relative group flex items-center justify-center bg-gray-800 rounded-xl overflow-hidden cursor-pointer border border-gray-700/50 ${
           isSelected 
             ? 'ring-4 ring-blue-500 ring-opacity-75 shadow-lg shadow-blue-500/20 translate-y-[-2px]' 
             : 'hover:shadow-2xl hover:shadow-black/50 hover:border-gray-600 hover:translate-y-[-4px]'

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1011,10 +1011,15 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const getGridScrollElement = useCallback(() => gridScrollRef.current ?? gridScopeRef.current, []);
 
   const getActiveColumnCount = useCallback(() => {
-    const measuredWidth = gridScrollRef.current?.clientWidth ?? gridScopeRef.current?.clientWidth ?? 0;
-    const measuredColumnCount = Math.floor(measuredWidth / (imageSize + GAP_SIZE));
+    if (isInfinite) {
+      return Math.max(1, columnCountRef.current || 1);
+    }
+
+    const gridBackground = gridScopeRef.current?.querySelector<HTMLElement>('[data-grid-background]');
+    const measuredWidth = gridBackground?.clientWidth ?? gridScopeRef.current?.clientWidth ?? 0;
+    const measuredColumnCount = Math.floor((measuredWidth + GAP_SIZE) / (imageSize + GAP_SIZE));
     return Math.max(1, measuredColumnCount || columnCountRef.current || 1);
-  }, [imageSize]);
+  }, [imageSize, isInfinite]);
 
   const getRenderedIndexForImageIndex = useCallback((imageIndex: number | null): number => {
     if (imageIndex == null || imageIndex < 0) {

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -155,6 +155,9 @@ const collectWarmupImages = (
   return images;
 };
 
+const getWarmupWindowImageKey = (images: IndexedImage[]): string =>
+  images.map((image) => image.id).join('|');
+
 const visibleGridThumbnailFlows = new Map<string, string>();
 
 const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, enableAuxClickOpen = true, isSelected, isFocused, onImageLoad, onContextMenu, onRenameRequest, onRenameComplete, isRenaming = false, baseWidth, isComparisonFirst, cardRef, isMarkedBest, isMarkedArchived, isBlurred }) => {
@@ -712,6 +715,9 @@ const FILENAME_HEIGHT = 40;
 const getItemHeight = (imageSize: number, showFilenames: boolean): number =>
   (imageSize * CARD_HEIGHT_RATIO) + (showFilenames ? FILENAME_HEIGHT : 0);
 
+const clampIndex = (index: number, itemCount: number): number =>
+  Math.max(0, Math.min(itemCount - 1, index));
+
 interface CellData {
   items: (IndexedImage | ImageStack)[];
   columnCount: number;
@@ -999,6 +1005,12 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const submenuHorizontalClass = contextMenu.horizontalDirection === 'left' ? 'right-full' : 'left-full';
 
   const getGridScrollElement = useCallback(() => gridScrollRef.current ?? gridScopeRef.current, []);
+
+  const getActiveColumnCount = useCallback(() => {
+    const measuredWidth = gridScrollRef.current?.clientWidth ?? gridScopeRef.current?.clientWidth ?? 0;
+    const measuredColumnCount = Math.floor(measuredWidth / (imageSize + GAP_SIZE));
+    return Math.max(1, measuredColumnCount || columnCountRef.current || 1);
+  }, [imageSize]);
 
   const setNonVirtualGridRef = useCallback((node: HTMLDivElement | null) => {
     gridScopeRef.current = node;
@@ -1480,66 +1492,67 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         }
       }
 
-      const currentIndex = focusedImageIndex ?? -1;
-      let nextIndex = currentIndex;
+      const navigationKeys = ['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'];
+      if (navigationKeys.includes(e.key)) {
+        e.preventDefault();
 
-      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-        e.preventDefault();
-        nextIndex = currentIndex + 1;
-        if (nextIndex < images.length) {
-          setFocusedImageIndex(nextIndex);
-          setPreviewImage(images[nextIndex]);
-        } else if (currentPage < totalPages) {
-          onPageChange(currentPage + 1);
-          setFocusedImageIndex(0);
-          nextIndex = -1;
-        } else {
-            nextIndex = -1;
+        const itemCount = itemsToRender.length;
+        if (itemCount === 0) {
+          return;
         }
-      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-        e.preventDefault();
-        nextIndex = currentIndex - 1;
-        if (nextIndex >= 0) {
-          setFocusedImageIndex(nextIndex);
-          setPreviewImage(images[nextIndex]);
-        } else if (currentPage > 1) {
-          onPageChange(currentPage - 1);
-          setFocusedImageIndex(-1);
-          nextIndex = -1;
-        } else {
-            nextIndex = -1;
+
+        const currentIndex = focusedImageIndex ?? -1;
+        let nextIndex = 0;
+
+        if (currentIndex >= 0) {
+          const columnCount = getActiveColumnCount();
+
+          if (e.key === 'ArrowRight') {
+            nextIndex = currentIndex + 1;
+          } else if (e.key === 'ArrowLeft') {
+            nextIndex = currentIndex - 1;
+          } else if (e.key === 'ArrowDown') {
+            nextIndex = currentIndex + columnCount;
+          } else if (e.key === 'ArrowUp') {
+            nextIndex = currentIndex - columnCount;
+          } else if (e.key === 'Home') {
+            nextIndex = 0;
+          } else if (e.key === 'End') {
+            nextIndex = itemCount - 1;
+          }
+        }
+
+        const resolvedIndex = clampIndex(nextIndex, itemCount);
+        const nextItem = itemsToRender[resolvedIndex];
+        const previewTarget: IndexedImage | undefined = nextItem
+          ? isImageStack(nextItem)
+            ? nextItem.coverImage
+            : nextItem
+          : undefined;
+
+        if (previewTarget) {
+          setFocusedImageIndex(resolvedIndex);
+          setPreviewImage(previewTarget);
         }
       } else if (e.key === 'PageDown') {
         e.preventDefault();
         if (currentPage < totalPages) {
           onPageChange(currentPage + 1);
           setFocusedImageIndex(0);
-          nextIndex = -1;
         }
       } else if (e.key === 'PageUp') {
         e.preventDefault();
         if (currentPage > 1) {
           onPageChange(currentPage - 1);
           setFocusedImageIndex(0);
-          nextIndex = -1;
         }
-      } else if (e.key === 'Home') {
-        e.preventDefault();
-        onPageChange(1);
-        setFocusedImageIndex(0);
-        nextIndex = -1;
-      } else if (e.key === 'End') {
-        e.preventDefault();
-        onPageChange(totalPages);
-        setFocusedImageIndex(0);
-        nextIndex = -1;
       }
 
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [focusedImageIndex, images, setFocusedImageIndex, setPreviewImage, onImageClick, currentPage, totalPages, onPageChange]);
+  }, [focusedImageIndex, getActiveColumnCount, itemsToRender, setFocusedImageIndex, setPreviewImage, onImageClick, currentPage, totalPages, onPageChange]);
 
   useEffect(() => {
     if (!gridKeyboardActiveRef.current || focusedImageIndex == null || focusedImageIndex < 0) {
@@ -2226,15 +2239,17 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                         itemsToRender.length - 1,
                         (((overscanRowStopIndex + 1) * safeColumnCount) - 1)
                       );
-                      const windowKey = `${visibleStartIndex}:${visibleStopIndex}:${aheadStopIndex}:${itemsToRender.length}:${safeColumnCount}`;
+                      const primaryImages = collectWarmupImages(itemsToRender, visibleStartIndex, visibleStopIndex);
+                      const secondaryImages = collectWarmupImages(itemsToRender, visibleStopIndex + 1, aheadStopIndex);
+                      const visibleImageKey = getWarmupWindowImageKey(primaryImages);
+                      const aheadImageKey = getWarmupWindowImageKey(secondaryImages);
+                      const windowKey = `${visibleStartIndex}:${visibleStopIndex}:${aheadStopIndex}:${itemsToRender.length}:${safeColumnCount}:${visibleImageKey}:${aheadImageKey}`;
 
                       if (lastWarmupWindowRef.current === windowKey) {
                         return;
                       }
                       lastWarmupWindowRef.current = windowKey;
 
-                      const primaryImages = collectWarmupImages(itemsToRender, visibleStartIndex, visibleStopIndex);
-                      const secondaryImages = collectWarmupImages(itemsToRender, visibleStopIndex + 1, aheadStopIndex);
                       const visibleImageIds = new Set(primaryImages.map((image) => image.id));
 
                       for (const [imageId, flowId] of visibleGridThumbnailFlows.entries()) {

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -726,7 +726,7 @@ interface CellData {
   onImageClick: (image: IndexedImage, event: React.MouseEvent) => void;
   onStackClick: (stack: ImageStack) => void;
   selectedImages: Set<string>;
-  focusedImageIndex: number | null;
+  focusedImageId: string | null;
   imageSize: number;
   handleImageLoad: (id: string, aspectRatio: number) => void;
   handleContextMenu: (image: IndexedImage, event: React.MouseEvent) => void;
@@ -750,7 +750,7 @@ const Cell = React.memo(({ columnIndex, rowIndex, style, data }: GridChildCompon
     onImageClick,
     onStackClick,
     selectedImages,
-    focusedImageIndex,
+    focusedImageId,
     imageSize,
     handleImageLoad,
     handleContextMenu,
@@ -805,7 +805,7 @@ const Cell = React.memo(({ columnIndex, rowIndex, style, data }: GridChildCompon
               }}
               enableAuxClickOpen={false}
               isSelected={selectedImages.has(item.coverImage.id)}
-              isFocused={false}
+              isFocused={item.images.some(stackImage => stackImage.id === focusedImageId)}
               onImageLoad={handleImageLoad}
               onContextMenu={(img, e) => handleContextMenu(img, e)}
               onRenameRequest={handleRenameRequest}
@@ -813,7 +813,7 @@ const Cell = React.memo(({ columnIndex, rowIndex, style, data }: GridChildCompon
               isRenaming={renamingImageId === item.coverImage.id}
               baseWidth={imageSize}
               isComparisonFirst={false}
-              cardRef={createCardRef(item.id)}
+              cardRef={createCardRef(item.coverImage.id)}
               isMarkedBest={markedBestIds?.has(item.coverImage.id)}
               isMarkedArchived={markedArchivedIds?.has(item.coverImage.id)}
               isBlurred={isSensitive && enableSafeMode && blurSensitiveImages}
@@ -832,7 +832,7 @@ const Cell = React.memo(({ columnIndex, rowIndex, style, data }: GridChildCompon
   }
 
   const image = item;
-  const isFocused = focusedImageIndex === index;
+  const isFocused = image.id === focusedImageId;
   const isSensitive = enableSafeMode &&
     sensitiveTagSet && sensitiveTagSet.size > 0 &&
     !!image.tags?.some(tag => sensitiveTagSet.has(tag.toLowerCase()));
@@ -1015,6 +1015,28 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     const measuredColumnCount = Math.floor(measuredWidth / (imageSize + GAP_SIZE));
     return Math.max(1, measuredColumnCount || columnCountRef.current || 1);
   }, [imageSize]);
+
+  const getRenderedIndexForImageIndex = useCallback((imageIndex: number | null): number => {
+    if (imageIndex == null || imageIndex < 0) {
+      return -1;
+    }
+
+    const focusedImage = images[imageIndex];
+    if (!focusedImage) {
+      return -1;
+    }
+
+    return itemsToRender.findIndex((item) =>
+      isImageStack(item)
+        ? item.images.some((stackImage) => stackImage.id === focusedImage.id)
+        : item.id === focusedImage.id
+    );
+  }, [images, itemsToRender]);
+
+  const getImageIndexForRenderedItem = useCallback((item: IndexedImage | ImageStack): number => {
+    const itemImage = getWarmupImage(item);
+    return images.findIndex((image) => image.id === itemImage.id);
+  }, [images]);
 
   useEffect(() => {
     focusedImageIndexRef.current = focusedImageIndex;
@@ -1518,38 +1540,39 @@ const ImageGrid: React.FC<ImageGridProps> = ({
           return;
         }
 
-        const currentIndex = focusedImageIndexRef.current ?? -1;
-        let nextIndex = 0;
+        const currentRenderedIndex = getRenderedIndexForImageIndex(focusedImageIndexRef.current);
+        let nextRenderedIndex = 0;
 
-        if (currentIndex >= 0) {
+        if (currentRenderedIndex >= 0) {
           const columnCount = getActiveColumnCount();
 
           if (e.key === 'ArrowRight') {
-            nextIndex = currentIndex + 1;
+            nextRenderedIndex = currentRenderedIndex + 1;
           } else if (e.key === 'ArrowLeft') {
-            nextIndex = currentIndex - 1;
+            nextRenderedIndex = currentRenderedIndex - 1;
           } else if (e.key === 'ArrowDown') {
-            nextIndex = currentIndex + columnCount;
+            nextRenderedIndex = currentRenderedIndex + columnCount;
           } else if (e.key === 'ArrowUp') {
-            nextIndex = currentIndex - columnCount;
+            nextRenderedIndex = currentRenderedIndex - columnCount;
           } else if (e.key === 'Home') {
-            nextIndex = 0;
+            nextRenderedIndex = 0;
           } else if (e.key === 'End') {
-            nextIndex = itemCount - 1;
+            nextRenderedIndex = itemCount - 1;
           }
         }
 
-        const resolvedIndex = clampIndex(nextIndex, itemCount);
-        const nextItem = itemsToRender[resolvedIndex];
+        const resolvedRenderedIndex = clampIndex(nextRenderedIndex, itemCount);
+        const nextItem = itemsToRender[resolvedRenderedIndex];
         const previewTarget: IndexedImage | undefined = nextItem
           ? isImageStack(nextItem)
             ? nextItem.coverImage
             : nextItem
           : undefined;
+        const resolvedImageIndex = nextItem ? getImageIndexForRenderedItem(nextItem) : -1;
 
-        if (previewTarget) {
-          focusedImageIndexRef.current = resolvedIndex;
-          setFocusedImageIndex(resolvedIndex);
+        if (previewTarget && resolvedImageIndex >= 0) {
+          focusedImageIndexRef.current = resolvedImageIndex;
+          setFocusedImageIndex(resolvedImageIndex);
           if (e.repeat) {
             pendingKeyboardPreviewRef.current = previewTarget;
           } else {
@@ -1561,12 +1584,14 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         e.preventDefault();
         if (currentPage < totalPages) {
           onPageChange(currentPage + 1);
+          focusedImageIndexRef.current = 0;
           setFocusedImageIndex(0);
         }
       } else if (e.key === 'PageUp') {
         e.preventDefault();
         if (currentPage > 1) {
           onPageChange(currentPage - 1);
+          focusedImageIndexRef.current = 0;
           setFocusedImageIndex(0);
         }
       }
@@ -1585,7 +1610,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('keyup', handleKeyUp);
     };
-  }, [flushKeyboardPreview, getActiveColumnCount, itemsToRender, setFocusedImageIndex, setPreviewImage, onImageClick, images, currentPage, totalPages, onPageChange]);
+  }, [flushKeyboardPreview, getActiveColumnCount, getImageIndexForRenderedItem, getRenderedIndexForImageIndex, itemsToRender, setFocusedImageIndex, setPreviewImage, onImageClick, focusedImageIndex, images, currentPage, totalPages, onPageChange]);
 
   useEffect(() => {
     return () => {
@@ -1598,29 +1623,34 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       return;
     }
 
+    const renderedIndex = getRenderedIndexForImageIndex(focusedImageIndex);
+    if (renderedIndex < 0) {
+      return;
+    }
+
     if (isInfinite) {
       const columnCount = Math.max(1, columnCountRef.current);
       virtualGridRef.current?.scrollToItem({
-        rowIndex: Math.floor(focusedImageIndex / columnCount),
-        columnIndex: focusedImageIndex % columnCount,
+        rowIndex: Math.floor(renderedIndex / columnCount),
+        columnIndex: renderedIndex % columnCount,
         align: 'auto',
       });
       return;
     }
 
-    const focusedImage = images[focusedImageIndex];
-    if (!focusedImage) {
+    const focusedItem = itemsToRender[renderedIndex];
+    if (!focusedItem) {
       return;
     }
 
-    const focusedElement = imageCardsRef.current.get(focusedImage.id);
+    const focusedElement = imageCardsRef.current.get(getWarmupImage(focusedItem).id);
     if (typeof focusedElement?.scrollIntoView === 'function') {
       focusedElement.scrollIntoView({
         block: 'nearest',
         inline: 'nearest',
       });
     }
-  }, [focusedImageIndex, images, isInfinite]);
+  }, [focusedImageIndex, getRenderedIndexForImageIndex, isInfinite, itemsToRender]);
 
   // Add global mouseup listener to handle selection end even outside the grid
   useEffect(() => {
@@ -2168,6 +2198,10 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const handleImageLoad = useCallback((id: string, aspectRatio: number) => {
   }, []);
 
+  const focusedImageId = focusedImageIndex != null && focusedImageIndex >= 0
+    ? images[focusedImageIndex]?.id ?? null
+    : null;
+
   if (isEmpty) {
      return (
         <React.Profiler id="ImageGrid" onRender={imageGridProfilerOnRender}>
@@ -2217,7 +2251,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                     onImageClick,
                     onStackClick: handleStackClick,
                     selectedImages,
-                    focusedImageIndex,
+                    focusedImageId,
                     imageSize,
                     handleImageLoad,
                     handleContextMenu,
@@ -2427,7 +2461,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                                 onImageClick={() => handleStackClick(item)}
                                 enableAuxClickOpen={false}
                                 isSelected={selectedImages.has(item.coverImage.id)}
-                                isFocused={false}
+                                isFocused={item.images.some(stackImage => stackImage.id === focusedImageId)}
                                 onImageLoad={handleImageLoad}
                 onContextMenu={(img, e) => handleContextMenu(img, e)}
                 onRenameRequest={openInlineRename}
@@ -2435,7 +2469,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                 isRenaming={renamingImageId === item.coverImage.id}
                 baseWidth={imageSize}
                                 isComparisonFirst={false}
-                                cardRef={createCardRef(item.id)}
+                                cardRef={createCardRef(item.coverImage.id)}
                                 isMarkedBest={markedBestIds?.has(item.coverImage.id)}
                                 isMarkedArchived={markedArchivedIds?.has(item.coverImage.id)}
                                 isBlurred={isSensitive && enableSafeMode && blurSensitiveImages}
@@ -2453,7 +2487,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             }
 
             const image = item;
-            const isFocused = focusedImageIndex === index;
+            const isFocused = image.id === focusedImageId;
             const isSensitive = enableSafeMode &&
               sensitiveTagSet.size > 0 &&
               !!image.tags?.some(tag => sensitiveTagSet.has(tag.toLowerCase()));

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -718,6 +718,8 @@ const getItemHeight = (imageSize: number, showFilenames: boolean): number =>
 const clampIndex = (index: number, itemCount: number): number =>
   Math.max(0, Math.min(itemCount - 1, index));
 
+const KEYBOARD_NAVIGATION_KEYS = ['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'];
+
 interface CellData {
   items: (IndexedImage | ImageStack)[];
   columnCount: number;
@@ -924,6 +926,8 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const lastWarmupWindowRef = useRef<string>('');
   const releasePaginatedBackgroundPauseRef = useRef<(() => void) | null>(null);
   const lastScrollSampleRef = useRef<{ top: number; at: number }>({ top: 0, at: 0 });
+  const focusedImageIndexRef = useRef<number | null>(null);
+  const pendingKeyboardPreviewRef = useRef<IndexedImage | null>(null);
 
   const sensitiveTags = useSettingsStore((state) => state.sensitiveTags);
   const blurSensitiveImages = useSettingsStore((state) => state.blurSensitiveImages);
@@ -1011,6 +1015,20 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     const measuredColumnCount = Math.floor(measuredWidth / (imageSize + GAP_SIZE));
     return Math.max(1, measuredColumnCount || columnCountRef.current || 1);
   }, [imageSize]);
+
+  useEffect(() => {
+    focusedImageIndexRef.current = focusedImageIndex;
+  }, [focusedImageIndex]);
+
+  const flushKeyboardPreview = useCallback(() => {
+    const pendingPreview = pendingKeyboardPreviewRef.current;
+    if (!pendingPreview) {
+      return;
+    }
+
+    pendingKeyboardPreviewRef.current = null;
+    setPreviewImage(pendingPreview);
+  }, [setPreviewImage]);
 
   const setNonVirtualGridRef = useCallback((node: HTMLDivElement | null) => {
     gridScopeRef.current = node;
@@ -1492,8 +1510,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         }
       }
 
-      const navigationKeys = ['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'];
-      if (navigationKeys.includes(e.key)) {
+      if (KEYBOARD_NAVIGATION_KEYS.includes(e.key)) {
         e.preventDefault();
 
         const itemCount = itemsToRender.length;
@@ -1501,7 +1518,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
           return;
         }
 
-        const currentIndex = focusedImageIndex ?? -1;
+        const currentIndex = focusedImageIndexRef.current ?? -1;
         let nextIndex = 0;
 
         if (currentIndex >= 0) {
@@ -1531,8 +1548,14 @@ const ImageGrid: React.FC<ImageGridProps> = ({
           : undefined;
 
         if (previewTarget) {
+          focusedImageIndexRef.current = resolvedIndex;
           setFocusedImageIndex(resolvedIndex);
-          setPreviewImage(previewTarget);
+          if (e.repeat) {
+            pendingKeyboardPreviewRef.current = previewTarget;
+          } else {
+            pendingKeyboardPreviewRef.current = null;
+            setPreviewImage(previewTarget);
+          }
         }
       } else if (e.key === 'PageDown') {
         e.preventDefault();
@@ -1550,9 +1573,25 @@ const ImageGrid: React.FC<ImageGridProps> = ({
 
     };
 
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (KEYBOARD_NAVIGATION_KEYS.includes(e.key)) {
+        flushKeyboardPreview();
+      }
+    };
+
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [focusedImageIndex, getActiveColumnCount, itemsToRender, setFocusedImageIndex, setPreviewImage, onImageClick, currentPage, totalPages, onPageChange]);
+    document.addEventListener('keyup', handleKeyUp);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [flushKeyboardPreview, getActiveColumnCount, itemsToRender, setFocusedImageIndex, setPreviewImage, onImageClick, images, currentPage, totalPages, onPageChange]);
+
+  useEffect(() => {
+    return () => {
+      pendingKeyboardPreviewRef.current = null;
+    };
+  }, []);
 
   useEffect(() => {
     if (!gridKeyboardActiveRef.current || focusedImageIndex == null || focusedImageIndex < 0) {

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -928,6 +928,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const lastScrollSampleRef = useRef<{ top: number; at: number }>({ top: 0, at: 0 });
   const focusedImageIndexRef = useRef<number | null>(null);
   const pendingKeyboardPreviewRef = useRef<IndexedImage | null>(null);
+  const pendingPageBoundaryFocusRef = useRef<'first' | 'last' | null>(null);
 
   const sensitiveTags = useSettingsStore((state) => state.sensitiveTags);
   const blurSensitiveImages = useSettingsStore((state) => state.blurSensitiveImages);
@@ -1046,6 +1047,19 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   useEffect(() => {
     focusedImageIndexRef.current = focusedImageIndex;
   }, [focusedImageIndex]);
+
+  useEffect(() => {
+    const pendingFocus = pendingPageBoundaryFocusRef.current;
+    if (!pendingFocus || images.length === 0 || !gridKeyboardActiveRef.current) {
+      return;
+    }
+
+    const nextIndex = pendingFocus === 'first' ? 0 : images.length - 1;
+    pendingPageBoundaryFocusRef.current = null;
+    focusedImageIndexRef.current = nextIndex;
+    setFocusedImageIndex(nextIndex);
+    setPreviewImage(images[nextIndex]);
+  }, [images, setFocusedImageIndex, setPreviewImage]);
 
   const flushKeyboardPreview = useCallback(() => {
     const pendingPreview = pendingKeyboardPreviewRef.current;
@@ -1551,6 +1565,28 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         if (currentRenderedIndex >= 0) {
           const columnCount = getActiveColumnCount();
 
+          if (!isInfinite && e.key === 'ArrowRight' && currentRenderedIndex >= itemCount - 1) {
+            if (currentPage < totalPages) {
+              pendingKeyboardPreviewRef.current = null;
+              pendingPageBoundaryFocusRef.current = 'first';
+              focusedImageIndexRef.current = 0;
+              setFocusedImageIndex(0);
+              onPageChange(currentPage + 1);
+            }
+            return;
+          }
+
+          if (!isInfinite && e.key === 'ArrowLeft' && currentRenderedIndex <= 0) {
+            if (currentPage > 1) {
+              pendingKeyboardPreviewRef.current = null;
+              pendingPageBoundaryFocusRef.current = 'last';
+              focusedImageIndexRef.current = -1;
+              setFocusedImageIndex(-1);
+              onPageChange(currentPage - 1);
+            }
+            return;
+          }
+
           if (e.key === 'ArrowRight') {
             nextRenderedIndex = currentRenderedIndex + 1;
           } else if (e.key === 'ArrowLeft') {
@@ -1620,6 +1656,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   useEffect(() => {
     return () => {
       pendingKeyboardPreviewRef.current = null;
+      pendingPageBoundaryFocusRef.current = null;
     };
   }, []);
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,19 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.4] - Unreleased
+## [0.15.4] - 2026-04-29
 
 ### Added
 
-- **Executable Generation Queue**: Added a real queue runner for A1111 and ComfyUI jobs so waiting generations start automatically when the active provider job finishes.
+- **Advanced Folder Management**: Added directory tree view with subfolder navigation, drag-and-drop file transfers, directory renaming, and global hotkey support for clipboard operations.
 
 ### Improved
 
-- **Generated Output Preview**: Added generated result thumbnails in the queue and a dedicated preview modal for completed queue jobs, including navigation for multi-image outputs and a path to full image metadata when the generated file is indexed.
-- **Generation Queue UX**: Clarified queue card actions with more intuitive cancel, stop, retry, and remove controls, improved accessible labels, made completed result cards clickable, and removed the confusing destructive "Clear all" behavior.
-- **Queue Ordering and Cancellation**: Queue scheduling now drains in FIFO order, and canceling a waiting job no longer interrupts the currently active provider generation.
-- **A1111 Batch Progress Display**: Improved the `Image X/Y` fallback logic so batch progress tracks the progress bar even when A1111 keeps reporting the same `job_no`.
-- **Generated Output Memory Handling**: A1111 queue previews now use temporary Blob URLs instead of storing full base64 image payloads directly in queue state.
+- **Generation Queue**: Rebuilt queue UX with clearer actions, clickable results, and thumbnails. Added a dedicated preview modal for completed jobs. Scheduling now drains in FIFO order without interruptions from cancellations. Improved memory handling by using Blob URLs instead of base64 payloads, and refined A1111 batch progress tracking.
+- **Workflow Analysis**: Enhanced ComfyUI workflow JSON handling, resolution, and streamlined dimension target extraction logic.
+- **Workspace Experience**: Improved workspace tab persistence and enhanced image modal functionality.
 
 ### Fixed
 
@@ -56,7 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Desktop Media Memory Safety**: Fixed a v0.15.0 regression where large video or audio files could be read fully into renderer memory when the desktop streaming media URL path failed, potentially causing black screens or renderer crashes on macOS.
 - **Video Thumbnail Guardrails**: Reduced thumbnail generation concurrency, capped active thumbnail object URLs, reused legacy thumbnail cache entries where possible, and skipped renderer-side video thumbnail generation for videos with unknown size or over 80 MB to avoid memory spikes during cache refresh.
-
 
 ## [0.15.0] - 2026-04-23
 


### PR DESCRIPTION
## Summary

Fixes thumbnail-grid keyboard navigation so focus moves spatially through the rendered ImageGrid instead of treating Up/Down like Left/Right.

## What changed

- Updates ImageGrid keyboard handling so Left/Right move by one item, Up/Down move by the active column count, Home moves to the first rendered item, and End moves to the last rendered item.
- Keeps the first navigation keypress behavior consistent by establishing focus on the first rendered item when there is no current focus.
- Defers preview/sidebar updates during repeated keydown navigation and flushes the pending preview on keyup, keeping long-press navigation responsive.
- Removes the card-shell `transition-all` that made the active thumbnail highlight disappear during long key repeats.
- Adds regression coverage for spatial navigation, Home/End, partial-row clamping, and repeated keydown preview deferral.
- Relates to #248 
- 
## Validation

- `npx vitest run __tests__/ImageGrid.contextMenu.test.tsx`
- `npx tsc -b`
- Manual long-press navigation check confirmed fixed.