### PR TITLE
Reduce renderer memory pressure for large libraries

### DIFF
--- a/components/ComfyUIGenerateModal.tsx
+++ b/components/ComfyUIGenerateModal.tsx
@@ -17,6 +17,7 @@ interface ComfyUIGenerateModalProps {
   isOpen: boolean;
   onClose: () => void;
   image: IndexedImage;
+  directoryPath?: string;
   onGenerate: (params: GenerationParams) => Promise<void>;
   isGenerating: boolean;
 }
@@ -28,6 +29,7 @@ export const ComfyUIGenerateModal: React.FC<ComfyUIGenerateModalProps> = ({
   isOpen,
   onClose,
   image,
+  directoryPath,
   onGenerate,
   isGenerating,
 }) => {
@@ -95,6 +97,7 @@ export const ComfyUIGenerateModal: React.FC<ComfyUIGenerateModalProps> = ({
         <div className="flex-1 overflow-y-auto pr-1">
           <ComfyUIWorkflowWorkspace
             image={image}
+            directoryPath={directoryPath}
             onGenerate={onGenerate}
             isGenerating={isGenerating}
             defaultTab="parameters"

--- a/components/ComfyUIWorkflowWorkspace.tsx
+++ b/components/ComfyUIWorkflowWorkspace.tsx
@@ -294,7 +294,15 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
     return () => {
       isCancelled = true;
     };
-  }, [directoryPath, image.directoryId, image.id]);
+  }, [
+    directoryPath,
+    image.contentModifiedMs,
+    image.directoryId,
+    image.id,
+    image.lastModified,
+    image.metadata,
+    image.metadataString,
+  ]);
 
   const visualPromptAnalysis = useMemo(() => {
     if (!workingPromptGraph) {

--- a/components/ComfyUIWorkflowWorkspace.tsx
+++ b/components/ComfyUIWorkflowWorkspace.tsx
@@ -17,6 +17,10 @@ import {
   type ComfyUISourceImagePolicy,
   type ComfyUIWorkflowMode,
 } from '../services/comfyUIWorkflowBuilder';
+import {
+  hasCompactedRuntimeMetadata,
+  hydrateImageForEmbeddedComfyWorkflow,
+} from '../services/comfyUIWorkflowHydration';
 import { buildVisualWorkflowGraph } from '../services/comfyUIVisualWorkflow';
 import ComfyUIWorkflowVisualEditor from './ComfyUIWorkflowVisualEditor';
 
@@ -54,6 +58,7 @@ interface ComfyUIWorkflowWorkspaceProps {
   showCancelButton?: boolean;
   status?: { success: boolean; message: string } | null;
   generateDisabledReason?: string | null;
+  directoryPath?: string;
 }
 
 const MODEL_FAMILY_LABELS: Record<ComfyUIModelFamily, string> = {
@@ -223,15 +228,20 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
   showCancelButton = true,
   status = null,
   generateDisabledReason = null,
+  directoryPath,
 }) => {
   const { resources, isLoading: isLoadingResources, error: resourcesError } = useComfyUIModels();
   const comfyUILastConnectionStatus = useSettingsStore((state) => state.comfyUILastConnectionStatus);
-  const normalizedMetadata = image.metadata?.normalizedMetadata as BaseMetadata | undefined;
+  const [workflowSourceImage, setWorkflowSourceImage] = useState<IndexedImage>(image);
+  const analysisImage = workflowSourceImage.id === image.id ? workflowSourceImage : image;
+  const normalizedMetadata = (
+    image.metadata?.normalizedMetadata ?? analysisImage.metadata?.normalizedMetadata
+  ) as BaseMetadata | undefined;
   const workflowAnalysis = useMemo(
-    () => analyzeComfyWorkflow(image, normalizedMetadata),
-    [image, normalizedMetadata]
+    () => analyzeComfyWorkflow(analysisImage, normalizedMetadata),
+    [analysisImage, normalizedMetadata]
   );
-  const embeddedWorkflow = useMemo(() => extractEmbeddedComfyWorkflow(image), [image]);
+  const embeddedWorkflow = useMemo(() => extractEmbeddedComfyWorkflow(analysisImage), [analysisImage]);
 
   const [params, setParams] = useState<GenerationParams>({
     prompt: '',
@@ -264,6 +274,27 @@ export const ComfyUIWorkflowWorkspace: React.FC<ComfyUIWorkflowWorkspaceProps> =
   const [selectedVisualNodeId, setSelectedVisualNodeId] = useState<string | null>(null);
   const [workingPromptGraph, setWorkingPromptGraph] = useState<ComfyUIPromptGraph | null>(null);
   const [workingWorkflowUi, setWorkingWorkflowUi] = useState(embeddedWorkflow.workflow);
+
+  useEffect(() => {
+    let isCancelled = false;
+    setWorkflowSourceImage(image);
+
+    if (extractEmbeddedComfyWorkflow(image).prompt || !hasCompactedRuntimeMetadata(image)) {
+      return () => {
+        isCancelled = true;
+      };
+    }
+
+    void hydrateImageForEmbeddedComfyWorkflow(image, directoryPath).then((hydratedImage) => {
+      if (!isCancelled) {
+        setWorkflowSourceImage(hydratedImage);
+      }
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [directoryPath, image.directoryId, image.id]);
 
   const visualPromptAnalysis = useMemo(() => {
     if (!workingPromptGraph) {

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -683,6 +683,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                   </div>
                   <ComfyUIWorkflowWorkspace
                     image={image}
+                    directoryPath={directoryPath}
                     onGenerate={handleGenerateFromWorkspace}
                     isGenerating={isGenerating}
                     status={generateStatus}

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -2172,6 +2172,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             setSelectedImageForGeneration(null);
           }}
           image={selectedImageForGeneration}
+          directoryPath={directories.find((directory) => directory.id === selectedImageForGeneration.directoryId)?.path}
           onGenerate={async (params: ComfyUIGenerationParams) => {
             const customMetadata: Partial<BaseMetadata> = {
               prompt: params.prompt,

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -3562,6 +3562,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
             <div className="space-y-4">
               <ComfyUIWorkflowWorkspace
                 image={image}
+                directoryPath={directoryPath}
                 onGenerate={async (params: ComfyUIGenerationParams) => {
                     const customMetadata: Partial<BaseMetadata> = {
                       prompt: params.prompt,

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -266,6 +266,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   // Calculate these BEFORE the early return to maintain hook order
   const nMeta: BaseMetadata | undefined = activeImage?.metadata?.normalizedMetadata;
   const effectiveMetadata = activeImage ? buildEffectiveMetadata(nMeta, shadowMetadata, showOriginal) : undefined;
+  const activeImageDirectoryPath = activeImage
+    ? directories.find((directory) => directory.id === activeImage.directoryId)?.path
+    : undefined;
   const generationImage: IndexedImage = activeImage && effectiveMetadata
     ? {
         ...activeImage,
@@ -941,6 +944,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                   isOpen={isComfyUIGenerateModalOpen}
                   onClose={() => setIsComfyUIGenerateModalOpen(false)}
                   image={generationImage}
+                  directoryPath={activeImageDirectoryPath}
                   onGenerate={async (params: ComfyUIGenerationParams) => {
                     const customMetadata: Partial<BaseMetadata> = {
                       prompt: params.prompt,

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { FixedSizeList as List } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -80,7 +80,6 @@ const ImageTable: React.FC<ImageTableProps> = ({
   const transferProgress = useImageStore((state) => state.transferProgress);
   const [sortField, setSortField] = useState<SortField | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>(null);
-  const [sortedImages, setSortedImages] = useState<IndexedImage[]>(images);
   const [transferMode, setTransferMode] = useState<'copy' | 'move' | null>(null);
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isTransferring, setIsTransferring] = useState(false);
@@ -418,11 +417,11 @@ const ImageTable: React.FC<ImageTableProps> = ({
     return <ArrowDown className="w-3 h-3" />;
   };
 
-  // Update sorted images when images prop changes OR when sort settings change
-  useEffect(() => {
-    const sorted = applySorting(images, sortField, sortDirection);
-    setSortedImages(sorted);
-  }, [images, sortField, sortDirection, applySorting]);
+  const sortedImages = useMemo(
+    () => applySorting(images, sortField, sortDirection),
+    [images, sortField, sortDirection, applySorting]
+  );
+  const enableRowThumbnails = sortedImages.length <= 5000;
 
   const columnWidths = [
     '96px', // Preview
@@ -447,6 +446,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
           isSelected={selectedImages.has(image.id)}
           onContextMenu={handleContextMenu}
           gridTemplateColumns={gridTemplateColumns}
+          enableThumbnail={enableRowThumbnails}
         />
       </div>
     );
@@ -853,12 +853,13 @@ interface ImageTableRowProps {
   isSelected: boolean;
   onContextMenu?: (image: IndexedImage, event: React.MouseEvent) => void;
   gridTemplateColumns: string;
+  enableThumbnail: boolean;
 }
 
-const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImageClick, isSelected, onContextMenu, gridTemplateColumns }) => {
+const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImageClick, isSelected, onContextMenu, gridTemplateColumns, enableThumbnail }) => {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const thumbnail = useResolvedThumbnail(image);
+  const thumbnail = useResolvedThumbnail(enableThumbnail ? image : null);
   const setPreviewImage = useImageStore((state) => state.setPreviewImage);
   const directories = useImageStore((state) => state.directories);
   const thumbnailsDisabled = useSettingsStore((state) => state.disableThumbnails);
@@ -871,10 +872,10 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
   const fullImagePath = joinDisplayPath(directoryPath, relativeImagePath);
   const displayName = showFullFilePath ? fullImagePath : image.handle.name;
 
-  useThumbnail(image);
+  useThumbnail(enableThumbnail ? image : null);
 
   useEffect(() => {
-    if (thumbnailsDisabled) {
+    if (thumbnailsDisabled || !enableThumbnail) {
       setImageUrl(null);
       setIsLoading(false);
       return;
@@ -900,7 +901,7 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
 
     setImageUrl(null);
     setIsLoading(true);
-  }, [thumbnail?.thumbnailHandle, image.handle, thumbnail?.thumbnailStatus, thumbnail?.thumbnailUrl, thumbnailsDisabled, isVideo, isAudio]);
+  }, [thumbnail?.thumbnailHandle, image.handle, thumbnail?.thumbnailStatus, thumbnail?.thumbnailUrl, thumbnailsDisabled, enableThumbnail, isVideo, isAudio]);
 
   const handlePreviewClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -977,6 +978,17 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
                 <Info className="h-4 w-4 text-white" />
               </button>
             </>
+          ) : thumbnailsDisabled || !enableThumbnail ? (
+            <>
+              <Package className="h-4 w-4 text-gray-500" />
+              <button
+                onClick={handlePreviewClick}
+                className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-blue-500/70"
+                title="Show details"
+              >
+                <Info className="h-4 w-4 text-white" />
+              </button>
+            </>
           ) : (
             <span className="text-xs text-gray-500">ERR</span>
           )}
@@ -1040,7 +1052,8 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
     prevProps.image.thumbnailStatus === nextProps.image.thumbnailStatus &&
     prevProps.image.rating === nextProps.image.rating &&
     prevProps.isSelected === nextProps.isSelected &&
-    prevProps.gridTemplateColumns === nextProps.gridTemplateColumns
+    prevProps.gridTemplateColumns === nextProps.gridTemplateColumns &&
+    prevProps.enableThumbnail === nextProps.enableThumbnail
   );
 });
 

--- a/electron.mjs
+++ b/electron.mjs
@@ -42,6 +42,8 @@ if (gpuMitigationEnabled) {
   console.warn('[GPU] Hardware acceleration disabled via IMH_DISABLE_GPU.');
 }
 
+app.commandLine.appendSwitch('js-flags', '--max-old-space-size=4096');
+
 // Parser version - increment when parser logic changes
 // This ensures cache is invalidated when parsing rules change
 const PARSER_VERSION = 7; // v7: Add audio media indexing and metadata

--- a/hooks/useCopyToComfyUI.ts
+++ b/hooks/useCopyToComfyUI.ts
@@ -6,6 +6,7 @@
 import { useState, useCallback } from 'react';
 import { BaseMetadata, IndexedImage } from '../types';
 import { formatImageForComfyUI, formatMetadataForComfyUI } from '../utils/comfyUIFormatter';
+import { hydrateImageForEmbeddedComfyWorkflow } from '../services/comfyUIWorkflowHydration';
 import {
   getClipboardErrorMessage,
   getNormalizedMetadata,
@@ -38,9 +39,12 @@ export function useCopyToComfyUI() {
     setCopyStatus(null);
 
     try {
+      const sourceImage = metadataOverride
+        ? image
+        : await hydrateImageForEmbeddedComfyWorkflow(image);
       const workflowJSON = metadataOverride
         ? formatMetadataForComfyUI(metadataOverride)
-        : formatImageForComfyUI(image);
+        : formatImageForComfyUI(sourceImage);
 
       // Copy to clipboard
       await navigator.clipboard.writeText(workflowJSON);

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -1340,6 +1340,22 @@ export function useImageLoader() {
                         return;
                     }
 
+                    const currentState = useImageStore.getState();
+                    const storedPathsAlreadyLoaded = paths.every((path: string) =>
+                        currentState.directories.some(directory => directory.path === path)
+                    );
+                    const hasHydratedStoredImages = currentState.images.some(image =>
+                        currentState.directories.some(directory =>
+                            paths.includes(directory.path) && directory.id === image.directoryId
+                        )
+                    );
+
+                    if (storedPathsAlreadyLoaded && hasHydratedStoredImages) {
+                        const allPaths = currentState.directories.map(directory => directory.path);
+                        await window.electronAPI?.updateAllowedPaths(allPaths);
+                        return;
+                    }
+
                     // Use global auto-watch setting for all directories
                     const globalAutoWatch = useSettingsStore.getState().globalAutoWatch;
 

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -541,13 +541,14 @@ export function useImageLoader() {
             }])
         );
 
+        const useLightweightReconcile = allCurrentFiles.length >= 10000;
         const diff = await cacheManager.validateCacheAndGetDiff(
             activeDirectory.path,
             activeDirectory.name,
             allCurrentFiles,
             shouldScanSubfolders,
             undefined,
-            { includeCachedImages: false },
+            { includeCachedImages: !useLightweightReconcile },
         );
 
         traceCacheDebug('loader:reconcileCachedDirectory:diff', () => ({
@@ -564,7 +565,7 @@ export function useImageLoader() {
             return false;
         }
 
-        if (allCurrentFiles.length >= 10000 && diff.cachedImages.length === 0) {
+        if (useLightweightReconcile) {
             console.warn(
                 `[startup-reconcile] Skipping heavy cache rewrite for ${activeDirectory.path}: ` +
                 `${diff.newAndModifiedFiles.length} changed/new, ${diff.deletedFileIds.length} deleted.`

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -567,10 +567,82 @@ export function useImageLoader() {
 
         if (useLightweightReconcile) {
             console.warn(
-                `[startup-reconcile] Skipping heavy cache rewrite for ${activeDirectory.path}: ` +
+                `[startup-reconcile] Applying lightweight UI reconcile for ${activeDirectory.path}: ` +
                 `${diff.newAndModifiedFiles.length} changed/new, ${diff.deletedFileIds.length} deleted.`
             );
-            return false;
+            setDirectoryRefreshing(activeDirectory.id, true);
+
+            try {
+                if (diff.deletedFileIds.length > 0) {
+                    removeImages(diff.deletedFileIds);
+                }
+
+                const changedIds = Array.from(new Set(
+                    diff.newAndModifiedFiles.map(file => `${activeDirectory.id}::${file.name}`)
+                ));
+                if (changedIds.length > 0) {
+                    removeImages(changedIds);
+                }
+
+                const sortedFilesWithStats = diff.newAndModifiedFiles.length > 0
+                    ? [...diff.newAndModifiedFiles]
+                        .sort((a, b) => b.lastModified - a.lastModified)
+                        .map(file => ({
+                            ...file,
+                            size: fileStatsMap.get(file.name)?.size ?? file.size,
+                            type: fileStatsMap.get(file.name)?.type ?? file.type,
+                            birthtimeMs: fileStatsMap.get(file.name)?.birthtimeMs ?? file.birthtimeMs ?? file.lastModified,
+                            contentModifiedMs: fileStatsMap.get(file.name)?.contentModifiedMs ?? file.contentModifiedMs ?? file.lastModified,
+                        }))
+                    : [];
+
+                const fileHandles = sortedFilesWithStats.length > 0
+                    ? await getFileHandles(activeDirectory.handle, activeDirectory.path, sortedFilesWithStats)
+                    : [];
+
+                const { phaseB } = await processFiles(
+                    fileHandles,
+                    () => {},
+                    (batch) => {
+                        addImages(batch);
+                    },
+                    activeDirectory.id,
+                    activeDirectory.name,
+                    shouldScanSubfolders,
+                    (deletedFileIds) => {
+                        if (deletedFileIds.length > 0) {
+                            removeImages(deletedFileIds);
+                        }
+                    },
+                    undefined,
+                    waitWhilePaused,
+                    {
+                        cacheWriter: null,
+                        concurrency: useSettingsStore.getState().indexingConcurrency ?? 4,
+                        fileStats: fileStatsMap,
+                        onEnrichmentBatch: (batch) => {
+                            mergeImages(batch);
+                        },
+                        hydratePreloadedImages: false,
+                    }
+                );
+
+                await phaseB;
+                await refreshLineageDirectorySignature(activeDirectory);
+                scheduleLineageRebuild(800);
+                traceCacheDebug('loader:reconcileCachedDirectory:lightweightComplete', () => ({
+                    directoryId: activeDirectory.id,
+                    snapshot: createCacheDebugSnapshot(useImageStore.getState()),
+                }));
+                return true;
+            } catch (reconcileError) {
+                console.error(`[startup-reconcile] Lightweight reconcile failed for ${activeDirectory.path}:`, reconcileError);
+                return false;
+            } finally {
+                setDirectoryRefreshing(activeDirectory.id, false);
+                setEnrichmentProgress(null);
+                setProgress(null);
+            }
         }
 
         setDirectoryRefreshing(activeDirectory.id, true);

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -601,6 +601,7 @@ export function useImageLoader() {
                 const fileHandles = sortedFilesWithStats.length > 0
                     ? await getFileHandles(activeDirectory.handle, activeDirectory.path, sortedFilesWithStats)
                     : [];
+                const cacheUpserts: IndexedImage[] = [];
 
                 const { phaseB } = await processFiles(
                     fileHandles,
@@ -623,6 +624,7 @@ export function useImageLoader() {
                         concurrency: useSettingsStore.getState().indexingConcurrency ?? 4,
                         fileStats: fileStatsMap,
                         onEnrichmentBatch: (batch) => {
+                            cacheUpserts.push(...batch);
                             mergeImages(batch);
                         },
                         hydratePreloadedImages: false,
@@ -630,6 +632,14 @@ export function useImageLoader() {
                 );
 
                 await phaseB;
+                await cacheManager.applyChunkedCacheDelta(
+                    activeDirectory.path,
+                    activeDirectory.name,
+                    cacheUpserts,
+                    [...diff.deletedFileIds, ...changedIds],
+                    [],
+                    shouldScanSubfolders
+                );
                 await refreshLineageDirectorySignature(activeDirectory);
                 scheduleLineageRebuild(800);
                 traceCacheDebug('loader:reconcileCachedDirectory:lightweightComplete', () => ({

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -541,15 +541,16 @@ export function useImageLoader() {
             }])
         );
 
-        const useLightweightReconcile = allCurrentFiles.length >= 10000;
+        const preferLightweightReconcile = allCurrentFiles.length >= 10000;
         const diff = await cacheManager.validateCacheAndGetDiff(
             activeDirectory.path,
             activeDirectory.name,
             allCurrentFiles,
             shouldScanSubfolders,
             undefined,
-            { includeCachedImages: !useLightweightReconcile },
+            { includeCachedImages: !preferLightweightReconcile },
         );
+        const useLightweightReconcile = preferLightweightReconcile && !diff.needsFullRefresh;
 
         traceCacheDebug('loader:reconcileCachedDirectory:diff', () => ({
             directoryId: activeDirectory.id,
@@ -557,6 +558,7 @@ export function useImageLoader() {
                 newAndModifiedFiles: diff.newAndModifiedFiles.length,
                 deletedFileIds: diff.deletedFileIds.length,
                 currentFiles: allCurrentFiles.length,
+                needsFullRefresh: diff.needsFullRefresh,
             },
             snapshot: createCacheDebugSnapshot(useImageStore.getState()),
         }));

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -52,6 +52,41 @@ type DirectoryFileRecord = {
     contentModifiedMs?: number;
 };
 
+const electronHandleGetFile = async function (this: { name: string; _filePath?: string }) {
+    const electronAPI = window.electronAPI;
+    if (!getIsElectron() || !electronAPI || !this._filePath) {
+        throw new Error(`Failed to read file: ${this.name}`);
+    }
+
+    const fileResult = await electronAPI.readFile(this._filePath);
+    if (fileResult.success && fileResult.data) {
+        const freshData = new Uint8Array(fileResult.data);
+        const type = this.name.toLowerCase().endsWith('.png')
+            ? 'image/png'
+            : this.name.toLowerCase().endsWith('.webp')
+                ? 'image/webp'
+                : 'image/jpeg';
+        return new File([freshData as any], this.name, { type });
+    }
+
+    if (fileResult.errorType && fileResult.errorType !== 'FILE_NOT_FOUND') {
+        console.error(`Failed to read file: ${this.name}`, {
+            error: fileResult.error,
+            errorType: fileResult.errorType,
+            errorCode: fileResult.errorCode,
+            path: this._filePath,
+        });
+    }
+    throw new Error(`Failed to read file: ${this.name}`);
+};
+
+const createElectronFileHandle = (name: string, filePath: string) => ({
+    name,
+    kind: 'file' as const,
+    _filePath: filePath,
+    getFile: electronHandleGetFile,
+});
+
 // Function to clear file data cache
 function clearFileDataCache() {
   fileDataCache.clear();
@@ -160,35 +195,7 @@ async function getFileHandles(
             const file = files[i];
             const filePath = filePaths[i];
 
-            const mockHandle = {
-                name: file.name,
-                kind: 'file' as const,
-                _filePath: filePath,
-                getFile: async () => {
-                    // Read file directly when needed (during processFiles)
-                    if (getIsElectron()) {
-                        const fileResult = await electronAPI.readFile(filePath);
-                        if (fileResult.success && fileResult.data) {
-                            const freshData = new Uint8Array(fileResult.data);
-                            const lowerName = file.name.toLowerCase();
-                            const type = lowerName.endsWith('.png') ? 'image/png' : 'image/jpeg';
-                            return new File([freshData as any], file.name, { type });
-                        } else {
-                            // Only log non-file-not-found errors to reduce console noise
-                            if (fileResult.errorType && fileResult.errorType !== 'FILE_NOT_FOUND') {
-                                console.error(`Failed to read file: ${file.name}`, {
-                                    error: fileResult.error,
-                                    errorType: fileResult.errorType,
-                                    errorCode: fileResult.errorCode,
-                                    path: filePath
-                                });
-                            }
-                            throw new Error(`Failed to read file: ${file.name}`);
-                        }
-                    }
-                    throw new Error(`Failed to read file: ${filePath}`);
-                }
-            };
+            const mockHandle = createElectronFileHandle(file.name, filePath);
             handles.push({ handle: mockHandle as any, path: file.name, lastModified: file.lastModified, size: file.size, type: file.type, birthtimeMs: file.birthtimeMs, contentModifiedMs: file.contentModifiedMs });
         }
     } else {
@@ -539,6 +546,8 @@ export function useImageLoader() {
             activeDirectory.name,
             allCurrentFiles,
             shouldScanSubfolders,
+            undefined,
+            { includeCachedImages: false },
         );
 
         traceCacheDebug('loader:reconcileCachedDirectory:diff', () => ({
@@ -552,6 +561,14 @@ export function useImageLoader() {
         }));
 
         if (diff.newAndModifiedFiles.length === 0 && diff.deletedFileIds.length === 0) {
+            return false;
+        }
+
+        if (allCurrentFiles.length >= 10000 && diff.cachedImages.length === 0) {
+            console.warn(
+                `[startup-reconcile] Skipping heavy cache rewrite for ${activeDirectory.path}: ` +
+                `${diff.newAndModifiedFiles.length} changed/new, ${diff.deletedFileIds.length} deleted.`
+            );
             return false;
         }
 
@@ -758,34 +775,7 @@ export function useImageLoader() {
                     const chunkImages: IndexedImage[] = metadataChunk.map((meta, i) => {
                         const filePath = filePaths[i];
 
-                        const mockHandle = {
-                            name: meta.name,
-                            kind: 'file' as const,
-                            _filePath: filePath,
-                            getFile: async () => {
-                                if (isElectron && filePath) {
-                                    const fileResult = await electronAPI.readFile(filePath);
-                                    if (fileResult.success && fileResult.data) {
-                                        const freshData = new Uint8Array(fileResult.data);
-                                        const lowerName = meta.name.toLowerCase();
-                                        const type = lowerName.endsWith('.png') ? 'image/png' : 'image/jpeg';
-                                        return new File([freshData as any], meta.name, { type });
-                                    } else {
-                                        // Only log non-file-not-found errors to reduce console noise
-                                        if (fileResult.errorType && fileResult.errorType !== 'FILE_NOT_FOUND') {
-                                            console.error(`Failed to read file: ${meta.name}`, {
-                                                error: fileResult.error,
-                                                errorType: fileResult.errorType,
-                                                errorCode: fileResult.errorCode,
-                                                path: filePath
-                                            });
-                                        }
-                                        throw new Error(`Failed to read file: ${meta.name}`);
-                                    }
-                                }
-                                throw new Error(`Failed to read file: ${meta.name}`);
-                            }
-                        };
+                        const mockHandle = createElectronFileHandle(meta.name, filePath);
 
                         return {
                             ...meta,
@@ -1398,30 +1388,7 @@ export function useImageLoader() {
             // Criar mock handles para os arquivos (necess├írio para processFiles)
             // Inclu├¡mos _filePath para que o Electron possa ler os arquivos via IPC batch
             const fileEntries = newFiles.map(file => ({
-                handle: {
-                    name: file.normalizedName,
-                    kind: 'file' as const,
-                    _filePath: file.path, // IMPORTANTE: Path para leitura via IPC no Electron
-                    getFile: async () => {
-                        // Read file directly when needed (during processFiles)
-                        const electronAPI = window.electronAPI;
-                        if (getIsElectron() && electronAPI) {
-                            const fileResult = await electronAPI.readFile(file.path);
-                            if (fileResult.success && fileResult.data) {
-                                const freshData = new Uint8Array(fileResult.data);
-                                const lowerName = file.normalizedName.toLowerCase();
-                                const type = lowerName.endsWith('.png')
-                                    ? 'image/png'
-                                    : lowerName.endsWith('.webp')
-                                        ? 'image/webp'
-                                        : 'image/jpeg';
-                                return new File([freshData as any], file.normalizedName, { type });
-                            }
-                            throw new Error(`Failed to read file: ${file.normalizedName}`);
-                        }
-                        throw new Error(`Failed to read file: ${file.path}`);
-                    }
-                } as any,
+                handle: createElectronFileHandle(file.normalizedName, file.path) as any,
                 path: file.relativePath || file.normalizedName,
                 lastModified: file.lastModified,
                 contentModifiedMs: file.contentModifiedMs ?? file.lastModified,

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,29 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.4] - 2026-04-29
+## [0.15.4] - 2026-05-02
 
 ### Added
 
 - **Advanced Folder Management**: Added directory tree view with subfolder navigation, drag-and-drop file transfers, directory renaming, and global hotkey support for clipboard operations.
+- **Generated Output Preview**: Added a dedicated preview modal for completed generation queue results.
 
 ### Improved
 
-- **Generation Queue**: Rebuilt queue UX with clearer actions, clickable results, and thumbnails. Added a dedicated preview modal for completed jobs. Scheduling now drains in FIFO order without interruptions from cancellations. Improved memory handling by using Blob URLs instead of base64 payloads, and refined A1111 batch progress tracking.
-- **Workflow Analysis**: Enhanced ComfyUI workflow JSON handling, resolution, and streamlined dimension target extraction logic.
-- **Workspace Experience**: Improved workspace tab persistence and enhanced image modal functionality.
+- **Generation Queue**: Rebuilt queue execution and progress tracking for clearer A1111/ComfyUI status, FIFO scheduling, clickable results, thumbnails, and lower-memory previews.
+- **Image Grid Navigation**: Improved keyboard navigation, focused image state, page-boundary handling, preview updates, and thumbnail warmup behavior.
+- **ComfyUI Workflow Experience**: Improved workflow JSON resolution, dimension target detection, error display, workspace tab persistence, and image modal integration.
+- **Slideshow Experience**: Improved slideshow exit behavior and covered it with focused tests.
+- **Accessibility**: Added accessible labels to modal close buttons.
 
 ### Fixed
 
 - **Maximum Update Depth Error**: Fixed a critical "Maximum update depth exceeded" error during heavy indexing. Stabilized array references in the application state to prevent infinite re-rendering loops when new batches of images are loaded.
-- **Queued Generation Deadlock**: Fixed a structural queue bug where jobs created as `waiting` could remain stuck forever because no runner existed to consume them after the active job completed.
-- **Provider Runner Races**: Reduced overlapping provider execution and stale scheduling states when active queue jobs are canceled or removed while the underlying executor is still unwinding.
-- **A1111 Progress Race**: Fixed stale delayed progress cleanup from one A1111 job clearing progress for the next queued A1111 job.
-
-### Known Bugs
-
-- **Queue Preview Blob URL Eviction Leak**: When the queue exceeds its 200-item cap, entries trimmed by the cap may not revoke their generated preview Blob URLs.
-- **Canceled A1111 Output Blob URL Leak**: If an in-flight A1111 job is canceled or removed after outputs have already been materialized, discarded generated preview Blob URLs may not be revoked.
+- **Generation Queue Cancellation**: Fixed canceled A1111 and ComfyUI jobs blocking the queue, leaving stale artifacts, or clearing progress for the next job.
+- **Folder Rename State**: Fixed directory rename edge cases including nested root remapping, folder filter preservation, and stale rename state.
+- **Clipboard Paste Recovery**: Fixed failed folder paste operations so the clipboard contents are retained.
+- **Image Grid Layout**: Fixed column count and transition issues that could make thumbnail navigation feel inconsistent.
 
 ## [0.15.3] - 2026-04-25
 

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -695,6 +695,102 @@ class CacheManager {
     }
   }
 
+  async applyChunkedCacheDelta(
+    directoryPath: string,
+    directoryName: string,
+    imagesToUpsert: IndexedImage[],
+    removedImageIds: string[],
+    removedImageNames: string[],
+    scanSubfolders: boolean
+  ): Promise<void> {
+    if (!this.isElectron) return;
+    if (imagesToUpsert.length === 0 && removedImageIds.length === 0 && removedImageNames.length === 0) return;
+
+    const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
+    const summary = await this.getCacheSummary(directoryPath, scanSubfolders);
+    if (!summary) {
+      if (imagesToUpsert.length > 0) {
+        await this.cacheData(directoryPath, directoryName, imagesToUpsert, scanSubfolders);
+      }
+      return;
+    }
+
+    const upserts = sanitizeCacheMetadata(toCacheMetadata(imagesToUpsert), { forceClone: true });
+    const pruneIds = [
+      ...removedImageIds,
+      ...upserts.map((image) => image.id),
+    ];
+    const pruneNames = [
+      ...removedImageNames,
+      ...upserts.map((image) => image.name),
+    ];
+    const outputChunkSize = DEFAULT_INCREMENTAL_CHUNK_SIZE;
+    const outputBuffer: CacheImageMetadata[] = [];
+    let outputChunkIndex = 0;
+    let imageCount = 0;
+
+    const flushOutputChunk = async (force = false) => {
+      if (outputBuffer.length === 0 || (!force && outputBuffer.length < outputChunkSize)) {
+        return;
+      }
+
+      const chunk = outputBuffer.splice(0, outputBuffer.length);
+      const result = await window.electronAPI.writeCacheChunk({
+        cacheId,
+        chunkIndex: outputChunkIndex,
+        data: chunk,
+      });
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to write cache delta chunk');
+      }
+
+      outputChunkIndex += 1;
+    };
+
+    const appendOutputEntries = async (entries: CacheImageMetadata[]) => {
+      for (const entry of entries) {
+        outputBuffer.push(entry);
+        imageCount += 1;
+        await flushOutputChunk();
+      }
+    };
+
+    const chunkCount = summary.chunkCount ?? 0;
+    for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+      const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex });
+      if (!chunkResult.success || !Array.isArray(chunkResult.data)) {
+        throw new Error(chunkResult.error || `Failed to read cache chunk ${chunkIndex}`);
+      }
+
+      const pruned = pruneCacheMetadata(compactCacheMetadataEntries(chunkResult.data), {
+        ids: pruneIds,
+        names: pruneNames,
+      });
+      await appendOutputEntries(pruned);
+    }
+
+    await appendOutputEntries(upserts);
+    await flushOutputChunk(true);
+
+    const finalizeResult = await window.electronAPI.finalizeCacheWrite({
+      cacheId,
+      record: {
+        id: cacheId,
+        directoryPath,
+        directoryName: summary.directoryName ?? directoryName,
+        lastScan: Date.now(),
+        imageCount,
+        chunkCount: outputChunkIndex,
+        parserVersion: PARSER_VERSION,
+      },
+    });
+
+    if (!finalizeResult.success) {
+      throw new Error(finalizeResult.error || 'Failed to finalize cache delta');
+    }
+  }
+
   async replaceCachedImages(
     directoryPath: string,
     directoryName: string,

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -821,12 +821,10 @@ class CacheManager {
     directoryName: string,
     currentFiles: { name: string; lastModified: number; size?: number; type?: string; birthtimeMs?: number; contentModifiedMs?: number }[],
     scanSubfolders: boolean,
-    scopePath?: string
+    scopePath?: string,
+    options: { includeCachedImages?: boolean } = {}
   ): Promise<CacheDiff> {
-    const cached = await this.getCachedData(directoryPath, scanSubfolders);
-    
-    // If no cache exists, all files are new
-    if (!cached) {
+    if (!this.isElectron) {
       return {
         newAndModifiedFiles: currentFiles,
         deletedFileIds: [],
@@ -834,22 +832,74 @@ class CacheManager {
         needsFullRefresh: true,
       };
     }
+
+    const cachedSummary = await this.getCacheSummary(directoryPath, scanSubfolders);
     
-    const cachedMetadataMap = new Map(cached.metadata.map(m => [m.name, m]));
+    // If no cache exists, all files are new
+    if (!cachedSummary) {
+      return {
+        newAndModifiedFiles: currentFiles,
+        deletedFileIds: [],
+        cachedImages: [],
+        needsFullRefresh: true,
+      };
+    }
+
+    const includeCachedImages = options.includeCachedImages ?? true;
     const newAndModifiedFiles: { name: string; lastModified: number; size?: number; type?: string; birthtimeMs?: number; contentModifiedMs?: number }[] = [];
     const cachedImages: IndexedImage[] = [];
-    const currentFileNames = new Set<string>();
+    const deletedFileIds: string[] = [];
+    const currentFilesMap = new Map<string, { name: string; lastModified: number; size?: number; type?: string; birthtimeMs?: number; contentModifiedMs?: number }>();
+    for (const file of currentFiles) {
+      currentFilesMap.set(file.name, file);
+    }
+    const seenCachedFileNames = new Set<string>();
 
     // Helper to normalize paths for comparison (ensure forward slashes)
     const normalize = (p: string) => p.replace(/\\/g, '/');
     const normalizedScope = scopePath ? normalize(scopePath) : undefined;
 
-    for (const file of currentFiles) {
-      currentFileNames.add(file.name);
-      const cachedFile = cachedMetadataMap.get(file.name);
+    await this.iterateCachedMetadata(directoryPath, scanSubfolders, async (cachedChunk) => {
+      for (const cachedFile of cachedChunk) {
+        seenCachedFileNames.add(cachedFile.name);
+        const file = currentFilesMap.get(cachedFile.name);
 
-      // File is new
-      if (!cachedFile) {
+        if (!file) {
+          if (normalizedScope) {
+            const authorized = cachedFile.name.startsWith(`${normalizedScope}/`) || cachedFile.name === normalizedScope;
+            if (!authorized) {
+              continue;
+            }
+          }
+          deletedFileIds.push(cachedFile.id);
+          continue;
+        }
+
+        const fileModifiedMs = file.contentModifiedMs ?? file.lastModified;
+        const cacheModifiedMs = cachedFile.contentModifiedMs ?? cachedFile.lastModified;
+        if (cacheModifiedMs < fileModifiedMs || cachedFile.enrichmentState === 'catalog') {
+          newAndModifiedFiles.push({
+            name: file.name,
+            lastModified: file.lastModified,
+            size: file.size,
+            type: file.type,
+            birthtimeMs: file.birthtimeMs,
+            contentModifiedMs: file.contentModifiedMs,
+          });
+          continue;
+        }
+
+        if (includeCachedImages) {
+          cachedImages.push({
+            ...cachedFile,
+            handle: { name: cachedFile.name, kind: 'file' } as any,
+          });
+        }
+      }
+    });
+
+    for (const file of currentFiles) {
+      if (!seenCachedFileNames.has(file.name)) {
         newAndModifiedFiles.push({
           name: file.name,
           lastModified: file.lastModified,
@@ -857,48 +907,9 @@ class CacheManager {
           type: file.type,
           birthtimeMs: file.birthtimeMs,
           contentModifiedMs: file.contentModifiedMs,
-        });
-      // File has been modified since last scan
-      } else if ((cachedFile.contentModifiedMs ?? cachedFile.lastModified) < (file.contentModifiedMs ?? file.lastModified)) {
-        newAndModifiedFiles.push({
-          name: file.name,
-          lastModified: file.lastModified,
-          size: file.size,
-          type: file.type,
-          birthtimeMs: file.birthtimeMs,
-          contentModifiedMs: file.contentModifiedMs,
-        });
-      // CRITICAL FIX: If file is in 'catalog' state (incomplete), force re-indexing
-      } else if (cachedFile.enrichmentState === 'catalog') {
-        newAndModifiedFiles.push({
-          name: file.name,
-          lastModified: file.lastModified, // Use current file time to be safe
-          size: file.size,
-          type: file.type,
-          birthtimeMs: file.birthtimeMs,
-          contentModifiedMs: file.contentModifiedMs,
-        });
-      // File is unchanged, add it to the list of images to be loaded from cache
-      } else {
-        cachedImages.push({
-          ...cachedFile,
-          handle: { name: cachedFile.name, kind: 'file' } as any, // Mock handle
         });
       }
     }
-
-    // Find files that were in the cache but are no longer on disk
-    // If scopePath is provided, ONLY consider files within that scope for deletion
-    const deletedFileIds = cached.metadata
-      .filter(m => {
-        // If scope is defined, ignore files outside the scope
-        if (normalizedScope) {
-           const authorized = m.name.startsWith(normalizedScope + '/') || m.name === normalizedScope;
-           if (!authorized) return false;
-        }
-        return !currentFileNames.has(m.name);
-      })
-      .map(m => m.id);
 
     return {
       newAndModifiedFiles,

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -63,6 +63,54 @@ export interface CacheDiff {
 }
 
 const DEFAULT_INCREMENTAL_CHUNK_SIZE = 1024;
+const MAX_INLINE_RAW_METADATA_BYTES = 32 * 1024;
+const RAW_METADATA_PREVIEW_BYTES = 4096;
+
+function compactCacheMetadataEntry(entry: CacheImageMetadata): CacheImageMetadata {
+  const metadataString = typeof entry.metadataString === 'string' ? entry.metadataString : '';
+  if (metadataString.length <= MAX_INLINE_RAW_METADATA_BYTES) {
+    return entry;
+  }
+
+  const metadata = entry.metadata && typeof entry.metadata === 'object'
+    ? entry.metadata as Record<string, any>
+    : {};
+  const normalizedMetadata = metadata.normalizedMetadata;
+  const compactedMetadata: Record<string, unknown> = {
+    _rawMetadataCompacted: true,
+    _rawMetadataSizeBytes: metadataString.length,
+    _rawMetadataKeys: Object.keys(metadata).filter(key => key !== 'normalizedMetadata'),
+  };
+
+  if (typeof metadata.parameters === 'string') {
+    compactedMetadata.parametersPreview = metadata.parameters.slice(0, RAW_METADATA_PREVIEW_BYTES);
+  }
+
+  if (metadata.imagemetahub_data && typeof metadata.imagemetahub_data === 'object') {
+    const payload = metadata.imagemetahub_data as Record<string, unknown>;
+    compactedMetadata.imagemetahub_data = {
+      generator: payload.generator,
+      analytics: payload.analytics,
+      _analytics: payload._analytics,
+      imh_pro: payload.imh_pro,
+      _metahub_pro: payload._metahub_pro,
+    };
+  }
+
+  if (normalizedMetadata) {
+    compactedMetadata.normalizedMetadata = normalizedMetadata;
+  }
+
+  return {
+    ...entry,
+    metadata: compactedMetadata,
+    metadataString: JSON.stringify(compactedMetadata),
+  };
+}
+
+function compactCacheMetadataEntries(metadata: CacheImageMetadata[]): CacheImageMetadata[] {
+  return metadata.map(compactCacheMetadataEntry);
+}
 
 export function pruneCacheMetadata(
   metadata: CacheImageMetadata[],
@@ -334,7 +382,9 @@ class CacheManager {
       return null;
     }
 
-    let metadata: CacheImageMetadata[] = Array.isArray(summary.metadata) ? summary.metadata : [];
+    let metadata: CacheImageMetadata[] = Array.isArray(summary.metadata)
+      ? compactCacheMetadataEntries(summary.metadata)
+      : [];
     const chunkCount = summary.chunkCount ?? 0;
 
     if (metadata.length === 0 && chunkCount > 0) {
@@ -342,7 +392,7 @@ class CacheManager {
       for (let i = 0; i < chunkCount; i++) {
         const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex: i });
         if (chunkResult.success && Array.isArray(chunkResult.data)) {
-          chunks.push(...chunkResult.data);
+          chunks.push(...compactCacheMetadataEntries(chunkResult.data));
         } else if (!chunkResult.success) {
           console.error(`Failed to load cache chunk ${i} for ${cacheId}:`, chunkResult.error);
         }
@@ -414,7 +464,7 @@ class CacheManager {
 
     const summary = result.data;
     if (Array.isArray(summary.metadata) && summary.metadata.length > 0) {
-      await onChunk(summary.metadata);
+      await onChunk(compactCacheMetadataEntries(summary.metadata));
       return;
     }
 
@@ -422,7 +472,7 @@ class CacheManager {
     for (let i = 0; i < chunkCount; i++) {
       const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex: i });
       if (chunkResult.success && Array.isArray(chunkResult.data) && chunkResult.data.length > 0) {
-        await onChunk(chunkResult.data);
+        await onChunk(compactCacheMetadataEntries(chunkResult.data));
       } else if (!chunkResult.success) {
         console.error(`Failed to load cache chunk ${i} for ${cacheId}:`, chunkResult.error);
       }

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -66,6 +66,16 @@ const DEFAULT_INCREMENTAL_CHUNK_SIZE = 1024;
 const MAX_INLINE_RAW_METADATA_BYTES = 32 * 1024;
 const RAW_METADATA_PREVIEW_BYTES = 4096;
 
+const isCurrentParserVersion = (parserVersion: number | undefined): boolean => (
+  parserVersion === PARSER_VERSION
+);
+
+const warnParserVersionMismatch = (cacheId: string, parserVersion: number | undefined) => {
+  console.warn(
+    `Cache parser version mismatch for ${cacheId}. Expected ${PARSER_VERSION}, got ${parserVersion ?? 'none'}. Invalidating cache.`
+  );
+};
+
 function compactCacheMetadataEntry(entry: CacheImageMetadata): CacheImageMetadata {
   const metadataString = typeof entry.metadataString === 'string' ? entry.metadataString : '';
   if (metadataString.length <= MAX_INLINE_RAW_METADATA_BYTES) {
@@ -381,6 +391,10 @@ class CacheManager {
     if (!summary) {
       return null;
     }
+    if (!isCurrentParserVersion(summary.parserVersion)) {
+      warnParserVersionMismatch(cacheId, summary.parserVersion);
+      return null;
+    }
 
     let metadata: CacheImageMetadata[] = Array.isArray(summary.metadata)
       ? compactCacheMetadataEntries(summary.metadata)
@@ -432,6 +446,11 @@ class CacheManager {
     }
 
     const summary = result.data;
+    if (!isCurrentParserVersion(summary.parserVersion)) {
+      warnParserVersionMismatch(cacheId, summary.parserVersion);
+      return null;
+    }
+
     return {
       id: summary.id,
       directoryPath: summary.directoryPath,
@@ -463,6 +482,11 @@ class CacheManager {
     }
 
     const summary = result.data;
+    if (!isCurrentParserVersion(summary.parserVersion)) {
+      warnParserVersionMismatch(cacheId, summary.parserVersion);
+      return;
+    }
+
     if (Array.isArray(summary.metadata) && summary.metadata.length > 0) {
       await onChunk(compactCacheMetadataEntries(summary.metadata));
       return;

--- a/services/comfyUIWorkflowHydration.ts
+++ b/services/comfyUIWorkflowHydration.ts
@@ -1,0 +1,33 @@
+import { type IndexedImage } from '../types';
+import { extractEmbeddedComfyWorkflow } from './comfyUIWorkflowBuilder';
+import { reparseIndexedImage } from './fileIndexer';
+
+const getDirectoryPathForImage = (image: IndexedImage, directoryPath?: string): string => (
+  directoryPath || image.directoryId || image.id.split('::')[0] || ''
+);
+
+export const hasCompactedRuntimeMetadata = (image: IndexedImage): boolean => (
+  Boolean((image.metadata as Record<string, unknown> | undefined)?._rawMetadataCompacted)
+);
+
+export async function hydrateImageForEmbeddedComfyWorkflow(
+  image: IndexedImage,
+  directoryPath?: string
+): Promise<IndexedImage> {
+  const embedded = extractEmbeddedComfyWorkflow(image);
+  if (embedded.prompt || !hasCompactedRuntimeMetadata(image)) {
+    return image;
+  }
+
+  const resolvedDirectoryPath = getDirectoryPathForImage(image, directoryPath);
+  if (!resolvedDirectoryPath) {
+    return image;
+  }
+
+  try {
+    return await reparseIndexedImage(image, resolvedDirectoryPath, { compactRawMetadata: false }) || image;
+  } catch (error) {
+    console.warn('[ComfyUI] Failed to reload full embedded workflow metadata:', error);
+    return image;
+  }
+}

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -1326,7 +1326,8 @@ async function processSingleFileOptimized(
   fileEntry: CatalogFileEntry,
   directoryId: string,
   fileData?: ArrayBuffer,
-  profile?: PhaseProfileSample
+  profile?: PhaseProfileSample,
+  options: { compactRawMetadata?: boolean } = {}
 ): Promise<IndexedImage | null> {
   try {
     const totalStart = profile ? performance.now() : 0;
@@ -1680,7 +1681,9 @@ if (normalizedMetadata && isAudio) {
       profile.totalMs = performance.now() - totalStart;
     }
 
-    const runtimeMetadata = compactRawMetadataForRuntime(rawMetadata, normalizedMetadata);
+    const runtimeMetadata = options.compactRawMetadata === false
+      ? buildUncompactedRawMetadataForRuntime(rawMetadata, normalizedMetadata)
+      : compactRawMetadataForRuntime(rawMetadata, normalizedMetadata);
 
     return {
       id: `${directoryId}::${fileEntry.path}`,
@@ -1716,7 +1719,8 @@ if (normalizedMetadata && isAudio) {
 
 export async function reparseIndexedImage(
   image: IndexedImage,
-  directoryPath: string
+  directoryPath: string,
+  options: { compactRawMetadata?: boolean } = {}
 ): Promise<IndexedImage | null> {
   if (!window.electronAPI?.joinPaths || !window.electronAPI?.readFile) {
     throw new Error('Metadata reparsing is only available in the desktop app.');
@@ -1760,7 +1764,9 @@ export async function reparseIndexedImage(
   return processSingleFileOptimized(
     fileEntry,
     image.directoryId || image.id.split('::')[0] || '',
-    fileData
+    fileData,
+    undefined,
+    options
   );
 }
 
@@ -1897,6 +1903,27 @@ export interface ProcessFilesResult {
 
 const MAX_INLINE_RAW_METADATA_BYTES = 32 * 1024;
 const RAW_METADATA_PREVIEW_BYTES = 4096;
+
+function buildUncompactedRawMetadataForRuntime(
+  rawMetadata: ImageMetadata | null,
+  normalizedMetadata?: BaseMetadata
+): { metadata: IndexedImage['metadata']; metadataString: string } {
+  if (!rawMetadata || Object.keys(rawMetadata).length === 0) {
+    return {
+      metadata: normalizedMetadata ? { normalizedMetadata } as IndexedImage['metadata'] : {},
+      metadataString: '',
+    };
+  }
+
+  const metadata = normalizedMetadata
+    ? { ...rawMetadata, normalizedMetadata } as IndexedImage['metadata']
+    : rawMetadata as IndexedImage['metadata'];
+
+  return {
+    metadata,
+    metadataString: JSON.stringify(rawMetadata),
+  };
+}
 
 function compactRawMetadataForRuntime(
   rawMetadata: ImageMetadata | null,

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -1361,8 +1361,37 @@ async function processSingleFileOptimized(
       }
       bufferForDimensions = fileData;
       fileSizeValue = fileSizeValue ?? fileData.byteLength;
+    } else if (isElectron && (fileEntry.handle as ElectronFileHandle)?._filePath && (window as any).electronAPI?.readFile) {
+      const absoluteFilePath = (fileEntry.handle as ElectronFileHandle)._filePath as string;
+      const fileResult = await (window as any).electronAPI.readFile(absoluteFilePath);
+      if (!fileResult.success || !fileResult.data) {
+        throw new Error(fileResult.error || `Failed to read file: ${fileEntry.handle.name}`);
+      }
+      const raw = fileResult.data as ArrayBuffer | ArrayBufferView;
+      if (raw instanceof ArrayBuffer) {
+        fileData = raw;
+      } else if (ArrayBuffer.isView(raw)) {
+        const view = raw as ArrayBufferView;
+        const copy = new Uint8Array(view.byteLength);
+        copy.set(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+        fileData = copy.buffer;
+      } else {
+        throw new Error(`Failed to read file: ${fileEntry.handle.name}`);
+      }
+      const view = new DataView(fileData);
+      const detectedType = detectImageType(view);
+      if (detectedType === 'png') {
+        rawMetadata = await parsePNGMetadata(fileData);
+      } else if (detectedType === 'jpeg') {
+        rawMetadata = await parseJPEGMetadata(fileData);
+      } else if (detectedType === 'webp') {
+        rawMetadata = await parseWebPMetadata(fileData);
+      } else {
+        rawMetadata = null;
+      }
+      bufferForDimensions = fileData;
+      fileSizeValue = fileSizeValue ?? fileData.byteLength;
     } else {
-      // Fallback to individual file read (browser path)
       const file = await fileEntry.handle.getFile();
       const parsed = await parseImageMetadata(file);
       rawMetadata = parsed.metadata;

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -1651,6 +1651,8 @@ if (normalizedMetadata && isAudio) {
       profile.totalMs = performance.now() - totalStart;
     }
 
+    const runtimeMetadata = compactRawMetadataForRuntime(rawMetadata, normalizedMetadata);
+
     return {
       id: `${directoryId}::${fileEntry.path}`,
       name: fileEntry.handle.name,
@@ -1658,8 +1660,8 @@ if (normalizedMetadata && isAudio) {
       thumbnailStatus: 'pending',
       thumbnailError: null,
       directoryId,
-      metadata: normalizedMetadata ? { ...(rawMetadata ?? {}), normalizedMetadata } : rawMetadata || {},
-      metadataString: (rawMetadata && Object.keys(rawMetadata).length > 0) ? JSON.stringify(rawMetadata) : '', // OPTIMIZED: Skip stringify if no metadata or empty object
+      metadata: runtimeMetadata.metadata,
+      metadataString: runtimeMetadata.metadataString,
       lastModified: sortDate, // Use the determined sort date
       contentModifiedMs: fileEntry.contentModifiedMs ?? fileEntry.lastModified,
       models: normalizedMetadata?.models || [],
@@ -1862,6 +1864,61 @@ interface ProcessFilesOptions {
 
 export interface ProcessFilesResult {
   phaseB: Promise<void>;
+}
+
+const MAX_INLINE_RAW_METADATA_BYTES = 32 * 1024;
+const RAW_METADATA_PREVIEW_BYTES = 4096;
+
+function compactRawMetadataForRuntime(
+  rawMetadata: ImageMetadata | null,
+  normalizedMetadata?: BaseMetadata
+): { metadata: IndexedImage['metadata']; metadataString: string } {
+  if (!rawMetadata || Object.keys(rawMetadata).length === 0) {
+    return {
+      metadata: normalizedMetadata ? { normalizedMetadata } as IndexedImage['metadata'] : {},
+      metadataString: '',
+    };
+  }
+
+  const rawMetadataString = JSON.stringify(rawMetadata);
+  if (rawMetadataString.length <= MAX_INLINE_RAW_METADATA_BYTES) {
+    return {
+      metadata: normalizedMetadata
+        ? { ...rawMetadata, normalizedMetadata } as IndexedImage['metadata']
+        : rawMetadata,
+      metadataString: rawMetadataString,
+    };
+  }
+
+  const compactedRawMetadata: Record<string, unknown> = {
+    _rawMetadataCompacted: true,
+    _rawMetadataSizeBytes: rawMetadataString.length,
+    _rawMetadataKeys: Object.keys(rawMetadata),
+  };
+
+  if ('parameters' in rawMetadata && typeof rawMetadata.parameters === 'string') {
+    compactedRawMetadata.parametersPreview = rawMetadata.parameters.slice(0, RAW_METADATA_PREVIEW_BYTES);
+  }
+
+  if ('imagemetahub_data' in rawMetadata && rawMetadata.imagemetahub_data && typeof rawMetadata.imagemetahub_data === 'object') {
+    const payload = rawMetadata.imagemetahub_data as Record<string, unknown>;
+    compactedRawMetadata.imagemetahub_data = {
+      generator: payload.generator,
+      analytics: payload.analytics,
+      _analytics: payload._analytics,
+      imh_pro: payload.imh_pro,
+      _metahub_pro: payload._metahub_pro,
+    };
+  }
+
+  if (normalizedMetadata) {
+    compactedRawMetadata.normalizedMetadata = normalizedMetadata;
+  }
+
+  return {
+    metadata: compactedRawMetadata as IndexedImage['metadata'],
+    metadataString: JSON.stringify(compactedRawMetadata),
+  };
 }
 
 function mapIndexedImageToCache(image: IndexedImage): CacheImageMetadata {
@@ -2699,11 +2756,12 @@ export async function processFiles(
       const rawMetadata = { ...(image.metadata || {}) } as Record<string, unknown>;
       delete rawMetadata.normalizedMetadata;
       rawMetadata.imagemetahub_data = metaHubData;
+      const runtimeMetadata = compactRawMetadataForRuntime(rawMetadata as ImageMetadata, normalizedMetadata);
 
       return {
         ...image,
-        metadata: { ...rawMetadata, normalizedMetadata },
-        metadataString: Object.keys(rawMetadata).length > 0 ? JSON.stringify(rawMetadata) : '',
+        metadata: runtimeMetadata.metadata,
+        metadataString: runtimeMetadata.metadataString,
         models: normalizedMetadata.models || [],
         loras: normalizedMetadata.loras || [],
         sampler: normalizedMetadata.sampler || '',


### PR DESCRIPTION
## Summary

- compact oversized raw metadata while preserving normalized metadata for search, filters, and display
- make cache diffing stream cached metadata chunks instead of materializing the full cache at once
- reduce per-image Electron handle overhead and avoid automatic table thumbnails for very large table views
- increase renderer V8 heap headroom for large local libraries

## Why

Large ComfyUI libraries can contain tens of thousands of images with embedded workflow metadata. Keeping raw metadata, cache chunks, handles, and table thumbnail work alive at the same time can push the renderer into OOM during indexing, startup reconciliation, or accidental Table View switches.

## Validation

- TypeScript and build were run locally before PR creation.