### PR TITLE
Fix macOS observations from v0.15.4

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1033,6 +1033,21 @@ export default function App() {
       if (currentLastViewed !== version) {
         setIsChangelogModalOpen(true);
         setLastViewedVersion(version);
+
+        if (window.electronAPI?.getSettings && window.electronAPI?.saveSettings) {
+          try {
+            const currentSettings = await window.electronAPI.getSettings();
+            const result = await window.electronAPI.saveSettings({
+              ...(currentSettings ?? {}),
+              lastViewedVersion: version,
+            });
+            if (!result?.success) {
+              console.warn('Failed to persist last viewed changelog version:', result?.error);
+            }
+          } catch (error) {
+            console.warn('Failed to persist last viewed changelog version:', error);
+          }
+        }
       }
     };
 

--- a/__tests__/smartLibraryClusterState.test.ts
+++ b/__tests__/smartLibraryClusterState.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { ImageCluster, IndexedImage } from '../types';
+import {
+  buildClusteringMetadata,
+  buildClusterSourceSignature,
+  isClusterCacheCompatible,
+  limitClustersForAccess,
+} from '../utils/smartLibraryClusterState';
+
+const makeImage = (index: number, prompt = `prompt ${index}`): IndexedImage => ({
+  id: `img-${index}`,
+  name: `image-${index}.png`,
+  path: `/library/image-${index}.png`,
+  directoryId: 'dir',
+  directoryName: 'Library',
+  lastModified: index,
+  prompt,
+  models: [],
+  loras: [],
+  hash: `hash-${index}`,
+  handle: {} as FileSystemFileHandle,
+  thumbnailStatus: 'pending',
+}) as IndexedImage;
+
+const makeCluster = (id: string, imageIds: string[]): ImageCluster => ({
+  id,
+  promptHash: id,
+  basePrompt: id,
+  imageIds,
+  coverImageId: imageIds[0],
+  size: imageIds.length,
+  similarityThreshold: 0.98,
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+describe('smart library cluster state', () => {
+  it('changes the cache source signature when prompt-bearing images change', () => {
+    const images = [makeImage(1), makeImage(2)];
+    const baseline = buildClusterSourceSignature(images);
+
+    expect(buildClusterSourceSignature([...images, makeImage(3)])).not.toBe(baseline);
+    expect(buildClusterSourceSignature([makeImage(1, 'changed'), makeImage(2)])).not.toBe(baseline);
+    expect(buildClusterSourceSignature([makeImage(2), makeImage(1)])).not.toBe(baseline);
+  });
+
+  it('trims restored clusters to the free preview range', () => {
+    const images = Array.from({ length: 510 }, (_, index) => makeImage(index));
+    const clusters = [
+      makeCluster('inside', ['img-0', 'img-1', 'img-2']),
+      makeCluster('mixed', ['img-498', 'img-500', 'img-501']),
+      makeCluster('outside', ['img-500', 'img-501', 'img-502']),
+    ];
+
+    const limited = limitClustersForAccess(clusters, images, false);
+
+    expect(limited.map((cluster) => cluster.id)).toEqual(['inside', 'mixed']);
+    expect(limited.find((cluster) => cluster.id === 'mixed')?.imageIds).toEqual(['img-498']);
+    expect(limited.find((cluster) => cluster.id === 'mixed')?.size).toBe(1);
+  });
+
+  it('builds free-tier lock metadata for preview images only', () => {
+    const metadata = buildClusteringMetadata(
+      Array.from({ length: 510 }, (_, index) => makeImage(index)),
+      false
+    );
+
+    expect(metadata.processedCount).toBe(300);
+    expect(metadata.remainingCount).toBe(10);
+    expect(metadata.isLimited).toBe(true);
+    expect(metadata.lockedImageIds.has('img-299')).toBe(false);
+    expect(metadata.lockedImageIds.has('img-300')).toBe(true);
+    expect(metadata.lockedImageIds.has('img-499')).toBe(true);
+    expect(metadata.lockedImageIds.has('img-500')).toBe(false);
+  });
+
+  it('rejects limited caches when full clustering is available', () => {
+    expect(isClusterCacheCompatible({
+      canUseFullClustering: true,
+      processedImageCount: 500,
+      sourceImageCount: 600,
+    })).toBe(false);
+
+    expect(isClusterCacheCompatible({
+      canUseFullClustering: true,
+      processedImageCount: 600,
+      sourceImageCount: 600,
+    })).toBe(true);
+
+    expect(isClusterCacheCompatible({
+      canUseFullClustering: false,
+      processedImageCount: 500,
+      sourceImageCount: 600,
+    })).toBe(true);
+  });
+});

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -270,6 +270,7 @@ export default function DirectoryList({
     path: string;
   } | null>(null);
   const treeRef = useRef<HTMLDivElement>(null);
+  const nodeRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const treeKeyboardActiveRef = useRef(false);
 
   // Focus input when prompt opens
@@ -392,6 +393,24 @@ export default function DirectoryList({
     onToggleFolderSelection(path, event.ctrlKey || event.metaKey);
   }, [onToggleFolderSelection]);
 
+  const registerNodeRef = useCallback((nodeKey: string) => (element: HTMLDivElement | null) => {
+    if (element) {
+      nodeRefs.current.set(nodeKey, element);
+    } else {
+      nodeRefs.current.delete(nodeKey);
+    }
+  }, []);
+
+  const scrollNodeIntoView = useCallback((nodeKey: string) => {
+    requestAnimationFrame(() => {
+      const element = nodeRefs.current.get(nodeKey);
+      element?.scrollIntoView({
+        block: 'nearest',
+        inline: 'nearest',
+      });
+    });
+  }, []);
+
   const handleContextMenu = useCallback((
     event: React.MouseEvent,
     path: string
@@ -496,6 +515,7 @@ export default function DirectoryList({
       return (
         <li key={childKey} className="py-1">
           <div
+            ref={registerNodeRef(childKey)}
             className={`flex items-center cursor-pointer rounded px-2 py-1 transition-colors group ${
               isSelected
                 ? 'bg-blue-500/15 ring-1 ring-blue-500/30 hover:bg-blue-500/20'
@@ -727,12 +747,15 @@ export default function DirectoryList({
 
       const selectNodeAt = (index: number) => {
         const safeIndex = Math.max(0, Math.min(visibleNodes.length - 1, index));
+        const nextNode = visibleNodes[safeIndex];
         if (selectedIndex >= 0 && safeIndex === currentIndex) {
           treeRef.current?.focus({ preventScroll: true });
+          scrollNodeIntoView(nextNode.key);
           return;
         }
-        onToggleFolderSelection(visibleNodes[safeIndex].path, false);
+        onToggleFolderSelection(nextNode.path, false);
         treeRef.current?.focus({ preventScroll: true });
+        scrollNodeIntoView(nextNode.key);
       };
 
       if (event.key === 'ArrowDown') {
@@ -892,6 +915,7 @@ export default function DirectoryList({
               return (
                 <li key={dir.id}>
                   <div
+                    ref={registerNodeRef(rootKey)}
                     className={`relative overflow-hidden flex items-center justify-between p-2 rounded-md transition-colors ${
                       isRootSelected
                         ? 'bg-blue-500/15 ring-1 ring-blue-500/30 hover:bg-blue-500/20'

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1637,6 +1637,32 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         }
       } else if (e.key === 'PageDown') {
         e.preventDefault();
+        const itemCount = itemsToRender.length;
+        if (isInfinite && itemCount > 0) {
+          const columnCount = getActiveColumnCount();
+          const rowHeight = getItemHeight(imageSize, showFilenameArea) + GAP_SIZE;
+          const viewportHeight = getGridScrollElement()?.clientHeight ?? rowHeight;
+          const visibleRows = Math.max(1, Math.floor(viewportHeight / rowHeight));
+          const currentRenderedIndex = getRenderedIndexForImageIndex(focusedImageIndexRef.current);
+          const nextRenderedIndex = clampIndex(
+            (currentRenderedIndex >= 0 ? currentRenderedIndex : 0) + (columnCount * visibleRows),
+            itemCount,
+          );
+          const nextItem = itemsToRender[nextRenderedIndex];
+          const previewTarget = nextItem
+            ? isImageStack(nextItem)
+              ? nextItem.coverImage
+              : nextItem
+            : undefined;
+          const resolvedImageIndex = nextItem ? getImageIndexForRenderedItem(nextItem) : -1;
+
+          if (previewTarget && resolvedImageIndex >= 0) {
+            focusedImageIndexRef.current = resolvedImageIndex;
+            setFocusedImageIndex(resolvedImageIndex);
+            setPreviewImage(previewTarget);
+          }
+          return;
+        }
         if (currentPage < totalPages) {
           onPageChange(currentPage + 1);
           focusedImageIndexRef.current = 0;
@@ -1644,6 +1670,32 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         }
       } else if (e.key === 'PageUp') {
         e.preventDefault();
+        const itemCount = itemsToRender.length;
+        if (isInfinite && itemCount > 0) {
+          const columnCount = getActiveColumnCount();
+          const rowHeight = getItemHeight(imageSize, showFilenameArea) + GAP_SIZE;
+          const viewportHeight = getGridScrollElement()?.clientHeight ?? rowHeight;
+          const visibleRows = Math.max(1, Math.floor(viewportHeight / rowHeight));
+          const currentRenderedIndex = getRenderedIndexForImageIndex(focusedImageIndexRef.current);
+          const nextRenderedIndex = clampIndex(
+            (currentRenderedIndex >= 0 ? currentRenderedIndex : 0) - (columnCount * visibleRows),
+            itemCount,
+          );
+          const nextItem = itemsToRender[nextRenderedIndex];
+          const previewTarget = nextItem
+            ? isImageStack(nextItem)
+              ? nextItem.coverImage
+              : nextItem
+            : undefined;
+          const resolvedImageIndex = nextItem ? getImageIndexForRenderedItem(nextItem) : -1;
+
+          if (previewTarget && resolvedImageIndex >= 0) {
+            focusedImageIndexRef.current = resolvedImageIndex;
+            setFocusedImageIndex(resolvedImageIndex);
+            setPreviewImage(previewTarget);
+          }
+          return;
+        }
         if (currentPage > 1) {
           onPageChange(currentPage - 1);
           focusedImageIndexRef.current = 0;
@@ -1665,7 +1717,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('keyup', handleKeyUp);
     };
-  }, [flushKeyboardPreview, getActiveColumnCount, getImageIndexForRenderedItem, getRenderedIndexForImageIndex, itemsToRender, setFocusedImageIndex, setPreviewImage, onImageClick, focusedImageIndex, images, currentPage, totalPages, onPageChange]);
+  }, [flushKeyboardPreview, getActiveColumnCount, getGridScrollElement, getImageIndexForRenderedItem, getRenderedIndexForImageIndex, imageSize, isInfinite, itemsToRender, setFocusedImageIndex, setPreviewImage, onImageClick, focusedImageIndex, images, currentPage, totalPages, onPageChange, showFilenameArea]);
 
   useEffect(() => {
     return () => {

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2667,7 +2667,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 />
               </div>
             ) : isVideo ? (
-              <div data-no-window-drag="true" className="max-h-full max-w-full">
+              <div data-no-window-drag="true" className="h-full min-h-0 w-full min-w-0">
                 <VideoPlayer
                   key={image.id}
                   src={imageUrl}

--- a/components/SmartLibrary.tsx
+++ b/components/SmartLibrary.tsx
@@ -2,6 +2,8 @@ import React, { useMemo, useEffect, useRef, useState } from 'react';
 import { Layers, Sparkles } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
+import { useLicenseStore } from '../store/useLicenseStore';
+import { CLUSTERING_FREE_TIER_LIMIT, CLUSTERING_PREVIEW_LIMIT } from '../hooks/useFeatureAccess';
 
 import { useA1111ProgressContext } from '../contexts/A1111ProgressContext';
 import { useGenerationQueueStore } from '../store/useGenerationQueueStore';
@@ -33,6 +35,7 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
   onOpenImageInBackground,
 }) => {
   const filteredImages = useImageStore((state) => state.filteredImages);
+  const images = useImageStore((state) => state.images);
   const clusters = useImageStore((state) => state.clusters);
   const directories = useImageStore((state) => state.directories);
   const scanSubfolders = useImageStore((state) => state.scanSubfolders);
@@ -54,6 +57,7 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
   const queueCount = useGenerationQueueStore((state) =>
     state.items.filter((item) => item.status === 'waiting' || item.status === 'processing').length
   );
+  const licenseStatus = useLicenseStore((state) => state.licenseStatus);
 
   const safeFilteredImages = Array.isArray(filteredImages) ? filteredImages : [];
 
@@ -183,7 +187,25 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
     loadClusterCache(primaryPath, scanSubfolders)
       .then((cache) => {
         if (!cancelled && cache?.clusters?.length) {
-          setClusters(cache.clusters);
+          const isPro = licenseStatus === 'pro' || licenseStatus === 'lifetime';
+          const isTrialActive = licenseStatus === 'trial';
+          const imagesWithPrompts = images.filter((image) => image.prompt && image.prompt.trim().length > 0);
+          const processingLimit = (isPro || isTrialActive) ? Infinity : CLUSTERING_PREVIEW_LIMIT;
+          const limitedImages = imagesWithPrompts.slice(0, processingLimit);
+          const lockedImageIds = new Set<string>();
+
+          if (!isPro && !isTrialActive && imagesWithPrompts.length > CLUSTERING_FREE_TIER_LIMIT) {
+            imagesWithPrompts
+              .slice(CLUSTERING_FREE_TIER_LIMIT, processingLimit)
+              .forEach((image) => lockedImageIds.add(image.id));
+          }
+
+          setClusters(cache.clusters, {
+            processedCount: Math.min(limitedImages.length, CLUSTERING_FREE_TIER_LIMIT),
+            remainingCount: Math.max(0, imagesWithPrompts.length - processingLimit),
+            isLimited: imagesWithPrompts.length > processingLimit,
+            lockedImageIds,
+          });
         }
       })
       .catch((error) => {
@@ -193,7 +215,7 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [clusters.length, isClustering, primaryPath, scanSubfolders, setClusters]);
+  }, [clusters.length, images, isClustering, licenseStatus, primaryPath, scanSubfolders, setClusters]);
 
   const handleGenerateClusters = () => {
     if (!primaryPath) return;

--- a/components/SmartLibrary.tsx
+++ b/components/SmartLibrary.tsx
@@ -6,6 +6,7 @@ import { useSettingsStore } from '../store/useSettingsStore';
 import { useA1111ProgressContext } from '../contexts/A1111ProgressContext';
 import { useGenerationQueueStore } from '../store/useGenerationQueueStore';
 import { ImageCluster, IndexedImage } from '../types';
+import { loadClusterCache } from '../services/clusterCacheManager';
 import StackCard from './StackCard';
 import StackExpandedView from './StackExpandedView';
 import ClusterUpgradeBanner from './ClusterUpgradeBanner';
@@ -42,6 +43,7 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
   const autoTaggingProgress = useImageStore((state) => state.autoTaggingProgress);
   const startClustering = useImageStore((state) => state.startClustering);
   const startAutoTagging = useImageStore((state) => state.startAutoTagging);
+  const setClusters = useImageStore((state) => state.setClusters);
   const setClusterNavigationContext = useImageStore((state) => state.setClusterNavigationContext);
   const selectionTotalImages = useImageStore((state) => state.selectionTotalImages);
   const selectionDirectoryCount = useImageStore((state) => state.selectionDirectoryCount);
@@ -62,6 +64,7 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
   const stackScrollRef = useRef<HTMLDivElement | null>(null);
   const stackScrollTopRef = useRef(0);
   const shouldRestoreStackScrollRef = useRef(false);
+  const restoredClusterCacheKeyRef = useRef<string | null>(null);
 
   const imageMap = useMemo(() => {
     return new Map(safeFilteredImages.map((image) => [image.id, image]));
@@ -163,6 +166,34 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
 
   const primaryPath = directories[0]?.path ?? '';
   const hasDirectories = directories.length > 0;
+
+  useEffect(() => {
+    if (!primaryPath || clusters.length > 0 || isClustering) {
+      return;
+    }
+
+    const cacheKey = `${primaryPath}::${scanSubfolders ? 'recursive' : 'flat'}`;
+    if (restoredClusterCacheKeyRef.current === cacheKey) {
+      return;
+    }
+
+    restoredClusterCacheKeyRef.current = cacheKey;
+    let cancelled = false;
+
+    loadClusterCache(primaryPath, scanSubfolders)
+      .then((cache) => {
+        if (!cancelled && cache?.clusters?.length) {
+          setClusters(cache.clusters);
+        }
+      })
+      .catch((error) => {
+        console.warn('Failed to restore Smart Library cluster cache:', error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [clusters.length, isClustering, primaryPath, scanSubfolders, setClusters]);
 
   const handleGenerateClusters = () => {
     if (!primaryPath) return;

--- a/components/SmartLibrary.tsx
+++ b/components/SmartLibrary.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useEffect, useRef, useState } from 'react';
 import { Layers, Sparkles } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -69,6 +69,7 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
   const stackScrollTopRef = useRef(0);
   const shouldRestoreStackScrollRef = useRef(false);
   const restoredClusterCacheKeyRef = useRef<string | null>(null);
+  const clusterMetadataSignatureRef = useRef<string | null>(null);
 
   const imageMap = useMemo(() => {
     return new Map(safeFilteredImages.map((image) => [image.id, image]));
@@ -171,8 +172,45 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
   const primaryPath = directories[0]?.path ?? '';
   const hasDirectories = directories.length > 0;
 
+  const buildClusteringMetadata = useCallback(() => {
+    const isPro = licenseStatus === 'pro' || licenseStatus === 'lifetime';
+    const isTrialActive = licenseStatus === 'trial';
+    const imagesWithPrompts = images.filter((image) => image.prompt && image.prompt.trim().length > 0);
+    const processingLimit = (isPro || isTrialActive) ? Infinity : CLUSTERING_PREVIEW_LIMIT;
+    const limitedImages = imagesWithPrompts.slice(0, processingLimit);
+    const lockedImageIds = new Set<string>();
+
+    if (!isPro && !isTrialActive && imagesWithPrompts.length > CLUSTERING_FREE_TIER_LIMIT) {
+      imagesWithPrompts
+        .slice(CLUSTERING_FREE_TIER_LIMIT, processingLimit)
+        .forEach((image) => lockedImageIds.add(image.id));
+    }
+
+    return {
+      processedCount: Math.min(limitedImages.length, CLUSTERING_FREE_TIER_LIMIT),
+      remainingCount: Math.max(0, imagesWithPrompts.length - processingLimit),
+      isLimited: imagesWithPrompts.length > processingLimit,
+      lockedImageIds,
+    };
+  }, [images, licenseStatus]);
+
+  const getClusteringMetadataSignature = useCallback((metadata: ReturnType<typeof buildClusteringMetadata>) => {
+    return [
+      metadata.processedCount,
+      metadata.remainingCount,
+      metadata.isLimited ? 'limited' : 'unlimited',
+      metadata.lockedImageIds.size,
+      Array.from(metadata.lockedImageIds).join(','),
+    ].join(':');
+  }, []);
+
   useEffect(() => {
     if (!primaryPath || clusters.length > 0 || isClustering) {
+      return;
+    }
+
+    const hasPromptImages = images.some((image) => image.prompt && image.prompt.trim().length > 0);
+    if (!hasPromptImages) {
       return;
     }
 
@@ -181,31 +219,15 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
       return;
     }
 
-    restoredClusterCacheKeyRef.current = cacheKey;
     let cancelled = false;
 
     loadClusterCache(primaryPath, scanSubfolders)
       .then((cache) => {
         if (!cancelled && cache?.clusters?.length) {
-          const isPro = licenseStatus === 'pro' || licenseStatus === 'lifetime';
-          const isTrialActive = licenseStatus === 'trial';
-          const imagesWithPrompts = images.filter((image) => image.prompt && image.prompt.trim().length > 0);
-          const processingLimit = (isPro || isTrialActive) ? Infinity : CLUSTERING_PREVIEW_LIMIT;
-          const limitedImages = imagesWithPrompts.slice(0, processingLimit);
-          const lockedImageIds = new Set<string>();
-
-          if (!isPro && !isTrialActive && imagesWithPrompts.length > CLUSTERING_FREE_TIER_LIMIT) {
-            imagesWithPrompts
-              .slice(CLUSTERING_FREE_TIER_LIMIT, processingLimit)
-              .forEach((image) => lockedImageIds.add(image.id));
-          }
-
-          setClusters(cache.clusters, {
-            processedCount: Math.min(limitedImages.length, CLUSTERING_FREE_TIER_LIMIT),
-            remainingCount: Math.max(0, imagesWithPrompts.length - processingLimit),
-            isLimited: imagesWithPrompts.length > processingLimit,
-            lockedImageIds,
-          });
+          restoredClusterCacheKeyRef.current = cacheKey;
+          const metadata = buildClusteringMetadata();
+          clusterMetadataSignatureRef.current = getClusteringMetadataSignature(metadata);
+          setClusters(cache.clusters, metadata);
         }
       })
       .catch((error) => {
@@ -215,7 +237,22 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [clusters.length, images, isClustering, licenseStatus, primaryPath, scanSubfolders, setClusters]);
+  }, [buildClusteringMetadata, clusters.length, getClusteringMetadataSignature, images, isClustering, primaryPath, scanSubfolders, setClusters]);
+
+  useEffect(() => {
+    if (clusters.length === 0 || isClustering) {
+      return;
+    }
+
+    const metadata = buildClusteringMetadata();
+    const signature = getClusteringMetadataSignature(metadata);
+    if (clusterMetadataSignatureRef.current === signature) {
+      return;
+    }
+
+    clusterMetadataSignatureRef.current = signature;
+    setClusters(clusters, metadata);
+  }, [buildClusteringMetadata, clusters, getClusteringMetadataSignature, isClustering, setClusters]);
 
   const handleGenerateClusters = () => {
     if (!primaryPath) return;

--- a/components/SmartLibrary.tsx
+++ b/components/SmartLibrary.tsx
@@ -1,14 +1,21 @@
-import React, { useCallback, useMemo, useEffect, useRef, useState } from 'react';
+import React, { useMemo, useEffect, useRef, useState } from 'react';
 import { Layers, Sparkles } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
-import { useLicenseStore } from '../store/useLicenseStore';
-import { CLUSTERING_FREE_TIER_LIMIT, CLUSTERING_PREVIEW_LIMIT } from '../hooks/useFeatureAccess';
+import { useFeatureAccess } from '../hooks/useFeatureAccess';
 
 import { useA1111ProgressContext } from '../contexts/A1111ProgressContext';
 import { useGenerationQueueStore } from '../store/useGenerationQueueStore';
 import { ImageCluster, IndexedImage } from '../types';
 import { loadClusterCache } from '../services/clusterCacheManager';
+import {
+  buildClusteringMetadata,
+  buildClusterSourceSignature,
+  buildClusterStateSignature,
+  getPromptImagesForClustering,
+  isClusterCacheCompatible,
+  limitClustersForAccess,
+} from '../utils/smartLibraryClusterState';
 import StackCard from './StackCard';
 import StackExpandedView from './StackExpandedView';
 import ClusterUpgradeBanner from './ClusterUpgradeBanner';
@@ -40,6 +47,7 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
   const directories = useImageStore((state) => state.directories);
   const scanSubfolders = useImageStore((state) => state.scanSubfolders);
   const isClustering = useImageStore((state) => state.isClustering);
+  const indexingState = useImageStore((state) => state.indexingState);
   const clusteringProgress = useImageStore((state) => state.clusteringProgress);
   const clusteringMetadata = useImageStore((state) => state.clusteringMetadata);
   const isAutoTagging = useImageStore((state) => state.isAutoTagging);
@@ -57,7 +65,7 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
   const queueCount = useGenerationQueueStore((state) =>
     state.items.filter((item) => item.status === 'waiting' || item.status === 'processing').length
   );
-  const licenseStatus = useLicenseStore((state) => state.licenseStatus);
+  const { canUseFullClustering, initialized: isLicenseInitialized } = useFeatureAccess();
 
   const safeFilteredImages = Array.isArray(filteredImages) ? filteredImages : [];
 
@@ -172,62 +180,60 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
   const primaryPath = directories[0]?.path ?? '';
   const hasDirectories = directories.length > 0;
 
-  const buildClusteringMetadata = useCallback(() => {
-    const isPro = licenseStatus === 'pro' || licenseStatus === 'lifetime';
-    const isTrialActive = licenseStatus === 'trial';
-    const imagesWithPrompts = images.filter((image) => image.prompt && image.prompt.trim().length > 0);
-    const processingLimit = (isPro || isTrialActive) ? Infinity : CLUSTERING_PREVIEW_LIMIT;
-    const limitedImages = imagesWithPrompts.slice(0, processingLimit);
-    const lockedImageIds = new Set<string>();
-
-    if (!isPro && !isTrialActive && imagesWithPrompts.length > CLUSTERING_FREE_TIER_LIMIT) {
-      imagesWithPrompts
-        .slice(CLUSTERING_FREE_TIER_LIMIT, processingLimit)
-        .forEach((image) => lockedImageIds.add(image.id));
-    }
-
-    return {
-      processedCount: Math.min(limitedImages.length, CLUSTERING_FREE_TIER_LIMIT),
-      remainingCount: Math.max(0, imagesWithPrompts.length - processingLimit),
-      isLimited: imagesWithPrompts.length > processingLimit,
-      lockedImageIds,
-    };
-  }, [images, licenseStatus]);
-
-  const getClusteringMetadataSignature = useCallback((metadata: ReturnType<typeof buildClusteringMetadata>) => {
-    return [
-      metadata.processedCount,
-      metadata.remainingCount,
-      metadata.isLimited ? 'limited' : 'unlimited',
-      metadata.lockedImageIds.size,
-      Array.from(metadata.lockedImageIds).join(','),
-    ].join(':');
-  }, []);
+  const promptImages = useMemo(() => getPromptImagesForClustering(images), [images]);
+  const clusterSourceSignature = useMemo(() => buildClusterSourceSignature(images), [images]);
+  const currentClusteringMetadata = useMemo(
+    () => buildClusteringMetadata(images, canUseFullClustering),
+    [canUseFullClustering, images]
+  );
 
   useEffect(() => {
-    if (!primaryPath || clusters.length > 0 || isClustering) {
+    if (
+      !primaryPath ||
+      !isLicenseInitialized ||
+      clusters.length > 0 ||
+      isClustering ||
+      indexingState === 'indexing' ||
+      indexingState === 'paused' ||
+      promptImages.length === 0
+    ) {
       return;
     }
 
-    const hasPromptImages = images.some((image) => image.prompt && image.prompt.trim().length > 0);
-    if (!hasPromptImages) {
-      return;
-    }
-
-    const cacheKey = `${primaryPath}::${scanSubfolders ? 'recursive' : 'flat'}`;
+    const cacheKey = [
+      primaryPath,
+      scanSubfolders ? 'recursive' : 'flat',
+      clusterSourceSignature,
+      canUseFullClustering ? 'full' : 'limited',
+    ].join('::');
     if (restoredClusterCacheKeyRef.current === cacheKey) {
       return;
     }
 
     let cancelled = false;
 
-    loadClusterCache(primaryPath, scanSubfolders)
+    loadClusterCache(primaryPath, scanSubfolders, clusterSourceSignature)
       .then((cache) => {
-        if (!cancelled && cache?.clusters?.length) {
-          restoredClusterCacheKeyRef.current = cacheKey;
-          const metadata = buildClusteringMetadata();
-          clusterMetadataSignatureRef.current = getClusteringMetadataSignature(metadata);
-          setClusters(cache.clusters, metadata);
+        if (cancelled) {
+          return;
+        }
+
+        restoredClusterCacheKeyRef.current = cacheKey;
+        if (
+          !cache?.clusters?.length ||
+          !isClusterCacheCompatible({
+            canUseFullClustering,
+            processedImageCount: cache.processedImageCount,
+            sourceImageCount: cache.sourceImageCount,
+          })
+        ) {
+          return;
+        }
+
+        const restoredClusters = limitClustersForAccess(cache.clusters, images, canUseFullClustering);
+        if (restoredClusters.length > 0) {
+          clusterMetadataSignatureRef.current = buildClusterStateSignature(restoredClusters, currentClusteringMetadata);
+          setClusters(restoredClusters, currentClusteringMetadata);
         }
       })
       .catch((error) => {
@@ -237,22 +243,35 @@ const SmartLibrary: React.FC<SmartLibraryProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [buildClusteringMetadata, clusters.length, getClusteringMetadataSignature, images, isClustering, primaryPath, scanSubfolders, setClusters]);
+  }, [
+    canUseFullClustering,
+    clusterSourceSignature,
+    clusters.length,
+    currentClusteringMetadata,
+    images,
+    indexingState,
+    isClustering,
+    isLicenseInitialized,
+    primaryPath,
+    promptImages.length,
+    scanSubfolders,
+    setClusters,
+  ]);
 
   useEffect(() => {
-    if (clusters.length === 0 || isClustering) {
+    if (clusters.length === 0 || isClustering || !isLicenseInitialized) {
       return;
     }
 
-    const metadata = buildClusteringMetadata();
-    const signature = getClusteringMetadataSignature(metadata);
+    const limitedClusters = limitClustersForAccess(clusters, images, canUseFullClustering);
+    const signature = buildClusterStateSignature(limitedClusters, currentClusteringMetadata);
     if (clusterMetadataSignatureRef.current === signature) {
       return;
     }
 
     clusterMetadataSignatureRef.current = signature;
-    setClusters(clusters, metadata);
-  }, [buildClusteringMetadata, clusters, getClusteringMetadataSignature, isClustering, setClusters]);
+    setClusters(limitedClusters, currentClusteringMetadata);
+  }, [canUseFullClustering, clusters, currentClusteringMetadata, images, isClustering, isLicenseInitialized, setClusters]);
 
   const handleGenerateClusters = () => {
     if (!primaryPath) return;

--- a/services/clusterCacheManager.ts
+++ b/services/clusterCacheManager.ts
@@ -17,6 +17,9 @@ export interface ClusterCacheEntry {
   directoryPath: string;                // Original directory path
   scanSubfolders: boolean;              // Scan mode
   clusters: ImageCluster[];
+  sourceSignature: string;              // Signature of prompt-bearing images used for cache validity
+  sourceImageCount: number;             // Total prompt-bearing images at generation time
+  processedImageCount: number;          // Images actually clustered under the active license
   lastGenerated: number;                // Timestamp
   parserVersion: number;                // Track clustering version
   similarityThreshold: number;          // Threshold used
@@ -126,7 +129,8 @@ export async function getCacheDirectory(): Promise<string> {
  */
 export async function loadClusterCache(
   directoryPath: string,
-  scanSubfolders: boolean
+  scanSubfolders: boolean,
+  expectedSourceSignature?: string
 ): Promise<ClusterCacheEntry | null> {
   try {
     const cacheDir = await getCacheDirectory();
@@ -144,6 +148,12 @@ export async function loadClusterCache(
       if (cache.parserVersion !== PARSER_VERSION) {
         console.warn(`Cluster cache version mismatch. Expected ${PARSER_VERSION}, got ${cache.parserVersion}. Invalidating cache.`);
         await invalidateClusterCache(directoryPath, scanSubfolders, 'version_mismatch');
+        return null;
+      }
+
+      if (expectedSourceSignature && cache.sourceSignature !== expectedSourceSignature) {
+        console.warn('Cluster cache source signature mismatch. Invalidating cache.');
+        await invalidateClusterCache(directoryPath, scanSubfolders, 'source_signature_mismatch');
         return null;
       }
 
@@ -166,7 +176,10 @@ export async function saveClusterCache(
   directoryPath: string,
   scanSubfolders: boolean,
   clusters: ImageCluster[],
-  similarityThreshold: number
+  similarityThreshold: number,
+  sourceSignature: string,
+  sourceImageCount: number,
+  processedImageCount: number
 ): Promise<void> {
   try {
     const cacheDir = await getCacheDirectory();
@@ -179,6 +192,9 @@ export async function saveClusterCache(
       directoryPath,
       scanSubfolders,
       clusters,
+      sourceSignature,
+      sourceImageCount,
+      processedImageCount,
       lastGenerated: Date.now(),
       parserVersion: PARSER_VERSION,
       similarityThreshold,

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -41,6 +41,7 @@ import { createCacheDebugSnapshot, traceCacheDebug } from '../utils/cacheDebugTr
 import { useLicenseStore } from './useLicenseStore';
 import { useSettingsStore } from './useSettingsStore';
 import { CLUSTERING_FREE_TIER_LIMIT, CLUSTERING_PREVIEW_LIMIT } from '../hooks/useFeatureAccess';
+import { buildClusterSourceSignature } from '../utils/smartLibraryClusterState';
 import {
     type LineageBuildState,
     type LineageDirectorySignature,
@@ -3667,14 +3668,15 @@ export const useImageStore = create<ImageState>((set, get) => {
             // Filter images with prompts
             const imagesWithPrompts = images.filter(img => img.prompt && img.prompt.trim().length > 0);
 
-            // For free users: process CLUSTERING_PREVIEW_LIMIT (1500) images
-            // - First 1000: shown normally
-            // - Next 500: shown blurred (locked preview)
+            // For free users, process a bounded preview:
+            // - First CLUSTERING_FREE_TIER_LIMIT images are shown normally
+            // - Remaining preview images up to CLUSTERING_PREVIEW_LIMIT are locked
             const processingLimit = (isPro || isTrialActive) ? Infinity : CLUSTERING_PREVIEW_LIMIT;
             const limitedImages = imagesWithPrompts.slice(0, processingLimit);
             const remainingCount = Math.max(0, imagesWithPrompts.length - processingLimit);
+            const clusterSourceSignature = buildClusterSourceSignature(imagesWithPrompts);
 
-            // Track which images are in the "locked preview" range (1001-1500)
+            // Track which images are in the locked preview range.
             const lockedImageIds = new Set<string>();
             if (!isPro && !isTrialActive && imagesWithPrompts.length > CLUSTERING_FREE_TIER_LIMIT) {
                 const lockedImages = imagesWithPrompts.slice(CLUSTERING_FREE_TIER_LIMIT, processingLimit);
@@ -3719,7 +3721,17 @@ export const useImageStore = create<ImageState>((set, get) => {
                         console.log(`Clustering complete: ${payload.clusters.length} clusters created`);
 
                         import('../services/clusterCacheManager')
-                            .then(({ saveClusterCache }) => saveClusterCache(directoryPath, scanSubfolders, payload.clusters, threshold))
+                            .then(({ saveClusterCache }) =>
+                                saveClusterCache(
+                                    directoryPath,
+                                    scanSubfolders,
+                                    payload.clusters,
+                                    threshold,
+                                    clusterSourceSignature,
+                                    imagesWithPrompts.length,
+                                    limitedImages.length
+                                )
+                            )
                             .catch(error => {
                                 console.warn('Failed to save cluster cache:', error);
                             });

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -3717,6 +3717,12 @@ export const useImageStore = create<ImageState>((set, get) => {
                         worker.terminate();
                         set({ clusteringWorker: null });
                         console.log(`Clustering complete: ${payload.clusters.length} clusters created`);
+
+                        import('../services/clusterCacheManager')
+                            .then(({ saveClusterCache }) => saveClusterCache(directoryPath, scanSubfolders, payload.clusters, threshold))
+                            .catch(error => {
+                                console.warn('Failed to save cluster cache:', error);
+                            });
                         break;
 
                     case 'error':

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -939,7 +939,7 @@ interface ImageState {
   // Clustering Actions (Phase 2)
   startClustering: (directoryPath: string, scanSubfolders: boolean, threshold: number) => Promise<void>;
   cancelClustering: () => void;
-  setClusters: (clusters: ImageCluster[]) => void;
+  setClusters: (clusters: ImageCluster[], clusteringMetadata?: ImageState['clusteringMetadata']) => void;
   setClusteringProgress: (progress: { current: number; total: number; message: string } | null) => void;
   handleClusterImageDeletion: (deletedImageIds: string[]) => void;
   setClusterNavigationContext: (images: IndexedImage[] | null) => void;
@@ -3768,7 +3768,8 @@ export const useImageStore = create<ImageState>((set, get) => {
             }
         },
 
-        setClusters: (clusters) => set({ clusters }),
+        setClusters: (clusters, clusteringMetadata) =>
+            set(clusteringMetadata === undefined ? { clusters } : { clusters, clusteringMetadata }),
 
         setClusteringProgress: (progress) => set({ clusteringProgress: progress }),
 

--- a/utils/smartLibraryClusterState.ts
+++ b/utils/smartLibraryClusterState.ts
@@ -1,0 +1,139 @@
+import type { ImageCluster, IndexedImage } from '../types';
+import { CLUSTERING_FREE_TIER_LIMIT, CLUSTERING_PREVIEW_LIMIT } from '../hooks/useFeatureAccess';
+
+export interface SmartLibraryClusteringMetadata {
+  processedCount: number;
+  remainingCount: number;
+  isLimited: boolean;
+  lockedImageIds: Set<string>;
+}
+
+export interface ClusterCacheCompatibilityInput {
+  canUseFullClustering: boolean;
+  processedImageCount?: number;
+  sourceImageCount?: number;
+}
+
+const FNV_OFFSET = 2166136261;
+const FNV_PRIME = 16777619;
+
+const updateHash = (hash: number, value: string): number => {
+  let nextHash = hash;
+  for (let index = 0; index < value.length; index += 1) {
+    nextHash ^= value.charCodeAt(index);
+    nextHash = Math.imul(nextHash, FNV_PRIME);
+  }
+  return nextHash;
+};
+
+const toHashString = (hash: number): string => (hash >>> 0).toString(16).padStart(8, '0');
+
+export const getPromptImagesForClustering = (images: IndexedImage[]): IndexedImage[] =>
+  images.filter((image) => image.prompt && image.prompt.trim().length > 0);
+
+export const getClusterProcessingLimit = (canUseFullClustering: boolean): number =>
+  canUseFullClustering ? Infinity : CLUSTERING_PREVIEW_LIMIT;
+
+export const buildClusterSourceSignature = (images: IndexedImage[]): string => {
+  const promptImages = getPromptImagesForClustering(images);
+  let hash = updateHash(FNV_OFFSET, `${promptImages.length}`);
+
+  for (const image of promptImages) {
+    hash = updateHash(hash, '\u0000');
+    hash = updateHash(hash, image.id);
+    hash = updateHash(hash, '\u0001');
+    hash = updateHash(hash, String(image.lastModified ?? 0));
+    hash = updateHash(hash, '\u0001');
+    hash = updateHash(hash, image.prompt?.trim() ?? '');
+  }
+
+  return `${promptImages.length}:${toHashString(hash)}`;
+};
+
+export const buildClusteringMetadata = (
+  images: IndexedImage[],
+  canUseFullClustering: boolean,
+): SmartLibraryClusteringMetadata => {
+  const promptImages = getPromptImagesForClustering(images);
+  const processingLimit = getClusterProcessingLimit(canUseFullClustering);
+  const limitedImages = promptImages.slice(0, processingLimit);
+  const lockedImageIds = new Set<string>();
+
+  if (!canUseFullClustering && promptImages.length > CLUSTERING_FREE_TIER_LIMIT) {
+    promptImages
+      .slice(CLUSTERING_FREE_TIER_LIMIT, processingLimit)
+      .forEach((image) => lockedImageIds.add(image.id));
+  }
+
+  return {
+    processedCount: Math.min(limitedImages.length, CLUSTERING_FREE_TIER_LIMIT),
+    remainingCount: Math.max(0, promptImages.length - processingLimit),
+    isLimited: promptImages.length > processingLimit,
+    lockedImageIds,
+  };
+};
+
+export const limitClustersForAccess = (
+  clusters: ImageCluster[],
+  images: IndexedImage[],
+  canUseFullClustering: boolean,
+): ImageCluster[] => {
+  const promptImages = getPromptImagesForClustering(images);
+  const processingLimit = getClusterProcessingLimit(canUseFullClustering);
+  const allowedImageIds = new Set(
+    promptImages.slice(0, processingLimit).map((image) => image.id)
+  );
+
+  return clusters.flatMap((cluster) => {
+    const imageIds = cluster.imageIds.filter((imageId) => allowedImageIds.has(imageId));
+    if (imageIds.length === 0) {
+      return [];
+    }
+
+    return [{
+      ...cluster,
+      imageIds,
+      coverImageId: imageIds.includes(cluster.coverImageId) ? cluster.coverImageId : imageIds[0],
+      size: imageIds.length,
+    }];
+  });
+};
+
+export const isClusterCacheCompatible = ({
+  canUseFullClustering,
+  processedImageCount,
+  sourceImageCount,
+}: ClusterCacheCompatibilityInput): boolean => {
+  if (typeof processedImageCount !== 'number' || typeof sourceImageCount !== 'number') {
+    return false;
+  }
+
+  return !canUseFullClustering || processedImageCount >= sourceImageCount;
+};
+
+export const buildClusterStateSignature = (
+  clusters: ImageCluster[],
+  metadata: SmartLibraryClusteringMetadata,
+): string => {
+  let hash = updateHash(FNV_OFFSET, `${clusters.length}`);
+
+  for (const cluster of clusters) {
+    hash = updateHash(hash, '\u0000');
+    hash = updateHash(hash, cluster.id);
+    hash = updateHash(hash, '\u0001');
+    hash = updateHash(hash, cluster.imageIds.join(','));
+    hash = updateHash(hash, '\u0001');
+    hash = updateHash(hash, cluster.coverImageId);
+  }
+
+  hash = updateHash(hash, '\u0002');
+  hash = updateHash(hash, String(metadata.processedCount));
+  hash = updateHash(hash, '\u0001');
+  hash = updateHash(hash, String(metadata.remainingCount));
+  hash = updateHash(hash, '\u0001');
+  hash = updateHash(hash, metadata.isLimited ? 'limited' : 'unlimited');
+  hash = updateHash(hash, '\u0001');
+  hash = updateHash(hash, Array.from(metadata.lockedImageIds).join(','));
+
+  return toHashString(hash);
+};


### PR DESCRIPTION
Refs #263

Addresses several macOS observations from v0.15.4, including keyboard navigation, changelog persistence, Smart Library cluster cache restore, and video modal sizing. Refs #263 