### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-02 - IndexedDB Transaction Overhead
+**Learning:** Sequential `Promise.all` with individual IndexedDB transactions causes significant overhead. This codebase heavily uses IndexedDB for persistence.
+**Action:** Always look for opportunities to replace `Promise.all(items.map(saveItem))` with a single `bulkSave` operation using a single transaction when interacting with IndexedDB.

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -1107,6 +1107,36 @@ export async function saveSmartCollection(collection: SmartCollection): Promise<
 }
 
 /**
+ * Save multiple smart collections in a single transaction
+ */
+export async function bulkSaveSmartCollections(collections: SmartCollection[]): Promise<void> {
+  const db = await openDatabase();
+  if (!db || collections.length === 0) return;
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction([SMART_COLLECTIONS_STORE_NAME], 'readwrite');
+    const store = transaction.objectStore(SMART_COLLECTIONS_STORE_NAME);
+
+    for (const collection of collections) {
+      const normalizedCollection = normalizeSmartCollection(
+        {
+          ...collection,
+          updatedAt: Date.now(),
+        },
+        collection.sortIndex,
+      );
+      store.put(normalizedCollection);
+    }
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => {
+      console.error('Error bulk saving smart collections:', transaction.error);
+      reject(transaction.error);
+    };
+  });
+}
+
+/**
  * Delete smart collection
  */
 export async function deleteSmartCollection(id: string): Promise<void> {
@@ -1196,7 +1226,7 @@ export async function reorderSmartCollections(collections: SmartCollection[]): P
     ),
   );
 
-  await Promise.all(normalizedCollections.map((collection) => saveSmartCollection(collection)));
+  await bulkSaveSmartCollections(normalizedCollections);
   return normalizedCollections;
 }
 


### PR DESCRIPTION
**What:**
Introduced a `bulkSaveSmartCollections` function that uses a single IndexedDB transaction to save an array of `SmartCollection` records. Updated `reorderSmartCollections` to use this new function.

**Why:**
Previously, `reorderSmartCollections` utilized `Promise.all(normalizedCollections.map((collection) => saveSmartCollection(collection)))`. Because `saveSmartCollection` creates its own transaction, reordering launched N concurrent IndexedDB transactions. This adds unnecessary overhead to the browser and database.

**Impact:**
Reduces the number of IndexedDB transactions launched during a reorder operation from N (where N is the number of collections) to 1. This noticeably speeds up persistence throughput and reduces browser overhead.

**Measurement:**
You can verify this by profiling the IndexedDB transaction count when dragging to reorder smart collections in the sidebar; previously it fired multiple transaction requests, and now it fires exactly one bulk transaction.

---
*PR created automatically by Jules for task [13411448489454612707](https://jules.google.com/task/13411448489454612707) started by @LuqP2*