### PR TITLE
Add image adjustment editing

### DIFF
--- a/__tests__/ImageAdjustmentPanel.test.tsx
+++ b/__tests__/ImageAdjustmentPanel.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ImageAdjustmentPanel from '../components/ImageAdjustmentPanel';
+import { DEFAULT_IMAGE_ADJUSTMENTS } from '../services/imageEditingService';
+
+describe('ImageAdjustmentPanel', () => {
+  it('emits slider changes', () => {
+    const onChange = vi.fn();
+    render(
+      <ImageAdjustmentPanel
+        adjustments={DEFAULT_IMAGE_ADJUSTMENTS}
+        onChange={onChange}
+        onReset={vi.fn()}
+        onSaveAs={vi.fn()}
+        onOverwrite={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('slider', { name: /brightness/i }), { target: { value: '140' } });
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_IMAGE_ADJUSTMENTS,
+      brightness: 140,
+    });
+  });
+
+  it('resets adjustments', () => {
+    const onReset = vi.fn();
+    render(
+      <ImageAdjustmentPanel
+        adjustments={{ ...DEFAULT_IMAGE_ADJUSTMENTS, contrast: 80 }}
+        onChange={vi.fn()}
+        onReset={onReset}
+        onSaveAs={vi.fn()}
+        onOverwrite={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it('wires save actions and disables them without changes', () => {
+    const onSaveAs = vi.fn();
+    const onOverwrite = vi.fn();
+    const { rerender } = render(
+      <ImageAdjustmentPanel
+        adjustments={DEFAULT_IMAGE_ADJUSTMENTS}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        onSaveAs={onSaveAs}
+        onOverwrite={onOverwrite}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /save as/i })).toHaveProperty('disabled', true);
+    expect(screen.getByRole('button', { name: /overwrite/i })).toHaveProperty('disabled', true);
+
+    rerender(
+      <ImageAdjustmentPanel
+        adjustments={{ ...DEFAULT_IMAGE_ADJUSTMENTS, saturation: 120 }}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        onSaveAs={onSaveAs}
+        onOverwrite={onOverwrite}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /save as/i }));
+    fireEvent.click(screen.getByRole('button', { name: /overwrite/i }));
+
+    expect(onSaveAs).toHaveBeenCalled();
+    expect(onOverwrite).toHaveBeenCalled();
+  });
+
+  it('disables controls while saving', () => {
+    render(
+      <ImageAdjustmentPanel
+        adjustments={{ ...DEFAULT_IMAGE_ADJUSTMENTS, hue: 20 }}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        onSaveAs={vi.fn()}
+        onOverwrite={vi.fn()}
+        isSaving
+      />
+    );
+
+    expect(screen.getByRole('spinbutton', { name: /hue/i })).toHaveProperty('disabled', true);
+    expect(screen.getByRole('button', { name: /overwrite/i })).toHaveProperty('disabled', true);
+  });
+});

--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_IMAGE_ADJUSTMENTS,
+  buildImageAdjustmentFilter,
+  clampImageAdjustment,
+  hasImageAdjustments,
+  normalizeImageAdjustments,
+  renderAdjustedImageToPngBytes,
+} from '../services/imageEditingService';
+
+describe('imageEditingService', () => {
+  it('treats default adjustments as neutral', () => {
+    expect(hasImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS)).toBe(false);
+    expect(hasImageAdjustments({ brightness: 101 })).toBe(true);
+  });
+
+  it('clamps adjustment values to supported ranges', () => {
+    expect(clampImageAdjustment('brightness', 250)).toBe(200);
+    expect(clampImageAdjustment('contrast', -10)).toBe(0);
+    expect(clampImageAdjustment('saturation', Number.NaN)).toBe(100);
+    expect(clampImageAdjustment('hue', 300)).toBe(180);
+
+    expect(normalizeImageAdjustments({ brightness: 101.4, hue: -220 })).toEqual({
+      brightness: 101,
+      contrast: 100,
+      saturation: 100,
+      hue: -180,
+    });
+  });
+
+  it('builds a CSS/canvas filter string', () => {
+    expect(buildImageAdjustmentFilter({ brightness: 120, contrast: 80, saturation: 150, hue: -30 }))
+      .toBe('brightness(120%) contrast(80%) saturate(150%) hue-rotate(-30deg)');
+  });
+
+  it('renders adjusted image bytes as PNG', async () => {
+    const drawImage = vi.fn();
+    const toBlob = vi.fn((callback: BlobCallback) => {
+      callback(new Blob([new Uint8Array([137, 80, 78, 71])], { type: 'image/png' }));
+    });
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+      if (tagName === 'canvas') {
+        return {
+          width: 0,
+          height: 0,
+          getContext: () => ({ filter: '', drawImage }),
+          toBlob,
+        } as unknown as HTMLCanvasElement;
+      }
+
+      return originalCreateElement(tagName);
+    }) as typeof document.createElement);
+
+    const OriginalImage = globalThis.Image;
+    class MockImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      decoding = '';
+      naturalWidth = 8;
+      naturalHeight = 6;
+      width = 8;
+      height = 6;
+
+      set src(_value: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+
+    globalThis.Image = MockImage as unknown as typeof Image;
+    try {
+      const bytes = await renderAdjustedImageToPngBytes('blob:test', { brightness: 120 });
+      expect([...bytes]).toEqual([137, 80, 78, 71]);
+      expect(drawImage).toHaveBeenCalled();
+      expect(toBlob).toHaveBeenCalled();
+    } finally {
+      globalThis.Image = OriginalImage;
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_IMAGE_ADJUSTMENTS,
   buildImageAdjustmentFilter,
   clampImageAdjustment,
+  embedMetaHubMetadataInPngBytes,
   hasImageAdjustments,
   normalizeImageAdjustments,
   renderAdjustedImageToPngBytes,
@@ -77,5 +78,35 @@ describe('imageEditingService', () => {
       globalThis.Image = OriginalImage;
       vi.restoreAllMocks();
     }
+  });
+
+  it('embeds MetaHub metadata chunks into PNG bytes', () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x00,
+      0x49, 0x45, 0x4e, 0x44,
+      0xae, 0x42, 0x60, 0x82,
+    ]);
+
+    const output = embedMetaHubMetadataInPngBytes(pngBytes, {
+      prompt: 'a test prompt',
+      negativePrompt: 'blur',
+      model: 'model.safetensors',
+      models: ['model.safetensors'],
+      width: 64,
+      height: 32,
+      steps: 20,
+      scheduler: 'normal',
+      sampler: 'euler',
+      cfg_scale: 7,
+      seed: 123,
+    }, DEFAULT_IMAGE_ADJUSTMENTS);
+    const text = new TextDecoder().decode(output);
+
+    expect(text).toContain('parameters');
+    expect(text).toContain('a test prompt');
+    expect(text).toContain('imagemetahub_data');
+    expect(text).toContain('Image MetaHub');
+    expect(text).toContain('model.safetensors');
   });
 });

