### PR TITLE
Enhance ComfyUI workspace integration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2324,13 +2324,13 @@ export default function App() {
             });
           }}
         />
-      ) : (
+      ) : hasRightSidebar ? (
         <ImagePreviewSidebar
           width={rightSidebarWidth}
           isResizing={isRightSidebarResizing}
           onResizeStart={handleRightSidebarResizeStart}
         />
-      )}
+      ) : null}
 
       {generatedOutputPreview && (
         <GeneratedOutputModal

--- a/App.tsx
+++ b/App.tsx
@@ -35,6 +35,7 @@ import NodeView from './components/NodeView';
 import FindSimilarModal from './components/FindSimilarModal';
 import ModelPromptPickerModal from './components/ModelPromptPickerModal';
 import CollectionsWorkspace from './components/CollectionsWorkspace';
+import ComfyUIWorkspace from './components/ComfyUIWorkspace';
 import GridToolbar from './components/GridToolbar';
 import AnalyticsSummaryStrip from './components/AnalyticsSummaryStrip';
 import BatchExportModal from './components/BatchExportModal';
@@ -297,6 +298,10 @@ export default function App() {
   const imageLookup = useMemo(() => {
     const lookup = new Map<string, IndexedImage>();
 
+    for (const image of safeImages) {
+      lookup.set(image.id, image);
+    }
+
     for (const image of safeFilteredImages) {
       lookup.set(image.id, image);
     }
@@ -308,7 +313,7 @@ export default function App() {
     }
 
     return lookup;
-  }, [safeClusterNavigationContext, safeFilteredImages]);
+  }, [safeClusterNavigationContext, safeFilteredImages, safeImages]);
 
   // --- Settings Store State ---
   const {
@@ -320,6 +325,7 @@ export default function App() {
     setLastViewedVersion,
     globalAutoWatch,
     generatorLaunchCommand,
+    comfyUIWorkspaceAutoOpenSelectedImage,
   } = useSettingsStore();
 
   // --- Local UI State ---
@@ -378,12 +384,13 @@ export default function App() {
   const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false);
   const [currentVersion, setCurrentVersion] = useState<string>('0.10.0');
   const [isQueueOpen, setIsQueueOpen] = useState(false);
-  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node' | 'collections'>('library');
+  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node' | 'collections' | 'comfyui'>('library');
   const [nodeViewVisibleImages, setNodeViewVisibleImages] = useState<IndexedImage[]>([]);
   const [nodeViewResultImages, setNodeViewResultImages] = useState<IndexedImage[]>([]);
   const [isA1111GenerateModalOpen, setIsA1111GenerateModalOpen] = useState(false);
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
+  const [comfyUIWorkspaceImageId, setComfyUIWorkspaceImageId] = useState<string | null>(null);
   const [newImagesToast, setNewImagesToast] = useState<{ message: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
   const [batchExportRequest, setBatchExportRequest] = useState<BatchExportRequestState | null>(null);
@@ -449,7 +456,7 @@ export default function App() {
       setNodeViewResultImages([]);
     }
   }, [libraryView, nodeViewResultImages.length]);
-  const hasRightSidebar = Boolean(previewImage || isQueueOpen);
+  const hasRightSidebar = Boolean(isQueueOpen || (previewImage && libraryView !== 'comfyui'));
   const { leftWidth: sidebarWidth, rightWidth: rightSidebarWidth } = useMemo(
     () =>
       resolveSidebarWidths({
@@ -1713,6 +1720,13 @@ export default function App() {
     openBatchExportModal();
   }, [openBatchExportModal]);
 
+  const handleOpenComfyUIWorkspace = useCallback((image?: IndexedImage | null) => {
+    if (image) {
+      setComfyUIWorkspaceImageId(image.id);
+    }
+    setLibraryView('comfyui');
+  }, []);
+
   const handleCloseBatchExport = useCallback(() => {
     setIsBatchExportModalOpen(false);
     setBatchExportRequest(null);
@@ -1811,6 +1825,23 @@ export default function App() {
   }, [openFindSimilar, safeImages]);
 
   const canSaveCurrentFilteredAsCollection = libraryView !== 'smart' && displayImages.length > 0;
+  const comfyUIWorkspaceImage = useMemo(() => {
+    if (comfyUIWorkspaceImageId) {
+      return imageLookup.get(comfyUIWorkspaceImageId) ?? null;
+    }
+
+    if (!comfyUIWorkspaceAutoOpenSelectedImage) {
+      return null;
+    }
+
+    return previewImage || selectedImage || null;
+  }, [
+    comfyUIWorkspaceAutoOpenSelectedImage,
+    comfyUIWorkspaceImageId,
+    imageLookup,
+    previewImage,
+    selectedImage,
+  ]);
   const slideshowPlaylistPreview = useMemo(
     () =>
       buildSlideshowPlaylist({
@@ -1969,6 +2000,21 @@ export default function App() {
   const hasActiveVisibleImageModal = openImageModalEntries.some(
     (modal) => !modal.isMinimized && modal.modalId === activeImageModalId
   );
+  const hasVisibleImageModal = openImageModalEntries.some((modal) => !modal.isMinimized);
+  const shouldShowEmbeddedComfyUIView =
+    libraryView === 'comfyui' &&
+    !hasVisibleImageModal &&
+    !isSettingsModalOpen &&
+    !isHotkeyHelpOpen &&
+    !isCommandPaletteOpen &&
+    !isChangelogModalOpen &&
+    !isAnalyticsOpen &&
+    !isComparisonModalOpen &&
+    !isBatchExportModalOpen &&
+    !isSaveFilteredCollectionModalOpen &&
+    !isA1111GenerateModalOpen &&
+    !isComfyUIGenerateModalOpen &&
+    !proModalOpen;
   const libraryContentFocusClass = hasActiveVisibleImageModal
     ? 'blur-[1px] opacity-95'
     : 'blur-0 opacity-100';
@@ -2436,6 +2482,14 @@ export default function App() {
                     onToggleQueue={() => setIsQueueOpen((prev) => !prev)}
                     onVisibleImagesChange={setNodeViewVisibleImages}
                     onResultImagesChange={handleNodeViewResultImagesChange}
+                  />
+                ) : libraryView === 'comfyui' ? (
+                  <ComfyUIWorkspace
+                    image={comfyUIWorkspaceImage}
+                    isActive={shouldShowEmbeddedComfyUIView}
+                    suspendBrowser={isGeneratingComfyUI}
+                    onOpenQueue={() => setIsQueueOpen(true)}
+                    onOpenSettings={handleOpenGeneratorIntegrations}
                   />
                 ) : (
                   <SmartLibrary

--- a/App.tsx
+++ b/App.tsx
@@ -392,6 +392,7 @@ export default function App() {
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
   const [comfyUIWorkspaceImageId, setComfyUIWorkspaceImageId] = useState<string | null>(null);
   const [comfyUIWorkspaceNavigationImageIds, setComfyUIWorkspaceNavigationImageIds] = useState<string[] | null>(null);
+  const [isComfyUIWorkspaceGenerating, setIsComfyUIWorkspaceGenerating] = useState(false);
   const [newImagesToast, setNewImagesToast] = useState<{ message: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
   const [batchExportRequest, setBatchExportRequest] = useState<BatchExportRequestState | null>(null);
@@ -2589,7 +2590,8 @@ export default function App() {
                     onSelectImage={(image) => setComfyUIWorkspaceImageId(image.id)}
                     onNavigatePrevious={() => handleComfyUIWorkspaceNavigate('previous')}
                     onNavigateNext={() => handleComfyUIWorkspaceNavigate('next')}
-                    suspendBrowser={isGeneratingComfyUI}
+                    onGenerationStateChange={setIsComfyUIWorkspaceGenerating}
+                    suspendBrowser={isGeneratingComfyUI || isComfyUIWorkspaceGenerating}
                     onOpenQueue={() => setIsQueueOpen(true)}
                     onOpenSettings={handleOpenGeneratorIntegrations}
                   />

--- a/App.tsx
+++ b/App.tsx
@@ -391,6 +391,7 @@ export default function App() {
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
   const [comfyUIWorkspaceImageId, setComfyUIWorkspaceImageId] = useState<string | null>(null);
+  const [comfyUIWorkspaceNavigationImageIds, setComfyUIWorkspaceNavigationImageIds] = useState<string[] | null>(null);
   const [newImagesToast, setNewImagesToast] = useState<{ message: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
   const [batchExportRequest, setBatchExportRequest] = useState<BatchExportRequestState | null>(null);
@@ -1720,12 +1721,37 @@ export default function App() {
     openBatchExportModal();
   }, [openBatchExportModal]);
 
-  const handleOpenComfyUIWorkspace = useCallback((image?: IndexedImage | null) => {
+  const handleOpenComfyUIWorkspace = useCallback((image?: IndexedImage | null, navigationImages?: IndexedImage[]) => {
     if (image) {
       setComfyUIWorkspaceImageId(image.id);
     }
+    if (navigationImages && navigationImages.length > 0) {
+      setComfyUIWorkspaceNavigationImageIds(navigationImages.map((item) => item.id));
+    } else if (image) {
+      setComfyUIWorkspaceNavigationImageIds([image.id]);
+    }
     setLibraryView('comfyui');
   }, []);
+
+  useEffect(() => {
+    if (libraryView !== 'comfyui') {
+      return;
+    }
+
+    setOpenImageModals((current) => {
+      let changed = false;
+      const next = current.map((modal) => {
+        if (modal.isMinimized) {
+          return modal;
+        }
+
+        changed = true;
+        return { ...modal, isMinimized: true };
+      });
+
+      return changed ? next : current;
+    });
+  }, [libraryView]);
 
   const handleCloseBatchExport = useCallback(() => {
     setIsBatchExportModalOpen(false);
@@ -1842,6 +1868,39 @@ export default function App() {
     previewImage,
     selectedImage,
   ]);
+  const comfyUIWorkspaceNavigationImages = useMemo(() => {
+    const imageIds = comfyUIWorkspaceNavigationImageIds ?? (comfyUIWorkspaceImage ? [comfyUIWorkspaceImage.id] : []);
+    const resolvedImages = imageIds
+      .map((imageId) => imageLookup.get(imageId) ?? null)
+      .filter((candidate): candidate is IndexedImage => Boolean(candidate));
+
+    if (comfyUIWorkspaceImage && !resolvedImages.some((candidate) => candidate.id === comfyUIWorkspaceImage.id)) {
+      return [comfyUIWorkspaceImage, ...resolvedImages];
+    }
+
+    return resolvedImages;
+  }, [comfyUIWorkspaceImage, comfyUIWorkspaceNavigationImageIds, imageLookup]);
+  const comfyUIWorkspaceCurrentIndex = useMemo(() => {
+    if (!comfyUIWorkspaceImage) {
+      return -1;
+    }
+
+    return comfyUIWorkspaceNavigationImages.findIndex((candidate) => candidate.id === comfyUIWorkspaceImage.id);
+  }, [comfyUIWorkspaceImage, comfyUIWorkspaceNavigationImages]);
+  const handleComfyUIWorkspaceNavigate = useCallback((direction: 'next' | 'previous') => {
+    if (comfyUIWorkspaceCurrentIndex === -1) {
+      return;
+    }
+
+    const nextIndex = direction === 'next'
+      ? comfyUIWorkspaceCurrentIndex + 1
+      : comfyUIWorkspaceCurrentIndex - 1;
+    const nextImage = comfyUIWorkspaceNavigationImages[nextIndex];
+
+    if (nextImage) {
+      setComfyUIWorkspaceImageId(nextImage.id);
+    }
+  }, [comfyUIWorkspaceCurrentIndex, comfyUIWorkspaceNavigationImages]);
   const slideshowPlaylistPreview = useMemo(
     () =>
       buildSlideshowPlaylist({
@@ -2000,10 +2059,8 @@ export default function App() {
   const hasActiveVisibleImageModal = openImageModalEntries.some(
     (modal) => !modal.isMinimized && modal.modalId === activeImageModalId
   );
-  const hasVisibleImageModal = openImageModalEntries.some((modal) => !modal.isMinimized);
   const shouldShowEmbeddedComfyUIView =
     libraryView === 'comfyui' &&
-    !hasVisibleImageModal &&
     !isSettingsModalOpen &&
     !isHotkeyHelpOpen &&
     !isCommandPaletteOpen &&
@@ -2391,6 +2448,7 @@ export default function App() {
                       setSelectedImageForGeneration(image);
                       setIsComfyUIGenerateModalOpen(true);
                     }}
+                    onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
                     onCompare={(images) => {
                       setComparisonImages(images);
                       openComparisonModal();
@@ -2419,6 +2477,7 @@ export default function App() {
                           onBatchExport={handleOpenBatchExport}
                           onImageRenamed={handleImageRenamed}
                           onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
+                          onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
                         />
                       ) : (
                         <ImageTable
@@ -2428,6 +2487,7 @@ export default function App() {
                           onBatchExport={handleOpenBatchExport}
                           onImageRenamed={handleImageRenamed}
                           onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
+                          onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
                         />
                   )
                 ) : libraryView === 'model' ? (
@@ -2458,6 +2518,7 @@ export default function App() {
                         isCollectionsView
                         onImageRenamed={handleImageRenamed}
                         onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
+                        onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
                       />
                     ) : (
                       <ImageTable
@@ -2469,6 +2530,7 @@ export default function App() {
                         isCollectionsView
                         onImageRenamed={handleImageRenamed}
                         onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
+                        onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
                       />
                     )}
                   </CollectionsWorkspace>
@@ -2486,7 +2548,12 @@ export default function App() {
                 ) : libraryView === 'comfyui' ? (
                   <ComfyUIWorkspace
                     image={comfyUIWorkspaceImage}
+                    navigationImages={comfyUIWorkspaceNavigationImages}
+                    currentIndex={comfyUIWorkspaceCurrentIndex}
                     isActive={shouldShowEmbeddedComfyUIView}
+                    onSelectImage={(image) => setComfyUIWorkspaceImageId(image.id)}
+                    onNavigatePrevious={() => handleComfyUIWorkspaceNavigate('previous')}
+                    onNavigateNext={() => handleComfyUIWorkspaceNavigate('next')}
                     suspendBrowser={isGeneratingComfyUI}
                     onOpenQueue={() => setIsQueueOpen(true)}
                     onOpenSettings={handleOpenGeneratorIntegrations}
@@ -2503,7 +2570,7 @@ export default function App() {
                 )}
               </div>
 
-              {(libraryView === 'library' || (libraryView === 'collections' && Boolean(activeCollection))) && (
+              {(libraryView === 'library' || libraryView === 'comfyui' || (libraryView === 'collections' && Boolean(activeCollection))) && (
                 <Footer
                   currentPage={currentPage}
                   totalPages={totalPages}
@@ -2525,8 +2592,14 @@ export default function App() {
                   queueCount={queueCount}
                   isQueueOpen={isQueueOpen}
                   onToggleQueue={() => setIsQueueOpen((prev) => !prev)}
+                  customText={libraryView === 'comfyui' ? 'ComfyUI Workspace' : undefined}
                   windowItems={footerWindowItems}
-                  onWindowSelect={handleActivateImageModal}
+                  onWindowSelect={(modalId) => {
+                    if (libraryView === 'comfyui') {
+                      setLibraryView('library');
+                    }
+                    handleActivateImageModal(modalId);
+                  }}
                   onWindowClose={handleCloseImageModalFromFooter}
                 />
               )}

--- a/App.tsx
+++ b/App.tsx
@@ -35,6 +35,7 @@ import NodeView from './components/NodeView';
 import FindSimilarModal from './components/FindSimilarModal';
 import ModelPromptPickerModal from './components/ModelPromptPickerModal';
 import CollectionsWorkspace from './components/CollectionsWorkspace';
+import ComfyUIWorkspace from './components/ComfyUIWorkspace';
 import GridToolbar from './components/GridToolbar';
 import AnalyticsSummaryStrip from './components/AnalyticsSummaryStrip';
 import BatchExportModal from './components/BatchExportModal';
@@ -297,6 +298,10 @@ export default function App() {
   const imageLookup = useMemo(() => {
     const lookup = new Map<string, IndexedImage>();
 
+    for (const image of safeImages) {
+      lookup.set(image.id, image);
+    }
+
     for (const image of safeFilteredImages) {
       lookup.set(image.id, image);
     }
@@ -308,7 +313,7 @@ export default function App() {
     }
 
     return lookup;
-  }, [safeClusterNavigationContext, safeFilteredImages]);
+  }, [safeClusterNavigationContext, safeFilteredImages, safeImages]);
 
   // --- Settings Store State ---
   const {
@@ -320,6 +325,7 @@ export default function App() {
     setLastViewedVersion,
     globalAutoWatch,
     generatorLaunchCommand,
+    comfyUIWorkspaceAutoOpenSelectedImage,
   } = useSettingsStore();
 
   // --- Local UI State ---
@@ -378,12 +384,13 @@ export default function App() {
   const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false);
   const [currentVersion, setCurrentVersion] = useState<string>('0.10.0');
   const [isQueueOpen, setIsQueueOpen] = useState(false);
-  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node' | 'collections'>('library');
+  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node' | 'collections' | 'comfyui'>('library');
   const [nodeViewVisibleImages, setNodeViewVisibleImages] = useState<IndexedImage[]>([]);
   const [nodeViewResultImages, setNodeViewResultImages] = useState<IndexedImage[]>([]);
   const [isA1111GenerateModalOpen, setIsA1111GenerateModalOpen] = useState(false);
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
+  const [comfyUIWorkspaceImageId, setComfyUIWorkspaceImageId] = useState<string | null>(null);
   const [newImagesToast, setNewImagesToast] = useState<{ message: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
   const [batchExportRequest, setBatchExportRequest] = useState<BatchExportRequestState | null>(null);
@@ -449,7 +456,7 @@ export default function App() {
       setNodeViewResultImages([]);
     }
   }, [libraryView, nodeViewResultImages.length]);
-  const hasRightSidebar = Boolean(previewImage || isQueueOpen);
+  const hasRightSidebar = Boolean(isQueueOpen || (previewImage && libraryView !== 'comfyui'));
   const { leftWidth: sidebarWidth, rightWidth: rightSidebarWidth } = useMemo(
     () =>
       resolveSidebarWidths({
@@ -1713,6 +1720,13 @@ export default function App() {
     openBatchExportModal();
   }, [openBatchExportModal]);
 
+  const handleOpenComfyUIWorkspace = useCallback((image?: IndexedImage | null) => {
+    if (image) {
+      setComfyUIWorkspaceImageId(image.id);
+    }
+    setLibraryView('comfyui');
+  }, []);
+
   const handleCloseBatchExport = useCallback(() => {
     setIsBatchExportModalOpen(false);
     setBatchExportRequest(null);
@@ -1811,6 +1825,23 @@ export default function App() {
   }, [openFindSimilar, safeImages]);
 
   const canSaveCurrentFilteredAsCollection = libraryView !== 'smart' && displayImages.length > 0;
+  const comfyUIWorkspaceImage = useMemo(() => {
+    if (comfyUIWorkspaceImageId) {
+      return imageLookup.get(comfyUIWorkspaceImageId) ?? null;
+    }
+
+    if (!comfyUIWorkspaceAutoOpenSelectedImage) {
+      return null;
+    }
+
+    return previewImage || selectedImage || null;
+  }, [
+    comfyUIWorkspaceAutoOpenSelectedImage,
+    comfyUIWorkspaceImageId,
+    imageLookup,
+    previewImage,
+    selectedImage,
+  ]);
   const slideshowPlaylistPreview = useMemo(
     () =>
       buildSlideshowPlaylist({
@@ -1969,6 +2000,21 @@ export default function App() {
   const hasActiveVisibleImageModal = openImageModalEntries.some(
     (modal) => !modal.isMinimized && modal.modalId === activeImageModalId
   );
+  const hasVisibleImageModal = openImageModalEntries.some((modal) => !modal.isMinimized);
+  const shouldShowEmbeddedComfyUIView =
+    libraryView === 'comfyui' &&
+    !hasVisibleImageModal &&
+    !isSettingsModalOpen &&
+    !isHotkeyHelpOpen &&
+    !isCommandPaletteOpen &&
+    !isChangelogModalOpen &&
+    !isAnalyticsOpen &&
+    !isComparisonModalOpen &&
+    !isBatchExportModalOpen &&
+    !isSaveFilteredCollectionModalOpen &&
+    !isA1111GenerateModalOpen &&
+    !isComfyUIGenerateModalOpen &&
+    !proModalOpen;
   const libraryContentFocusClass = hasActiveVisibleImageModal
     ? 'blur-[1px] opacity-95'
     : 'blur-0 opacity-100';
@@ -2234,7 +2280,7 @@ export default function App() {
           onSubmit={handleSaveCurrentFilteredAsCollection}
         />
 
-        <main className="mx-auto p-4 flex-1 flex flex-col min-h-0 w-full">
+        <main className={`flex-1 flex flex-col min-h-0 w-full ${libraryView === 'comfyui' ? 'p-0' : 'mx-auto p-4'}`}>
           {showGeneratorSetupNotice && (
             <div className="my-4 flex items-center justify-between gap-3 rounded-lg border border-blue-700/40 bg-blue-900/30 p-3 text-blue-100">
               <div className="flex-1 text-sm">
@@ -2436,6 +2482,14 @@ export default function App() {
                     onToggleQueue={() => setIsQueueOpen((prev) => !prev)}
                     onVisibleImagesChange={setNodeViewVisibleImages}
                     onResultImagesChange={handleNodeViewResultImagesChange}
+                  />
+                ) : libraryView === 'comfyui' ? (
+                  <ComfyUIWorkspace
+                    image={comfyUIWorkspaceImage}
+                    isActive={shouldShowEmbeddedComfyUIView}
+                    suspendBrowser={isGeneratingComfyUI}
+                    onOpenQueue={() => setIsQueueOpen(true)}
+                    onOpenSettings={handleOpenGeneratorIntegrations}
                   />
                 ) : (
                   <SmartLibrary

--- a/App.tsx
+++ b/App.tsx
@@ -1735,6 +1735,7 @@ export default function App() {
 
   useEffect(() => {
     if (libraryView !== 'comfyui') {
+      setComfyUIWorkspaceNavigationImageIds(null);
       return;
     }
 
@@ -1810,6 +1811,26 @@ export default function App() {
       : libraryView === 'node'
       ? nodeViewResultImages
       : safeFilteredImages;
+
+  useEffect(() => {
+    if (libraryView !== 'comfyui' || displayImages.length === 0) {
+      return;
+    }
+
+    setComfyUIWorkspaceNavigationImageIds((current) => current ?? displayImages.map((image) => image.id));
+    setComfyUIWorkspaceImageId((current) => {
+      if (current && displayImages.some((image) => image.id === current)) {
+        return current;
+      }
+
+      const preferredImage =
+        (previewImage && displayImages.some((image) => image.id === previewImage.id) ? previewImage : null) ||
+        (selectedImage && displayImages.some((image) => image.id === selectedImage.id) ? selectedImage : null) ||
+        displayImages[0];
+
+      return preferredImage.id;
+    });
+  }, [displayImages, libraryView, previewImage, selectedImage]);
 
   const openFindSimilar = useCallback((
     sourceImage: IndexedImage,
@@ -1901,6 +1922,18 @@ export default function App() {
       setComfyUIWorkspaceImageId(nextImage.id);
     }
   }, [comfyUIWorkspaceCurrentIndex, comfyUIWorkspaceNavigationImages]);
+  const comfyUIWorkspaceDirectoryPathByImageId = useMemo(() => {
+    const paths: Record<string, string> = {};
+
+    for (const image of comfyUIWorkspaceNavigationImages) {
+      const directoryPath = image.directoryId ? directoryPathById.get(image.directoryId) : undefined;
+      if (directoryPath) {
+        paths[image.id] = directoryPath;
+      }
+    }
+
+    return paths;
+  }, [comfyUIWorkspaceNavigationImages, directoryPathById]);
   const slideshowPlaylistPreview = useMemo(
     () =>
       buildSlideshowPlaylist({
@@ -2548,7 +2581,9 @@ export default function App() {
                 ) : libraryView === 'comfyui' ? (
                   <ComfyUIWorkspace
                     image={comfyUIWorkspaceImage}
+                    directoryPath={comfyUIWorkspaceImage?.directoryId ? directoryPathById.get(comfyUIWorkspaceImage.directoryId) : undefined}
                     navigationImages={comfyUIWorkspaceNavigationImages}
+                    directoryPathByImageId={comfyUIWorkspaceDirectoryPathByImageId}
                     currentIndex={comfyUIWorkspaceCurrentIndex}
                     isActive={shouldShowEmbeddedComfyUIView}
                     onSelectImage={(image) => setComfyUIWorkspaceImageId(image.id)}

--- a/App.tsx
+++ b/App.tsx
@@ -2105,6 +2105,7 @@ export default function App() {
     !isSaveFilteredCollectionModalOpen &&
     !isA1111GenerateModalOpen &&
     !isComfyUIGenerateModalOpen &&
+    !generatedOutputPreview &&
     !proModalOpen;
   const libraryContentFocusClass = hasActiveVisibleImageModal
     ? 'blur-[1px] opacity-95'

--- a/__tests__/comfy-view-security.test.ts
+++ b/__tests__/comfy-view-security.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getComfyUIViewAllowedOrigin,
+  isComfyUIViewUrlAllowed,
+  normalizeComfyUIViewUrl,
+} from '../utils/comfyUIViewSecurity.mjs';
+
+describe('ComfyUI embedded view URL security', () => {
+  it('allows the configured origin and paths under it', () => {
+    expect(isComfyUIViewUrlAllowed('http://127.0.0.1:8188/', 'http://127.0.0.1:8188')).toBe(true);
+    expect(isComfyUIViewUrlAllowed('http://127.0.0.1:8188/?foo=bar', 'http://127.0.0.1:8188')).toBe(true);
+  });
+
+  it('allows equivalent loopback hostnames on the same protocol and port', () => {
+    expect(isComfyUIViewUrlAllowed('http://localhost:8188/', 'http://127.0.0.1:8188')).toBe(true);
+    expect(isComfyUIViewUrlAllowed('http://127.0.0.1:8188/', 'http://localhost:8188')).toBe(true);
+  });
+
+  it('rejects different ports, protocols, and non-loopback hosts', () => {
+    expect(isComfyUIViewUrlAllowed('http://127.0.0.1:8189/', 'http://127.0.0.1:8188')).toBe(false);
+    expect(isComfyUIViewUrlAllowed('https://127.0.0.1:8188/', 'http://127.0.0.1:8188')).toBe(false);
+    expect(isComfyUIViewUrlAllowed('http://example.com:8188/', 'http://127.0.0.1:8188')).toBe(false);
+  });
+
+  it('rejects unsupported or malformed URLs', () => {
+    expect(normalizeComfyUIViewUrl('javascript:alert(1)')).toBeNull();
+    expect(normalizeComfyUIViewUrl('not a url')).toBeNull();
+    expect(isComfyUIViewUrlAllowed('file:///tmp/index.html', 'http://127.0.0.1:8188')).toBe(false);
+  });
+
+  it('reports the normalized allowed origin', () => {
+    expect(getComfyUIViewAllowedOrigin('http://127.0.0.1:8188/foo')).toBe('http://127.0.0.1:8188');
+    expect(getComfyUIViewAllowedOrigin('nope')).toBeNull();
+  });
+});

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -8,11 +8,13 @@ import {
   CheckCircle,
   Clipboard,
   ExternalLink,
+  ImageIcon,
+  Info,
   Loader2,
   Play,
-  RefreshCw,
   Rocket,
   SlidersHorizontal,
+  Workflow,
 } from 'lucide-react';
 import { BaseMetadata, ComfyUIViewLoadFailure, ComfyUIViewState, IndexedImage } from '../types';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -22,12 +24,16 @@ import { type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGener
 import ComfyUIWorkflowWorkspace from './ComfyUIWorkflowWorkspace';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
-import { ComfyUIApiClient } from '../services/comfyUIApiClient';
 
 interface ComfyUIWorkspaceProps {
   image: IndexedImage | null;
+  navigationImages?: IndexedImage[];
+  currentIndex?: number;
   isActive: boolean;
   suspendBrowser?: boolean;
+  onSelectImage?: (image: IndexedImage) => void;
+  onNavigatePrevious?: () => void;
+  onNavigateNext?: () => void;
   onOpenQueue: () => void;
   onOpenSettings: () => void;
 }
@@ -59,6 +65,33 @@ const MetadataLine: React.FC<{ label: string; value: unknown }> = ({ label, valu
   </div>
 );
 
+const WorkspaceThumbnailButton: React.FC<{
+  image: IndexedImage;
+  isActive: boolean;
+  onClick: () => void;
+}> = ({ image, isActive, onClick }) => {
+  const thumbnail = useResolvedThumbnail(image);
+
+  return (
+    <button
+      onClick={onClick}
+      className={`h-14 w-14 shrink-0 overflow-hidden rounded-md border bg-black transition-colors ${
+        isActive ? 'border-purple-400 ring-1 ring-purple-400/60' : 'border-gray-700 hover:border-gray-500'
+      }`}
+      title={image.name}
+      aria-label={`Show ${image.name}`}
+    >
+      {thumbnail?.thumbnailUrl ? (
+        <img src={thumbnail.thumbnailUrl} alt="" className="h-full w-full object-cover image-alpha-grid" />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-[10px] text-gray-600">
+          <ImageIcon className="h-4 w-4" />
+        </div>
+      )}
+    </button>
+  );
+};
+
 const getBounds = (element: HTMLElement) => {
   const rect = element.getBoundingClientRect();
   return {
@@ -74,8 +107,13 @@ const getWorkflowMetadata = (image: IndexedImage | null): BaseMetadata | null =>
 
 const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   image,
+  navigationImages = [],
+  currentIndex = -1,
   isActive,
   suspendBrowser = false,
+  onSelectImage,
+  onNavigatePrevious,
+  onNavigateNext,
   onOpenQueue,
   onOpenSettings,
 }) => {
@@ -84,8 +122,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const [viewState, setViewState] = useState<ComfyUIViewState>(DEFAULT_VIEW_STATE);
   const [loadFailure, setLoadFailure] = useState<ComfyUIViewLoadFailure | null>(null);
   const [connectionMessage, setConnectionMessage] = useState<string>('');
-  const [isCheckingConnection, setIsCheckingConnection] = useState(false);
-  const [isLaunchingGenerator, setIsLaunchingGenerator] = useState(false);
+  const [activeInspectorTab, setActiveInspectorTab] = useState<'image' | 'metadata' | 'workflow'>('image');
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(() => {
     if (typeof window === 'undefined') {
       return false;
@@ -96,8 +133,6 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
   const comfyUILastConnectionStatus = useSettingsStore((state) => state.comfyUILastConnectionStatus);
   const setComfyUIConnectionStatus = useSettingsStore((state) => state.setComfyUIConnectionStatus);
-  const generatorLaunchCommand = useSettingsStore((state) => state.generatorLaunchCommand);
-  const generatorLaunchWorkingDirectory = useSettingsStore((state) => state.generatorLaunchWorkingDirectory);
   const comfyUIWorkspaceLastUrl = useSettingsStore((state) => state.comfyUIWorkspaceLastUrl);
   const setComfyUIWorkspaceLastUrl = useSettingsStore((state) => state.setComfyUIWorkspaceLastUrl);
   const panelWidth = useSettingsStore((state) => state.comfyUIWorkspacePanelWidth);
@@ -107,6 +142,24 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const { copyToComfyUI, isCopying, copyStatus } = useCopyToComfyUI();
   const thumbnail = useResolvedThumbnail(image);
   const metadata = getWorkflowMetadata(image);
+  const normalizedNavigationImages = useMemo(
+    () => (navigationImages.length > 0 ? navigationImages : image ? [image] : []),
+    [image, navigationImages],
+  );
+  const currentPosition = currentIndex >= 0 ? currentIndex + 1 : 0;
+  const canNavigatePrevious = currentIndex > 0;
+  const canNavigateNext = currentIndex >= 0 && currentIndex < normalizedNavigationImages.length - 1;
+  const visibleNavigationImages = useMemo(() => {
+    if (normalizedNavigationImages.length <= 24 || currentIndex < 0) {
+      return normalizedNavigationImages;
+    }
+
+    const startIndex = Math.max(0, currentIndex - 11);
+    const endIndex = Math.min(normalizedNavigationImages.length, startIndex + 24);
+    const adjustedStartIndex = Math.max(0, endIndex - 24);
+
+    return normalizedNavigationImages.slice(adjustedStartIndex, endIndex);
+  }, [currentIndex, normalizedNavigationImages]);
   const isElectron = typeof window !== 'undefined' && Boolean(window.electronAPI?.comfyUIViewOpen);
   const targetUrl = comfyUIWorkspaceLastUrl || comfyUIServerUrl;
   const shouldShowBrowser = isActive && !suspendBrowser;
@@ -223,41 +276,6 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     };
   }, [setComfyUIConnectionStatus, setComfyUIWorkspaceLastUrl]);
 
-  const testConnection = async () => {
-    setIsCheckingConnection(true);
-    setConnectionMessage('');
-    try {
-      const result = await new ComfyUIApiClient({ serverUrl: comfyUIServerUrl, timeout: 2500 }).testConnection();
-      setComfyUIConnectionStatus(result.success ? 'connected' : 'error');
-      setConnectionMessage(result.success ? 'Connected to ComfyUI.' : result.error || 'ComfyUI is unreachable.');
-      if (result.success) {
-        setLoadFailure(null);
-        await openEmbeddedView();
-      }
-    } finally {
-      setIsCheckingConnection(false);
-    }
-  };
-
-  const launchGenerator = async () => {
-    if (!window.electronAPI?.launchGenerator) {
-      setConnectionMessage('Launch is available only in the desktop app.');
-      return;
-    }
-
-    setIsLaunchingGenerator(true);
-    setConnectionMessage('');
-    try {
-      const result = await window.electronAPI.launchGenerator({
-        command: generatorLaunchCommand,
-        workingDirectory: generatorLaunchWorkingDirectory,
-      });
-      setConnectionMessage(result.success ? 'Launch command started.' : result.error || 'Failed to launch ComfyUI.');
-    } finally {
-      setIsLaunchingGenerator(false);
-    }
-  };
-
   const openExternally = async () => {
     const result = await window.electronAPI?.openExternalUrl?.(targetUrl);
     if (!result?.success) {
@@ -330,6 +348,12 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     void syncBounds();
   };
 
+  const inspectorTabs = [
+    { id: 'image' as const, label: 'Image', icon: ImageIcon },
+    { id: 'metadata' as const, label: 'Metadata', icon: Info },
+    { id: 'workflow' as const, label: 'Workflow', icon: Workflow },
+  ];
+
   if (!isElectron) {
     return (
       <div className="flex h-full min-h-0 items-center justify-center rounded-lg border border-gray-800 bg-gray-950 p-8 text-center">
@@ -358,7 +382,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
             className={`inline-flex h-5 w-5 items-center justify-center rounded border text-xs ${connectionClasses}`}
             title={`${comfyUILastConnectionStatus === 'connected' ? 'Connected' : loadFailure ? 'Load failed' : 'ComfyUI'} - ${viewState.url || targetUrl}`}
           >
-            {viewState.isLoading || isCheckingConnection ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle className="h-3 w-3" />}
+            {viewState.isLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle className="h-3 w-3" />}
           </div>
           {connectionMessage && (
             <div className="max-w-[360px] truncate text-[11px] text-gray-500" title={connectionMessage}>
@@ -382,17 +406,8 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
           <button onClick={() => window.electronAPI?.comfyUIViewGoForward?.()} disabled={!viewState.canGoForward} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Forward">
             <ArrowRight className="h-3.5 w-3.5" />
           </button>
-          <button onClick={() => window.electronAPI?.comfyUIViewReload?.()} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Reload">
-            <RefreshCw className="h-3.5 w-3.5" />
-          </button>
           <button onClick={openExternally} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open externally">
             <ExternalLink className="h-3.5 w-3.5" />
-          </button>
-          <button onClick={testConnection} disabled={isCheckingConnection} className="h-6 rounded border border-gray-700 px-2 text-[11px] font-medium text-gray-200 hover:bg-gray-800 disabled:opacity-50">
-            {isCheckingConnection ? '...' : 'Check'}
-          </button>
-          <button onClick={launchGenerator} disabled={isLaunchingGenerator || !generatorLaunchCommand.trim()} className="h-6 rounded border border-purple-500/40 bg-purple-500/15 px-2 text-[11px] font-medium text-purple-100 hover:bg-purple-500/25 disabled:opacity-50" title={generatorLaunchCommand.trim() ? 'Run saved launch command' : 'Add a launch command in Settings > Integrations'}>
-            {isLaunchingGenerator ? '...' : 'Launch'}
           </button>
         </div>
       </div>
@@ -414,7 +429,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 <p className="mt-2 text-sm text-gray-400">
                   {suspendBrowser
                     ? 'Image MetaHub is generating through the API and temporarily hides the embedded ComfyUI UI to reduce memory pressure.'
-                    : 'Start ComfyUI, check the endpoint, then reconnect. The browser will stay attached to this workspace.'}
+                    : 'Start ComfyUI or open it externally. The browser stays attached to this workspace once the endpoint responds.'}
                 </p>
               </div>
             </div>
@@ -451,8 +466,10 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
           <>
           <div className="flex items-center justify-between gap-3">
             <div>
-              <h2 className="text-sm font-semibold text-gray-100">IMH Context</h2>
-              <p className="text-xs text-gray-500">API-first workflow handoff</p>
+              <h2 className="text-sm font-semibold text-gray-100">Image Inspector</h2>
+              <p className="text-xs text-gray-500">
+                {currentPosition > 0 ? `${currentPosition} / ${normalizedNavigationImages.length}` : 'No image selected'}
+              </p>
             </div>
             <div className="flex items-center gap-1">
               <button onClick={togglePanelCollapsed} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Hide IMH context panel">
@@ -464,12 +481,69 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
             </div>
           </div>
 
-          {!image || !metadata ? (
+          {!image ? (
             <div className="mt-6 rounded-lg border border-gray-800 bg-gray-950/80 p-4 text-sm text-gray-400">
               Select an image to send workflow data from Image MetaHub into ComfyUI.
             </div>
           ) : (
             <div className="mt-4 space-y-4">
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={onNavigatePrevious}
+                  disabled={!canNavigatePrevious}
+                  className="rounded border border-gray-700 px-2 py-1 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-40"
+                >
+                  Previous
+                </button>
+                <div className="min-w-0 flex-1 truncate text-center text-xs text-gray-500">
+                  {currentPosition} / {normalizedNavigationImages.length}
+                </div>
+                <button
+                  onClick={onNavigateNext}
+                  disabled={!canNavigateNext}
+                  className="rounded border border-gray-700 px-2 py-1 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-40"
+                >
+                  Next
+                </button>
+              </div>
+
+              {normalizedNavigationImages.length > 1 && (
+                <div className="flex gap-2 overflow-x-auto pb-1">
+                  {visibleNavigationImages.map((candidate) => (
+                    <WorkspaceThumbnailButton
+                      key={candidate.id}
+                      image={candidate}
+                      isActive={candidate.id === image.id}
+                      onClick={() => onSelectImage?.(candidate)}
+                    />
+                  ))}
+                </div>
+              )}
+
+              <div className="grid grid-cols-3 gap-1 rounded-lg border border-gray-800 bg-gray-950/80 p-1">
+                {inspectorTabs.map((tab) => {
+                  const Icon = tab.icon;
+                  const isSelected = activeInspectorTab === tab.id;
+
+                  return (
+                    <button
+                      key={tab.id}
+                      onClick={() => setActiveInspectorTab(tab.id)}
+                      className={`inline-flex items-center justify-center gap-1 rounded-md px-2 py-1.5 text-xs font-semibold transition-colors ${
+                        isSelected
+                          ? 'bg-purple-500/20 text-purple-100'
+                          : 'text-gray-400 hover:bg-gray-800 hover:text-gray-100'
+                      }`}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                      {tab.label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {activeInspectorTab === 'image' && (
+                <>
               <div className="overflow-hidden rounded-lg border border-gray-800 bg-gray-950">
                 {thumbnail?.thumbnailUrl ? (
                   <img src={thumbnail.thumbnailUrl} alt={image.name} className="h-44 w-full object-contain bg-black" />
@@ -488,23 +562,9 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
               </div>
 
               <div className="grid grid-cols-2 gap-2">
-                <MetadataLine label="Model" value={metadata.model} />
-                <MetadataLine label="Seed" value={metadata.seed} />
-                <MetadataLine label="Steps" value={metadata.steps} />
-                <MetadataLine label="CFG" value={(metadata as any).cfgScale ?? metadata.cfg_scale} />
-                <MetadataLine label="Sampler" value={metadata.sampler} />
-                <MetadataLine label="Scheduler" value={metadata.scheduler} />
-              </div>
-
-              <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
-                <div className="text-[10px] uppercase tracking-wide text-gray-500">Prompt</div>
-                <p className="mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs text-gray-200">{metadata.prompt || 'Not found'}</p>
-              </div>
-
-              <div className="grid grid-cols-2 gap-2">
                 <button
                   onClick={generateFromMetadata}
-                  disabled={isGenerating || !metadata.prompt}
+                  disabled={isGenerating || !metadata?.prompt}
                   className="inline-flex items-center justify-center gap-2 rounded-md border border-purple-500/40 bg-purple-500/15 px-3 py-2 text-xs font-semibold text-purple-100 hover:bg-purple-500/25 disabled:opacity-50"
                 >
                   <Play className="h-3.5 w-3.5" />
@@ -512,7 +572,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 </button>
                 <button
                   onClick={() => copyToComfyUI(image)}
-                  disabled={isCopying || !metadata.prompt}
+                  disabled={isCopying || !metadata?.prompt}
                   className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-50"
                 >
                   <Clipboard className="h-3.5 w-3.5" />
@@ -525,6 +585,8 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                   Open generation queue
                 </button>
               </div>
+                </>
+              )}
 
               {(copyStatus || generateStatus) && (
                 <div className={`rounded-md border px-3 py-2 text-xs ${
@@ -536,20 +598,57 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 </div>
               )}
 
-              <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
-                <div className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                  Workflow controls
+              {activeInspectorTab === 'metadata' && (
+                metadata ? (
+                  <div className="space-y-3">
+                  <div className="grid grid-cols-2 gap-2">
+                    <MetadataLine label="Model" value={metadata.model} />
+                    <MetadataLine label="Seed" value={metadata.seed} />
+                    <MetadataLine label="Steps" value={metadata.steps} />
+                    <MetadataLine label="CFG" value={(metadata as any).cfgScale ?? metadata.cfg_scale} />
+                    <MetadataLine label="Sampler" value={metadata.sampler} />
+                    <MetadataLine label="Scheduler" value={metadata.scheduler} />
+                  </div>
+
+                  <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
+                    <div className="text-[10px] uppercase tracking-wide text-gray-500">Prompt</div>
+                    <p className="mt-2 max-h-40 overflow-y-auto whitespace-pre-wrap text-xs text-gray-200">{metadata.prompt || 'Not found'}</p>
+                  </div>
+
+                  <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
+                    <div className="text-[10px] uppercase tracking-wide text-gray-500">Negative prompt</div>
+                    <p className="mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs text-gray-200">{metadata.negativePrompt || 'Not found'}</p>
+                  </div>
                 </div>
-                <ComfyUIWorkflowWorkspace
-                  image={image}
-                  onGenerate={handleGenerateFromWorkspace}
-                  isGenerating={isGenerating}
-                  status={generateStatus}
-                  defaultTab="parameters"
-                  viewportHeight={320}
-                  showCancelButton={false}
-                />
-              </div>
+                ) : (
+                  <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-4 text-sm text-gray-400">
+                    No normalized metadata is available for this image.
+                  </div>
+                )
+              )}
+
+              {activeInspectorTab === 'workflow' && (
+                metadata ? (
+                <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
+                  <div className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Workflow controls
+                  </div>
+                  <ComfyUIWorkflowWorkspace
+                    image={image}
+                    onGenerate={handleGenerateFromWorkspace}
+                    isGenerating={isGenerating}
+                    status={generateStatus}
+                    defaultTab="parameters"
+                    viewportHeight={360}
+                    showCancelButton={false}
+                  />
+                </div>
+                ) : (
+                  <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-4 text-sm text-gray-400">
+                    Workflow controls need normalized generation metadata.
+                  </div>
+                )
+              )}
             </div>
           )}
           </>

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -111,6 +111,17 @@ const getBounds = (element: HTMLElement) => {
 const getWorkflowMetadata = (image: IndexedImage | null): BaseMetadata | null =>
   (image?.metadata?.normalizedMetadata as BaseMetadata | undefined) ?? null;
 
+const getSameOriginUrl = (candidateUrl: string, configuredUrl: string): string => {
+  try {
+    const candidate = new URL(candidateUrl);
+    const configured = new URL(configuredUrl);
+
+    return candidate.origin === configured.origin ? candidate.toString() : configured.toString();
+  } catch {
+    return configuredUrl;
+  }
+};
+
 const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   image,
   directoryPath,
@@ -169,7 +180,9 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     return normalizedNavigationImages.slice(adjustedStartIndex, endIndex);
   }, [currentIndex, normalizedNavigationImages]);
   const isElectron = typeof window !== 'undefined' && Boolean(window.electronAPI?.comfyUIViewOpen);
-  const targetUrl = comfyUIWorkspaceLastUrl || comfyUIServerUrl;
+  const targetUrl = comfyUIWorkspaceLastUrl
+    ? getSameOriginUrl(comfyUIWorkspaceLastUrl, comfyUIServerUrl)
+    : comfyUIServerUrl;
   const shouldShowBrowser = isActive && !suspendBrowser;
 
   const togglePanelCollapsed = useCallback(() => {

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -36,6 +36,7 @@ interface ComfyUIWorkspaceProps {
   onSelectImage?: (image: IndexedImage) => void;
   onNavigatePrevious?: () => void;
   onNavigateNext?: () => void;
+  onGenerationStateChange?: (isGenerating: boolean) => void;
   onOpenQueue: () => void;
   onOpenSettings: () => void;
 }
@@ -133,6 +134,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   onSelectImage,
   onNavigatePrevious,
   onNavigateNext,
+  onGenerationStateChange,
   onOpenQueue,
   onOpenSettings,
 }) => {
@@ -184,6 +186,14 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     ? getSameOriginUrl(comfyUIWorkspaceLastUrl, comfyUIServerUrl)
     : comfyUIServerUrl;
   const shouldShowBrowser = isActive && !suspendBrowser;
+
+  useEffect(() => {
+    onGenerationStateChange?.(isGenerating);
+
+    return () => {
+      onGenerationStateChange?.(false);
+    };
+  }, [isGenerating, onGenerationStateChange]);
 
   const togglePanelCollapsed = useCallback(() => {
     setIsPanelCollapsed((current) => {

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -1,0 +1,563 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  ChevronLeft,
+  ChevronRight,
+  CheckCircle,
+  Clipboard,
+  ExternalLink,
+  Loader2,
+  Play,
+  RefreshCw,
+  Rocket,
+  SlidersHorizontal,
+} from 'lucide-react';
+import { BaseMetadata, ComfyUIViewLoadFailure, ComfyUIViewState, IndexedImage } from '../types';
+import { useSettingsStore } from '../store/useSettingsStore';
+import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
+import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
+import { type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGenerateModal';
+import ComfyUIWorkflowWorkspace from './ComfyUIWorkflowWorkspace';
+import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
+import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+import { ComfyUIApiClient } from '../services/comfyUIApiClient';
+
+interface ComfyUIWorkspaceProps {
+  image: IndexedImage | null;
+  isActive: boolean;
+  suspendBrowser?: boolean;
+  onOpenQueue: () => void;
+  onOpenSettings: () => void;
+}
+
+const DEFAULT_VIEW_STATE: ComfyUIViewState = {
+  url: '',
+  title: '',
+  isLoading: false,
+  canGoBack: false,
+  canGoForward: false,
+  visible: false,
+};
+
+const PANEL_COLLAPSED_STORAGE_KEY = 'image-metahub-comfyui-workspace-panel-collapsed';
+
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined || value === '') {
+    return 'Not found';
+  }
+  return String(value);
+};
+
+const MetadataLine: React.FC<{ label: string; value: unknown }> = ({ label, value }) => (
+  <div className="rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2">
+    <div className="text-[10px] uppercase tracking-wide text-gray-500">{label}</div>
+    <div className="mt-1 truncate font-mono text-xs text-gray-200" title={formatValue(value)}>
+      {formatValue(value)}
+    </div>
+  </div>
+);
+
+const getBounds = (element: HTMLElement) => {
+  const rect = element.getBoundingClientRect();
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+  };
+};
+
+const getWorkflowMetadata = (image: IndexedImage | null): BaseMetadata | null =>
+  (image?.metadata?.normalizedMetadata as BaseMetadata | undefined) ?? null;
+
+const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
+  image,
+  isActive,
+  suspendBrowser = false,
+  onOpenQueue,
+  onOpenSettings,
+}) => {
+  const browserHostRef = useRef<HTMLDivElement>(null);
+  const resizeStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const [viewState, setViewState] = useState<ComfyUIViewState>(DEFAULT_VIEW_STATE);
+  const [loadFailure, setLoadFailure] = useState<ComfyUIViewLoadFailure | null>(null);
+  const [connectionMessage, setConnectionMessage] = useState<string>('');
+  const [isCheckingConnection, setIsCheckingConnection] = useState(false);
+  const [isLaunchingGenerator, setIsLaunchingGenerator] = useState(false);
+  const [isPanelCollapsed, setIsPanelCollapsed] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    return window.localStorage.getItem(PANEL_COLLAPSED_STORAGE_KEY) === 'true';
+  });
+
+  const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
+  const comfyUILastConnectionStatus = useSettingsStore((state) => state.comfyUILastConnectionStatus);
+  const setComfyUIConnectionStatus = useSettingsStore((state) => state.setComfyUIConnectionStatus);
+  const generatorLaunchCommand = useSettingsStore((state) => state.generatorLaunchCommand);
+  const generatorLaunchWorkingDirectory = useSettingsStore((state) => state.generatorLaunchWorkingDirectory);
+  const comfyUIWorkspaceLastUrl = useSettingsStore((state) => state.comfyUIWorkspaceLastUrl);
+  const setComfyUIWorkspaceLastUrl = useSettingsStore((state) => state.setComfyUIWorkspaceLastUrl);
+  const panelWidth = useSettingsStore((state) => state.comfyUIWorkspacePanelWidth);
+  const setPanelWidth = useSettingsStore((state) => state.setComfyUIWorkspacePanelWidth);
+
+  const { generateWithComfyUI, isGenerating, generateStatus } = useGenerateWithComfyUI();
+  const { copyToComfyUI, isCopying, copyStatus } = useCopyToComfyUI();
+  const thumbnail = useResolvedThumbnail(image);
+  const metadata = getWorkflowMetadata(image);
+  const isElectron = typeof window !== 'undefined' && Boolean(window.electronAPI?.comfyUIViewOpen);
+  const targetUrl = comfyUIWorkspaceLastUrl || comfyUIServerUrl;
+  const shouldShowBrowser = isActive && !suspendBrowser;
+
+  const togglePanelCollapsed = useCallback(() => {
+    setIsPanelCollapsed((current) => {
+      const next = !current;
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(PANEL_COLLAPSED_STORAGE_KEY, String(next));
+      }
+      return next;
+    });
+  }, []);
+
+  const connectionClasses = useMemo(() => {
+    if (comfyUILastConnectionStatus === 'connected') {
+      return 'border-green-500/30 bg-green-500/10 text-green-200';
+    }
+    if (comfyUILastConnectionStatus === 'error' || loadFailure) {
+      return 'border-red-500/30 bg-red-500/10 text-red-200';
+    }
+    return 'border-gray-700 bg-gray-900 text-gray-300';
+  }, [comfyUILastConnectionStatus, loadFailure]);
+
+  const syncBounds = useCallback(async () => {
+    if (!shouldShowBrowser || !isElectron || !browserHostRef.current) {
+      return;
+    }
+
+    const bounds = getBounds(browserHostRef.current);
+    if (bounds.width <= 0 || bounds.height <= 0) {
+      return;
+    }
+
+    await window.electronAPI?.comfyUIViewSetBounds({ bounds });
+  }, [isElectron, shouldShowBrowser]);
+
+  const openEmbeddedView = useCallback(async () => {
+    if (!shouldShowBrowser || !isElectron || !browserHostRef.current) {
+      return;
+    }
+
+    const bounds = getBounds(browserHostRef.current);
+    const result = await window.electronAPI?.comfyUIViewOpen({ url: targetUrl, bounds });
+    if (result?.success && result.state) {
+      setViewState(result.state);
+      setLoadFailure(null);
+    } else if (result?.error) {
+      setConnectionMessage(result.error);
+    }
+  }, [isElectron, shouldShowBrowser, targetUrl]);
+
+  useEffect(() => {
+    if (!shouldShowBrowser || !isElectron) {
+      if (suspendBrowser) {
+        window.electronAPI?.comfyUIViewSuspend?.();
+      } else {
+        window.electronAPI?.comfyUIViewHide?.();
+      }
+      return;
+    }
+
+    void openEmbeddedView();
+
+    const host = browserHostRef.current;
+    if (!host) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      void syncBounds();
+    });
+    observer.observe(host);
+
+    const handleResize = () => {
+      void syncBounds();
+    };
+    window.addEventListener('resize', handleResize);
+    const unsubscribeZoom = window.electronAPI?.onZoomFactorChanged?.(() => {
+      window.requestAnimationFrame(() => {
+        void syncBounds();
+      });
+    });
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', handleResize);
+      unsubscribeZoom?.();
+      window.electronAPI?.comfyUIViewHide?.();
+    };
+  }, [isElectron, openEmbeddedView, shouldShowBrowser, suspendBrowser, syncBounds]);
+
+  useEffect(() => {
+    const unsubscribeState = window.electronAPI?.onComfyUIViewStateChanged?.((state) => {
+      setViewState(state);
+      if (state.url) {
+        setComfyUIWorkspaceLastUrl(state.url);
+      }
+    });
+    const unsubscribeFailure = window.electronAPI?.onComfyUIViewLoadFailed?.((failure) => {
+      setLoadFailure(failure);
+      setComfyUIConnectionStatus('error');
+    });
+
+    window.electronAPI?.comfyUIViewGetState?.().then((result) => {
+      if (result?.state) {
+        setViewState(result.state);
+      }
+    });
+
+    return () => {
+      unsubscribeState?.();
+      unsubscribeFailure?.();
+    };
+  }, [setComfyUIConnectionStatus, setComfyUIWorkspaceLastUrl]);
+
+  const testConnection = async () => {
+    setIsCheckingConnection(true);
+    setConnectionMessage('');
+    try {
+      const result = await new ComfyUIApiClient({ serverUrl: comfyUIServerUrl, timeout: 2500 }).testConnection();
+      setComfyUIConnectionStatus(result.success ? 'connected' : 'error');
+      setConnectionMessage(result.success ? 'Connected to ComfyUI.' : result.error || 'ComfyUI is unreachable.');
+      if (result.success) {
+        setLoadFailure(null);
+        await openEmbeddedView();
+      }
+    } finally {
+      setIsCheckingConnection(false);
+    }
+  };
+
+  const launchGenerator = async () => {
+    if (!window.electronAPI?.launchGenerator) {
+      setConnectionMessage('Launch is available only in the desktop app.');
+      return;
+    }
+
+    setIsLaunchingGenerator(true);
+    setConnectionMessage('');
+    try {
+      const result = await window.electronAPI.launchGenerator({
+        command: generatorLaunchCommand,
+        workingDirectory: generatorLaunchWorkingDirectory,
+      });
+      setConnectionMessage(result.success ? 'Launch command started.' : result.error || 'Failed to launch ComfyUI.');
+    } finally {
+      setIsLaunchingGenerator(false);
+    }
+  };
+
+  const openExternally = async () => {
+    const result = await window.electronAPI?.openExternalUrl?.(targetUrl);
+    if (!result?.success) {
+      setConnectionMessage(result?.error || 'Failed to open ComfyUI externally.');
+    }
+  };
+
+  const generateFromMetadata = async () => {
+    if (!image || !metadata) {
+      return;
+    }
+    await generateWithComfyUI(image);
+  };
+
+  const handleGenerateFromWorkspace = async (params: ComfyUIGenerationParams) => {
+    if (!image || !metadata) {
+      return;
+    }
+
+    const customMetadata: Partial<BaseMetadata> = {
+      prompt: params.prompt,
+      negativePrompt: params.negativePrompt,
+      cfg_scale: params.cfgScale,
+      steps: params.steps,
+      seed: params.randomSeed ? -1 : params.seed,
+      width: params.width,
+      height: params.height,
+      batch_size: params.numberOfImages,
+      model: params.model?.name || metadata.model,
+      ...(params.sampler ? { sampler: params.sampler } : {}),
+      ...(params.scheduler ? { scheduler: params.scheduler } : {}),
+    };
+
+    await generateWithComfyUI(image, {
+      customMetadata,
+      overrides: {
+        model: params.model || undefined,
+        loras: params.loras,
+      },
+      workflowMode: params.workflowMode,
+      sourceImagePolicy: params.sourceImagePolicy,
+      advancedPromptJson: params.advancedPromptJson,
+      advancedWorkflowJson: params.advancedWorkflowJson,
+      maskFile: params.maskFile,
+    });
+  };
+
+  const beginPanelResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    resizeStateRef.current = {
+      startX: event.clientX,
+      startWidth: panelWidth,
+    };
+  };
+
+  const handlePanelResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (isPanelCollapsed) {
+      return;
+    }
+    const resizeState = resizeStateRef.current;
+    if (!resizeState) {
+      return;
+    }
+    setPanelWidth(resizeState.startWidth - (event.clientX - resizeState.startX));
+  };
+
+  const endPanelResize = () => {
+    resizeStateRef.current = null;
+    void syncBounds();
+  };
+
+  if (!isElectron) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center rounded-lg border border-gray-800 bg-gray-950 p-8 text-center">
+        <div className="max-w-md">
+          <Rocket className="mx-auto h-10 w-10 text-purple-300" />
+          <h2 className="mt-4 text-lg font-semibold text-gray-100">ComfyUI workspace is desktop-only</h2>
+          <p className="mt-2 text-sm text-gray-400">
+            The embedded ComfyUI browser uses Electron. In the browser build, use the external ComfyUI window.
+          </p>
+          <button
+            onClick={() => window.open(targetUrl, '_blank', 'noopener,noreferrer')}
+            className="mt-5 rounded-md border border-purple-500/40 bg-purple-500/15 px-4 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-500/25"
+          >
+            Open ComfyUI externally
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-gray-950">
+      <div className="flex min-h-[32px] items-center justify-between gap-2 border-b border-gray-800 bg-gray-900 px-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <div
+            className={`inline-flex h-5 w-5 items-center justify-center rounded border text-xs ${connectionClasses}`}
+            title={`${comfyUILastConnectionStatus === 'connected' ? 'Connected' : loadFailure ? 'Load failed' : 'ComfyUI'} - ${viewState.url || targetUrl}`}
+          >
+            {viewState.isLoading || isCheckingConnection ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle className="h-3 w-3" />}
+          </div>
+          {connectionMessage && (
+            <div className="max-w-[360px] truncate text-[11px] text-gray-500" title={connectionMessage}>
+              {connectionMessage}
+            </div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            onClick={togglePanelCollapsed}
+            className="inline-flex h-6 items-center gap-1 rounded border border-gray-700 px-2 text-[11px] font-medium text-gray-200 hover:bg-gray-800"
+            title={isPanelCollapsed ? 'Show IMH context panel' : 'Hide IMH context panel'}
+          >
+            {isPanelCollapsed ? <ChevronLeft className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+            <span>Context</span>
+          </button>
+          <button onClick={() => window.electronAPI?.comfyUIViewGoBack?.()} disabled={!viewState.canGoBack} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Back">
+            <ArrowLeft className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={() => window.electronAPI?.comfyUIViewGoForward?.()} disabled={!viewState.canGoForward} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Forward">
+            <ArrowRight className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={() => window.electronAPI?.comfyUIViewReload?.()} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Reload">
+            <RefreshCw className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={openExternally} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open externally">
+            <ExternalLink className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={testConnection} disabled={isCheckingConnection} className="h-6 rounded border border-gray-700 px-2 text-[11px] font-medium text-gray-200 hover:bg-gray-800 disabled:opacity-50">
+            {isCheckingConnection ? '...' : 'Check'}
+          </button>
+          <button onClick={launchGenerator} disabled={isLaunchingGenerator || !generatorLaunchCommand.trim()} className="h-6 rounded border border-purple-500/40 bg-purple-500/15 px-2 text-[11px] font-medium text-purple-100 hover:bg-purple-500/25 disabled:opacity-50" title={generatorLaunchCommand.trim() ? 'Run saved launch command' : 'Add a launch command in Settings > Integrations'}>
+            {isLaunchingGenerator ? '...' : 'Launch'}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        <div className="relative min-w-0 flex-1 bg-black">
+          <div ref={browserHostRef} className="absolute inset-0" />
+          {(suspendBrowser || loadFailure || !viewState.visible) && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-gray-950 text-center">
+              <div className="max-w-sm px-6">
+                {suspendBrowser ? (
+                  <Loader2 className="mx-auto h-9 w-9 animate-spin text-purple-300" />
+                ) : (
+                  <AlertTriangle className="mx-auto h-9 w-9 text-amber-300" />
+                )}
+                <h3 className="mt-3 text-base font-semibold text-gray-100">
+                  {suspendBrowser ? 'ComfyUI browser paused during generation' : 'ComfyUI is not visible yet'}
+                </h3>
+                <p className="mt-2 text-sm text-gray-400">
+                  {suspendBrowser
+                    ? 'Image MetaHub is generating through the API and temporarily hides the embedded ComfyUI UI to reduce memory pressure.'
+                    : 'Start ComfyUI, check the endpoint, then reconnect. The browser will stay attached to this workspace.'}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {!isPanelCollapsed && (
+          <div
+            className="w-1 cursor-ew-resize bg-gray-800 hover:bg-purple-500/50"
+            onPointerDown={beginPanelResize}
+            onPointerMove={handlePanelResize}
+            onPointerUp={endPanelResize}
+            onPointerCancel={endPanelResize}
+            title="Resize ComfyUI context panel"
+          />
+        )}
+
+        <aside
+          className={`min-h-0 border-l border-gray-800 bg-gray-900/95 transition-[width] duration-200 ${
+            isPanelCollapsed ? 'overflow-hidden p-0' : 'overflow-y-auto p-4'
+          }`}
+          style={{ width: isPanelCollapsed ? 44 : panelWidth }}
+        >
+          {isPanelCollapsed ? (
+            <button
+              onClick={togglePanelCollapsed}
+              className="flex h-full w-full items-start justify-center pt-3 text-gray-400 hover:bg-gray-800 hover:text-gray-100"
+              title="Show IMH context panel"
+              aria-label="Show IMH context panel"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+          ) : (
+          <>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-100">IMH Context</h2>
+              <p className="text-xs text-gray-500">API-first workflow handoff</p>
+            </div>
+            <div className="flex items-center gap-1">
+              <button onClick={togglePanelCollapsed} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Hide IMH context panel">
+                <ChevronRight className="h-4 w-4" />
+              </button>
+              <button onClick={onOpenSettings} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open integration settings">
+                <SlidersHorizontal className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          {!image || !metadata ? (
+            <div className="mt-6 rounded-lg border border-gray-800 bg-gray-950/80 p-4 text-sm text-gray-400">
+              Select an image to send workflow data from Image MetaHub into ComfyUI.
+            </div>
+          ) : (
+            <div className="mt-4 space-y-4">
+              <div className="overflow-hidden rounded-lg border border-gray-800 bg-gray-950">
+                {thumbnail?.thumbnailUrl ? (
+                  <img src={thumbnail.thumbnailUrl} alt={image.name} className="h-44 w-full object-contain bg-black" />
+                ) : (
+                  <div className="flex h-44 items-center justify-center bg-black text-xs text-gray-600">No thumbnail</div>
+                )}
+                <div className="border-t border-gray-800 p-3">
+                  <div className="truncate text-sm font-medium text-gray-100" title={image.name}>{image.name}</div>
+                  {hasVerifiedTelemetry(image) && (
+                    <div className="mt-2 inline-flex items-center gap-1 rounded-full border border-green-500/30 bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-300">
+                      <CheckCircle className="h-3.5 w-3.5" />
+                      Verified telemetry
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <MetadataLine label="Model" value={metadata.model} />
+                <MetadataLine label="Seed" value={metadata.seed} />
+                <MetadataLine label="Steps" value={metadata.steps} />
+                <MetadataLine label="CFG" value={(metadata as any).cfgScale ?? metadata.cfg_scale} />
+                <MetadataLine label="Sampler" value={metadata.sampler} />
+                <MetadataLine label="Scheduler" value={metadata.scheduler} />
+              </div>
+
+              <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
+                <div className="text-[10px] uppercase tracking-wide text-gray-500">Prompt</div>
+                <p className="mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs text-gray-200">{metadata.prompt || 'Not found'}</p>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  onClick={generateFromMetadata}
+                  disabled={isGenerating || !metadata.prompt}
+                  className="inline-flex items-center justify-center gap-2 rounded-md border border-purple-500/40 bg-purple-500/15 px-3 py-2 text-xs font-semibold text-purple-100 hover:bg-purple-500/25 disabled:opacity-50"
+                >
+                  <Play className="h-3.5 w-3.5" />
+                  Generate
+                </button>
+                <button
+                  onClick={() => copyToComfyUI(image)}
+                  disabled={isCopying || !metadata.prompt}
+                  className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-50"
+                >
+                  <Clipboard className="h-3.5 w-3.5" />
+                  Copy JSON
+                </button>
+                <button
+                  onClick={onOpenQueue}
+                  className="col-span-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800"
+                >
+                  Open generation queue
+                </button>
+              </div>
+
+              {(copyStatus || generateStatus) && (
+                <div className={`rounded-md border px-3 py-2 text-xs ${
+                  (copyStatus?.success || generateStatus?.success)
+                    ? 'border-green-700/40 bg-green-500/10 text-green-200'
+                    : 'border-red-700/40 bg-red-500/10 text-red-200'
+                }`}>
+                  {copyStatus?.message || generateStatus?.message}
+                </div>
+              )}
+
+              <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
+                <div className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Workflow controls
+                </div>
+                <ComfyUIWorkflowWorkspace
+                  image={image}
+                  onGenerate={handleGenerateFromWorkspace}
+                  isGenerating={isGenerating}
+                  status={generateStatus}
+                  defaultTab="parameters"
+                  viewportHeight={320}
+                  showCancelButton={false}
+                />
+              </div>
+            </div>
+          )}
+          </>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default ComfyUIWorkspace;

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -1,0 +1,557 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  ChevronLeft,
+  ChevronRight,
+  CheckCircle,
+  Clipboard,
+  ExternalLink,
+  Loader2,
+  Play,
+  RefreshCw,
+  Rocket,
+  SlidersHorizontal,
+} from 'lucide-react';
+import { BaseMetadata, ComfyUIViewLoadFailure, ComfyUIViewState, IndexedImage } from '../types';
+import { useSettingsStore } from '../store/useSettingsStore';
+import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
+import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
+import { type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGenerateModal';
+import ComfyUIWorkflowWorkspace from './ComfyUIWorkflowWorkspace';
+import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
+import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+import { ComfyUIApiClient } from '../services/comfyUIApiClient';
+
+interface ComfyUIWorkspaceProps {
+  image: IndexedImage | null;
+  isActive: boolean;
+  suspendBrowser?: boolean;
+  onOpenQueue: () => void;
+  onOpenSettings: () => void;
+}
+
+const DEFAULT_VIEW_STATE: ComfyUIViewState = {
+  url: '',
+  title: '',
+  isLoading: false,
+  canGoBack: false,
+  canGoForward: false,
+  visible: false,
+};
+
+const PANEL_COLLAPSED_STORAGE_KEY = 'image-metahub-comfyui-workspace-panel-collapsed';
+
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined || value === '') {
+    return 'Not found';
+  }
+  return String(value);
+};
+
+const MetadataLine: React.FC<{ label: string; value: unknown }> = ({ label, value }) => (
+  <div className="rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2">
+    <div className="text-[10px] uppercase tracking-wide text-gray-500">{label}</div>
+    <div className="mt-1 truncate font-mono text-xs text-gray-200" title={formatValue(value)}>
+      {formatValue(value)}
+    </div>
+  </div>
+);
+
+const getBounds = (element: HTMLElement) => {
+  const rect = element.getBoundingClientRect();
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+  };
+};
+
+const getWorkflowMetadata = (image: IndexedImage | null): BaseMetadata | null =>
+  (image?.metadata?.normalizedMetadata as BaseMetadata | undefined) ?? null;
+
+const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
+  image,
+  isActive,
+  suspendBrowser = false,
+  onOpenQueue,
+  onOpenSettings,
+}) => {
+  const browserHostRef = useRef<HTMLDivElement>(null);
+  const resizeStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const [viewState, setViewState] = useState<ComfyUIViewState>(DEFAULT_VIEW_STATE);
+  const [loadFailure, setLoadFailure] = useState<ComfyUIViewLoadFailure | null>(null);
+  const [connectionMessage, setConnectionMessage] = useState<string>('');
+  const [isCheckingConnection, setIsCheckingConnection] = useState(false);
+  const [isLaunchingGenerator, setIsLaunchingGenerator] = useState(false);
+  const [isPanelCollapsed, setIsPanelCollapsed] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    return window.localStorage.getItem(PANEL_COLLAPSED_STORAGE_KEY) === 'true';
+  });
+
+  const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
+  const comfyUILastConnectionStatus = useSettingsStore((state) => state.comfyUILastConnectionStatus);
+  const setComfyUIConnectionStatus = useSettingsStore((state) => state.setComfyUIConnectionStatus);
+  const generatorLaunchCommand = useSettingsStore((state) => state.generatorLaunchCommand);
+  const generatorLaunchWorkingDirectory = useSettingsStore((state) => state.generatorLaunchWorkingDirectory);
+  const comfyUIWorkspaceLastUrl = useSettingsStore((state) => state.comfyUIWorkspaceLastUrl);
+  const setComfyUIWorkspaceLastUrl = useSettingsStore((state) => state.setComfyUIWorkspaceLastUrl);
+  const panelWidth = useSettingsStore((state) => state.comfyUIWorkspacePanelWidth);
+  const setPanelWidth = useSettingsStore((state) => state.setComfyUIWorkspacePanelWidth);
+
+  const { generateWithComfyUI, isGenerating, generateStatus } = useGenerateWithComfyUI();
+  const { copyToComfyUI, isCopying, copyStatus } = useCopyToComfyUI();
+  const thumbnail = useResolvedThumbnail(image);
+  const metadata = getWorkflowMetadata(image);
+  const isElectron = typeof window !== 'undefined' && Boolean(window.electronAPI?.comfyUIViewOpen);
+  const targetUrl = comfyUIWorkspaceLastUrl || comfyUIServerUrl;
+  const shouldShowBrowser = isActive && !suspendBrowser;
+
+  const togglePanelCollapsed = useCallback(() => {
+    setIsPanelCollapsed((current) => {
+      const next = !current;
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(PANEL_COLLAPSED_STORAGE_KEY, String(next));
+      }
+      return next;
+    });
+  }, []);
+
+  const connectionClasses = useMemo(() => {
+    if (comfyUILastConnectionStatus === 'connected') {
+      return 'border-green-500/30 bg-green-500/10 text-green-200';
+    }
+    if (comfyUILastConnectionStatus === 'error' || loadFailure) {
+      return 'border-red-500/30 bg-red-500/10 text-red-200';
+    }
+    return 'border-gray-700 bg-gray-900 text-gray-300';
+  }, [comfyUILastConnectionStatus, loadFailure]);
+
+  const syncBounds = useCallback(async () => {
+    if (!shouldShowBrowser || !isElectron || !browserHostRef.current) {
+      return;
+    }
+
+    const bounds = getBounds(browserHostRef.current);
+    if (bounds.width <= 0 || bounds.height <= 0) {
+      return;
+    }
+
+    await window.electronAPI?.comfyUIViewSetBounds({ bounds });
+  }, [isElectron, shouldShowBrowser]);
+
+  const openEmbeddedView = useCallback(async () => {
+    if (!shouldShowBrowser || !isElectron || !browserHostRef.current) {
+      return;
+    }
+
+    const bounds = getBounds(browserHostRef.current);
+    const result = await window.electronAPI?.comfyUIViewOpen({ url: targetUrl, bounds });
+    if (result?.success && result.state) {
+      setViewState(result.state);
+      setLoadFailure(null);
+    } else if (result?.error) {
+      setConnectionMessage(result.error);
+    }
+  }, [isElectron, shouldShowBrowser, targetUrl]);
+
+  useEffect(() => {
+    if (!shouldShowBrowser || !isElectron) {
+      if (suspendBrowser) {
+        window.electronAPI?.comfyUIViewSuspend?.();
+      } else {
+        window.electronAPI?.comfyUIViewHide?.();
+      }
+      return;
+    }
+
+    void openEmbeddedView();
+
+    const host = browserHostRef.current;
+    if (!host) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      void syncBounds();
+    });
+    observer.observe(host);
+
+    const handleResize = () => {
+      void syncBounds();
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', handleResize);
+      window.electronAPI?.comfyUIViewHide?.();
+    };
+  }, [isElectron, openEmbeddedView, shouldShowBrowser, suspendBrowser, syncBounds]);
+
+  useEffect(() => {
+    const unsubscribeState = window.electronAPI?.onComfyUIViewStateChanged?.((state) => {
+      setViewState(state);
+      if (state.url) {
+        setComfyUIWorkspaceLastUrl(state.url);
+      }
+    });
+    const unsubscribeFailure = window.electronAPI?.onComfyUIViewLoadFailed?.((failure) => {
+      setLoadFailure(failure);
+      setComfyUIConnectionStatus('error');
+    });
+
+    window.electronAPI?.comfyUIViewGetState?.().then((result) => {
+      if (result?.state) {
+        setViewState(result.state);
+      }
+    });
+
+    return () => {
+      unsubscribeState?.();
+      unsubscribeFailure?.();
+    };
+  }, [setComfyUIConnectionStatus, setComfyUIWorkspaceLastUrl]);
+
+  const testConnection = async () => {
+    setIsCheckingConnection(true);
+    setConnectionMessage('');
+    try {
+      const result = await new ComfyUIApiClient({ serverUrl: comfyUIServerUrl, timeout: 2500 }).testConnection();
+      setComfyUIConnectionStatus(result.success ? 'connected' : 'error');
+      setConnectionMessage(result.success ? 'Connected to ComfyUI.' : result.error || 'ComfyUI is unreachable.');
+      if (result.success) {
+        setLoadFailure(null);
+        await openEmbeddedView();
+      }
+    } finally {
+      setIsCheckingConnection(false);
+    }
+  };
+
+  const launchGenerator = async () => {
+    if (!window.electronAPI?.launchGenerator) {
+      setConnectionMessage('Launch is available only in the desktop app.');
+      return;
+    }
+
+    setIsLaunchingGenerator(true);
+    setConnectionMessage('');
+    try {
+      const result = await window.electronAPI.launchGenerator({
+        command: generatorLaunchCommand,
+        workingDirectory: generatorLaunchWorkingDirectory,
+      });
+      setConnectionMessage(result.success ? 'Launch command started.' : result.error || 'Failed to launch ComfyUI.');
+    } finally {
+      setIsLaunchingGenerator(false);
+    }
+  };
+
+  const openExternally = async () => {
+    const result = await window.electronAPI?.openExternalUrl?.(targetUrl);
+    if (!result?.success) {
+      setConnectionMessage(result?.error || 'Failed to open ComfyUI externally.');
+    }
+  };
+
+  const generateFromMetadata = async () => {
+    if (!image || !metadata) {
+      return;
+    }
+    await generateWithComfyUI(image);
+  };
+
+  const handleGenerateFromWorkspace = async (params: ComfyUIGenerationParams) => {
+    if (!image || !metadata) {
+      return;
+    }
+
+    const customMetadata: Partial<BaseMetadata> = {
+      prompt: params.prompt,
+      negativePrompt: params.negativePrompt,
+      cfg_scale: params.cfgScale,
+      steps: params.steps,
+      seed: params.randomSeed ? -1 : params.seed,
+      width: params.width,
+      height: params.height,
+      batch_size: params.numberOfImages,
+      model: params.model?.name || metadata.model,
+      ...(params.sampler ? { sampler: params.sampler } : {}),
+      ...(params.scheduler ? { scheduler: params.scheduler } : {}),
+    };
+
+    await generateWithComfyUI(image, {
+      customMetadata,
+      overrides: {
+        model: params.model || undefined,
+        loras: params.loras,
+      },
+      workflowMode: params.workflowMode,
+      sourceImagePolicy: params.sourceImagePolicy,
+      advancedPromptJson: params.advancedPromptJson,
+      advancedWorkflowJson: params.advancedWorkflowJson,
+      maskFile: params.maskFile,
+    });
+  };
+
+  const beginPanelResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    resizeStateRef.current = {
+      startX: event.clientX,
+      startWidth: panelWidth,
+    };
+  };
+
+  const handlePanelResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (isPanelCollapsed) {
+      return;
+    }
+    const resizeState = resizeStateRef.current;
+    if (!resizeState) {
+      return;
+    }
+    setPanelWidth(resizeState.startWidth - (event.clientX - resizeState.startX));
+  };
+
+  const endPanelResize = () => {
+    resizeStateRef.current = null;
+    void syncBounds();
+  };
+
+  if (!isElectron) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center rounded-lg border border-gray-800 bg-gray-950 p-8 text-center">
+        <div className="max-w-md">
+          <Rocket className="mx-auto h-10 w-10 text-purple-300" />
+          <h2 className="mt-4 text-lg font-semibold text-gray-100">ComfyUI workspace is desktop-only</h2>
+          <p className="mt-2 text-sm text-gray-400">
+            The embedded ComfyUI browser uses Electron. In the browser build, use the external ComfyUI window.
+          </p>
+          <button
+            onClick={() => window.open(targetUrl, '_blank', 'noopener,noreferrer')}
+            className="mt-5 rounded-md border border-purple-500/40 bg-purple-500/15 px-4 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-500/25"
+          >
+            Open ComfyUI externally
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-gray-800 bg-gray-950">
+      <div className="flex min-h-[32px] items-center justify-between gap-2 border-b border-gray-800 bg-gray-900 px-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <div
+            className={`inline-flex h-5 w-5 items-center justify-center rounded border text-xs ${connectionClasses}`}
+            title={`${comfyUILastConnectionStatus === 'connected' ? 'Connected' : loadFailure ? 'Load failed' : 'ComfyUI'} - ${viewState.url || targetUrl}`}
+          >
+            {viewState.isLoading || isCheckingConnection ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle className="h-3 w-3" />}
+          </div>
+          {connectionMessage && (
+            <div className="max-w-[360px] truncate text-[11px] text-gray-500" title={connectionMessage}>
+              {connectionMessage}
+            </div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            onClick={togglePanelCollapsed}
+            className="inline-flex h-6 items-center gap-1 rounded border border-gray-700 px-2 text-[11px] font-medium text-gray-200 hover:bg-gray-800"
+            title={isPanelCollapsed ? 'Show IMH context panel' : 'Hide IMH context panel'}
+          >
+            {isPanelCollapsed ? <ChevronLeft className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+            <span>Context</span>
+          </button>
+          <button onClick={() => window.electronAPI?.comfyUIViewGoBack?.()} disabled={!viewState.canGoBack} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Back">
+            <ArrowLeft className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={() => window.electronAPI?.comfyUIViewGoForward?.()} disabled={!viewState.canGoForward} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Forward">
+            <ArrowRight className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={() => window.electronAPI?.comfyUIViewReload?.()} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Reload">
+            <RefreshCw className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={openExternally} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open externally">
+            <ExternalLink className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={testConnection} disabled={isCheckingConnection} className="h-6 rounded border border-gray-700 px-2 text-[11px] font-medium text-gray-200 hover:bg-gray-800 disabled:opacity-50">
+            {isCheckingConnection ? '...' : 'Check'}
+          </button>
+          <button onClick={launchGenerator} disabled={isLaunchingGenerator || !generatorLaunchCommand.trim()} className="h-6 rounded border border-purple-500/40 bg-purple-500/15 px-2 text-[11px] font-medium text-purple-100 hover:bg-purple-500/25 disabled:opacity-50" title={generatorLaunchCommand.trim() ? 'Run saved launch command' : 'Add a launch command in Settings > Integrations'}>
+            {isLaunchingGenerator ? '...' : 'Launch'}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        <div className="relative min-w-0 flex-1 bg-black">
+          <div ref={browserHostRef} className="absolute inset-0" />
+          {(suspendBrowser || loadFailure || !viewState.visible) && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-gray-950 text-center">
+              <div className="max-w-sm px-6">
+                {suspendBrowser ? (
+                  <Loader2 className="mx-auto h-9 w-9 animate-spin text-purple-300" />
+                ) : (
+                  <AlertTriangle className="mx-auto h-9 w-9 text-amber-300" />
+                )}
+                <h3 className="mt-3 text-base font-semibold text-gray-100">
+                  {suspendBrowser ? 'ComfyUI browser paused during generation' : 'ComfyUI is not visible yet'}
+                </h3>
+                <p className="mt-2 text-sm text-gray-400">
+                  {suspendBrowser
+                    ? 'Image MetaHub is generating through the API and temporarily hides the embedded ComfyUI UI to reduce memory pressure.'
+                    : 'Start ComfyUI, check the endpoint, then reconnect. The browser will stay attached to this workspace.'}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {!isPanelCollapsed && (
+          <div
+            className="w-1 cursor-ew-resize bg-gray-800 hover:bg-purple-500/50"
+            onPointerDown={beginPanelResize}
+            onPointerMove={handlePanelResize}
+            onPointerUp={endPanelResize}
+            onPointerCancel={endPanelResize}
+            title="Resize ComfyUI context panel"
+          />
+        )}
+
+        <aside
+          className={`min-h-0 border-l border-gray-800 bg-gray-900/95 transition-[width] duration-200 ${
+            isPanelCollapsed ? 'overflow-hidden p-0' : 'overflow-y-auto p-4'
+          }`}
+          style={{ width: isPanelCollapsed ? 44 : panelWidth }}
+        >
+          {isPanelCollapsed ? (
+            <button
+              onClick={togglePanelCollapsed}
+              className="flex h-full w-full items-start justify-center pt-3 text-gray-400 hover:bg-gray-800 hover:text-gray-100"
+              title="Show IMH context panel"
+              aria-label="Show IMH context panel"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+          ) : (
+          <>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-100">IMH Context</h2>
+              <p className="text-xs text-gray-500">API-first workflow handoff</p>
+            </div>
+            <div className="flex items-center gap-1">
+              <button onClick={togglePanelCollapsed} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Hide IMH context panel">
+                <ChevronRight className="h-4 w-4" />
+              </button>
+              <button onClick={onOpenSettings} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open integration settings">
+                <SlidersHorizontal className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          {!image || !metadata ? (
+            <div className="mt-6 rounded-lg border border-gray-800 bg-gray-950/80 p-4 text-sm text-gray-400">
+              Select an image to send workflow data from Image MetaHub into ComfyUI.
+            </div>
+          ) : (
+            <div className="mt-4 space-y-4">
+              <div className="overflow-hidden rounded-lg border border-gray-800 bg-gray-950">
+                {thumbnail?.thumbnailUrl ? (
+                  <img src={thumbnail.thumbnailUrl} alt={image.name} className="h-44 w-full object-contain bg-black" />
+                ) : (
+                  <div className="flex h-44 items-center justify-center bg-black text-xs text-gray-600">No thumbnail</div>
+                )}
+                <div className="border-t border-gray-800 p-3">
+                  <div className="truncate text-sm font-medium text-gray-100" title={image.name}>{image.name}</div>
+                  {hasVerifiedTelemetry(image) && (
+                    <div className="mt-2 inline-flex items-center gap-1 rounded-full border border-green-500/30 bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-300">
+                      <CheckCircle className="h-3.5 w-3.5" />
+                      Verified telemetry
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <MetadataLine label="Model" value={metadata.model} />
+                <MetadataLine label="Seed" value={metadata.seed} />
+                <MetadataLine label="Steps" value={metadata.steps} />
+                <MetadataLine label="CFG" value={(metadata as any).cfgScale ?? metadata.cfg_scale} />
+                <MetadataLine label="Sampler" value={metadata.sampler} />
+                <MetadataLine label="Scheduler" value={metadata.scheduler} />
+              </div>
+
+              <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
+                <div className="text-[10px] uppercase tracking-wide text-gray-500">Prompt</div>
+                <p className="mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs text-gray-200">{metadata.prompt || 'Not found'}</p>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  onClick={generateFromMetadata}
+                  disabled={isGenerating || !metadata.prompt}
+                  className="inline-flex items-center justify-center gap-2 rounded-md border border-purple-500/40 bg-purple-500/15 px-3 py-2 text-xs font-semibold text-purple-100 hover:bg-purple-500/25 disabled:opacity-50"
+                >
+                  <Play className="h-3.5 w-3.5" />
+                  Generate
+                </button>
+                <button
+                  onClick={() => copyToComfyUI(image)}
+                  disabled={isCopying || !metadata.prompt}
+                  className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-50"
+                >
+                  <Clipboard className="h-3.5 w-3.5" />
+                  Copy JSON
+                </button>
+                <button
+                  onClick={onOpenQueue}
+                  className="col-span-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800"
+                >
+                  Open generation queue
+                </button>
+              </div>
+
+              {(copyStatus || generateStatus) && (
+                <div className={`rounded-md border px-3 py-2 text-xs ${
+                  (copyStatus?.success || generateStatus?.success)
+                    ? 'border-green-700/40 bg-green-500/10 text-green-200'
+                    : 'border-red-700/40 bg-red-500/10 text-red-200'
+                }`}>
+                  {copyStatus?.message || generateStatus?.message}
+                </div>
+              )}
+
+              <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
+                <div className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Workflow controls
+                </div>
+                <ComfyUIWorkflowWorkspace
+                  image={image}
+                  onGenerate={handleGenerateFromWorkspace}
+                  isGenerating={isGenerating}
+                  status={generateStatus}
+                  defaultTab="parameters"
+                  viewportHeight={320}
+                  showCancelButton={false}
+                />
+              </div>
+            </div>
+          )}
+          </>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default ComfyUIWorkspace;

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -27,7 +27,9 @@ import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 
 interface ComfyUIWorkspaceProps {
   image: IndexedImage | null;
+  directoryPath?: string;
   navigationImages?: IndexedImage[];
+  directoryPathByImageId?: Record<string, string>;
   currentIndex?: number;
   isActive: boolean;
   suspendBrowser?: boolean;
@@ -68,8 +70,10 @@ const MetadataLine: React.FC<{ label: string; value: unknown }> = ({ label, valu
 const WorkspaceThumbnailButton: React.FC<{
   image: IndexedImage;
   isActive: boolean;
+  directoryPath?: string;
   onClick: () => void;
-}> = ({ image, isActive, onClick }) => {
+  onDragStart: (event: React.DragEvent<HTMLElement>, image: IndexedImage, directoryPath?: string) => void;
+}> = ({ image, isActive, directoryPath, onClick, onDragStart }) => {
   const thumbnail = useResolvedThumbnail(image);
 
   return (
@@ -80,6 +84,8 @@ const WorkspaceThumbnailButton: React.FC<{
       }`}
       title={image.name}
       aria-label={`Show ${image.name}`}
+      draggable={Boolean(directoryPath && window.electronAPI?.startFileDrag)}
+      onDragStart={(event) => onDragStart(event, image, directoryPath)}
     >
       {thumbnail?.thumbnailUrl ? (
         <img src={thumbnail.thumbnailUrl} alt="" className="h-full w-full object-cover image-alpha-grid" />
@@ -107,7 +113,9 @@ const getWorkflowMetadata = (image: IndexedImage | null): BaseMetadata | null =>
 
 const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   image,
+  directoryPath,
   navigationImages = [],
+  directoryPathByImageId = {},
   currentIndex = -1,
   isActive,
   suspendBrowser = false,
@@ -354,6 +362,23 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     { id: 'workflow' as const, label: 'Workflow', icon: Workflow },
   ];
 
+  const startImageFileDrag = useCallback((
+    event: React.DragEvent<HTMLElement>,
+    dragImage: IndexedImage,
+    dragDirectoryPath?: string,
+  ) => {
+    if (!dragDirectoryPath || !window.electronAPI?.startFileDrag) {
+      return;
+    }
+
+    const [, relativeFromId] = dragImage.id.split('::');
+    const relativePath = relativeFromId || dragImage.name;
+
+    event.preventDefault();
+    event.dataTransfer.effectAllowed = 'copy';
+    window.electronAPI.startFileDrag({ directoryPath: dragDirectoryPath, relativePath });
+  }, []);
+
   if (!isElectron) {
     return (
       <div className="flex h-full min-h-0 items-center justify-center rounded-lg border border-gray-800 bg-gray-950 p-8 text-center">
@@ -376,42 +401,6 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-gray-950">
-      <div className="flex min-h-[32px] items-center justify-between gap-2 border-b border-gray-800 bg-gray-900 px-2">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <div
-            className={`inline-flex h-5 w-5 items-center justify-center rounded border text-xs ${connectionClasses}`}
-            title={`${comfyUILastConnectionStatus === 'connected' ? 'Connected' : loadFailure ? 'Load failed' : 'ComfyUI'} - ${viewState.url || targetUrl}`}
-          >
-            {viewState.isLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle className="h-3 w-3" />}
-          </div>
-          {connectionMessage && (
-            <div className="max-w-[360px] truncate text-[11px] text-gray-500" title={connectionMessage}>
-              {connectionMessage}
-            </div>
-          )}
-        </div>
-
-        <div className="flex shrink-0 items-center gap-1">
-          <button
-            onClick={togglePanelCollapsed}
-            className="inline-flex h-6 items-center gap-1 rounded border border-gray-700 px-2 text-[11px] font-medium text-gray-200 hover:bg-gray-800"
-            title={isPanelCollapsed ? 'Show IMH context panel' : 'Hide IMH context panel'}
-          >
-            {isPanelCollapsed ? <ChevronLeft className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-            <span>Context</span>
-          </button>
-          <button onClick={() => window.electronAPI?.comfyUIViewGoBack?.()} disabled={!viewState.canGoBack} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Back">
-            <ArrowLeft className="h-3.5 w-3.5" />
-          </button>
-          <button onClick={() => window.electronAPI?.comfyUIViewGoForward?.()} disabled={!viewState.canGoForward} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Forward">
-            <ArrowRight className="h-3.5 w-3.5" />
-          </button>
-          <button onClick={openExternally} className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open externally">
-            <ExternalLink className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      </div>
-
       <div className="flex min-h-0 flex-1">
         <div className="relative min-w-0 flex-1 bg-black">
           <div ref={browserHostRef} className="absolute inset-0" />
@@ -464,20 +453,39 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
             </button>
           ) : (
           <>
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <h2 className="text-sm font-semibold text-gray-100">Image Inspector</h2>
-              <p className="text-xs text-gray-500">
-                {currentPosition > 0 ? `${currentPosition} / ${normalizedNavigationImages.length}` : 'No image selected'}
-              </p>
-            </div>
-            <div className="flex items-center gap-1">
-              <button onClick={togglePanelCollapsed} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Hide IMH context panel">
-                <ChevronRight className="h-4 w-4" />
-              </button>
-              <button onClick={onOpenSettings} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open integration settings">
-                <SlidersHorizontal className="h-4 w-4" />
-              </button>
+          <div className="space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <div
+                    className={`inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border text-xs ${connectionClasses}`}
+                    title={`${comfyUILastConnectionStatus === 'connected' ? 'Connected' : loadFailure ? 'Load failed' : 'ComfyUI'} - ${viewState.url || targetUrl}`}
+                  >
+                    {viewState.isLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle className="h-3 w-3" />}
+                  </div>
+                  <h2 className="truncate text-sm font-semibold text-gray-100">Image Inspector</h2>
+                </div>
+                <p className="mt-1 text-xs text-gray-500">
+                  {connectionMessage || (currentPosition > 0 ? `${currentPosition} / ${normalizedNavigationImages.length}` : 'No image selected')}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <button onClick={() => window.electronAPI?.comfyUIViewGoBack?.()} disabled={!viewState.canGoBack} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Back">
+                  <ArrowLeft className="h-4 w-4" />
+                </button>
+                <button onClick={() => window.electronAPI?.comfyUIViewGoForward?.()} disabled={!viewState.canGoForward} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Forward">
+                  <ArrowRight className="h-4 w-4" />
+                </button>
+                <button onClick={openExternally} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open externally">
+                  <ExternalLink className="h-4 w-4" />
+                </button>
+                <button onClick={togglePanelCollapsed} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Hide image inspector">
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+                <button onClick={onOpenSettings} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open integration settings">
+                  <SlidersHorizontal className="h-4 w-4" />
+                </button>
+              </div>
             </div>
           </div>
 
@@ -514,7 +522,9 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                       key={candidate.id}
                       image={candidate}
                       isActive={candidate.id === image.id}
+                      directoryPath={directoryPathByImageId[candidate.id]}
                       onClick={() => onSelectImage?.(candidate)}
+                      onDragStart={startImageFileDrag}
                     />
                   ))}
                 </div>
@@ -546,7 +556,14 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 <>
               <div className="overflow-hidden rounded-lg border border-gray-800 bg-gray-950">
                 {thumbnail?.thumbnailUrl ? (
-                  <img src={thumbnail.thumbnailUrl} alt={image.name} className="h-44 w-full object-contain bg-black" />
+                  <img
+                    src={thumbnail.thumbnailUrl}
+                    alt={image.name}
+                    className="h-44 w-full cursor-grab object-contain bg-black active:cursor-grabbing"
+                    draggable={Boolean(directoryPath && window.electronAPI?.startFileDrag)}
+                    onDragStart={(event) => startImageFileDrag(event, image, directoryPath)}
+                    title="Drag into ComfyUI"
+                  />
                 ) : (
                   <div className="flex h-44 items-center justify-center bg-black text-xs text-gray-600">No thumbnail</div>
                 )}

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -297,6 +297,14 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     };
   }, [setComfyUIConnectionStatus, setComfyUIWorkspaceLastUrl]);
 
+  useEffect(() => {
+    if (!shouldShowBrowser || !isElectron || viewState.visible || loadFailure) {
+      return;
+    }
+
+    void openEmbeddedView();
+  }, [isElectron, loadFailure, openEmbeddedView, shouldShowBrowser, viewState]);
+
   const openExternally = async () => {
     const result = await window.electronAPI?.openExternalUrl?.(targetUrl);
     if (!result?.success) {

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -11,7 +11,8 @@ import {
   Tag,
   RefreshCw,
   Plus,
-  Play
+  Play,
+  Workflow
 } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
@@ -36,6 +37,7 @@ interface GridToolbarProps {
   onDeleteSelected: () => void;
   onGenerateA1111: (image: IndexedImage) => void;
   onGenerateComfyUI: (image: IndexedImage) => void;
+  onOpenComfyUIWorkspace?: (image: IndexedImage) => void;
   onCompare: (images: IndexedImage[]) => void;
   onBatchExport: () => void;
   onStartSlideshow: () => void;
@@ -65,6 +67,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   onDeleteSelected,
   onGenerateA1111,
   onGenerateComfyUI,
+  onOpenComfyUIWorkspace,
   onCompare,
   onBatchExport,
   onStartSlideshow,
@@ -185,6 +188,18 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
     }
     if (firstSelectedImage) {
       onGenerateComfyUI(firstSelectedImage);
+    }
+    setGenerateDropdownOpen(false);
+  };
+
+  const handleOpenComfyUIWorkspace = () => {
+    if (!canUseComfyUI) {
+      showProModal('comfyui');
+      setGenerateDropdownOpen(false);
+      return;
+    }
+    if (firstSelectedImage && onOpenComfyUIWorkspace) {
+      onOpenComfyUIWorkspace(firstSelectedImage);
     }
     setGenerateDropdownOpen(false);
   };
@@ -431,6 +446,13 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                       >
                         <Sparkles className="w-3.5 h-3.5" />
                         with ComfyUI
+                      </button>
+                      <button
+                        onClick={handleOpenComfyUIWorkspace}
+                        className="w-full text-left px-3 py-1.5 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+                      >
+                        <Workflow className="w-3.5 h-3.5" />
+                        ComfyUI Workspace
                       </button>
                     </div>
                   )}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -28,6 +28,7 @@ const Header: React.FC<HeaderProps> = ({
 }) => {
   const {
     canUseAnalytics,
+    canUseComfyUI,
     showProModal,
     isTrialActive,
     trialDaysRemaining,
@@ -331,6 +332,14 @@ const Header: React.FC<HeaderProps> = ({
     [clustersCount]
   );
   const utilityButtonClassName = 'app-top-icon-button';
+  const handleViewTabClick = useCallback((view: LibraryView) => {
+    if (view === 'comfyui' && !canUseComfyUI) {
+      showProModal('comfyui');
+      return;
+    }
+
+    onLibraryViewChange?.(view);
+  }, [canUseComfyUI, onLibraryViewChange, showProModal]);
 
   return (
     <header className="sticky top-0 z-50 border-b border-gray-800/70 bg-gray-900/85 px-4 py-2.5 backdrop-blur-md shadow-lg shadow-black/20 transition-all duration-300">
@@ -354,7 +363,7 @@ const Header: React.FC<HeaderProps> = ({
                   return (
                     <button
                       key={tab.id}
-                      onClick={() => onLibraryViewChange(tab.id)}
+                      onClick={() => handleViewTabClick(tab.id)}
                       className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
                     >
                       {Icon && <Icon size={14} />}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Settings, Bug, BarChart3, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft } from 'lucide-react';
+import { Settings, Bug, BarChart3, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft, Workflow } from 'lucide-react';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
@@ -7,7 +7,7 @@ import { A1111ApiClient } from '../services/a1111ApiClient';
 import { ComfyUIApiClient } from '../services/comfyUIApiClient';
 import { detectGeneratorFromLaunchCommand } from '../utils/detectGeneratorLaunch';
 
-type LibraryView = 'library' | 'smart' | 'model' | 'node' | 'collections';
+type LibraryView = 'library' | 'smart' | 'model' | 'node' | 'collections' | 'comfyui';
 
 interface HeaderProps {
     onOpenSettings: () => void;
@@ -326,6 +326,7 @@ const Header: React.FC<HeaderProps> = ({
       { id: 'model' as const, label: 'Model View' },
       { id: 'node' as const, label: 'Node View' },
       { id: 'collections' as const, label: 'Collections' },
+      { id: 'comfyui' as const, label: 'ComfyUI', icon: Workflow },
     ],
     [clustersCount]
   );
@@ -347,24 +348,29 @@ const Header: React.FC<HeaderProps> = ({
           {libraryView && onLibraryViewChange && (
             <div className="min-w-0 max-w-full overflow-x-auto scrollbar-thin">
               <div className="app-top-segmented w-max">
-                {viewTabs.map((tab) => (
-                  <button
-                    key={tab.id}
-                    onClick={() => onLibraryViewChange(tab.id)}
-                    className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
-                  >
-                    <span>{tab.label}</span>
-                    {tab.count ? (
-                      <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${
-                        libraryView === tab.id
-                          ? 'border-white/20 bg-black/20 text-white/90'
-                          : 'border-gray-700/80 bg-gray-950/80 text-gray-500'
-                      }`}>
-                        {tab.count}
-                      </span>
-                    ) : null}
-                  </button>
-                ))}
+                {viewTabs.map((tab) => {
+                  const Icon = 'icon' in tab ? tab.icon : null;
+                  const count = 'count' in tab ? tab.count : null;
+                  return (
+                    <button
+                      key={tab.id}
+                      onClick={() => onLibraryViewChange(tab.id)}
+                      className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
+                    >
+                      {Icon && <Icon size={14} />}
+                      <span>{tab.label}</span>
+                      {count ? (
+                        <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${
+                          libraryView === tab.id
+                            ? 'border-white/20 bg-black/20 text-white/90'
+                            : 'border-gray-700/80 bg-gray-950/80 text-gray-500'
+                        }`}>
+                          {count}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -18,7 +18,8 @@ import { Heart, Info, Copy, Folder, Download, Clipboard, Sparkles, GitCompare, S
   Music,
   Tag,
   RefreshCw,
-  Pencil
+  Pencil,
+  Workflow
 } from 'lucide-react';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
@@ -882,6 +883,7 @@ interface ImageGridProps {
   isCollectionsView?: boolean;
   onImageRenamed?: (oldImageId: string, newImageId: string) => void;
   onFindSimilar?: (image: IndexedImage) => void;
+  onOpenComfyUIWorkspace?: (image: IndexedImage) => void;
   markedBestIds?: Set<string>;      // IDs of images marked as best
   markedArchivedIds?: Set<string>;  // IDs of images marked for archive
 }
@@ -902,6 +904,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   isCollectionsView = false,
   onImageRenamed,
   onFindSimilar,
+  onOpenComfyUIWorkspace,
   markedBestIds,
   markedArchivedIds,
 }) => {
@@ -1131,6 +1134,17 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     setIsComfyUIGenerateModalOpen(true);
     hideContextMenu();
   }, [contextMenu.image, hideContextMenu, canUseComfyUI, showProModal]);
+
+  const openComfyUIWorkspace = useCallback(() => {
+    if (!contextMenu.image || !onOpenComfyUIWorkspace) return;
+    if (!canUseComfyUI) {
+      showProModal('comfyui');
+      hideContextMenu();
+      return;
+    }
+    onOpenComfyUIWorkspace(contextMenu.image);
+    hideContextMenu();
+  }, [contextMenu.image, hideContextMenu, onOpenComfyUIWorkspace, canUseComfyUI, showProModal]);
 
   const selectForComparison = useCallback(() => {
     if (!contextMenu.image) return;
@@ -2065,6 +2079,18 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             <span className="flex-1">Generate with ComfyUI</span>
             {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
           </button>
+
+          {onOpenComfyUIWorkspace && (
+            <button
+              onClick={openComfyUIWorkspace}
+              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+              title={!canUseComfyUI && initialized ? 'Pro feature - start trial' : 'Open this image in the ComfyUI workspace context panel'}
+            >
+              <Workflow className="w-4 h-4" />
+              <span className="flex-1">Open ComfyUI Workspace</span>
+              {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
+            </button>
+          )}
         </div>,
         document.body,
       )

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -5,7 +5,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { type IndexedImage, type Directory, SmartCollection } from '../types';
 import { useContextMenu } from '../hooks/useContextMenu';
 import { useImageStore } from '../store/useImageStore';
-import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Search, Star, Pencil } from 'lucide-react';
+import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Search, Star, Pencil, Workflow } from 'lucide-react';
 import { useThumbnail } from '../hooks/useThumbnail';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -29,6 +29,7 @@ interface ImageTableProps {
   isCollectionsView?: boolean;
   onImageRenamed?: (oldImageId: string, newImageId: string) => void;
   onFindSimilar?: (image: IndexedImage) => void;
+  onOpenComfyUIWorkspace?: (image: IndexedImage) => void;
 }
 
 type SortField = 'filename' | 'model' | 'steps' | 'cfg' | 'size' | 'seed';
@@ -73,6 +74,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
   isCollectionsView = false,
   onImageRenamed,
   onFindSimilar,
+  onOpenComfyUIWorkspace,
 }) => {
   const directories = useImageStore((state) => state.directories);
   const transferProgress = useImageStore((state) => state.transferProgress);
@@ -146,6 +148,15 @@ const ImageTable: React.FC<ImageTableProps> = ({
     onFindSimilar(contextMenu.image);
     hideContextMenu();
   }, [contextMenu.image, hideContextMenu, onFindSimilar]);
+
+  const openComfyUIWorkspace = useCallback(() => {
+    if (!contextMenu.image || !onOpenComfyUIWorkspace) {
+      return;
+    }
+
+    onOpenComfyUIWorkspace(contextMenu.image);
+    hideContextMenu();
+  }, [contextMenu.image, hideContextMenu, onOpenComfyUIWorkspace]);
 
   const getContextTargetImages = useCallback(() => {
     if (!contextMenu.image) {
@@ -708,6 +719,17 @@ const ImageTable: React.FC<ImageTableProps> = ({
             <Search className="w-4 h-4" />
             Find similar...
           </button>
+
+          {onOpenComfyUIWorkspace && (
+            <button
+              onClick={openComfyUIWorkspace}
+              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+              title="Open this image in the ComfyUI workspace context panel"
+            >
+              <Workflow className="w-4 h-4" />
+              Open ComfyUI Workspace
+            </button>
+          )}
 
           <button
             onClick={handleReparseMetadata}

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -96,7 +96,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
   const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
   const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
   const updateCollection = useImageStore((state) => state.updateCollection);
-  const { canUseFileManagement, showProModal, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
+  const { canUseComfyUI, canUseFileManagement, showProModal, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
   const { isReparsing, reparseImages } = useReparseMetadata();
 
   const {
@@ -154,9 +154,15 @@ const ImageTable: React.FC<ImageTableProps> = ({
       return;
     }
 
+    if (!canUseComfyUI) {
+      showProModal('comfyui');
+      hideContextMenu();
+      return;
+    }
+
     onOpenComfyUIWorkspace(contextMenu.image);
     hideContextMenu();
-  }, [contextMenu.image, hideContextMenu, onOpenComfyUIWorkspace]);
+  }, [canUseComfyUI, contextMenu.image, hideContextMenu, onOpenComfyUIWorkspace, showProModal]);
 
   const getContextTargetImages = useCallback(() => {
     if (!contextMenu.image) {

--- a/electron.mjs
+++ b/electron.mjs
@@ -1782,6 +1782,10 @@ async function createWindow(startupDirectory = null) {
     hideComfyUIView();
   });
 
+  mainWindow.on('restore', () => {
+    updateComfyUIViewState({ visible: false });
+  });
+
   mainWindow.webContents.on('context-menu', (_event, params) => {
     showEditableTextContextMenu(mainWindow.webContents, params);
   });

--- a/electron.mjs
+++ b/electron.mjs
@@ -278,6 +278,7 @@ let comfyUIViewState = {
   canGoBack: false,
   canGoForward: false,
   visible: false,
+  lastLoadFailed: false,
 };
 let skippedVersions = new Set();
 let isManualUpdateCheck = false;
@@ -985,10 +986,10 @@ function configureComfyUIViewHandlers(view) {
     });
   });
 
-  contents.on('did-start-loading', () => updateComfyUIViewState({ isLoading: true }));
+  contents.on('did-start-loading', () => updateComfyUIViewState({ isLoading: true, lastLoadFailed: false }));
   contents.on('did-stop-loading', () => updateComfyUIViewState({ isLoading: false }));
-  contents.on('did-navigate', () => updateComfyUIViewState());
-  contents.on('did-navigate-in-page', () => updateComfyUIViewState());
+  contents.on('did-navigate', () => updateComfyUIViewState({ lastLoadFailed: false }));
+  contents.on('did-navigate-in-page', () => updateComfyUIViewState({ lastLoadFailed: false }));
   contents.on('page-title-updated', () => updateComfyUIViewState());
   contents.on('context-menu', (_event, params) => {
     showEditableTextContextMenu(contents, params);
@@ -1003,7 +1004,7 @@ function configureComfyUIViewHandlers(view) {
       errorDescription,
       url: validatedURL,
     });
-    updateComfyUIViewState({ isLoading: false });
+    updateComfyUIViewState({ isLoading: false, lastLoadFailed: true });
   });
 }
 
@@ -1075,7 +1076,7 @@ async function openComfyUIView({ url, bounds } = {}) {
   updateComfyUIViewState({ visible: true });
 
   const currentUrl = view.webContents.getURL();
-  if (!currentUrl || !isComfyNavigationAllowed(currentUrl)) {
+  if (!currentUrl || comfyUIViewState.lastLoadFailed || !isComfyNavigationAllowed(currentUrl)) {
     await view.webContents.loadURL(parsed.toString());
   }
 

--- a/electron.mjs
+++ b/electron.mjs
@@ -990,6 +990,9 @@ function configureComfyUIViewHandlers(view) {
   contents.on('did-navigate', () => updateComfyUIViewState());
   contents.on('did-navigate-in-page', () => updateComfyUIViewState());
   contents.on('page-title-updated', () => updateComfyUIViewState());
+  contents.on('context-menu', (_event, params) => {
+    showEditableTextContextMenu(contents, params);
+  });
   contents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
     if (!isMainFrame || errorCode === -3) {
       return;
@@ -1002,6 +1005,25 @@ function configureComfyUIViewHandlers(view) {
     });
     updateComfyUIViewState({ isLoading: false });
   });
+}
+
+function showEditableTextContextMenu(contents, params) {
+  if (!params.isEditable || !contents || contents.isDestroyed()) {
+    return;
+  }
+
+  const menu = Menu.buildFromTemplate([
+    { label: 'Undo', enabled: params.editFlags?.canUndo ?? false, click: () => contents.undo() },
+    { label: 'Redo', enabled: params.editFlags?.canRedo ?? false, click: () => contents.redo() },
+    { type: 'separator' },
+    { label: 'Cut', enabled: params.editFlags?.canCut ?? false, click: () => contents.cut() },
+    { label: 'Copy', enabled: params.editFlags?.canCopy ?? false, click: () => contents.copy() },
+    { label: 'Paste', enabled: params.editFlags?.canPaste ?? false, click: () => contents.paste() },
+    { type: 'separator' },
+    { label: 'Select All', enabled: params.editFlags?.canSelectAll ?? true, click: () => contents.selectAll() },
+  ]);
+
+  menu.popup({ window: mainWindow });
 }
 
 function ensureComfyUIView() {
@@ -1761,17 +1783,7 @@ async function createWindow(startupDirectory = null) {
   });
 
   mainWindow.webContents.on('context-menu', (_event, params) => {
-    if (!params.isEditable) {
-      return;
-    }
-
-    const menu = Menu.buildFromTemplate([
-      { role: 'cut', enabled: params.editFlags?.canCut ?? false },
-      { role: 'copy', enabled: params.editFlags?.canCopy ?? false },
-      { role: 'paste', enabled: params.editFlags?.canPaste ?? false },
-    ]);
-
-    menu.popup({ window: mainWindow });
+    showEditableTextContextMenu(mainWindow.webContents, params);
   });
 
   mainWindow.webContents.on('before-input-event', (event, input) => {

--- a/electron.mjs
+++ b/electron.mjs
@@ -1,5 +1,5 @@
 import electron from 'electron';
-const { app, BrowserWindow, shell, dialog, ipcMain, nativeTheme, Menu, nativeImage, screen, protocol } = electron;
+const { app, BrowserWindow, shell, dialog, ipcMain, nativeTheme, Menu, nativeImage, screen, protocol, WebContentsView } = electron;
 // console.log('📦 Loaded electron module');
 
 import electronUpdater from 'electron-updater';
@@ -25,6 +25,10 @@ import {
   inferMimeTypeFromName,
   isSupportedMediaFileName,
 } from './utils/mediaTypes.js';
+import {
+  isComfyUIViewUrlAllowed,
+  normalizeComfyUIViewUrl,
+} from './utils/comfyUIViewSecurity.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -265,6 +269,16 @@ async function readMediaMetadataWithFfprobe(filePath) {
 }
 
 let mainWindow;
+let comfyUIView = null;
+let comfyUIViewConfiguredUrl = '';
+let comfyUIViewState = {
+  url: '',
+  title: '',
+  isLoading: false,
+  canGoBack: false,
+  canGoForward: false,
+  visible: false,
+};
 let skippedVersions = new Set();
 let isManualUpdateCheck = false;
 
@@ -860,6 +874,256 @@ function attachWindowProcessDiagnostics(window) {
   });
 }
 // --- End Settings Management ---
+
+function sanitizeViewBounds(bounds = {}) {
+  const numberOrZero = (value) => Number.isFinite(value) ? Math.round(value) : 0;
+  return {
+    x: Math.max(0, numberOrZero(bounds.x)),
+    y: Math.max(0, numberOrZero(bounds.y)),
+    width: Math.max(0, numberOrZero(bounds.width)),
+    height: Math.max(0, numberOrZero(bounds.height)),
+  };
+}
+
+function updateComfyUIViewState(patch = {}) {
+  const webContents = comfyUIView?.webContents;
+  const navigationHistory = webContents?.navigationHistory;
+  const navigationState = webContents && !webContents.isDestroyed()
+    ? {
+        canGoBack: typeof navigationHistory?.canGoBack === 'function'
+          ? navigationHistory.canGoBack()
+          : false,
+        canGoForward: typeof navigationHistory?.canGoForward === 'function'
+          ? navigationHistory.canGoForward()
+          : false,
+      }
+    : {};
+
+  comfyUIViewState = {
+    ...comfyUIViewState,
+    ...patch,
+    ...(webContents && !webContents.isDestroyed()
+      ? {
+          url: webContents.getURL(),
+          title: webContents.getTitle(),
+          isLoading: webContents.isLoading(),
+          ...navigationState,
+        }
+      : {}),
+  };
+
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('comfy-view-state-changed', comfyUIViewState);
+  }
+
+  return comfyUIViewState;
+}
+
+function sendComfyUIViewLoadFailed(payload) {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('comfy-view-load-failed', payload);
+  }
+}
+
+function isComfyNavigationAllowed(url) {
+  return isComfyUIViewUrlAllowed(url, comfyUIViewConfiguredUrl);
+}
+
+async function openExternalIfSafe(url) {
+  const parsed = normalizeComfyUIViewUrl(url);
+  if (parsed) {
+    await shell.openExternal(parsed.toString());
+  }
+}
+
+function configureComfyUIViewHandlers(view) {
+  const contents = view.webContents;
+
+  contents.setWindowOpenHandler(({ url }) => {
+    if (isComfyNavigationAllowed(url)) {
+      return { action: 'allow' };
+    }
+
+    openExternalIfSafe(url).catch((error) => {
+      console.warn('Failed to open external ComfyUI URL:', error);
+    });
+    return { action: 'deny' };
+  });
+
+  contents.on('will-navigate', (event, url) => {
+    if (isComfyNavigationAllowed(url)) {
+      return;
+    }
+
+    event.preventDefault();
+    openExternalIfSafe(url).catch((error) => {
+      console.warn('Failed to open external ComfyUI navigation:', error);
+    });
+  });
+
+  contents.on('did-start-loading', () => updateComfyUIViewState({ isLoading: true }));
+  contents.on('did-stop-loading', () => updateComfyUIViewState({ isLoading: false }));
+  contents.on('did-navigate', () => updateComfyUIViewState());
+  contents.on('did-navigate-in-page', () => updateComfyUIViewState());
+  contents.on('page-title-updated', () => updateComfyUIViewState());
+  contents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (!isMainFrame || errorCode === -3) {
+      return;
+    }
+
+    sendComfyUIViewLoadFailed({
+      errorCode,
+      errorDescription,
+      url: validatedURL,
+    });
+    updateComfyUIViewState({ isLoading: false });
+  });
+}
+
+function ensureComfyUIView() {
+  if (comfyUIView && !comfyUIView.webContents.isDestroyed()) {
+    return comfyUIView;
+  }
+
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    throw new Error('Main window is not available.');
+  }
+
+  if (!WebContentsView) {
+    throw new Error('Embedded ComfyUI view is not supported by this Electron version.');
+  }
+
+  comfyUIView = new WebContentsView({
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+      partition: 'persist:imagemetahub-comfyui',
+      backgroundThrottling: false,
+    },
+  });
+
+  comfyUIView.setVisible(false);
+  mainWindow.contentView.addChildView(comfyUIView);
+  configureComfyUIViewHandlers(comfyUIView);
+  updateComfyUIViewState({ visible: false });
+  return comfyUIView;
+}
+
+async function openComfyUIView({ url, bounds } = {}) {
+  const parsed = normalizeComfyUIViewUrl(url);
+  if (!parsed) {
+    return { success: false, error: 'Invalid ComfyUI URL.' };
+  }
+
+  comfyUIViewConfiguredUrl = parsed.toString();
+  const view = ensureComfyUIView();
+
+  if (bounds) {
+    view.setBounds(sanitizeViewBounds(bounds));
+  }
+
+  view.setVisible(true);
+  updateComfyUIViewState({ visible: true });
+
+  const currentUrl = view.webContents.getURL();
+  if (!currentUrl || !isComfyNavigationAllowed(currentUrl)) {
+    await view.webContents.loadURL(parsed.toString());
+  }
+
+  return { success: true, state: updateComfyUIViewState({ visible: true }) };
+}
+
+function showComfyUIView(bounds) {
+  const view = ensureComfyUIView();
+  if (bounds) {
+    view.setBounds(sanitizeViewBounds(bounds));
+  }
+  view.setVisible(true);
+  return { success: true, state: updateComfyUIViewState({ visible: true }) };
+}
+
+function hideComfyUIView() {
+  if (comfyUIView && !comfyUIView.webContents.isDestroyed()) {
+    comfyUIView.setVisible(false);
+  }
+  return { success: true, state: updateComfyUIViewState({ visible: false }) };
+}
+
+function disposeComfyUIView(reason = 'disposed') {
+  if (!comfyUIView) {
+    return { success: true, state: updateComfyUIViewState({ visible: false, isLoading: false }) };
+  }
+
+  const view = comfyUIView;
+  const contents = view.webContents;
+  let lastUrl = comfyUIViewState.url;
+  let lastTitle = comfyUIViewState.title;
+
+  try {
+    if (contents && !contents.isDestroyed()) {
+      lastUrl = contents.getURL() || lastUrl;
+      lastTitle = contents.getTitle() || lastTitle;
+    }
+  } catch {
+    // Best effort during native teardown.
+  }
+
+  try {
+    view.setVisible(false);
+  } catch {
+    // Ignore native view teardown errors.
+  }
+
+  try {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.contentView.removeChildView(view);
+    }
+  } catch (error) {
+    console.warn('Failed to detach ComfyUI embedded view:', error);
+  }
+
+  comfyUIView = null;
+
+  try {
+    if (contents && !contents.isDestroyed()) {
+      contents.close({ waitForBeforeUnload: false });
+    }
+  } catch (error) {
+    console.warn('Failed to close ComfyUI embedded webContents:', error);
+  }
+
+  logProcessEvent({
+    kind: 'comfy-view-disposed',
+    reason,
+    url: lastUrl || null,
+  });
+
+  return {
+    success: true,
+    state: updateComfyUIViewState({
+      url: lastUrl,
+      title: lastTitle,
+      visible: false,
+      isLoading: false,
+      canGoBack: false,
+      canGoForward: false,
+    }),
+  };
+}
+
+function suspendComfyUIView() {
+  return disposeComfyUIView('suspended');
+}
+
+function setComfyUIViewBounds(bounds) {
+  if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+    return { success: false, error: 'ComfyUI view is not open.' };
+  }
+  comfyUIView.setBounds(sanitizeViewBounds(bounds));
+  return { success: true, state: updateComfyUIViewState() };
+}
 
 const launcherScriptsPath = path.join(app.getPath('userData'), 'launchers');
 async function writeLauncherScript(command) {
@@ -1467,6 +1731,10 @@ async function createWindow(startupDirectory = null) {
     return { action: 'deny' };
   });
 
+  mainWindow.on('minimize', () => {
+    hideComfyUIView();
+  });
+
   mainWindow.webContents.on('context-menu', (_event, params) => {
     if (!params.isEditable) {
       return;
@@ -1504,8 +1772,8 @@ async function createWindow(startupDirectory = null) {
     }
   });
 
-  // Handle window closed
   mainWindow.on('closed', () => {
+    disposeComfyUIView('main-window-closed');
     mainWindow = null;
   });
 
@@ -2349,6 +2617,92 @@ function setupFileOperationHandlers() {
     } catch (error) {
       return { success: false, error: error?.message || 'Failed to open external URL.' };
     }
+  });
+
+  ipcMain.handle('comfy-view-open', async (event, payload) => {
+    try {
+      return await openComfyUIView(payload);
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to open embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-show', async (event, payload) => {
+    try {
+      return showComfyUIView(payload?.bounds);
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to show embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-hide', async () => {
+    try {
+      return hideComfyUIView();
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to hide embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-suspend', async () => {
+    try {
+      return suspendComfyUIView();
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to suspend embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-set-bounds', async (event, payload) => {
+    try {
+      return setComfyUIViewBounds(payload?.bounds ?? payload);
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to resize embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-reload', async () => {
+    try {
+      if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+        return { success: false, error: 'ComfyUI view is not open.' };
+      }
+      comfyUIView.webContents.reload();
+      return { success: true, state: updateComfyUIViewState() };
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to reload embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-go-back', async () => {
+    try {
+      if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+        return { success: false, error: 'ComfyUI view is not open.' };
+      }
+      const history = comfyUIView.webContents.navigationHistory;
+      if (typeof history?.canGoBack === 'function' && history.canGoBack()) {
+        history.goBack();
+      }
+      return { success: true, state: updateComfyUIViewState() };
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to navigate embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-go-forward', async () => {
+    try {
+      if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+        return { success: false, error: 'ComfyUI view is not open.' };
+      }
+      const history = comfyUIView.webContents.navigationHistory;
+      if (typeof history?.canGoForward === 'function' && history.canGoForward()) {
+        history.goForward();
+      }
+      return { success: true, state: updateComfyUIViewState() };
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to navigate embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-get-state', async () => {
+    return { success: true, state: updateComfyUIViewState() };
   });
 
   ipcMain.handle('get-default-cache-path', () => {

--- a/electron.mjs
+++ b/electron.mjs
@@ -1,5 +1,5 @@
 import electron from 'electron';
-const { app, BrowserWindow, shell, dialog, ipcMain, nativeTheme, Menu, nativeImage, screen, protocol } = electron;
+const { app, BrowserWindow, shell, dialog, ipcMain, nativeTheme, Menu, nativeImage, screen, protocol, WebContentsView } = electron;
 // console.log('📦 Loaded electron module');
 
 import electronUpdater from 'electron-updater';
@@ -25,6 +25,10 @@ import {
   inferMimeTypeFromName,
   isSupportedMediaFileName,
 } from './utils/mediaTypes.js';
+import {
+  isComfyUIViewUrlAllowed,
+  normalizeComfyUIViewUrl,
+} from './utils/comfyUIViewSecurity.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -265,6 +269,16 @@ async function readMediaMetadataWithFfprobe(filePath) {
 }
 
 let mainWindow;
+let comfyUIView = null;
+let comfyUIViewConfiguredUrl = '';
+let comfyUIViewState = {
+  url: '',
+  title: '',
+  isLoading: false,
+  canGoBack: false,
+  canGoForward: false,
+  visible: false,
+};
 let skippedVersions = new Set();
 let isManualUpdateCheck = false;
 
@@ -287,6 +301,11 @@ function setZoomFactor(factor) {
 
   const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, factor));
   contents.setZoomFactor(clamped);
+  syncComfyUIViewZoomFactor(clamped);
+
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('zoom-factor-changed', clamped);
+  }
 }
 
 function resetZoom() {
@@ -860,6 +879,276 @@ function attachWindowProcessDiagnostics(window) {
   });
 }
 // --- End Settings Management ---
+
+function getMainWindowZoomFactor() {
+  const contents = getSafeWebContents();
+  if (!contents) {
+    return 1;
+  }
+
+  const zoomFactor = contents.getZoomFactor();
+  return Number.isFinite(zoomFactor) && zoomFactor > 0 ? zoomFactor : 1;
+}
+
+function syncComfyUIViewZoomFactor(zoomFactor = getMainWindowZoomFactor()) {
+  if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+    return;
+  }
+
+  comfyUIView.webContents.setZoomFactor(zoomFactor);
+}
+
+function sanitizeViewBounds(bounds = {}) {
+  const zoomFactor = getMainWindowZoomFactor();
+  const numberOrZero = (value) => Number.isFinite(value) ? Math.round(value) : 0;
+  return {
+    x: Math.max(0, numberOrZero(bounds.x * zoomFactor)),
+    y: Math.max(0, numberOrZero(bounds.y * zoomFactor)),
+    width: Math.max(0, numberOrZero(bounds.width * zoomFactor)),
+    height: Math.max(0, numberOrZero(bounds.height * zoomFactor)),
+  };
+}
+
+function updateComfyUIViewState(patch = {}) {
+  const webContents = comfyUIView?.webContents;
+  const navigationHistory = webContents?.navigationHistory;
+  const navigationState = webContents && !webContents.isDestroyed()
+    ? {
+        canGoBack: typeof navigationHistory?.canGoBack === 'function'
+          ? navigationHistory.canGoBack()
+          : false,
+        canGoForward: typeof navigationHistory?.canGoForward === 'function'
+          ? navigationHistory.canGoForward()
+          : false,
+      }
+    : {};
+
+  comfyUIViewState = {
+    ...comfyUIViewState,
+    ...patch,
+    ...(webContents && !webContents.isDestroyed()
+      ? {
+          url: webContents.getURL(),
+          title: webContents.getTitle(),
+          isLoading: webContents.isLoading(),
+          ...navigationState,
+        }
+      : {}),
+  };
+
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('comfy-view-state-changed', comfyUIViewState);
+  }
+
+  return comfyUIViewState;
+}
+
+function sendComfyUIViewLoadFailed(payload) {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('comfy-view-load-failed', payload);
+  }
+}
+
+function isComfyNavigationAllowed(url) {
+  return isComfyUIViewUrlAllowed(url, comfyUIViewConfiguredUrl);
+}
+
+async function openExternalIfSafe(url) {
+  const parsed = normalizeComfyUIViewUrl(url);
+  if (parsed) {
+    await shell.openExternal(parsed.toString());
+  }
+}
+
+function configureComfyUIViewHandlers(view) {
+  const contents = view.webContents;
+
+  contents.setWindowOpenHandler(({ url }) => {
+    if (isComfyNavigationAllowed(url)) {
+      return { action: 'allow' };
+    }
+
+    openExternalIfSafe(url).catch((error) => {
+      console.warn('Failed to open external ComfyUI URL:', error);
+    });
+    return { action: 'deny' };
+  });
+
+  contents.on('will-navigate', (event, url) => {
+    if (isComfyNavigationAllowed(url)) {
+      return;
+    }
+
+    event.preventDefault();
+    openExternalIfSafe(url).catch((error) => {
+      console.warn('Failed to open external ComfyUI navigation:', error);
+    });
+  });
+
+  contents.on('did-start-loading', () => updateComfyUIViewState({ isLoading: true }));
+  contents.on('did-stop-loading', () => updateComfyUIViewState({ isLoading: false }));
+  contents.on('did-navigate', () => updateComfyUIViewState());
+  contents.on('did-navigate-in-page', () => updateComfyUIViewState());
+  contents.on('page-title-updated', () => updateComfyUIViewState());
+  contents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (!isMainFrame || errorCode === -3) {
+      return;
+    }
+
+    sendComfyUIViewLoadFailed({
+      errorCode,
+      errorDescription,
+      url: validatedURL,
+    });
+    updateComfyUIViewState({ isLoading: false });
+  });
+}
+
+function ensureComfyUIView() {
+  if (comfyUIView && !comfyUIView.webContents.isDestroyed()) {
+    return comfyUIView;
+  }
+
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    throw new Error('Main window is not available.');
+  }
+
+  if (!WebContentsView) {
+    throw new Error('Embedded ComfyUI view is not supported by this Electron version.');
+  }
+
+  comfyUIView = new WebContentsView({
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+      partition: 'persist:imagemetahub-comfyui',
+      backgroundThrottling: false,
+    },
+  });
+
+  comfyUIView.setVisible(false);
+  mainWindow.contentView.addChildView(comfyUIView);
+  configureComfyUIViewHandlers(comfyUIView);
+  syncComfyUIViewZoomFactor();
+  updateComfyUIViewState({ visible: false });
+  return comfyUIView;
+}
+
+async function openComfyUIView({ url, bounds } = {}) {
+  const parsed = normalizeComfyUIViewUrl(url);
+  if (!parsed) {
+    return { success: false, error: 'Invalid ComfyUI URL.' };
+  }
+
+  comfyUIViewConfiguredUrl = parsed.toString();
+  const view = ensureComfyUIView();
+
+  if (bounds) {
+    view.setBounds(sanitizeViewBounds(bounds));
+  }
+
+  view.setVisible(true);
+  updateComfyUIViewState({ visible: true });
+
+  const currentUrl = view.webContents.getURL();
+  if (!currentUrl || !isComfyNavigationAllowed(currentUrl)) {
+    await view.webContents.loadURL(parsed.toString());
+  }
+
+  return { success: true, state: updateComfyUIViewState({ visible: true }) };
+}
+
+function showComfyUIView(bounds) {
+  const view = ensureComfyUIView();
+  if (bounds) {
+    view.setBounds(sanitizeViewBounds(bounds));
+  }
+  view.setVisible(true);
+  return { success: true, state: updateComfyUIViewState({ visible: true }) };
+}
+
+function hideComfyUIView() {
+  if (comfyUIView && !comfyUIView.webContents.isDestroyed()) {
+    comfyUIView.setVisible(false);
+  }
+  return { success: true, state: updateComfyUIViewState({ visible: false }) };
+}
+
+function disposeComfyUIView(reason = 'disposed') {
+  if (!comfyUIView) {
+    return { success: true, state: updateComfyUIViewState({ visible: false, isLoading: false }) };
+  }
+
+  const view = comfyUIView;
+  const contents = view.webContents;
+  let lastUrl = comfyUIViewState.url;
+  let lastTitle = comfyUIViewState.title;
+
+  try {
+    if (contents && !contents.isDestroyed()) {
+      lastUrl = contents.getURL() || lastUrl;
+      lastTitle = contents.getTitle() || lastTitle;
+    }
+  } catch {
+    // Best effort during native teardown.
+  }
+
+  try {
+    view.setVisible(false);
+  } catch {
+    // Ignore native view teardown errors.
+  }
+
+  try {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.contentView.removeChildView(view);
+    }
+  } catch (error) {
+    console.warn('Failed to detach ComfyUI embedded view:', error);
+  }
+
+  comfyUIView = null;
+
+  try {
+    if (contents && !contents.isDestroyed()) {
+      contents.close({ waitForBeforeUnload: false });
+    }
+  } catch (error) {
+    console.warn('Failed to close ComfyUI embedded webContents:', error);
+  }
+
+  logProcessEvent({
+    kind: 'comfy-view-disposed',
+    reason,
+    url: lastUrl || null,
+  });
+
+  return {
+    success: true,
+    state: updateComfyUIViewState({
+      url: lastUrl,
+      title: lastTitle,
+      visible: false,
+      isLoading: false,
+      canGoBack: false,
+      canGoForward: false,
+    }),
+  };
+}
+
+function suspendComfyUIView() {
+  return disposeComfyUIView('suspended');
+}
+
+function setComfyUIViewBounds(bounds) {
+  if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+    return { success: false, error: 'ComfyUI view is not open.' };
+  }
+  comfyUIView.setBounds(sanitizeViewBounds(bounds));
+  return { success: true, state: updateComfyUIViewState() };
+}
 
 const launcherScriptsPath = path.join(app.getPath('userData'), 'launchers');
 async function writeLauncherScript(command) {
@@ -1467,6 +1756,10 @@ async function createWindow(startupDirectory = null) {
     return { action: 'deny' };
   });
 
+  mainWindow.on('minimize', () => {
+    hideComfyUIView();
+  });
+
   mainWindow.webContents.on('context-menu', (_event, params) => {
     if (!params.isEditable) {
       return;
@@ -1504,8 +1797,8 @@ async function createWindow(startupDirectory = null) {
     }
   });
 
-  // Handle window closed
   mainWindow.on('closed', () => {
+    disposeComfyUIView('main-window-closed');
     mainWindow = null;
   });
 
@@ -2349,6 +2642,92 @@ function setupFileOperationHandlers() {
     } catch (error) {
       return { success: false, error: error?.message || 'Failed to open external URL.' };
     }
+  });
+
+  ipcMain.handle('comfy-view-open', async (event, payload) => {
+    try {
+      return await openComfyUIView(payload);
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to open embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-show', async (event, payload) => {
+    try {
+      return showComfyUIView(payload?.bounds);
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to show embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-hide', async () => {
+    try {
+      return hideComfyUIView();
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to hide embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-suspend', async () => {
+    try {
+      return suspendComfyUIView();
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to suspend embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-set-bounds', async (event, payload) => {
+    try {
+      return setComfyUIViewBounds(payload?.bounds ?? payload);
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to resize embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-reload', async () => {
+    try {
+      if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+        return { success: false, error: 'ComfyUI view is not open.' };
+      }
+      comfyUIView.webContents.reload();
+      return { success: true, state: updateComfyUIViewState() };
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to reload embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-go-back', async () => {
+    try {
+      if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+        return { success: false, error: 'ComfyUI view is not open.' };
+      }
+      const history = comfyUIView.webContents.navigationHistory;
+      if (typeof history?.canGoBack === 'function' && history.canGoBack()) {
+        history.goBack();
+      }
+      return { success: true, state: updateComfyUIViewState() };
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to navigate embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-go-forward', async () => {
+    try {
+      if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+        return { success: false, error: 'ComfyUI view is not open.' };
+      }
+      const history = comfyUIView.webContents.navigationHistory;
+      if (typeof history?.canGoForward === 'function' && history.canGoForward()) {
+        history.goForward();
+      }
+      return { success: true, state: updateComfyUIViewState() };
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to navigate embedded ComfyUI.' };
+    }
+  });
+
+  ipcMain.handle('comfy-view-get-state', async () => {
+    return { success: true, state: updateComfyUIViewState() };
   });
 
   ipcMain.handle('get-default-cache-path', () => {

--- a/preload.js
+++ b/preload.js
@@ -119,6 +119,14 @@ const electronAPI = {
     };
   },
 
+  onZoomFactorChanged: (callback) => {
+    const handler = (event, ...args) => callback(...args);
+    ipcRenderer.on('zoom-factor-changed', handler);
+    return () => {
+      ipcRenderer.removeListener('zoom-factor-changed', handler);
+    };
+  },
+
   // --- Invokable renderer-to-main functions ---
   getTheme: () => ipcRenderer.invoke('get-theme'),
   trashFile: (filePath) => ipcRenderer.invoke('trash-file', filePath),
@@ -151,6 +159,29 @@ const electronAPI = {
   saveSettings: (settings) => ipcRenderer.invoke('save-settings', settings),
   launchGenerator: (payload) => ipcRenderer.invoke('launch-generator', payload),
   openExternalUrl: (url) => ipcRenderer.invoke('open-external-url', url),
+  comfyUIViewOpen: (payload) => ipcRenderer.invoke('comfy-view-open', payload),
+  comfyUIViewShow: (payload) => ipcRenderer.invoke('comfy-view-show', payload),
+  comfyUIViewHide: () => ipcRenderer.invoke('comfy-view-hide'),
+  comfyUIViewSuspend: () => ipcRenderer.invoke('comfy-view-suspend'),
+  comfyUIViewSetBounds: (payload) => ipcRenderer.invoke('comfy-view-set-bounds', payload),
+  comfyUIViewReload: () => ipcRenderer.invoke('comfy-view-reload'),
+  comfyUIViewGoBack: () => ipcRenderer.invoke('comfy-view-go-back'),
+  comfyUIViewGoForward: () => ipcRenderer.invoke('comfy-view-go-forward'),
+  comfyUIViewGetState: () => ipcRenderer.invoke('comfy-view-get-state'),
+  onComfyUIViewStateChanged: (callback) => {
+    const handler = (event, ...args) => callback(...args);
+    ipcRenderer.on('comfy-view-state-changed', handler);
+    return () => {
+      ipcRenderer.removeListener('comfy-view-state-changed', handler);
+    };
+  },
+  onComfyUIViewLoadFailed: (callback) => {
+    const handler = (event, ...args) => callback(...args);
+    ipcRenderer.on('comfy-view-load-failed', handler);
+    return () => {
+      ipcRenderer.removeListener('comfy-view-load-failed', handler);
+    };
+  },
   getDefaultCachePath: () => ipcRenderer.invoke('get-default-cache-path'),
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
   joinPaths: (...paths) => ipcRenderer.invoke('join-paths', ...paths),

--- a/preload.js
+++ b/preload.js
@@ -151,6 +151,29 @@ const electronAPI = {
   saveSettings: (settings) => ipcRenderer.invoke('save-settings', settings),
   launchGenerator: (payload) => ipcRenderer.invoke('launch-generator', payload),
   openExternalUrl: (url) => ipcRenderer.invoke('open-external-url', url),
+  comfyUIViewOpen: (payload) => ipcRenderer.invoke('comfy-view-open', payload),
+  comfyUIViewShow: (payload) => ipcRenderer.invoke('comfy-view-show', payload),
+  comfyUIViewHide: () => ipcRenderer.invoke('comfy-view-hide'),
+  comfyUIViewSuspend: () => ipcRenderer.invoke('comfy-view-suspend'),
+  comfyUIViewSetBounds: (payload) => ipcRenderer.invoke('comfy-view-set-bounds', payload),
+  comfyUIViewReload: () => ipcRenderer.invoke('comfy-view-reload'),
+  comfyUIViewGoBack: () => ipcRenderer.invoke('comfy-view-go-back'),
+  comfyUIViewGoForward: () => ipcRenderer.invoke('comfy-view-go-forward'),
+  comfyUIViewGetState: () => ipcRenderer.invoke('comfy-view-get-state'),
+  onComfyUIViewStateChanged: (callback) => {
+    const handler = (event, ...args) => callback(...args);
+    ipcRenderer.on('comfy-view-state-changed', handler);
+    return () => {
+      ipcRenderer.removeListener('comfy-view-state-changed', handler);
+    };
+  },
+  onComfyUIViewLoadFailed: (callback) => {
+    const handler = (event, ...args) => callback(...args);
+    ipcRenderer.on('comfy-view-load-failed', handler);
+    return () => {
+      ipcRenderer.removeListener('comfy-view-load-failed', handler);
+    };
+  },
   getDefaultCachePath: () => ipcRenderer.invoke('get-default-cache-path'),
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
   joinPaths: (...paths) => ipcRenderer.invoke('join-paths', ...paths),

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,29 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.4] - 2026-04-29
+## [0.15.4] - 2026-05-02
 
 ### Added
 
 - **Advanced Folder Management**: Added directory tree view with subfolder navigation, drag-and-drop file transfers, directory renaming, and global hotkey support for clipboard operations.
+- **Generated Output Preview**: Added a dedicated preview modal for completed generation queue results.
 
 ### Improved
 
-- **Generation Queue**: Rebuilt queue UX with clearer actions, clickable results, and thumbnails. Added a dedicated preview modal for completed jobs. Scheduling now drains in FIFO order without interruptions from cancellations. Improved memory handling by using Blob URLs instead of base64 payloads, and refined A1111 batch progress tracking.
-- **Workflow Analysis**: Enhanced ComfyUI workflow JSON handling, resolution, and streamlined dimension target extraction logic.
-- **Workspace Experience**: Improved workspace tab persistence and enhanced image modal functionality.
+- **Generation Queue**: Rebuilt queue execution and progress tracking for clearer A1111/ComfyUI status, FIFO scheduling, clickable results, thumbnails, and lower-memory previews.
+- **Image Grid Navigation**: Improved keyboard navigation, focused image state, page-boundary handling, preview updates, and thumbnail warmup behavior.
+- **ComfyUI Workflow Experience**: Improved workflow JSON resolution, dimension target detection, error display, workspace tab persistence, and image modal integration.
+- **Slideshow Experience**: Improved slideshow exit behavior and covered it with focused tests.
+- **Accessibility**: Added accessible labels to modal close buttons.
 
 ### Fixed
 
 - **Maximum Update Depth Error**: Fixed a critical "Maximum update depth exceeded" error during heavy indexing. Stabilized array references in the application state to prevent infinite re-rendering loops when new batches of images are loaded.
-- **Queued Generation Deadlock**: Fixed a structural queue bug where jobs created as `waiting` could remain stuck forever because no runner existed to consume them after the active job completed.
-- **Provider Runner Races**: Reduced overlapping provider execution and stale scheduling states when active queue jobs are canceled or removed while the underlying executor is still unwinding.
-- **A1111 Progress Race**: Fixed stale delayed progress cleanup from one A1111 job clearing progress for the next queued A1111 job.
-
-### Known Bugs
-
-- **Queue Preview Blob URL Eviction Leak**: When the queue exceeds its 200-item cap, entries trimmed by the cap may not revoke their generated preview Blob URLs.
-- **Canceled A1111 Output Blob URL Leak**: If an in-flight A1111 job is canceled or removed after outputs have already been materialized, discarded generated preview Blob URLs may not be revoked.
+- **Generation Queue Cancellation**: Fixed canceled A1111 and ComfyUI jobs blocking the queue, leaving stale artifacts, or clearing progress for the next job.
+- **Folder Rename State**: Fixed directory rename edge cases including nested root remapping, folder filter preservation, and stale rename state.
+- **Clipboard Paste Recovery**: Fixed failed folder paste operations so the clipboard contents are retained.
+- **Image Grid Layout**: Fixed column count and transition issues that could make thumbnail navigation feel inconsistent.
 
 ## [0.15.3] - 2026-04-25
 

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -133,6 +133,9 @@ interface SettingsState {
   comfyUIEnabled: boolean;
   comfyUIServerUrl: string;
   comfyUILastConnectionStatus: 'unknown' | 'connected' | 'error';
+  comfyUIWorkspaceLastUrl: string;
+  comfyUIWorkspacePanelWidth: number;
+  comfyUIWorkspaceAutoOpenSelectedImage: boolean;
   generatorLaunchCommand: string;
   generatorLaunchWorkingDirectory: string;
 
@@ -171,6 +174,9 @@ interface SettingsState {
   setComfyUIEnabled: (value: boolean) => void;
   setComfyUIServerUrl: (url: string) => void;
   setComfyUIConnectionStatus: (status: 'unknown' | 'connected' | 'error') => void;
+  setComfyUIWorkspaceLastUrl: (url: string) => void;
+  setComfyUIWorkspacePanelWidth: (width: number) => void;
+  setComfyUIWorkspaceAutoOpenSelectedImage: (value: boolean) => void;
   setGeneratorLaunchCommand: (command: string) => void;
   setGeneratorLaunchWorkingDirectory: (directory: string) => void;
   resetState: () => void;
@@ -222,6 +228,9 @@ export const useSettingsStore = create<SettingsState>()(
       comfyUIEnabled: true,
       comfyUIServerUrl: 'http://127.0.0.1:8188',
       comfyUILastConnectionStatus: 'unknown',
+      comfyUIWorkspaceLastUrl: '',
+      comfyUIWorkspacePanelWidth: 360,
+      comfyUIWorkspaceAutoOpenSelectedImage: true,
       generatorLaunchCommand: '',
       generatorLaunchWorkingDirectory: '',
 
@@ -288,6 +297,9 @@ export const useSettingsStore = create<SettingsState>()(
       setComfyUIEnabled: (value) => set({ comfyUIEnabled: !!value }),
       setComfyUIServerUrl: (url) => set({ comfyUIServerUrl: url }),
       setComfyUIConnectionStatus: (status) => set({ comfyUILastConnectionStatus: status }),
+      setComfyUIWorkspaceLastUrl: (url) => set({ comfyUIWorkspaceLastUrl: url }),
+      setComfyUIWorkspacePanelWidth: (width) => set({ comfyUIWorkspacePanelWidth: Math.min(Math.max(Math.round(width) || 360, 280), 560) }),
+      setComfyUIWorkspaceAutoOpenSelectedImage: (value) => set({ comfyUIWorkspaceAutoOpenSelectedImage: !!value }),
       setGeneratorLaunchCommand: (command) => set({ generatorLaunchCommand: command }),
       setGeneratorLaunchWorkingDirectory: (directory) => set({ generatorLaunchWorkingDirectory: directory }),
 
@@ -325,6 +337,9 @@ export const useSettingsStore = create<SettingsState>()(
         comfyUIEnabled: true,
         comfyUIServerUrl: 'http://127.0.0.1:8188',
         comfyUILastConnectionStatus: 'unknown',
+        comfyUIWorkspaceLastUrl: '',
+        comfyUIWorkspacePanelWidth: 360,
+        comfyUIWorkspaceAutoOpenSelectedImage: true,
         generatorLaunchCommand: '',
         generatorLaunchWorkingDirectory: '',
       }),
@@ -410,6 +425,26 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.comfyUIEnabled !== 'boolean') {
           state.comfyUIEnabled = true;
+        }
+
+        if (state && typeof state.comfyUIWorkspaceLastUrl !== 'string') {
+          state.comfyUIWorkspaceLastUrl = '';
+        }
+
+        if (
+          state &&
+          (typeof state.comfyUIWorkspacePanelWidth !== 'number' ||
+            !Number.isFinite(state.comfyUIWorkspacePanelWidth))
+        ) {
+          state.comfyUIWorkspacePanelWidth = 360;
+        }
+
+        if (state) {
+          state.comfyUIWorkspacePanelWidth = Math.min(Math.max(Math.round(state.comfyUIWorkspacePanelWidth), 280), 560);
+        }
+
+        if (state && typeof state.comfyUIWorkspaceAutoOpenSelectedImage !== 'boolean') {
+          state.comfyUIWorkspaceAutoOpenSelectedImage = true;
         }
 
         if (state && typeof state.generatorLaunchCommand !== 'string') {

--- a/types.ts
+++ b/types.ts
@@ -40,6 +40,34 @@ export type MetadataExportPolicy = 'preserve' | 'strip' | 'metahub_standard';
 export type ExportScope = 'single' | 'selected' | 'filtered' | 'folder';
 export type ExportTargetFormat = 'original' | 'png';
 
+export interface ComfyUIViewBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ComfyUIViewState {
+  url: string;
+  title: string;
+  isLoading: boolean;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  visible: boolean;
+}
+
+export interface ComfyUIViewResult {
+  success: boolean;
+  state?: ComfyUIViewState;
+  error?: string;
+}
+
+export interface ComfyUIViewLoadFailure {
+  errorCode: number;
+  errorDescription: string;
+  url: string;
+}
+
 export interface ExportFileDescriptor {
   imageId?: string;
   directoryPath: string;
@@ -224,6 +252,17 @@ export interface ElectronAPI {
   saveSettings: (settings: any) => Promise<{ success: boolean; error?: string }>;
   launchGenerator: (payload: { command: string; workingDirectory?: string }) => Promise<{ success: boolean; error?: string; scriptPath?: string }>;
   openExternalUrl: (url: string) => Promise<{ success: boolean; error?: string }>;
+  comfyUIViewOpen: (payload: { url: string; bounds?: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;
+  comfyUIViewShow: (payload?: { bounds?: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;
+  comfyUIViewHide: () => Promise<ComfyUIViewResult>;
+  comfyUIViewSuspend: () => Promise<ComfyUIViewResult>;
+  comfyUIViewSetBounds: (payload: { bounds: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;
+  comfyUIViewReload: () => Promise<ComfyUIViewResult>;
+  comfyUIViewGoBack: () => Promise<ComfyUIViewResult>;
+  comfyUIViewGoForward: () => Promise<ComfyUIViewResult>;
+  comfyUIViewGetState: () => Promise<ComfyUIViewResult>;
+  onComfyUIViewStateChanged: (callback: (state: ComfyUIViewState) => void) => () => void;
+  onComfyUIViewLoadFailed: (callback: (failure: ComfyUIViewLoadFailure) => void) => () => void;
   getDefaultCachePath: () => Promise<{ success: boolean; path?: string; error?: string }>;
   getAppVersion: () => Promise<string>;
   joinPaths: (...paths: string[]) => Promise<{ success: boolean; path?: string; error?: string }>;
@@ -274,6 +313,7 @@ export interface ElectronAPI {
   setFullscreen: (isFullscreen: boolean) => Promise<{ success: boolean; isFullscreen?: boolean; error?: string }>;
   onFullscreenChanged: (callback: (state: { isFullscreen: boolean }) => void) => () => void;
   onFullscreenStateCheck: (callback: (state: { isFullscreen: boolean }) => void) => () => void;
+  onZoomFactorChanged: (callback: (zoomFactor: number) => void) => () => void;
   onExportBatchProgress: (callback: (progress: ExportBatchProgress) => void) => () => void;
   onTransferIndexedImagesProgress: (callback: (progress: IndexedImageTransferProgress) => void) => () => void;
 

--- a/types.ts
+++ b/types.ts
@@ -40,6 +40,34 @@ export type MetadataExportPolicy = 'preserve' | 'strip' | 'metahub_standard';
 export type ExportScope = 'single' | 'selected' | 'filtered' | 'folder';
 export type ExportTargetFormat = 'original' | 'png';
 
+export interface ComfyUIViewBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ComfyUIViewState {
+  url: string;
+  title: string;
+  isLoading: boolean;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  visible: boolean;
+}
+
+export interface ComfyUIViewResult {
+  success: boolean;
+  state?: ComfyUIViewState;
+  error?: string;
+}
+
+export interface ComfyUIViewLoadFailure {
+  errorCode: number;
+  errorDescription: string;
+  url: string;
+}
+
 export interface ExportFileDescriptor {
   imageId?: string;
   directoryPath: string;
@@ -224,6 +252,17 @@ export interface ElectronAPI {
   saveSettings: (settings: any) => Promise<{ success: boolean; error?: string }>;
   launchGenerator: (payload: { command: string; workingDirectory?: string }) => Promise<{ success: boolean; error?: string; scriptPath?: string }>;
   openExternalUrl: (url: string) => Promise<{ success: boolean; error?: string }>;
+  comfyUIViewOpen: (payload: { url: string; bounds?: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;
+  comfyUIViewShow: (payload?: { bounds?: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;
+  comfyUIViewHide: () => Promise<ComfyUIViewResult>;
+  comfyUIViewSuspend: () => Promise<ComfyUIViewResult>;
+  comfyUIViewSetBounds: (payload: { bounds: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;
+  comfyUIViewReload: () => Promise<ComfyUIViewResult>;
+  comfyUIViewGoBack: () => Promise<ComfyUIViewResult>;
+  comfyUIViewGoForward: () => Promise<ComfyUIViewResult>;
+  comfyUIViewGetState: () => Promise<ComfyUIViewResult>;
+  onComfyUIViewStateChanged: (callback: (state: ComfyUIViewState) => void) => () => void;
+  onComfyUIViewLoadFailed: (callback: (failure: ComfyUIViewLoadFailure) => void) => () => void;
   getDefaultCachePath: () => Promise<{ success: boolean; path?: string; error?: string }>;
   getAppVersion: () => Promise<string>;
   joinPaths: (...paths: string[]) => Promise<{ success: boolean; path?: string; error?: string }>;

--- a/utils/comfyUIViewSecurity.mjs
+++ b/utils/comfyUIViewSecurity.mjs
@@ -1,0 +1,56 @@
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+export function normalizeComfyUIViewUrl(value) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeHostname(hostname) {
+  return String(hostname || '').toLowerCase();
+}
+
+function isLoopbackHost(hostname) {
+  return LOOPBACK_HOSTS.has(normalizeHostname(hostname));
+}
+
+export function isComfyUIViewUrlAllowed(targetUrl, configuredUrl) {
+  const target = normalizeComfyUIViewUrl(targetUrl);
+  const configured = normalizeComfyUIViewUrl(configuredUrl);
+
+  if (!target || !configured) {
+    return false;
+  }
+
+  if (target.protocol !== configured.protocol) {
+    return false;
+  }
+
+  if (target.port !== configured.port) {
+    return false;
+  }
+
+  const targetHost = normalizeHostname(target.hostname);
+  const configuredHost = normalizeHostname(configured.hostname);
+
+  if (targetHost === configuredHost) {
+    return true;
+  }
+
+  return isLoopbackHost(targetHost) && isLoopbackHost(configuredHost);
+}
+
+export function getComfyUIViewAllowedOrigin(configuredUrl) {
+  const configured = normalizeComfyUIViewUrl(configuredUrl);
+  return configured ? configured.origin : null;
+}


### PR DESCRIPTION
## Summary

- Adds the embedded ComfyUI workspace flow with a side-panel image inspector, current-scope navigation, and drag-and-drop from the inspector into ComfyUI.
- Keeps the ComfyUI WebContentsView usable while image inspection happens in the workspace panel instead of a floating React modal.
- Adds native editable-text context menus for the embedded ComfyUI view and integrates workspace entry points from grid/table/toolbar surfaces.

## Why

The ComfyUI embedded view is a native Electron view, so React modals cannot reliably appear above it. Moving image inspection into the workspace sidebar preserves the ComfyUI browser while keeping image metadata, workflow controls, and navigation close at hand.

## Validation

- Typecheck: passed locally per user report.
- Build: passed locally per user report.