### PR TITLE
Clarify cache clearing and app data reset

### DIFF
--- a/components/settings/LibrarySettingsPanel.tsx
+++ b/components/settings/LibrarySettingsPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { useSettingsStore } from '../../store/useSettingsStore';
-import { resetAllCaches } from '../../utils/cacheReset';
+import { clearLibraryCaches, resetAllCaches } from '../../utils/cacheReset';
 import { AdvancedSection } from './AdvancedSection';
 import { SettingRow } from './SettingRow';
 import { SettingsPanel } from './SettingsPanel';
@@ -95,18 +95,46 @@ export const LibrarySettingsPanel: React.FC<{ onClose: () => void }> = ({ onClos
     }
   };
 
-  const handleClearCache = async () => {
+  const handleClearLibraryCache = async () => {
     const confirmed = window.confirm(
       [
-        'Clear all cache and reset the app?',
+        'Clear library cache?',
+        '',
+        'This will remove cached indexed metadata, thumbnails and smart library cache files.',
+        '',
+        'Your image files, saved folders, preferences, tags, ratings and license/trial state will be kept.',
+        'The app will reload so the library can rebuild fresh cache data.',
+      ].join('\n')
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await clearLibraryCaches();
+      alert('Library cache cleared. The app will now reload.');
+      window.location.reload();
+    } catch (error) {
+      console.error('Failed to clear library cache:', error);
+      alert('Failed to clear library cache. Check console for details.');
+    }
+  };
+
+  const handleResetAppData = async () => {
+    const confirmed = window.confirm(
+      [
+        'Reset app data?',
         '',
         'This will:',
         '- delete indexed image metadata',
         '- remove loaded directories',
         '- clear search filters and selections',
         '- reset cache location and local settings',
+        '- clear tags, ratings, smart collections and automation rules',
         '',
         'Your image files will not be deleted.',
+        'Your license and trial state will be kept.',
         'The app will reload after the reset.',
         '',
         'This action cannot be undone.',
@@ -119,11 +147,11 @@ export const LibrarySettingsPanel: React.FC<{ onClose: () => void }> = ({ onClos
 
     try {
       await resetAllCaches();
-      alert('Cache cleared. The app will now reload to complete the reset.');
+      alert('App data reset. The app will now reload to complete the reset.');
       onClose();
     } catch (error) {
-      console.error('Failed to clear cache:', error);
-      alert('Failed to clear cache. Check console for details.');
+      console.error('Failed to reset app data:', error);
+      alert('Failed to reset app data. Check console for details.');
     }
   };
 
@@ -229,21 +257,40 @@ export const LibrarySettingsPanel: React.FC<{ onClose: () => void }> = ({ onClos
         />
 
         <SettingsSectionCard
-          title="Clear all cache"
-          description="Use this only when the library index or local settings need a full reset."
+          title="Clear library cache"
+          description="Rebuild indexed metadata, thumbnails and smart library cache without changing your preferences."
           tone="danger"
           className="space-y-3"
         >
           <div className="flex items-start gap-3 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-            <p>This removes indexed metadata, loaded directories and local settings, but keeps your image files intact.</p>
+            <p>This removes only cache data that can be rebuilt. Saved folders, preferences, tags, ratings and license/trial state are kept.</p>
           </div>
           <button
             type="button"
-            onClick={handleClearCache}
+            onClick={handleClearLibraryCache}
             className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500"
           >
-            Clear all cache
+            Clear library cache
+          </button>
+        </SettingsSectionCard>
+
+        <SettingsSectionCard
+          title="Reset app data"
+          description="Use this when local app state needs a fresh start. License and trial state are preserved."
+          tone="danger"
+          className="space-y-3"
+        >
+          <div className="flex items-start gap-3 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>This removes saved folders, preferences, filters, annotations, smart collections and automation rules. Image files, license and trial state are kept.</p>
+          </div>
+          <button
+            type="button"
+            onClick={handleResetAppData}
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500"
+          >
+            Reset app data
           </button>
         </SettingsSectionCard>
       </AdvancedSection>

--- a/components/settings/LibrarySettingsPanel.tsx
+++ b/components/settings/LibrarySettingsPanel.tsx
@@ -259,40 +259,45 @@ export const LibrarySettingsPanel: React.FC<{ onClose: () => void }> = ({ onClos
         <SettingsSectionCard
           title="Clear library cache"
           description="Rebuild indexed metadata, thumbnails and smart library cache without changing your preferences."
-          tone="danger"
           className="space-y-3"
         >
-          <div className="flex items-start gap-3 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-            <p>This removes only cache data that can be rebuilt. Saved folders, preferences, tags, ratings and license/trial state are kept.</p>
+          <div className="rounded-xl border border-gray-800 bg-gray-950/60 px-4 py-3 text-sm text-gray-300">
+            <p>Removes only cache data that can be rebuilt. Saved folders, preferences, tags, ratings and license/trial state are kept.</p>
           </div>
           <button
             type="button"
             onClick={handleClearLibraryCache}
-            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500"
+            className="rounded-lg bg-gray-700 px-4 py-2 text-sm font-medium text-gray-100 hover:bg-gray-600"
           >
             Clear library cache
           </button>
         </SettingsSectionCard>
 
-        <SettingsSectionCard
-          title="Reset app data"
-          description="Use this when local app state needs a fresh start. License and trial state are preserved."
-          tone="danger"
-          className="space-y-3"
-        >
-          <div className="flex items-start gap-3 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-            <p>This removes saved folders, preferences, filters, annotations, smart collections and automation rules. Image files, license and trial state are kept.</p>
+        <div className="space-y-3 pt-2">
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold text-red-100">Danger zone</h3>
+            <p className="text-sm text-gray-400">Destructive local recovery actions. Image files, license and trial state are preserved.</p>
           </div>
-          <button
-            type="button"
-            onClick={handleResetAppData}
-            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500"
+
+          <SettingsSectionCard
+            title="Reset app data"
+            description="Use this when local app state needs a fresh start."
+            tone="danger"
+            className="space-y-3"
           >
-            Reset app data
-          </button>
-        </SettingsSectionCard>
+            <div className="flex items-start gap-3 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>This removes saved folders, preferences, filters, annotations, smart collections and automation rules.</p>
+            </div>
+            <button
+              type="button"
+              onClick={handleResetAppData}
+              className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500"
+            >
+              Reset app data
+            </button>
+          </SettingsSectionCard>
+        </div>
       </AdvancedSection>
     </SettingsPanel>
   );

--- a/electron.mjs
+++ b/electron.mjs
@@ -3225,10 +3225,78 @@ function setupFileOperationHandlers() {
     }
   });
 
+  ipcMain.handle('clear-library-cache', async () => {
+    try {
+      const rootPath = await getCacheRootPath();
+      const metadataCacheDir = path.join(rootPath, 'json_cache');
+      const thumbnailCacheDir = path.join(rootPath, 'thumbnails');
+      const smartLibraryCacheDir = path.join(app.getPath('userData'), 'smart-library-cache');
+
+      if (fsSync.existsSync(metadataCacheDir)) {
+        await fs.rm(metadataCacheDir, { recursive: true, force: true });
+      }
+      await fs.mkdir(metadataCacheDir, { recursive: true });
+
+      if (fsSync.existsSync(thumbnailCacheDir)) {
+        await fs.rm(thumbnailCacheDir, { recursive: true, force: true });
+      }
+      await fs.mkdir(thumbnailCacheDir, { recursive: true });
+      clearThumbnailManifestState(rootPath);
+
+      if (fsSync.existsSync(smartLibraryCacheDir)) {
+        await fs.rm(smartLibraryCacheDir, { recursive: true, force: true });
+      }
+
+      try {
+        const files = await fs.readdir(rootPath);
+        const cacheRecordFiles = [];
+        for (const file of files) {
+          if (!file.endsWith('.json') || ['settings.json', 'settings.json.bak', 'settings.json.tmp'].includes(file)) {
+            continue;
+          }
+
+          const filePath = path.join(rootPath, file);
+          try {
+            const parsed = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+            if (
+              parsed &&
+              typeof parsed === 'object' &&
+              (
+                typeof parsed.parserVersion === 'number' ||
+                (typeof parsed.schemaVersion === 'number' && typeof parsed.librarySignature === 'string')
+              )
+            ) {
+              cacheRecordFiles.push(filePath);
+            }
+          } catch (error) {
+            console.warn(`Skipping non-cache JSON while clearing library cache: ${file}`, error?.message);
+          }
+        }
+
+        await Promise.all(
+          cacheRecordFiles.map(filePath => fs.unlink(filePath).catch(error => {
+              if (error.code !== 'ENOENT') throw error;
+            }))
+        );
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
+      }
+
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
   // Delete all cache files and folders (but not userData itself, as app is using it)
-  ipcMain.handle('delete-cache-folder', async () => {
+  ipcMain.handle('delete-cache-folder', async (event, options = {}) => {
     try {
       const userDataDir = app.getPath('userData');
+      const settingsBeforeDelete = await readSettings();
+      const preservedLicense = options?.preserveLicense === true ? settingsBeforeDelete?.license : undefined;
+
       try {
         const files = await fs.readdir(userDataDir);
 
@@ -3251,6 +3319,11 @@ function setupFileOperationHandlers() {
           throw error;
         }
       }
+
+      if (preservedLicense) {
+        await saveSettings({ license: preservedLicense });
+      }
+
       return { success: true, needsRestart: true };
     } catch (error) {
       console.error('Error deleting cache folder:', error);

--- a/preload.js
+++ b/preload.js
@@ -211,7 +211,8 @@ const electronAPI = {
   generateThumbnailToCache: (args) => ipcRenderer.invoke('generate-thumbnail-to-cache', args),
   clearMetadataCache: () => ipcRenderer.invoke('clear-metadata-cache'),
   clearThumbnailCache: () => ipcRenderer.invoke('clear-thumbnail-cache'),
-  deleteCacheFolder: () => ipcRenderer.invoke('delete-cache-folder'),
+  clearLibraryCache: () => ipcRenderer.invoke('clear-library-cache'),
+  deleteCacheFolder: (options) => ipcRenderer.invoke('delete-cache-folder', options),
   restartApp: () => ipcRenderer.invoke('restart-app'),
 
   // File watching

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0-rc.1] [Unreleased]
+
+### Added
+
+- **Image Adjustment Editing**: Added an adjustment panel in the Image Modal for brightness, contrast, saturation, and hue, with desktop Save As and Overwrite workflows that export PNG output while preserving generation metadata.
+- **Embedded ComfyUI Workspace**: Added a dedicated ComfyUI Workspace view with an embedded ComfyUI browser, image context panel, workflow metadata tabs, thumbnail navigation, copy/generate actions, and direct open actions from grid/table image contexts.
+
+### Improved
+
+- **Large Library Memory Usage**: Reduced OOM risk in large ComfyUI libraries by compacting oversized raw metadata, streaming cache diffing across chunks, using lighter Electron file handles, increasing renderer heap headroom, and avoiding automatic table thumbnails in very large result sets.
+- **Large Library Cache Reconciliation**: Improved startup and manual cache checks for large folders by applying lightweight UI deltas and persisting chunked cache updates without rehydrating the entire library.
+- **Accessibility**: Added accessible labels to search, compare zoom controls, reset zoom, and generate variation icon-only controls.
+
+### Fixed
+
+- **macOS Keyboard Navigation**: Fixed Page Up/Page Down navigation in the image grid and kept folder tree keyboard navigation scrolled to the focused folder.
+- **What's New Persistence**: Fixed the changelog splash screen reopening on every launch after the current version had already been viewed.
+- **Video Viewer Scaling**: Fixed video sizing in the Image Modal so portrait and landscape videos fit the available viewer area without cropping playback controls.
+- **Smart Library Cluster Persistence**: Fixed Smart Library cluster restore so cached stacks persist across sessions.
+- **Cache Version Reindexing**: Fixed stale parser-version cache summaries so app updates reparse invalid cached metadata instead of leaving outdated metadata or empty cached libraries.
+- **Scoped Folder Refresh Cache Persistence**: Fixed scoped folder refreshes so cache updates preserve unrelated cached entries while correctly applying changed and deleted files.
+- **Desktop Saved Image Indexing**: Fixed desktop file handling paths used when saved or overwritten images are indexed/reparsed, including more accurate file type handling for edited outputs.
+
 ## [0.15.4] - 2026-05-02
 
 ### Added

--- a/types.ts
+++ b/types.ts
@@ -297,7 +297,8 @@ export interface ElectronAPI {
   generateThumbnailToCache: (args: ThumbnailGenerateToCacheRequest) => Promise<{ success: boolean; url?: string; thumbnailId?: string; extension?: string; error?: string }>;
   clearMetadataCache: () => Promise<{ success: boolean; error?: string }>;
   clearThumbnailCache: () => Promise<{ success: boolean; error?: string }>;
-  deleteCacheFolder: () => Promise<{ success: boolean; needsRestart?: boolean; error?: string }>;
+  clearLibraryCache: () => Promise<{ success: boolean; error?: string }>;
+  deleteCacheFolder: (options?: { preserveLicense?: boolean }) => Promise<{ success: boolean; needsRestart?: boolean; error?: string }>;
   restartApp: () => Promise<{ success: boolean; error?: string }>;
 
   onLoadDirectoryFromCLI: (callback: (dirPath: string) => void) => () => void;

--- a/utils/cacheReset.ts
+++ b/utils/cacheReset.ts
@@ -8,6 +8,24 @@
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 
+const LICENSE_STORAGE_KEY = 'image-metahub-license';
+
+export async function clearLibraryCaches(): Promise<void> {
+  console.log('🧹 Clearing library caches...');
+
+  if (window.electronAPI?.clearLibraryCache) {
+    const result = await window.electronAPI.clearLibraryCache();
+    if (!result?.success) {
+      throw new Error(result?.error || 'Failed to clear library cache.');
+    }
+  } else {
+    await Promise.allSettled([
+      window.electronAPI?.clearMetadataCache?.(),
+      window.electronAPI?.clearThumbnailCache?.(),
+    ]);
+  }
+}
+
 export async function resetAllCaches(): Promise<void> {
   console.log('🧹 ========================================');
   console.log('🧹 COMPLETE CACHE RESET STARTED');
@@ -16,6 +34,8 @@ export async function resetAllCaches(): Promise<void> {
   console.log('🔧 This will delete ALL app data and force a fresh start');
 
   let needsRestart = false;
+  const preservedLicenseStorage =
+    typeof localStorage !== 'undefined' ? localStorage.getItem(LICENSE_STORAGE_KEY) : null;
 
   try {
     // 1. Delete all cache files/folders from AppData/Roaming
@@ -29,10 +49,10 @@ export async function resetAllCaches(): Promise<void> {
 
     if (window.electronAPI) {
       try {
-        const deleteResult = await window.electronAPI.deleteCacheFolder();
+        const deleteResult = await window.electronAPI.deleteCacheFolder({ preserveLicense: true });
         if (deleteResult?.success) {
           console.log('✅ Cache files deleted successfully from disk');
-          console.log('   → settings.json is now DELETED (will use defaults on reload)');
+          console.log('   → settings.json was reset while preserving license/trial state');
           needsRestart = deleteResult.needsRestart || false;
         } else {
           console.warn('⚠️ Could not delete cache folder:', deleteResult?.error);
@@ -108,11 +128,16 @@ export async function resetAllCaches(): Promise<void> {
     // Also clear any keys that match patterns (for dynamic directory caches)
     const allKeys = Object.keys(localStorage);
     allKeys.forEach(key => {
-      if (key.startsWith('image-metahub-') || key.startsWith('invokeai-')) {
+      if ((key.startsWith('image-metahub-') || key.startsWith('invokeai-')) && key !== LICENSE_STORAGE_KEY) {
         localStorage.removeItem(key);
         console.log(`🗑️ Removed localStorage key (pattern match): ${key}`);
       }
     });
+
+    if (preservedLicenseStorage) {
+      localStorage.setItem(LICENSE_STORAGE_KEY, preservedLicenseStorage);
+      console.log('✅ Preserved license/trial localStorage state');
+    }
 
     console.log('✅ localStorage cleared');
 
@@ -157,6 +182,9 @@ export async function resetAllCaches(): Promise<void> {
     if (typeof localStorage !== 'undefined') {
       localStorage.removeItem(storageName1);
       localStorage.removeItem(storageName2);
+      if (preservedLicenseStorage) {
+        localStorage.setItem(LICENSE_STORAGE_KEY, preservedLicenseStorage);
+      }
       console.log('✅ Zustand persistence cleared from localStorage');
     }
 
@@ -176,6 +204,7 @@ export async function resetAllCaches(): Promise<void> {
   console.log('   ✅ Disk cache deleted (settings.json, metadata, thumbnails)');
   console.log('   ✅ IndexedDB cleared');
   console.log('   ✅ localStorage cleared');
+  console.log('   ✅ License/trial state preserved');
   console.log('   ✅ sessionStorage cleared');
   console.log('   ✅ Zustand stores reset');
   console.log('');


### PR DESCRIPTION
## Summary

- Split the previous all-cache reset flow into separate library cache clearing and app data reset actions.
- Added a dedicated IPC path for clearing rebuildable library caches while preserving preferences and user data.
- Preserved license and trial state during the broader app data reset.
- Updated Settings copy and layout so routine cache maintenance is neutral and only destructive app data reset appears in the danger zone.

## Validation

- Not run in this publish step per request; build was already run locally by the maintainer.