--- a/components/ImageAdjustmentPanel.tsx
+++ b/components/ImageAdjustmentPanel.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { RotateCcw, Save, SaveAll } from 'lucide-react';
+import type { ImageAdjustments } from '../types';
+import {
+  DEFAULT_IMAGE_ADJUSTMENTS,
+  clampImageAdjustment,
+  hasImageAdjustments,
+} from '../services/imageEditingService';
+
+interface ImageAdjustmentPanelProps {
+  adjustments: ImageAdjustments;
+  onChange: (adjustments: ImageAdjustments) => void;
+  onReset: () => void;
+  onSaveAs: () => void;
+  onOverwrite: () => void;
+  isSaving?: boolean;
+  disabled?: boolean;
+}
+
+const CONTROLS: Array<{
+  key: keyof ImageAdjustments;
+  label: string;
+  min: number;
+  max: number;
+  unit: string;
+}> = [
+  { key: 'brightness', label: 'Brightness', min: 0, max: 200, unit: '%' },
+  { key: 'contrast', label: 'Contrast', min: 0, max: 200, unit: '%' },
+  { key: 'saturation', label: 'Saturation', min: 0, max: 200, unit: '%' },
+  { key: 'hue', label: 'Hue', min: -180, max: 180, unit: 'deg' },
+];
+
+const ImageAdjustmentPanel: React.FC<ImageAdjustmentPanelProps> = ({
+  adjustments,
+  onChange,
+  onReset,
+  onSaveAs,
+  onOverwrite,
+  isSaving = false,
+  disabled = false,
+}) => {
+  const hasChanges = hasImageAdjustments(adjustments);
+  const controlsDisabled = disabled || isSaving;
+
+  const updateAdjustment = (key: keyof ImageAdjustments, rawValue: number) => {
+    onChange({
+      ...adjustments,
+      [key]: clampImageAdjustment(key, rawValue),
+    });
+  };
+
+  return (
+    <div className="space-y-4 rounded-lg border border-cyan-500/20 bg-gray-950/50 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-100">Adjust</h3>
+          <p className="text-xs text-gray-500">PNG output</p>
+        </div>
+        <button
+          type="button"
+          onClick={onReset}
+          disabled={controlsDisabled || !hasChanges}
+          className="inline-flex items-center gap-1.5 rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-xs font-medium text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+          title="Reset adjustments"
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+          Reset
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {CONTROLS.map((control) => (
+          <label key={control.key} className="block space-y-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs font-medium text-gray-300">{control.label}</span>
+              <div className="flex items-center gap-1">
+                <input
+                  type="number"
+                  min={control.min}
+                  max={control.max}
+                  value={adjustments[control.key]}
+                  disabled={controlsDisabled}
+                  onChange={(event) => updateAdjustment(control.key, Number(event.target.value))}
+                  className="h-7 w-16 rounded-md border border-gray-700 bg-gray-900 px-2 text-right text-xs text-gray-100 outline-none transition-colors focus:border-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label={control.label}
+                />
+                <span className="w-7 text-xs text-gray-500">{control.unit}</span>
+              </div>
+            </div>
+            <input
+              type="range"
+              aria-label={`${control.label} slider`}
+              min={control.min}
+              max={control.max}
+              value={adjustments[control.key]}
+              disabled={controlsDisabled}
+              onChange={(event) => updateAdjustment(control.key, Number(event.target.value))}
+              className="w-full accent-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+            />
+          </label>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          onClick={onSaveAs}
+          disabled={controlsDisabled || !hasChanges}
+          className="inline-flex items-center justify-center gap-1.5 rounded-md border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-xs font-semibold text-cyan-200 transition-colors hover:border-cyan-400/50 hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
+          title="Save edited copy"
+        >
+          <Save className="h-3.5 w-3.5" />
+          Save As
+        </button>
+        <button
+          type="button"
+          onClick={onOverwrite}
+          disabled={controlsDisabled || !hasChanges}
+          className="inline-flex items-center justify-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-200 transition-colors hover:border-amber-400/50 hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
+          title="Overwrite original file"
+        >
+          <SaveAll className="h-3.5 w-3.5" />
+          Overwrite
+        </button>
+      </div>
+
+      {isSaving && (
+        <div className="text-xs text-gray-400">Saving edited image...</div>
+      )}
+      {!hasChanges && (
+        <div className="text-xs text-gray-500">
+          Neutral: {DEFAULT_IMAGE_ADJUSTMENTS.brightness}/{DEFAULT_IMAGE_ADJUSTMENTS.contrast}/{DEFAULT_IMAGE_ADJUSTMENTS.saturation}/{DEFAULT_IMAGE_ADJUSTMENTS.hue}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ImageAdjustmentPanel;

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -86,6 +86,57 @@ const buildTagSuggestions = (
   return suggestions;
 };
 
+const parseDimensions = (value?: string): { width: number; height: number } => {
+  const match = String(value || '').match(/(\d+)\s*x\s*(\d+)/i);
+  return {
+    width: match ? Number(match[1]) : 0,
+    height: match ? Number(match[2]) : 0,
+  };
+};
+
+const getUsableNormalizedMetadata = (image: IndexedImage): BaseMetadata | undefined => {
+  const normalized = image.metadata?.normalizedMetadata as BaseMetadata | undefined;
+  if (normalized) {
+    return normalized;
+  }
+
+  const hasFlattenedMetadata = Boolean(
+    image.prompt ||
+    image.negativePrompt ||
+    image.models?.length ||
+    image.loras?.length ||
+    image.sampler ||
+    image.scheduler ||
+    image.seed !== undefined ||
+    image.steps !== undefined ||
+    image.cfgScale !== undefined ||
+    image.dimensions
+  );
+
+  if (!hasFlattenedMetadata) {
+    return undefined;
+  }
+
+  const dimensions = parseDimensions(image.dimensions);
+  const model = image.models?.[0] || '';
+  return {
+    prompt: image.prompt || '',
+    negativePrompt: image.negativePrompt || '',
+    model,
+    models: image.models || [],
+    loras: image.loras || [],
+    sampler: image.sampler || '',
+    scheduler: image.scheduler || '',
+    seed: image.seed,
+    steps: image.steps || 0,
+    cfgScale: image.cfgScale,
+    cfg_scale: image.cfgScale,
+    width: dimensions.width,
+    height: dimensions.height,
+    dimensions: image.dimensions,
+  };
+};
+
 interface ImageModalProps {
   modalId?: string;
   image: IndexedImage;
@@ -1250,7 +1301,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     };
   }, [applyModalWindowStyles, isFullViewportModal, modalInteraction, scheduleModalWindowPaint]);
 
-  const nMeta: BaseMetadata | undefined = liveImage.metadata?.normalizedMetadata;
+  const nMeta: BaseMetadata | undefined = getUsableNormalizedMetadata(liveImage);
   const canFindSimilar = Boolean(nMeta?.prompt) && Boolean(onFindSimilar);
   const effectiveMetadata = buildEffectiveMetadata(nMeta, shadowMetadata, showOriginal);
   const generationImage = useMemo<IndexedImage>(() => (
@@ -1724,20 +1775,27 @@ const ImageModal: React.FC<ImageModalProps> = ({
       if (targetDirectory) {
         const indexedImage = await indexImageFileAtPath(saveResult.path, targetDirectory);
         if (indexedImage) {
+          const sourceMetadata = getUsableNormalizedMetadata(liveImage);
+          const savedMetadata = sourceMetadata
+            ? {
+                ...liveImage.metadata,
+                normalizedMetadata: sourceMetadata,
+              }
+            : liveImage.metadata;
           const savedImage: IndexedImage = {
             ...indexedImage,
-            metadata: liveImage.metadata,
-            metadataString: liveImage.metadataString,
-            models: liveImage.models,
-            loras: liveImage.loras,
-            sampler: liveImage.sampler,
-            scheduler: liveImage.scheduler,
-            board: liveImage.board,
-            prompt: liveImage.prompt,
-            negativePrompt: liveImage.negativePrompt,
-            cfgScale: liveImage.cfgScale,
-            steps: liveImage.steps,
-            seed: liveImage.seed,
+            metadata: savedMetadata,
+            metadataString: sourceMetadata ? JSON.stringify(savedMetadata) : liveImage.metadataString,
+            models: sourceMetadata?.models || liveImage.models,
+            loras: sourceMetadata?.loras || liveImage.loras,
+            sampler: sourceMetadata?.sampler || liveImage.sampler,
+            scheduler: sourceMetadata?.scheduler || liveImage.scheduler,
+            board: sourceMetadata?.board || liveImage.board,
+            prompt: sourceMetadata?.prompt || liveImage.prompt,
+            negativePrompt: sourceMetadata?.negativePrompt || liveImage.negativePrompt,
+            cfgScale: sourceMetadata?.cfgScale ?? sourceMetadata?.cfg_scale ?? liveImage.cfgScale,
+            steps: sourceMetadata?.steps || liveImage.steps,
+            seed: sourceMetadata?.seed ?? liveImage.seed,
             workflowNodes: liveImage.workflowNodes,
             enrichmentState: 'enriched',
           };
@@ -1813,21 +1871,28 @@ const ImageModal: React.FC<ImageModalProps> = ({
         throw new Error('The edited image was saved, but metadata reparsing returned no image.');
       }
 
+      const sourceMetadata = getUsableNormalizedMetadata(liveImage);
+      const preservedMetadata = sourceMetadata
+        ? {
+            ...liveImage.metadata,
+            normalizedMetadata: sourceMetadata,
+          }
+        : liveImage.metadata;
       const preservedMetadataImage: IndexedImage = {
         ...liveImage,
         ...reparsed,
-        metadata: liveImage.metadata,
-        metadataString: liveImage.metadataString,
-        models: liveImage.models,
-        loras: liveImage.loras,
-        sampler: liveImage.sampler,
-        scheduler: liveImage.scheduler,
-        board: liveImage.board,
-        prompt: liveImage.prompt,
-        negativePrompt: liveImage.negativePrompt,
-        cfgScale: liveImage.cfgScale,
-        steps: liveImage.steps,
-        seed: liveImage.seed,
+        metadata: preservedMetadata,
+        metadataString: sourceMetadata ? JSON.stringify(preservedMetadata) : liveImage.metadataString,
+        models: sourceMetadata?.models || liveImage.models,
+        loras: sourceMetadata?.loras || liveImage.loras,
+        sampler: sourceMetadata?.sampler || liveImage.sampler,
+        scheduler: sourceMetadata?.scheduler || liveImage.scheduler,
+        board: sourceMetadata?.board || liveImage.board,
+        prompt: sourceMetadata?.prompt || liveImage.prompt,
+        negativePrompt: sourceMetadata?.negativePrompt || liveImage.negativePrompt,
+        cfgScale: sourceMetadata?.cfgScale ?? sourceMetadata?.cfg_scale ?? liveImage.cfgScale,
+        steps: sourceMetadata?.steps || liveImage.steps,
+        seed: sourceMetadata?.seed ?? liveImage.seed,
         workflowNodes: liveImage.workflowNodes,
         handle: liveImage.handle,
         thumbnailHandle: liveImage.thumbnailHandle,

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -26,6 +26,7 @@ import { indexImageFileAtPath, reparseIndexedImage } from '../services/fileIndex
 import {
   DEFAULT_IMAGE_ADJUSTMENTS,
   buildImageAdjustmentFilter,
+  embedMetaHubMetadataInPngBytes,
   hasImageAdjustments,
   renderAdjustedImageToPngBytes,
 } from '../services/imageEditingService';
@@ -1728,7 +1729,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }) ?? null;
   }, [directories]);
 
-  const writeEditedImage = useCallback(async (targetPath: string) => {
+  const writeEditedImage = useCallback(async (targetPath: string, sourceMetadata?: BaseMetadata) => {
     if (!imageUrl || !isFullImageSourceReady) {
       throw new Error('The full image is still loading.');
     }
@@ -1738,7 +1739,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }
 
     const pngBytes = await renderAdjustedImageToPngBytes(imageUrl, imageAdjustments);
-    const result = await window.electronAPI.writeFile(targetPath, pngBytes);
+    const outputBytes = embedMetaHubMetadataInPngBytes(pngBytes, sourceMetadata, imageAdjustments);
+    const result = await window.electronAPI.writeFile(targetPath, outputBytes);
     if (!result.success) {
       throw new Error(result.error || 'Failed to write edited image.');
     }
@@ -1769,13 +1771,13 @@ const ImageModal: React.FC<ImageModalProps> = ({
         return;
       }
 
-      await writeEditedImage(saveResult.path);
+      const sourceMetadata = getUsableNormalizedMetadata(liveImage);
+      await writeEditedImage(saveResult.path, sourceMetadata);
 
       const targetDirectory = findDirectoryForAbsolutePath(saveResult.path);
       if (targetDirectory) {
         const indexedImage = await indexImageFileAtPath(saveResult.path, targetDirectory);
         if (indexedImage) {
-          const sourceMetadata = getUsableNormalizedMetadata(liveImage);
           const savedMetadata = sourceMetadata
             ? {
                 ...liveImage.metadata,
@@ -1864,14 +1866,14 @@ const ImageModal: React.FC<ImageModalProps> = ({
         throw new Error(joined.error || 'Failed to resolve the original image path.');
       }
 
-      await writeEditedImage(joined.path);
+      const sourceMetadata = getUsableNormalizedMetadata(liveImage);
+      await writeEditedImage(joined.path, sourceMetadata);
 
       const reparsed = await reparseIndexedImage(liveImage, sourceDirectory.path);
       if (!reparsed) {
         throw new Error('The edited image was saved, but metadata reparsing returned no image.');
       }
 
-      const sourceMetadata = getUsableNormalizedMetadata(liveImage);
       const preservedMetadata = sourceMetadata
         ? {
             ...liveImage.metadata,

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useLayoutEffect, useState, FC, useCallback, useMemo, useRef } from 'react';
-import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollection } from '../types';
+import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollection, type ImageAdjustments } from '../types';
 import { FileOperations } from '../services/fileOperations';
 import { getRenameBasename, renameIndexedImage } from '../services/imageRenameService';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
-import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw } from 'lucide-react';
+import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw, SlidersHorizontal } from 'lucide-react';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
@@ -21,6 +21,14 @@ import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { getElectronAbsoluteMediaPath, mediaSourceCache } from '../services/mediaSourceCache';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+import cacheManager from '../services/cacheManager';
+import { indexImageFileAtPath, reparseIndexedImage } from '../services/fileIndexer';
+import {
+  DEFAULT_IMAGE_ADJUSTMENTS,
+  buildImageAdjustmentFilter,
+  hasImageAdjustments,
+  renderAdjustedImageToPngBytes,
+} from '../services/imageEditingService';
 
 import { bulkSaveShadowMetadata } from '../services/imageAnnotationsStorage';
 import { copyEditableMetadata, readEditableMetadataClipboard } from '../services/metadataClipboard';
@@ -37,7 +45,9 @@ import TagInputCombobox from './TagInputCombobox';
 import { getRecentTagChips } from '../utils/tagSuggestions';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 import AudioPlayer from './AudioPlayer';
-import { isAudioFileName, isVideoFileName, SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
+import ImageAdjustmentPanel from './ImageAdjustmentPanel';
+import { getRelativeImagePath, splitRelativePath } from '../utils/imagePaths';
+import { getFileExtension, isAudioFileName, isVideoFileName, SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
 import {
   createProfilerOnRender,
   finishPerformanceFlow,
@@ -695,6 +705,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const [detailsPlacement, setDetailsPlacement] = useState<'right' | 'bottom'>('right');
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
+  const [isAdjustmentPanelOpen, setIsAdjustmentPanelOpen] = useState(false);
+  const [imageAdjustments, setImageAdjustments] = useState<ImageAdjustments>(DEFAULT_IMAGE_ADJUSTMENTS);
+  const [isSavingEditedImage, setIsSavingEditedImage] = useState(false);
+  const [isFullImageSourceReady, setIsFullImageSourceReady] = useState(false);
   const [modalWindow, setModalWindow] = useState<ModalWindowState>(() => {
     if (initialWindowState) {
       return clampModalWindowToViewport(initialWindowState);
@@ -798,7 +812,13 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const collections = useImageStore((state) => state.collections);
   const createCollection = useImageStore((state) => state.createCollection);
   const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
+  const addImages = useImageStore((state) => state.addImages);
+  const mergeImages = useImageStore((state) => state.mergeImages);
+  const setImageThumbnail = useImageStore((state) => state.setImageThumbnail);
+  const setError = useImageStore((state) => state.setError);
+  const setSuccess = useImageStore((state) => state.setSuccess);
   const directories = useImageStore((state) => state.directories);
+  const scanSubfolders = useImageStore((state) => state.scanSubfolders);
   const filteredImages = useImageStore((state) => state.filteredImages);
   const allImages = useImageStore((state) => state.images);
   const selectedImages = useImageStore((state) => state.selectedImages);
@@ -821,6 +841,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const isVideo = isVideoFileName(image.name, image.fileType);
   const isAudio = isAudioFileName(image.name, image.fileType);
   const isPlayableMedia = isVideo || isAudio;
+  const canEditImage = !isPlayableMedia && getFileExtension(liveImage.name) !== '.gif';
   const showA1111Actions = !isPlayableMedia && a1111Enabled;
   const showComfyUIActions = !isPlayableMedia && comfyUIEnabled;
   const showComfyUIHeading = showA1111Actions && visibleProviders.length > 1;
@@ -876,6 +897,16 @@ const ImageModal: React.FC<ImageModalProps> = ({
     ? `${directoryPath}${/[\\/]$/.test(directoryPath) ? '' : '\\'}${image.name}`
     : image.name;
   const mediaOverlayVisibilityClass = isMediaOverlayVisible ? 'opacity-100' : 'opacity-0 pointer-events-none';
+  const adjustmentFilter = useMemo(
+    () => buildImageAdjustmentFilter(imageAdjustments),
+    [imageAdjustments]
+  );
+  const hasAdjustmentChanges = hasImageAdjustments(imageAdjustments);
+
+  useEffect(() => {
+    setImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS);
+    setIsAdjustmentPanelOpen(false);
+  }, [image.id]);
 
   useEffect(() => {
     const mountStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -1622,6 +1653,228 @@ const ImageModal: React.FC<ImageModalProps> = ({
     setPan({ x: 0, y: 0 });
   };
 
+  const buildEditedDefaultPath = useCallback(async () => {
+    const relativePath = getRelativeImagePath(liveImage);
+    const { folderPath, fileName } = splitRelativePath(relativePath);
+    const dotIndex = fileName.lastIndexOf('.');
+    const basename = dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName;
+    const editedRelativePath = folderPath ? `${folderPath}/${basename}-edited.png` : `${basename}-edited.png`;
+
+    if (!directoryPath || !window.electronAPI?.joinPaths) {
+      return `${basename}-edited.png`;
+    }
+
+    const joined = await window.electronAPI.joinPaths(directoryPath, editedRelativePath);
+    return joined.success && joined.path ? joined.path : `${basename}-edited.png`;
+  }, [directoryPath, liveImage]);
+
+  const findDirectoryForAbsolutePath = useCallback((filePath: string) => {
+    const normalize = (value: string) => value.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+    const normalizedFile = normalize(filePath);
+    return directories.find((directory) => {
+      const normalizedDirectory = normalize(directory.path);
+      return normalizedFile.startsWith(`${normalizedDirectory}/`);
+    }) ?? null;
+  }, [directories]);
+
+  const writeEditedImage = useCallback(async (targetPath: string) => {
+    if (!imageUrl || !isFullImageSourceReady) {
+      throw new Error('The full image is still loading.');
+    }
+
+    if (!window.electronAPI?.writeFile) {
+      throw new Error('Image editing saves are only available in the desktop app.');
+    }
+
+    const pngBytes = await renderAdjustedImageToPngBytes(imageUrl, imageAdjustments);
+    const result = await window.electronAPI.writeFile(targetPath, pngBytes);
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to write edited image.');
+    }
+
+    return pngBytes;
+  }, [imageAdjustments, imageUrl, isFullImageSourceReady]);
+
+  const handleSaveEditedImageAs = useCallback(async () => {
+    if (!canEditImage || !hasAdjustmentChanges || isSavingEditedImage) {
+      return;
+    }
+
+    if (!window.electronAPI?.showSaveDialog) {
+      setError('Save As is only available in the desktop app.');
+      return;
+    }
+
+    setIsSavingEditedImage(true);
+    try {
+      const defaultPath = await buildEditedDefaultPath();
+      const saveResult = await window.electronAPI.showSaveDialog({
+        title: 'Save edited image',
+        defaultPath,
+        filters: [{ name: 'PNG Image', extensions: ['png'] }],
+      });
+
+      if (saveResult.canceled || !saveResult.path) {
+        return;
+      }
+
+      await writeEditedImage(saveResult.path);
+
+      const targetDirectory = findDirectoryForAbsolutePath(saveResult.path);
+      if (targetDirectory) {
+        const indexedImage = await indexImageFileAtPath(saveResult.path, targetDirectory);
+        if (indexedImage) {
+          const savedImage: IndexedImage = {
+            ...indexedImage,
+            metadata: liveImage.metadata,
+            metadataString: liveImage.metadataString,
+            models: liveImage.models,
+            loras: liveImage.loras,
+            sampler: liveImage.sampler,
+            scheduler: liveImage.scheduler,
+            board: liveImage.board,
+            prompt: liveImage.prompt,
+            negativePrompt: liveImage.negativePrompt,
+            cfgScale: liveImage.cfgScale,
+            steps: liveImage.steps,
+            seed: liveImage.seed,
+            workflowNodes: liveImage.workflowNodes,
+            enrichmentState: 'enriched',
+          };
+          const targetAlreadyIndexed = allImages.some((candidate) => candidate.id === savedImage.id);
+          if (targetAlreadyIndexed) {
+            mergeImages([savedImage]);
+            await cacheManager.updateCachedImages(targetDirectory.path, targetDirectory.name, [savedImage], scanSubfolders);
+          } else {
+            addImages([savedImage]);
+            await cacheManager.appendToCache(targetDirectory.path, targetDirectory.name, [savedImage], scanSubfolders);
+          }
+          setSuccess(`Saved edited image as ${savedImage.name}.`);
+        } else {
+          setSuccess('Saved edited image.');
+        }
+      } else {
+        setSuccess('Saved edited image.');
+      }
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to save edited image.');
+    } finally {
+      setIsSavingEditedImage(false);
+    }
+  }, [
+    addImages,
+    allImages,
+    buildEditedDefaultPath,
+    canEditImage,
+    findDirectoryForAbsolutePath,
+    hasAdjustmentChanges,
+    isSavingEditedImage,
+    liveImage,
+    mergeImages,
+    scanSubfolders,
+    setError,
+    setSuccess,
+    writeEditedImage,
+  ]);
+
+  const handleOverwriteEditedImage = useCallback(async () => {
+    if (!canEditImage || !hasAdjustmentChanges || isSavingEditedImage) {
+      return;
+    }
+
+    if (!window.electronAPI?.joinPaths) {
+      setError('Overwrite is only available in the desktop app.');
+      return;
+    }
+
+    const confirmed = window.confirm('Overwrite the original image with these edits? This cannot be undone.');
+    if (!confirmed) {
+      return;
+    }
+
+    const sourceDirectory = directories.find((directory) => directory.id === liveImage.directoryId);
+    if (!sourceDirectory) {
+      setError('Cannot overwrite because the source directory is unavailable.');
+      return;
+    }
+
+    setIsSavingEditedImage(true);
+    try {
+      const relativePath = getRelativeImagePath(liveImage);
+      const joined = await window.electronAPI.joinPaths(sourceDirectory.path, relativePath);
+      if (!joined.success || !joined.path) {
+        throw new Error(joined.error || 'Failed to resolve the original image path.');
+      }
+
+      await writeEditedImage(joined.path);
+
+      const reparsed = await reparseIndexedImage(liveImage, sourceDirectory.path);
+      if (!reparsed) {
+        throw new Error('The edited image was saved, but metadata reparsing returned no image.');
+      }
+
+      const preservedMetadataImage: IndexedImage = {
+        ...liveImage,
+        ...reparsed,
+        metadata: liveImage.metadata,
+        metadataString: liveImage.metadataString,
+        models: liveImage.models,
+        loras: liveImage.loras,
+        sampler: liveImage.sampler,
+        scheduler: liveImage.scheduler,
+        board: liveImage.board,
+        prompt: liveImage.prompt,
+        negativePrompt: liveImage.negativePrompt,
+        cfgScale: liveImage.cfgScale,
+        steps: liveImage.steps,
+        seed: liveImage.seed,
+        workflowNodes: liveImage.workflowNodes,
+        handle: liveImage.handle,
+        thumbnailHandle: liveImage.thumbnailHandle,
+        thumbnailUrl: undefined,
+        thumbnailStatus: 'pending',
+        thumbnailError: null,
+        directoryId: liveImage.directoryId,
+        directoryName: liveImage.directoryName,
+        isFavorite: liveImage.isFavorite,
+        tags: liveImage.tags,
+        rating: liveImage.rating,
+        clusterId: liveImage.clusterId,
+        clusterPosition: liveImage.clusterPosition,
+        autoTags: liveImage.autoTags,
+        autoTagsGeneratedAt: liveImage.autoTagsGeneratedAt,
+        enrichmentState: 'enriched',
+      };
+
+      mergeImages([preservedMetadataImage]);
+      setImageThumbnail(liveImage.id, {
+        thumbnailUrl: null,
+        thumbnailHandle: null,
+        status: 'pending',
+        error: null,
+      });
+      await cacheManager.updateCachedImages(sourceDirectory.path, sourceDirectory.name, [preservedMetadataImage], scanSubfolders);
+      setImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS);
+      setSuccess('Overwrote original image with edits.');
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to overwrite edited image.');
+    } finally {
+      setIsSavingEditedImage(false);
+    }
+  }, [
+    canEditImage,
+    directories,
+    hasAdjustmentChanges,
+    isSavingEditedImage,
+    liveImage,
+    mergeImages,
+    scanSubfolders,
+    setError,
+    setImageThumbnail,
+    setSuccess,
+    writeEditedImage,
+  ]);
+
   const clearSlideshowTimer = useCallback(() => {
     if (typeof window === 'undefined' || slideshowTimeoutRef.current === null) {
       return;
@@ -1636,12 +1889,13 @@ const ImageModal: React.FC<ImageModalProps> = ({
     const hasPreview = Boolean(preferredThumbnailUrl);
     const sourceLoadStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
 
+    setIsFullImageSourceReady(false);
     setImageUrl(isPlayableMedia ? null : (preferredThumbnailUrl ?? null));
 
     const loadImage = async () => {
       if (!isMounted) return;
 
-      const electronAbsoluteMediaPath = window.electronAPI ? getElectronAbsoluteMediaPath(image) : null;
+      const electronAbsoluteMediaPath = window.electronAPI ? getElectronAbsoluteMediaPath(liveImage) : null;
 
       if (!directoryPath && window.electronAPI && !electronAbsoluteMediaPath) {
         console.error('Cannot load image: directoryPath is undefined');
@@ -1653,17 +1907,18 @@ const ImageModal: React.FC<ImageModalProps> = ({
       }
 
       try {
-        const url = await mediaSourceCache.getOrLoad(image, directoryPath, { prioritize: true });
+        const url = await mediaSourceCache.getOrLoad(liveImage, directoryPath, { prioritize: true });
         if (isMounted) {
           setImageUrl(url);
+          setIsFullImageSourceReady(true);
           markPerformanceFlow(diagnosticsFlowId, 'full-source-ready', {
-            imageId: image.id,
+            imageId: liveImage.id,
             isPlayableMedia,
           });
 
           const state = useImageStore.getState();
           const navigationImages = state.clusterNavigationContext || state.filteredImages;
-          const currentNavigationIndex = navigationImages.findIndex((candidate) => candidate.id === image.id);
+          const currentNavigationIndex = navigationImages.findIndex((candidate) => candidate.id === liveImage.id);
           if (currentNavigationIndex !== -1) {
             const directoryMap = new Map(state.directories.map((dir) => [dir.id, dir.path]));
             const neighborCandidates = [
@@ -1684,7 +1939,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         }
       } finally {
         recordPerformanceDuration('modal.full-source-load', (typeof performance !== 'undefined' ? performance.now() : Date.now()) - sourceLoadStartedAt, {
-          imageId: image.id,
+          imageId: liveImage.id,
           hasPreview,
           isPlayableMedia,
         });
@@ -1696,7 +1951,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [diagnosticsFlowId, image.id, image.handle, image.thumbnailHandle, image.name, directoryPath, preferredThumbnailUrl, isPlayableMedia, isVideo]);
+  }, [diagnosticsFlowId, liveImage.id, liveImage.handle, liveImage.thumbnailHandle, liveImage.name, liveImage.lastModified, directoryPath, preferredThumbnailUrl, isPlayableMedia, isVideo]);
 
   useEffect(() => {
     if (!preferredThumbnailUrl || hasMarkedPreviewVisibleRef.current) {
@@ -2391,6 +2646,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 onDragStart={handleDragStart}
                 style={{
                   transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+                  filter: canEditImage ? adjustmentFilter : undefined,
                   transition: isDragging ? 'none' : 'transform 0.1s ease-out',
                 }}
                 draggable={canDragExternally && zoom === 1}
@@ -2524,6 +2780,23 @@ const ImageModal: React.FC<ImageModalProps> = ({
               </div>
             ) : (
               <div className="flex flex-row items-center gap-2">
+                {canEditImage && (
+                  <button
+                    onClick={() => {
+                      setIsAdjustmentPanelOpen((current) => !current);
+                      setIsSidebarCollapsed(false);
+                      setSidebarTab('details');
+                    }}
+                    className={`rounded-full border p-2 text-white/90 backdrop-blur-sm transition-colors ${
+                      isAdjustmentPanelOpen
+                        ? 'border-cyan-400/40 bg-cyan-500/25'
+                        : 'border-white/10 bg-black/35 hover:bg-black/55'
+                    }`}
+                    title={isAdjustmentPanelOpen ? 'Hide image adjustments' : 'Edit image adjustments'}
+                  >
+                    <SlidersHorizontal className="h-4 w-4" />
+                  </button>
+                )}
                 <button
                   onClick={() => setDetailsPlacement((current) => current === 'right' ? 'bottom' : 'right')}
                   className="rounded-full border border-white/10 bg-black/35 p-2 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/55"
@@ -2586,6 +2859,18 @@ const ImageModal: React.FC<ImageModalProps> = ({
             </div>
           )}
           <div className="p-6 space-y-4 overflow-y-auto flex-1">
+          {canEditImage && isAdjustmentPanelOpen && (
+            <ImageAdjustmentPanel
+              adjustments={imageAdjustments}
+              onChange={setImageAdjustments}
+              onReset={() => setImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS)}
+              onSaveAs={() => void handleSaveEditedImageAs()}
+              onOverwrite={() => void handleOverwriteEditedImage()}
+              isSaving={isSavingEditedImage}
+              disabled={!isFullImageSourceReady}
+            />
+          )}
+
           {/* Annotations Section */}
           <div className="bg-gray-900/50 p-3 rounded-lg border border-gray-700/50 space-y-2">
             {/* Favorite, Rating, and Tags */}

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -2,7 +2,7 @@
 /// <reference lib="dom.iterable" />
 import { IncrementalCacheWriter, type CacheImageMetadata } from './cacheManager';
 
-import { type IndexedImage, type ImageMetadata, type BaseMetadata, type VideoMetadata, type VideoInfo, type AudioInfo, isInvokeAIMetadata, isAutomatic1111Metadata, isComfyUIMetadata, isSwarmUIMetadata, isEasyDiffusionMetadata, isEasyDiffusionJson, isMidjourneyMetadata, isNijiMetadata, isForgeMetadata, isDalleMetadata, isFireflyMetadata, isDreamStudioMetadata, isDrawThingsMetadata, ComfyUIMetadata, InvokeAIMetadata, SwarmUIMetadata, EasyDiffusionMetadata, EasyDiffusionJson, MidjourneyMetadata, NijiMetadata, ForgeMetadata, DalleMetadata, FireflyMetadata, DrawThingsMetadata, FooocusMetadata } from '../types';
+import { type IndexedImage, type Directory, type ImageMetadata, type BaseMetadata, type VideoMetadata, type VideoInfo, type AudioInfo, isInvokeAIMetadata, isAutomatic1111Metadata, isComfyUIMetadata, isSwarmUIMetadata, isEasyDiffusionMetadata, isEasyDiffusionJson, isMidjourneyMetadata, isNijiMetadata, isForgeMetadata, isDalleMetadata, isFireflyMetadata, isDreamStudioMetadata, isDrawThingsMetadata, ComfyUIMetadata, InvokeAIMetadata, SwarmUIMetadata, EasyDiffusionMetadata, EasyDiffusionJson, MidjourneyMetadata, NijiMetadata, ForgeMetadata, DalleMetadata, FireflyMetadata, DrawThingsMetadata, FooocusMetadata } from '../types';
 import { parse } from 'exifr';
 import { resolvePromptFromGraph, parseComfyUIMetadataEnhanced } from './parsers/comfyUIParser';
 import { parseVideoMetaHubMetadata } from './parsers/videoMetaHubParser';
@@ -1731,6 +1731,74 @@ export async function reparseIndexedImage(
     image.directoryId || image.id.split('::')[0] || '',
     fileData
   );
+}
+
+const normalizePathForComparison = (value: string): string => value.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+
+const getRelativePathWithinDirectory = (filePath: string, directoryPath: string): string | null => {
+  const normalizedFile = filePath.replace(/\\/g, '/');
+  const normalizedDirectory = directoryPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  const fileKey = normalizePathForComparison(normalizedFile);
+  const directoryKey = normalizePathForComparison(normalizedDirectory);
+
+  if (fileKey === directoryKey || !fileKey.startsWith(`${directoryKey}/`)) {
+    return null;
+  }
+
+  return normalizedFile.slice(normalizedDirectory.length + 1).replace(/^\/+/, '');
+};
+
+export async function indexImageFileAtPath(
+  filePath: string,
+  directory: Pick<Directory, 'id' | 'name' | 'path'>,
+): Promise<IndexedImage | null> {
+  if (!window.electronAPI?.readFile || !window.electronAPI?.getFileStats) {
+    throw new Error('Indexing saved images is only available in the desktop app.');
+  }
+
+  const relativePath = getRelativePathWithinDirectory(filePath, directory.path);
+  if (!relativePath) {
+    return null;
+  }
+
+  const readResult = await window.electronAPI.readFile(filePath);
+  if (!readResult.success || !readResult.data) {
+    throw new Error(readResult.error || 'Failed to read the saved image file.');
+  }
+
+  const statsResult = await window.electronAPI.getFileStats(filePath);
+  const stats = statsResult.success ? statsResult.stats : undefined;
+  const fileName = relativePath.split('/').pop() || relativePath;
+  const bytes = new Uint8Array(readResult.data);
+  const fileData = bytes.slice().buffer;
+  const fileEntry: CatalogFileEntry = {
+    handle: {
+      name: fileName,
+      kind: 'file',
+      _filePath: filePath,
+      getFile: async () => new File([fileData.slice(0) as any], fileName, {
+        type: inferMimeTypeFromName(fileName),
+        lastModified: typeof stats?.mtimeMs === 'number' ? stats.mtimeMs : Date.now(),
+      }),
+    } as ElectronFileHandle,
+    path: relativePath,
+    lastModified: typeof stats?.mtimeMs === 'number' ? stats.mtimeMs : Date.now(),
+    contentModifiedMs: typeof stats?.mtimeMs === 'number' ? stats.mtimeMs : undefined,
+    size: typeof stats?.size === 'number' ? stats.size : fileData.byteLength,
+    type: inferMimeTypeFromName(fileName),
+    birthtimeMs: typeof stats?.birthtimeMs === 'number' ? stats.birthtimeMs : undefined,
+  };
+
+  const indexed = await processSingleFileOptimized(fileEntry, directory.id, fileData);
+  if (!indexed) {
+    return null;
+  }
+
+  return {
+    ...indexed,
+    directoryId: directory.id,
+    directoryName: directory.name,
+  };
 }
 
 /**

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -1,0 +1,124 @@
+import type { ImageAdjustments } from '../types';
+
+export const DEFAULT_IMAGE_ADJUSTMENTS: ImageAdjustments = {
+  brightness: 100,
+  contrast: 100,
+  saturation: 100,
+  hue: 0,
+};
+
+const ADJUSTMENT_RANGES: Record<keyof ImageAdjustments, { min: number; max: number }> = {
+  brightness: { min: 0, max: 200 },
+  contrast: { min: 0, max: 200 },
+  saturation: { min: 0, max: 200 },
+  hue: { min: -180, max: 180 },
+};
+
+export const clampImageAdjustment = (
+  key: keyof ImageAdjustments,
+  value: number,
+): number => {
+  const range = ADJUSTMENT_RANGES[key];
+  if (!Number.isFinite(value)) {
+    return DEFAULT_IMAGE_ADJUSTMENTS[key];
+  }
+
+  return Math.min(range.max, Math.max(range.min, Math.round(value)));
+};
+
+export const normalizeImageAdjustments = (
+  adjustments: Partial<ImageAdjustments>,
+): ImageAdjustments => ({
+  brightness: clampImageAdjustment('brightness', adjustments.brightness ?? DEFAULT_IMAGE_ADJUSTMENTS.brightness),
+  contrast: clampImageAdjustment('contrast', adjustments.contrast ?? DEFAULT_IMAGE_ADJUSTMENTS.contrast),
+  saturation: clampImageAdjustment('saturation', adjustments.saturation ?? DEFAULT_IMAGE_ADJUSTMENTS.saturation),
+  hue: clampImageAdjustment('hue', adjustments.hue ?? DEFAULT_IMAGE_ADJUSTMENTS.hue),
+});
+
+export const hasImageAdjustments = (adjustments: Partial<ImageAdjustments>): boolean => {
+  const normalized = normalizeImageAdjustments(adjustments);
+  return (
+    normalized.brightness !== DEFAULT_IMAGE_ADJUSTMENTS.brightness ||
+    normalized.contrast !== DEFAULT_IMAGE_ADJUSTMENTS.contrast ||
+    normalized.saturation !== DEFAULT_IMAGE_ADJUSTMENTS.saturation ||
+    normalized.hue !== DEFAULT_IMAGE_ADJUSTMENTS.hue
+  );
+};
+
+export const buildImageAdjustmentFilter = (adjustments: Partial<ImageAdjustments>): string => {
+  const normalized = normalizeImageAdjustments(adjustments);
+  return [
+    `brightness(${normalized.brightness}%)`,
+    `contrast(${normalized.contrast}%)`,
+    `saturate(${normalized.saturation}%)`,
+    `hue-rotate(${normalized.hue}deg)`,
+  ].join(' ');
+};
+
+const loadImageElement = (sourceUrl: string): Promise<HTMLImageElement> => new Promise((resolve, reject) => {
+  const image = new Image();
+  image.onload = () => resolve(image);
+  image.onerror = () => reject(new Error('Failed to load image for editing.'));
+  image.decoding = 'async';
+  image.src = sourceUrl;
+});
+
+const canvasToBlob = (canvas: HTMLCanvasElement): Promise<Blob> => new Promise((resolve, reject) => {
+  canvas.toBlob((blob) => {
+    if (blob) {
+      resolve(blob);
+    } else {
+      reject(new Error('Failed to encode edited image as PNG.'));
+    }
+  }, 'image/png');
+});
+
+export async function renderAdjustedImageToPngBlob(
+  sourceUrl: string,
+  adjustments: Partial<ImageAdjustments>,
+): Promise<Blob> {
+  const image = await loadImageElement(sourceUrl);
+  const width = image.naturalWidth || image.width;
+  const height = image.naturalHeight || image.height;
+
+  if (!width || !height) {
+    throw new Error('Edited image has invalid dimensions.');
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Canvas rendering is not available in this browser.');
+  }
+
+  context.filter = buildImageAdjustmentFilter(adjustments);
+  context.drawImage(image, 0, 0, width, height);
+  return canvasToBlob(canvas);
+}
+
+export async function renderAdjustedImageToPngBytes(
+  sourceUrl: string,
+  adjustments: Partial<ImageAdjustments>,
+): Promise<Uint8Array> {
+  const blob = await renderAdjustedImageToPngBlob(sourceUrl, adjustments);
+  if (typeof blob.arrayBuffer === 'function') {
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+
+  const buffer = await new Promise<ArrayBuffer>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) {
+        resolve(reader.result);
+      } else {
+        reject(new Error('Failed to read edited PNG bytes.'));
+      }
+    };
+    reader.onerror = () => reject(reader.error || new Error('Failed to read edited PNG bytes.'));
+    reader.readAsArrayBuffer(blob);
+  });
+  return new Uint8Array(buffer);
+}

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -1,4 +1,4 @@
-import type { ImageAdjustments } from '../types';
+import type { BaseMetadata, ImageAdjustments, LoRAInfo } from '../types';
 
 export const DEFAULT_IMAGE_ADJUSTMENTS: ImageAdjustments = {
   brightness: 100,
@@ -122,3 +122,226 @@ export async function renderAdjustedImageToPngBytes(
   });
   return new Uint8Array(buffer);
 }
+
+const PNG_SIGNATURE = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const createCrc32Table = () => {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < 256; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) !== 0 ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+};
+
+const CRC32_TABLE = createCrc32Table();
+const textEncoder = new TextEncoder();
+
+const computeCrc32 = (bytes: Uint8Array): number => {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+const concatBytes = (parts: Uint8Array[]): Uint8Array => {
+  const totalLength = parts.reduce((sum, part) => sum + part.byteLength, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.byteLength;
+  }
+  return result;
+};
+
+const writeUInt32BE = (value: number): Uint8Array => {
+  const bytes = new Uint8Array(4);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, value >>> 0, false);
+  return bytes;
+};
+
+const createPngChunk = (type: string, data: Uint8Array): Uint8Array => {
+  const typeBytes = textEncoder.encode(type);
+  const crcBytes = concatBytes([typeBytes, data]);
+  return concatBytes([
+    writeUInt32BE(data.byteLength),
+    typeBytes,
+    data,
+    writeUInt32BE(computeCrc32(crcBytes)),
+  ]);
+};
+
+const createPngTextChunk = (keyword: string, text: string): Uint8Array => (
+  createPngChunk('tEXt', concatBytes([
+    textEncoder.encode(keyword),
+    new Uint8Array([0]),
+    textEncoder.encode(text),
+  ]))
+);
+
+const createPngInternationalTextChunk = (keyword: string, text: string): Uint8Array => (
+  createPngChunk('iTXt', concatBytes([
+    textEncoder.encode(keyword),
+    new Uint8Array([0, 0, 0, 0, 0]),
+    textEncoder.encode(text),
+  ]))
+);
+
+const ensurePngBytes = (pngBytes: Uint8Array): void => {
+  if (pngBytes.byteLength < PNG_SIGNATURE.byteLength + 12) {
+    throw new Error('Invalid PNG buffer.');
+  }
+
+  for (let index = 0; index < PNG_SIGNATURE.byteLength; index += 1) {
+    if (pngBytes[index] !== PNG_SIGNATURE[index]) {
+      throw new Error('PNG signature missing.');
+    }
+  }
+};
+
+export const appendChunksToPngBytes = (pngBytes: Uint8Array, chunks: Uint8Array[]): Uint8Array => {
+  ensurePngBytes(pngBytes);
+
+  let offset = PNG_SIGNATURE.byteLength;
+  while (offset + 12 <= pngBytes.byteLength) {
+    const view = new DataView(pngBytes.buffer, pngBytes.byteOffset + offset, 8);
+    const chunkLength = view.getUint32(0, false);
+    const chunkType = String.fromCharCode(
+      pngBytes[offset + 4],
+      pngBytes[offset + 5],
+      pngBytes[offset + 6],
+      pngBytes[offset + 7],
+    );
+    const chunkTotalLength = chunkLength + 12;
+    if (offset + chunkTotalLength > pngBytes.byteLength) {
+      break;
+    }
+
+    if (chunkType === 'IEND') {
+      return concatBytes([
+        pngBytes.slice(0, offset),
+        ...chunks,
+        pngBytes.slice(offset),
+      ]);
+    }
+
+    offset += chunkTotalLength;
+  }
+
+  throw new Error('PNG IEND chunk not found.');
+};
+
+const toLoraPayload = (loras: BaseMetadata['loras']) => {
+  if (!Array.isArray(loras)) {
+    return [];
+  }
+
+  return loras
+    .map((entry) => {
+      if (typeof entry === 'string') {
+        const name = entry.trim();
+        return name ? { name } : null;
+      }
+
+      const lora = entry as LoRAInfo;
+      const name = typeof lora.name === 'string' && lora.name.trim()
+        ? lora.name.trim()
+        : (typeof lora.model_name === 'string' ? lora.model_name.trim() : '');
+      if (!name) {
+        return null;
+      }
+
+      const weight = Number.isFinite(lora.weight)
+        ? lora.weight
+        : Number.isFinite(lora.model_weight)
+          ? lora.model_weight
+          : undefined;
+
+      return weight !== undefined ? { name, weight } : { name };
+    })
+    .filter(Boolean);
+};
+
+const formatMetadataForA1111Compat = (metadata: BaseMetadata): string => {
+  const lines = [metadata.prompt?.trim() || ''];
+  if (metadata.negativePrompt?.trim()) {
+    lines.push(`Negative prompt: ${metadata.negativePrompt.trim()}`);
+  }
+
+  const params: string[] = [];
+  if (Number.isFinite(metadata.steps)) {
+    params.push(`Steps: ${metadata.steps}`);
+  }
+  const sampler = metadata.sampler || metadata.scheduler;
+  if (sampler?.trim()) {
+    params.push(`Sampler: ${sampler.trim()}`);
+  }
+  const cfg = metadata.cfg_scale ?? metadata.cfgScale;
+  if (Number.isFinite(cfg)) {
+    params.push(`CFG scale: ${cfg}`);
+  }
+  if (Number.isFinite(metadata.seed)) {
+    params.push(`Seed: ${metadata.seed}`);
+  }
+  if (Number.isFinite(metadata.width) && Number.isFinite(metadata.height) && metadata.width > 0 && metadata.height > 0) {
+    params.push(`Size: ${metadata.width}x${metadata.height}`);
+  }
+  if (metadata.model?.trim()) {
+    params.push(`Model: ${metadata.model.trim()}`);
+  }
+  if (params.length > 0) {
+    lines.push(params.join(', '));
+  }
+
+  return lines.join('\n');
+};
+
+const buildMetaHubEditPayload = (
+  metadata: BaseMetadata,
+  adjustments: ImageAdjustments,
+) => ({
+  generator: 'Image MetaHub',
+  source_generator: typeof metadata.generator === 'string' ? metadata.generator : null,
+  edited_at: new Date().toISOString(),
+  edit: {
+    tool: 'image-adjustments',
+    adjustments,
+  },
+  prompt: metadata.prompt || '',
+  negativePrompt: metadata.negativePrompt || '',
+  seed: Number.isFinite(metadata.seed) ? metadata.seed : undefined,
+  steps: Number.isFinite(metadata.steps) ? metadata.steps : undefined,
+  cfg: Number.isFinite(metadata.cfg_scale ?? metadata.cfgScale) ? (metadata.cfg_scale ?? metadata.cfgScale) : undefined,
+  sampler_name: metadata.sampler || '',
+  scheduler: metadata.scheduler || '',
+  model: metadata.model || metadata.models?.[0] || '',
+  width: Number.isFinite(metadata.width) ? metadata.width : 0,
+  height: Number.isFinite(metadata.height) ? metadata.height : 0,
+  loras: toLoraPayload(metadata.loras),
+  imh_pro: {
+    notes: typeof metadata.notes === 'string' ? metadata.notes : '',
+    user_tags: Array.isArray(metadata.tags) ? metadata.tags.join(', ') : '',
+  },
+});
+
+export const embedMetaHubMetadataInPngBytes = (
+  pngBytes: Uint8Array,
+  metadata: BaseMetadata | undefined,
+  adjustments: Partial<ImageAdjustments>,
+): Uint8Array => {
+  if (!metadata) {
+    return pngBytes;
+  }
+
+  const normalizedAdjustments = normalizeImageAdjustments(adjustments);
+  return appendChunksToPngBytes(pngBytes, [
+    createPngTextChunk('parameters', formatMetadataForA1111Compat(metadata)),
+    createPngInternationalTextChunk('imagemetahub_data', JSON.stringify(buildMetaHubEditPayload(metadata, normalizedAdjustments))),
+  ]);
+};

--- a/types.ts
+++ b/types.ts
@@ -56,6 +56,23 @@ export interface ExportBatchRequest {
   targetFormat?: ExportTargetFormat;
 }
 
+export interface ImageAdjustments {
+  brightness: number;
+  contrast: number;
+  saturation: number;
+  hue: number;
+}
+
+export type ImageEditSaveMode = 'save_as' | 'overwrite';
+
+export interface ImageEditSaveResult {
+  success: boolean;
+  mode: ImageEditSaveMode;
+  path?: string;
+  image?: IndexedImage;
+  error?: string;
+}
+
 export type IndexedImageTransferMode = 'copy' | 'move';
 
 export interface IndexedImageTransferProgress {


### PR DESCRIPTION
## Summary
- Add brightness, contrast, saturation, and hue editing in ImageModal
- Save edited output as PNG with MetaHub/A1111-compatible metadata chunks
- Support Save As and confirmed Overwrite flows with library/cache updates

## Tests
- `npm test -- imageEditingService ImageAdjustmentPanel --run`
- `npm run build`