### PR TITLE
Fix scoped refresh cache persistence

### DIFF
--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -1002,8 +1002,13 @@ export function useImageLoader() {
                 refreshPath ? relativePrefix : undefined
             );
 
+            const isScopedRefresh = Boolean(refreshPath);
+            const changedIds = Array.from(new Set(
+                diff.newAndModifiedFiles.map(file => `${directory.id}::${file.name}`)
+            ));
+            const scopedCacheUpserts: IndexedImage[] = [];
             let cacheWriter: IncrementalCacheWriter | null = null;
-            const shouldUseWriter = getIsElectron() && (diff.needsFullRefresh || diff.newAndModifiedFiles.length > 0 || diff.deletedFileIds.length > 0);
+            const shouldUseWriter = getIsElectron() && !isScopedRefresh && (diff.needsFullRefresh || diff.newAndModifiedFiles.length > 0 || diff.deletedFileIds.length > 0);
 
             if (shouldUseWriter) {
                 try {
@@ -1034,10 +1039,7 @@ export function useImageLoader() {
 
             if (shouldHydratePreloadedImages) {
                 clearImages(directory.id);
-            } else if (diff.newAndModifiedFiles.length > 0) {
-                const changedIds = Array.from(new Set(
-                    diff.newAndModifiedFiles.map(file => `${directory.id}::${file.name}`)
-                ));
+            } else if (changedIds.length > 0) {
                 if (changedIds.length > 0) {
                     removeImages(changedIds);
                 }
@@ -1105,6 +1107,9 @@ export function useImageLoader() {
 
             const handleEnrichmentBatch = (batch: IndexedImage[]) => {
                 const start = performance.now();
+                if (isScopedRefresh) {
+                    scopedCacheUpserts.push(...batch);
+                }
                 mergeImages(batch);
                 const durationMs = performance.now() - start;
                 traceCacheDebug('loader:handleEnrichmentBatch', () => ({
@@ -1127,7 +1132,8 @@ export function useImageLoader() {
                 removeImages(deletedFileIds);
             };
 
-            const shouldProcessPipeline = (fileHandles.length > 0) || !!cacheWriter || (shouldHydratePreloadedImages && preloadedImages.length > 0);
+            const shouldApplyScopedCacheDelta = isScopedRefresh && (diff.newAndModifiedFiles.length > 0 || diff.deletedFileIds.length > 0);
+            const shouldProcessPipeline = (fileHandles.length > 0) || !!cacheWriter || shouldApplyScopedCacheDelta || (shouldHydratePreloadedImages && preloadedImages.length > 0);
 
             if (shouldProcessPipeline) {
                 if (shouldCancelIndexing(suppressIndexingState)) {
@@ -1171,23 +1177,51 @@ export function useImageLoader() {
                     }
                 );
 
-                phaseB
-                    .then(() => {
-                        releaseThumbnailPause();
-                        const indexedImages = useImageStore.getState().images.filter(img => img.directoryId === directory.id);
-                        scheduleDirectoryThumbnailWarmup(`directory:${directory.id}:indexed`, indexedImages);
-                        // Keep the progress bar visible for 2 seconds after completion
-                        setTimeout(() => setEnrichmentProgress(null), 2000);
-                    })
-                    .catch(err => {
-                        releaseThumbnailPause();
-                        console.error('Phase B enrichment failed', err);
-                        // Keep error visible for 2 seconds
-                        setTimeout(() => setEnrichmentProgress(null), 2000);
-                    });
+                const handlePhaseBComplete = () => {
+                    releaseThumbnailPause();
+                    const indexedImages = useImageStore.getState().images.filter(img => img.directoryId === directory.id);
+                    scheduleDirectoryThumbnailWarmup(`directory:${directory.id}:indexed`, indexedImages);
+                    // Keep the progress bar visible for 2 seconds after completion
+                    setTimeout(() => setEnrichmentProgress(null), 2000);
+                };
 
-                if (!shouldCancelIndexing(suppressIndexingState)) {
-                    finalizeDirectoryLoad(directory, { suppressIndexingState, suppressSuccessMessage });
+                if (isScopedRefresh) {
+                    try {
+                        await phaseB;
+                        if (shouldApplyScopedCacheDelta && getIsElectron()) {
+                            await cacheManager.applyChunkedCacheDelta(
+                                directory.path,
+                                directory.name,
+                                scopedCacheUpserts,
+                                [...diff.deletedFileIds, ...changedIds],
+                                [],
+                                shouldScanSubfolders
+                            );
+                        }
+                        handlePhaseBComplete();
+                    } catch (err) {
+                        releaseThumbnailPause();
+                        console.error('Scoped refresh enrichment failed', err);
+                        setTimeout(() => setEnrichmentProgress(null), 2000);
+                        throw err;
+                    }
+
+                    if (!shouldCancelIndexing(suppressIndexingState)) {
+                        finalizeDirectoryLoad(directory, { suppressIndexingState, suppressSuccessMessage });
+                    }
+                } else {
+                    phaseB
+                        .then(handlePhaseBComplete)
+                        .catch(err => {
+                            releaseThumbnailPause();
+                            console.error('Phase B enrichment failed', err);
+                            // Keep error visible for 2 seconds
+                            setTimeout(() => setEnrichmentProgress(null), 2000);
+                        });
+
+                    if (!shouldCancelIndexing(suppressIndexingState)) {
+                        finalizeDirectoryLoad(directory, { suppressIndexingState, suppressSuccessMessage });
+                    }
                 }
             } else {
                 releaseThumbnailPause();

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -1006,7 +1006,7 @@ export function useImageLoader() {
             const changedIds = Array.from(new Set(
                 diff.newAndModifiedFiles.map(file => `${directory.id}::${file.name}`)
             ));
-            const scopedCacheUpserts: IndexedImage[] = [];
+            const scopedCacheUpsertsById = new Map<string, IndexedImage>();
             let cacheWriter: IncrementalCacheWriter | null = null;
             const shouldUseWriter = getIsElectron() && !isScopedRefresh && (diff.needsFullRefresh || diff.newAndModifiedFiles.length > 0 || diff.deletedFileIds.length > 0);
 
@@ -1040,9 +1040,7 @@ export function useImageLoader() {
             if (shouldHydratePreloadedImages) {
                 clearImages(directory.id);
             } else if (changedIds.length > 0) {
-                if (changedIds.length > 0) {
-                    removeImages(changedIds);
-                }
+                removeImages(changedIds);
             }
 
             // Add cached images (both first load and refresh)
@@ -1095,6 +1093,11 @@ export function useImageLoader() {
             }
 
             const handleBatchProcessed = (batch: IndexedImage[]) => {
+                if (isScopedRefresh) {
+                    for (const image of batch) {
+                        scopedCacheUpsertsById.set(image.id, image);
+                    }
+                }
                 addImages(batch);
                 if (totalCatalogItems > 0) {
                     loadedCatalogItems += batch.length;
@@ -1108,7 +1111,9 @@ export function useImageLoader() {
             const handleEnrichmentBatch = (batch: IndexedImage[]) => {
                 const start = performance.now();
                 if (isScopedRefresh) {
-                    scopedCacheUpserts.push(...batch);
+                    for (const image of batch) {
+                        scopedCacheUpsertsById.set(image.id, image);
+                    }
                 }
                 mergeImages(batch);
                 const durationMs = performance.now() - start;
@@ -1192,7 +1197,7 @@ export function useImageLoader() {
                             await cacheManager.applyChunkedCacheDelta(
                                 directory.path,
                                 directory.name,
-                                scopedCacheUpserts,
+                                Array.from(scopedCacheUpsertsById.values()),
                                 [...diff.deletedFileIds, ...changedIds],
                                 [],
                                 shouldScanSubfolders

--- a/services/cacheManager.custom.test.ts
+++ b/services/cacheManager.custom.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { cacheManager, CacheImageMetadata } from './cacheManager';
 
 describe('CacheManager', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    (cacheManager as any).isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
+  });
+
   describe('validateCacheAndGetDiff', () => {
     it('should force re-indexing for files in "catalog" state', async () => {
       // Mock cached data
@@ -31,14 +36,19 @@ describe('CacheManager', () => {
         },
       ];
 
-      // Mock cacheManager.getCachedData to return our mock data
-      cacheManager.getCachedData = async () => ({
+      (cacheManager as any).isElectron = true;
+
+      vi.spyOn(cacheManager, 'getCacheSummary').mockResolvedValue({
         id: 'test-cache',
         directoryPath: '/test',
         directoryName: 'test',
         lastScan: Date.now(),
         imageCount: 2,
-        metadata: mockCachedMetadata,
+        chunkCount: 1,
+        parserVersion: 7,
+      });
+      vi.spyOn(cacheManager, 'iterateCachedMetadata').mockImplementation(async (_directoryPath, _scanSubfolders, onChunk) => {
+        await onChunk(mockCachedMetadata);
       });
 
       // Current files on disk (same timestamps as cache)


### PR DESCRIPTION
## Summary

- Preserve the existing directory cache when refreshing an individual subfolder.
- Apply scoped cache deltas after metadata enrichment completes so refreshed Easy Diffusion and similar metadata persists across sessions.
- Update the cache diff unit test to mock the current chunked cache APIs.

## Root Cause

Refreshing a subfolder validated only that scoped path, but still used the full incremental cache writer. That could rewrite the cache without entries outside the refreshed scope, and the enriched metadata from the scoped refresh could remain only in memory instead of being merged back into the persisted cache.

Fixes #156.

## Validation

- `npm run build`
- `npm test -- cacheManager.prune services/cacheManager.custom.test.ts`