### PR TITLE
🎨 Palette: Improve accessibility of modal close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+# Palette's Journal
+
+No critical learnings yet.

--- a/components/A1111GenerateModal.tsx
+++ b/components/A1111GenerateModal.tsx
@@ -263,7 +263,7 @@ export const A1111GenerateModal: React.FC<A1111GenerateModalProps> = ({
         >
           <div className="flex justify-between items-center mb-4">
             <h2 className="text-xl font-bold text-red-400">No Metadata Available</h2>
-            <button onClick={handleClose} className="p-1 rounded-full hover:bg-gray-700">
+            <button onClick={handleClose} className="p-1 rounded-full hover:bg-gray-700" aria-label="Close generate modal">
               <X size={20} />
             </button>
           </div>
@@ -304,6 +304,7 @@ export const A1111GenerateModal: React.FC<A1111GenerateModalProps> = ({
             <button
               onClick={handleClose}
               className="p-1 rounded-full hover:bg-gray-700 transition-colors"
+              aria-label="Close generate modal"
             >
               <X size={24} />
             </button>

--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -324,7 +324,7 @@ const Analytics: React.FC<AnalyticsProps> = ({ isOpen, onClose }) => {
                 <div className="inline-flex rounded-full border border-gray-700 bg-gray-950/70 p-1">
                   {(['context', 'library'] as AnalyticsScopeMode[]).map((mode) => <button key={mode} type="button" onClick={() => setScopeMode(mode)} className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${scopeMode === mode ? 'bg-cyan-500/15 text-cyan-100' : 'text-gray-400 hover:text-white'}`}>{mode === 'context' ? 'Current Scope' : 'Full Library'}</button>)}
                 </div>
-                <button type="button" onClick={onClose} className="rounded-full border border-gray-700 bg-gray-950/70 p-2 text-gray-400 transition-colors hover:border-gray-600 hover:text-white"><X size={18} /></button>
+                <button type="button" onClick={onClose} className="rounded-full border border-gray-700 bg-gray-950/70 p-2 text-gray-400 transition-colors hover:border-gray-600 hover:text-white" aria-label="Close analytics"><X size={18} /></button>
               </div>
             </div>
             <div className="mt-4 flex flex-col gap-3 border-t border-gray-800 pt-4 lg:flex-row lg:items-center lg:justify-between">

--- a/components/ChangelogModal.tsx
+++ b/components/ChangelogModal.tsx
@@ -114,6 +114,7 @@ const ChangelogModal: React.FC<ChangelogModalProps> = ({ isOpen, onClose, curren
             onClick={onClose}
             className="p-2 rounded-lg hover:bg-gray-700 transition-colors text-gray-400 hover:text-gray-50"
             title="Close"
+            aria-label="Close changelog"
           >
             <X size={24} />
           </button>

--- a/components/ComfyUIGenerateModal.tsx
+++ b/components/ComfyUIGenerateModal.tsx
@@ -86,7 +86,7 @@ export const ComfyUIGenerateModal: React.FC<ComfyUIGenerateModalProps> = ({
             >
               {isExpandedModal ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
             </button>
-            <button onClick={onClose} className="rounded-full p-1 hover:bg-gray-700">
+            <button onClick={onClose} className="rounded-full p-1 hover:bg-gray-700" aria-label="Close generate modal">
               <X size={24} />
             </button>
           </div>

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -171,6 +171,7 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
               onClick={handleClose}
               className="p-1.5 hover:bg-gray-700/50 text-gray-400 hover:text-white rounded-lg transition-colors"
               title="Close (Escape)"
+              aria-label="Close comparison"
             >
               <X className="w-5 h-5" />
             </button>

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -103,6 +103,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
             type="button"
             onClick={onClose}
             className="rounded-full p-2 text-gray-300 transition-colors hover:bg-gray-700 hover:text-white"
+            aria-label="Close settings"
           >
             <X size={20} />
           </button>

--- a/components/TagManagerModal.tsx
+++ b/components/TagManagerModal.tsx
@@ -166,6 +166,7 @@ const TagManagerModal: React.FC<TagManagerModalProps> = ({
           <button
             onClick={onClose}
             className="text-gray-400 hover:text-white transition-colors"
+            aria-label="Close tag manager"
           >
             <X size={20} />
           </button>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to the close buttons (`<X />` icons) across several modal components (`ChangelogModal`, `A1111GenerateModal`, `ComfyUIGenerateModal`, `TagManagerModal`, `ComparisonModal`, `Analytics`, `SettingsModal`).
🎯 **Why:** Icon-only buttons without accessible labels are invisible or confusing to screen reader users. Adding contextual `aria-labels` ensures the purpose of these buttons is clearly communicated to assistive technologies.
♿ **Accessibility:** Fixes a critical WCAG guideline related to missing labels on interactive controls, directly improving keyboard and screen reader navigation.

---
*PR created automatically by Jules for task [5311916646335002961](https://jules.google.com/task/5311916646335002961) started by @LuqP2*