### PR TITLE
⚡ Optimize move/copy persistence with bulk operations

### DIFF
--- a/services/fileTransferService.ts
+++ b/services/fileTransferService.ts
@@ -1,5 +1,5 @@
 import { processFiles } from './fileIndexer';
-import { transferImagePersistence } from './imageAnnotationsStorage';
+import { bulkTransferImagePersistence } from './imageAnnotationsStorage';
 import { useImageStore } from '../store/useImageStore';
 import type {
   Directory,
@@ -181,7 +181,6 @@ export async function transferIndexedImages({
 
     const targetImageId = `${destinationDirectory.id}::${item.destinationRelativePath}`;
     persistenceTransfers.push({ sourceImage, targetImageId });
-    await transferImagePersistence(sourceImage.id, targetImageId, 'copy');
 
     const sourceAnnotation = annotationsMap.get(sourceImage.id);
     if (sourceAnnotation) {
@@ -192,6 +191,11 @@ export async function transferIndexedImages({
       });
     }
   }
+
+  await bulkTransferImagePersistence(
+    persistenceTransfers.map((t) => ({ sourceImageId: t.sourceImage.id, targetImageId: t.targetImageId })),
+    'copy',
+  );
 
   const transferredEntries = transferredItems.map(buildTransferredEntry);
   const fileStatsMap = new Map(
@@ -228,9 +232,10 @@ export async function transferIndexedImages({
 
   if (shouldRelyOnWatcher) {
     if (mode === 'move') {
-      for (const transfer of persistenceTransfers) {
-        await transferImagePersistence(transfer.sourceImage.id, transfer.targetImageId, 'move');
-      }
+      await bulkTransferImagePersistence(
+        persistenceTransfers.map((t) => ({ sourceImageId: t.sourceImage.id, targetImageId: t.targetImageId })),
+        'move',
+      );
     }
 
     if (mode === 'move') {
@@ -287,9 +292,10 @@ export async function transferIndexedImages({
   flushPendingImages();
 
   if (mode === 'move') {
-    for (const transfer of persistenceTransfers) {
-      await transferImagePersistence(transfer.sourceImage.id, transfer.targetImageId, 'move');
-    }
+    await bulkTransferImagePersistence(
+      persistenceTransfers.map((t) => ({ sourceImageId: t.sourceImage.id, targetImageId: t.targetImageId })),
+      'move',
+    );
     removeImages(images.map((image) => image.id));
   }
 

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -315,6 +315,116 @@ export async function transferImagePersistence(
 }
 
 /**
+ * Bulk transfer persistence (annotations and shadow metadata) for multiple images
+ */
+export async function bulkTransferImagePersistence(
+  transfers: { sourceImageId: string; targetImageId: string }[],
+  mode: 'copy' | 'move',
+): Promise<void> {
+  if (transfers.length === 0) {
+    return;
+  }
+
+  const timestamp = Date.now();
+
+  // Update in-memory cache for those already present
+  for (const { sourceImageId, targetImageId } of transfers) {
+    if (!sourceImageId || !targetImageId || sourceImageId === targetImageId) continue;
+
+    const currentAnnotation = inMemoryAnnotations.get(sourceImageId);
+    if (currentAnnotation) {
+      const targetAnnotation = {
+        ...currentAnnotation,
+        imageId: targetImageId,
+        updatedAt: timestamp,
+      };
+      inMemoryAnnotations.set(targetImageId, targetAnnotation);
+      if (mode === 'move') {
+        inMemoryAnnotations.delete(sourceImageId);
+      }
+    }
+  }
+
+  if (isPersistenceDisabled) {
+    return;
+  }
+
+  const db = await openDatabase();
+  if (!db) {
+    return;
+  }
+
+  const hasShadowStore = db.objectStoreNames.contains(SHADOW_METADATA_STORE_NAME);
+  const stores = [STORE_NAME];
+  if (hasShadowStore) {
+    stores.push(SHADOW_METADATA_STORE_NAME);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(stores, 'readwrite');
+    const annotationStore = transaction.objectStore(STORE_NAME);
+    const shadowStore = hasShadowStore ? transaction.objectStore(SHADOW_METADATA_STORE_NAME) : null;
+
+    transaction.oncomplete = () => {
+      resolve();
+    };
+    transaction.onabort = () => {
+      reject(transaction.error);
+    };
+    transaction.onerror = () => {
+      reject(transaction.error);
+    };
+
+    for (const { sourceImageId, targetImageId } of transfers) {
+      if (!sourceImageId || !targetImageId || sourceImageId === targetImageId) continue;
+
+      // Handle Annotations
+      const annGetRequest = annotationStore.get(sourceImageId);
+      annGetRequest.onsuccess = () => {
+        const currentAnnotation = annGetRequest.result as ImageAnnotations | undefined;
+        if (currentAnnotation) {
+          const targetAnnotation = {
+            ...currentAnnotation,
+            imageId: targetImageId,
+            updatedAt: timestamp,
+          };
+          annotationStore.put(targetAnnotation);
+          inMemoryAnnotations.set(targetImageId, targetAnnotation);
+
+          if (mode === 'move') {
+            annotationStore.delete(sourceImageId);
+            inMemoryAnnotations.delete(sourceImageId);
+          }
+        }
+      };
+
+      // Handle Shadow Metadata
+      if (shadowStore) {
+        const shadowGetRequest = shadowStore.get(sourceImageId);
+        shadowGetRequest.onsuccess = () => {
+          const currentShadow = shadowGetRequest.result as ShadowMetadata | undefined;
+          if (currentShadow) {
+            const targetShadow = {
+              ...currentShadow,
+              imageId: targetImageId,
+              updatedAt: timestamp,
+            };
+            shadowStore.put(targetShadow);
+
+            if (mode === 'move') {
+              shadowStore.delete(sourceImageId);
+            }
+          }
+        };
+      }
+    }
+  }).catch((error) => {
+    console.error('IndexedDB bulk transfer error:', error);
+    disablePersistence(error);
+  });
+}
+
+/**
  * Bulk save multiple annotations in a single transaction (for performance)
  */
 export async function bulkSaveAnnotations(annotations: ImageAnnotations[]): Promise<void> {


### PR DESCRIPTION
### ⚡ Performance Optimization: Bulk Move Persistence

This PR implements a performance optimization for the file transfer process by batching database updates.

#### 💡 What:
- Introduced a new `bulkTransferImagePersistence` function in `services/imageAnnotationsStorage.ts` that handles multiple transfers in a single IndexedDB transaction.
- Updated `services/fileTransferService.ts` to use this bulk operation instead of sequential `await transferImagePersistence(...)` calls in loops.

#### 🎯 Why:
The original implementation was calling `transferImagePersistence` for each file being moved or copied. Each call created a new IndexedDB transaction and awaited its completion before proceeding to the next file. This sequential approach caused significant performance bottlenecks due to transaction overhead and I/O serialization, especially when transferring large numbers of files.

#### 📊 Measured Improvement:
- **Reduced Overhead:** By combining multiple operations into a single transaction, we significantly reduce the overhead of opening and closing database connections and transactions.
- **Improved Throughput:** The batching approach allows the browser's IndexedDB implementation to optimize the disk I/O for multiple updates, leading to faster completion of the persistence phase of file transfers.
- **Efficiency:** Removed sequential awaits in loops, allowing the persistence layer to process all changes in one go.

#### ✅ Verification:
- Verified that both 'copy' and 'move' modes correctly update the database and the in-memory cache.
- Ensure that both primary annotations and shadow metadata are preserved during the bulk transfer.
- Confirmed that the database connection remains open and functional for subsequent operations.


---
*PR created automatically by Jules for task [13730740430745156533](https://jules.google.com/task/13730740430745156533) started by @LuqP2*