### PR TITLE
🎨 Palette: Add ARIA labels to SearchBar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 # Palette's Journal
 
 No critical learnings yet.
+
+## 2024-05-18 - SearchBar Accessibility (Placeholder vs Label)
+**Learning:** Found an accessibility issue where an input relied exclusively on its placeholder for descriptive context. Screen readers often don't announce placeholders reliably as labels, or they disappear once the user starts typing. Additionally, inline decorative SVGs were unhidden.
+**Action:** Always add an explicit `aria-label` to inputs that don't have a linked `<label>`. Mark decorative icons (like search magnifiers or clear 'X's) with `aria-hidden="true"`.

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -33,11 +33,12 @@ const SearchBar: React.FC<SearchBarProps> = ({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder="Search by prompt, model, etc..."
+        aria-label="Search"
         className="w-full bg-gray-800/50 backdrop-blur-sm text-gray-200 placeholder-gray-400 py-3 pl-10 pr-10 rounded-xl border border-gray-700/50 focus:outline-none focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 transition-all duration-300 shadow-sm hover:bg-gray-800/70"
         data-testid="search-input"
       />
       <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors duration-300 group-focus-within:text-blue-500">
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
       </div>
@@ -48,7 +49,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
           className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white transition-colors p-1 rounded-full hover:bg-gray-700/50"
           aria-label="Clear search"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label="Search"` to the search input and `aria-hidden="true"` to the decorative SVG icons in the `SearchBar` component.
🎯 **Why**: To improve accessibility for screen reader users. The input previously relied solely on its placeholder text, which can be inconsistently announced or disappear when typing begins. Additionally, marking decorative icons as hidden prevents screen readers from making redundant or confusing announcements.
♿ **Accessibility**: Improved keyboard and screen reader accessibility by providing an explicit label for the search input and hiding visual-only decorative elements.

---
*PR created automatically by Jules for task [262060777278543491](https://jules.google.com/task/262060777278543491) started by @LuqP2*