### PR TITLE
Improve ComfyUI queue monitoring and workspace previews

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -43,6 +43,7 @@ import CollectionFormModal, { CollectionFormValues } from './components/Collecti
 import { useA1111ProgressContext } from './contexts/A1111ProgressContext';
 import { useGenerationQueueSync } from './hooks/useGenerationQueueSync';
 import { useGenerationQueueRunner } from './hooks/useGenerationQueueRunner';
+import { useComfyUIQueueMonitor } from './hooks/useComfyUIQueueMonitor';
 import {
   beginPerformanceFlow,
   createProfilerOnRender,
@@ -179,6 +180,7 @@ const resolveSidebarWidths = ({
 export default function App() {
   const { progressState: a1111Progress } = useA1111ProgressContext();
   useGenerationQueueSync();
+  useComfyUIQueueMonitor();
 
   // --- Hooks ---
   const { handleSelectFolder, handleUpdateFolder, handleLoadFromStorage, handleRemoveDirectory, loadDirectory, processNewWatchedFiles } = useImageLoader();

--- a/App.tsx
+++ b/App.tsx
@@ -394,6 +394,7 @@ export default function App() {
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
   const [comfyUIWorkspaceImageId, setComfyUIWorkspaceImageId] = useState<string | null>(null);
   const [comfyUIWorkspaceNavigationImageIds, setComfyUIWorkspaceNavigationImageIds] = useState<string[] | null>(null);
+  const [comfyUIWorkspaceDirectoryId, setComfyUIWorkspaceDirectoryId] = useState<string>('');
   const [isComfyUIWorkspaceGenerating, setIsComfyUIWorkspaceGenerating] = useState(false);
   const [newImagesToast, setNewImagesToast] = useState<{ message: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
@@ -460,11 +461,12 @@ export default function App() {
       setNodeViewResultImages([]);
     }
   }, [libraryView, nodeViewResultImages.length]);
+  const hasLeftSidebar = hasDirectories && libraryView !== 'comfyui';
   const hasRightSidebar = Boolean(isQueueOpen || (previewImage && libraryView !== 'comfyui'));
   const { leftWidth: sidebarWidth, rightWidth: rightSidebarWidth } = useMemo(
     () =>
       resolveSidebarWidths({
-        hasDirectories,
+        hasDirectories: hasLeftSidebar,
         isSidebarCollapsed,
         hasRightSidebar,
         viewportWidth,
@@ -472,7 +474,7 @@ export default function App() {
         preferredRightWidth: preferredRightSidebarWidth,
       }),
     [
-      hasDirectories,
+      hasLeftSidebar,
       hasRightSidebar,
       isSidebarCollapsed,
       preferredRightSidebarWidth,
@@ -480,7 +482,7 @@ export default function App() {
       viewportWidth,
     ]
   );
-  const mainContentMarginLeft = hasDirectories
+  const mainContentMarginLeft = hasLeftSidebar
     ? (isSidebarCollapsed ? SIDEBAR_COLLAPSED_CONTENT_OFFSET : sidebarWidth)
     : 0;
   const mainContentMarginRight = hasRightSidebar ? rightSidebarWidth : 0;
@@ -1831,24 +1833,29 @@ export default function App() {
       : safeFilteredImages;
 
   useEffect(() => {
-    if (libraryView !== 'comfyui' || displayImages.length === 0) {
+    if (libraryView !== 'comfyui') {
       return;
     }
 
-    setComfyUIWorkspaceNavigationImageIds((current) => current ?? displayImages.map((image) => image.id));
+    const scopedImages = comfyUIWorkspaceDirectoryId
+      ? displayImages.filter((image) => image.directoryId === comfyUIWorkspaceDirectoryId)
+      : displayImages;
+    const scopedImageIds = scopedImages.map((image) => image.id);
+
+    setComfyUIWorkspaceNavigationImageIds(scopedImageIds);
     setComfyUIWorkspaceImageId((current) => {
-      if (current && displayImages.some((image) => image.id === current)) {
+      if (current && scopedImageIds.includes(current)) {
         return current;
       }
 
       const preferredImage =
-        (previewImage && displayImages.some((image) => image.id === previewImage.id) ? previewImage : null) ||
-        (selectedImage && displayImages.some((image) => image.id === selectedImage.id) ? selectedImage : null) ||
-        displayImages[0];
+        (previewImage && scopedImageIds.includes(previewImage.id) ? previewImage : null) ||
+        (selectedImage && scopedImageIds.includes(selectedImage.id) ? selectedImage : null) ||
+        scopedImages[0];
 
-      return preferredImage.id;
+      return preferredImage?.id ?? null;
     });
-  }, [displayImages, libraryView, previewImage, selectedImage]);
+  }, [comfyUIWorkspaceDirectoryId, displayImages, libraryView, previewImage, selectedImage]);
 
   const openFindSimilar = useCallback((
     sourceImage: IndexedImage,
@@ -1926,6 +1933,17 @@ export default function App() {
 
     return comfyUIWorkspaceNavigationImages.findIndex((candidate) => candidate.id === comfyUIWorkspaceImage.id);
   }, [comfyUIWorkspaceImage, comfyUIWorkspaceNavigationImages]);
+  const handleComfyUIWorkspaceDirectoryChange = useCallback((directoryId: string | null) => {
+    const nextDirectoryId = directoryId || '';
+    setComfyUIWorkspaceDirectoryId(nextDirectoryId);
+
+    const nextImages = nextDirectoryId
+      ? displayImages.filter((candidate) => candidate.directoryId === nextDirectoryId)
+      : displayImages;
+
+    setComfyUIWorkspaceNavigationImageIds(nextImages.map((candidate) => candidate.id));
+    setComfyUIWorkspaceImageId(nextImages[0]?.id ?? null);
+  }, [displayImages]);
   const handleComfyUIWorkspaceNavigate = useCallback((direction: 'next' | 'previous') => {
     if (comfyUIWorkspaceCurrentIndex === -1) {
       return;
@@ -2244,7 +2262,7 @@ export default function App() {
         restrictToRequestedSelection={!canUseBatchExport && (batchExportRequest?.imageIds?.length ?? 0) === 1}
       />
 
-      {hasDirectories && (
+      {hasLeftSidebar && (
         <Sidebar
           isCollapsed={isSidebarCollapsed}
           onToggleCollapse={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
@@ -2605,13 +2623,17 @@ export default function App() {
                     directoryPathByImageId={comfyUIWorkspaceDirectoryPathByImageId}
                     currentIndex={comfyUIWorkspaceCurrentIndex}
                     isActive={shouldShowEmbeddedComfyUIView}
-                    onSelectImage={(image) => setComfyUIWorkspaceImageId(image.id)}
                     onNavigatePrevious={() => handleComfyUIWorkspaceNavigate('previous')}
                     onNavigateNext={() => handleComfyUIWorkspaceNavigate('next')}
                     onGenerationStateChange={setIsComfyUIWorkspaceGenerating}
                     suspendBrowser={isGeneratingComfyUI || isComfyUIWorkspaceGenerating}
                     onOpenQueue={() => setIsQueueOpen(true)}
                     onOpenSettings={handleOpenGeneratorIntegrations}
+                    directories={safeDirectories}
+                    selectedDirectoryId={comfyUIWorkspaceDirectoryId}
+                    onSelectDirectory={handleComfyUIWorkspaceDirectoryChange}
+                    onInspectImage={(image) => setComfyUIWorkspaceImageId(image.id)}
+                    onOpenCompare={handleOpenFindSimilarCompare}
                   />
                 ) : (
                   <SmartLibrary

--- a/App.tsx
+++ b/App.tsx
@@ -1744,6 +1744,7 @@ export default function App() {
   const handleOpenComfyUIWorkspace = useCallback((image?: IndexedImage | null, navigationImages?: IndexedImage[]) => {
     if (image) {
       setComfyUIWorkspaceImageId(image.id);
+      setComfyUIWorkspaceDirectoryId('');
     }
     if (navigationImages && navigationImages.length > 0) {
       setComfyUIWorkspaceNavigationImageIds(navigationImages.map((item) => item.id));
@@ -1837,8 +1838,20 @@ export default function App() {
       return;
     }
 
-    const scopedImages = comfyUIWorkspaceDirectoryId
-      ? displayImages.filter((image) => image.directoryId === comfyUIWorkspaceDirectoryId)
+    const currentWorkspaceImage = comfyUIWorkspaceImageId ? imageLookup.get(comfyUIWorkspaceImageId) ?? null : null;
+    const shouldIgnoreDirectoryScope = Boolean(
+      comfyUIWorkspaceDirectoryId &&
+      currentWorkspaceImage &&
+      currentWorkspaceImage.directoryId !== comfyUIWorkspaceDirectoryId
+    );
+
+    if (shouldIgnoreDirectoryScope) {
+      setComfyUIWorkspaceDirectoryId('');
+    }
+
+    const effectiveDirectoryId = shouldIgnoreDirectoryScope ? '' : comfyUIWorkspaceDirectoryId;
+    const scopedImages = effectiveDirectoryId
+      ? displayImages.filter((image) => image.directoryId === effectiveDirectoryId)
       : displayImages;
     const scopedImageIds = scopedImages.map((image) => image.id);
 
@@ -1855,7 +1868,7 @@ export default function App() {
 
       return preferredImage?.id ?? null;
     });
-  }, [comfyUIWorkspaceDirectoryId, displayImages, libraryView, previewImage, selectedImage]);
+  }, [comfyUIWorkspaceDirectoryId, comfyUIWorkspaceImageId, displayImages, imageLookup, libraryView, previewImage, selectedImage]);
 
   const openFindSimilar = useCallback((
     sourceImage: IndexedImage,

--- a/__tests__/useGenerationQueueStore.test.ts
+++ b/__tests__/useGenerationQueueStore.test.ts
@@ -123,4 +123,31 @@ describe('useGenerationQueueStore', () => {
     expect(state.items[0].origin).toBe('metahub');
     expect(state.items[0].providerJobId).toBe('prompt-shared');
   });
+
+  it('does not downgrade an internal processing ComfyUI job to waiting when the monitor sees it pending', () => {
+    const internalId = useGenerationQueueStore.getState().createJob({
+      provider: 'comfyui',
+      imageId: 'image-1',
+      imageName: 'source.png',
+      prompt: 'internal prompt',
+      payload: {
+        provider: 'comfyui',
+      },
+    });
+
+    useGenerationQueueStore.getState().updateJob(internalId, {
+      providerJobId: 'prompt-internal',
+    });
+
+    useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+      providerJobId: 'prompt-internal',
+      status: 'waiting',
+    });
+
+    const state = useGenerationQueueStore.getState();
+    expect(state.items).toHaveLength(1);
+    expect(state.items[0].id).toBe(internalId);
+    expect(state.items[0].origin).toBe('metahub');
+    expect(state.items[0].status).toBe('processing');
+  });
 });

--- a/__tests__/useGenerationQueueStore.test.ts
+++ b/__tests__/useGenerationQueueStore.test.ts
@@ -77,4 +77,50 @@ describe('useGenerationQueueStore', () => {
     expect(useGenerationQueueStore.getState().items).toHaveLength(0);
     expect(useGenerationQueueStore.getState().activeJobs.a1111).toBeNull();
   });
+
+  it('upserts external ComfyUI jobs without assigning the provider active job', () => {
+    const id = useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+      providerJobId: 'prompt-external-1',
+      status: 'waiting',
+      prompt: 'external prompt',
+    });
+
+    const state = useGenerationQueueStore.getState();
+    const item = state.items.find((candidate) => candidate.id === id);
+
+    expect(item?.origin).toBe('comfyui-external');
+    expect(item?.providerJobId).toBe('prompt-external-1');
+    expect(item?.prompt).toBe('external prompt');
+    expect(state.activeJobs.comfyui).toBeNull();
+    expect(state.getNextWaitingJobId('comfyui')).toBeNull();
+  });
+
+  it('deduplicates an observed external ComfyUI job when an internal job receives the same prompt id', () => {
+    const internalId = useGenerationQueueStore.getState().createJob({
+      provider: 'comfyui',
+      imageId: 'image-1',
+      imageName: 'source.png',
+      prompt: 'internal prompt',
+      payload: {
+        provider: 'comfyui',
+      },
+    });
+
+    useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+      providerJobId: 'prompt-shared',
+      status: 'processing',
+    });
+
+    expect(useGenerationQueueStore.getState().items).toHaveLength(2);
+
+    useGenerationQueueStore.getState().updateJob(internalId, {
+      providerJobId: 'prompt-shared',
+    });
+
+    const state = useGenerationQueueStore.getState();
+    expect(state.items).toHaveLength(1);
+    expect(state.items[0].id).toBe(internalId);
+    expect(state.items[0].origin).toBe('metahub');
+    expect(state.items[0].providerJobId).toBe('prompt-shared');
+  });
 });

--- a/__tests__/useSettingsStore.persistence.test.ts
+++ b/__tests__/useSettingsStore.persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mergeSettingsWithExisting, stripLicenseFromSettings } from '../store/useSettingsStore';
+import { mergeSettingsWithExisting, stripLicenseFromSettings, useSettingsStore } from '../store/useSettingsStore';
 
 describe('useSettingsStore persistence helpers', () => {
   it('strips license data before hydrating the settings store', () => {
@@ -44,5 +44,15 @@ describe('useSettingsStore persistence helpers', () => {
         licenseKey: 'ABCD-EFGH-IJKL-MNOP',
       },
     });
+  });
+
+  it('enables ComfyUI queue monitoring by default and persists toggle changes', () => {
+    useSettingsStore.getState().resetState();
+
+    expect(useSettingsStore.getState().comfyUIQueueMonitoringEnabled).toBe(true);
+
+    useSettingsStore.getState().setComfyUIQueueMonitoringEnabled(false);
+
+    expect(useSettingsStore.getState().comfyUIQueueMonitoringEnabled).toBe(false);
   });
 });

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -15,6 +15,7 @@ import {
   Rocket,
   SlidersHorizontal,
   Workflow,
+  X,
 } from 'lucide-react';
 import { BaseMetadata, ComfyUIViewLoadFailure, ComfyUIViewState, IndexedImage } from '../types';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -80,22 +81,116 @@ const WorkspaceThumbnailButton: React.FC<{
   return (
     <button
       onClick={onClick}
-      className={`h-14 w-14 shrink-0 overflow-hidden rounded-md border bg-black transition-colors ${
+      className={`flex h-16 w-full shrink-0 items-center gap-3 overflow-hidden rounded-md border bg-gray-950 p-1.5 text-left transition-colors ${
         isActive ? 'border-purple-400 ring-1 ring-purple-400/60' : 'border-gray-700 hover:border-gray-500'
       }`}
-      title={image.name}
-      aria-label={`Show ${image.name}`}
+      title={`Preview ${image.name}`}
+      aria-label={`Preview ${image.name}`}
       draggable={Boolean(directoryPath && window.electronAPI?.startFileDrag)}
       onDragStart={(event) => onDragStart(event, image, directoryPath)}
     >
-      {thumbnail?.thumbnailUrl ? (
-        <img src={thumbnail.thumbnailUrl} alt="" className="h-full w-full object-cover image-alpha-grid" />
-      ) : (
-        <div className="flex h-full w-full items-center justify-center text-[10px] text-gray-600">
-          <ImageIcon className="h-4 w-4" />
+      <div className="h-12 w-12 shrink-0 overflow-hidden rounded border border-gray-800 bg-black">
+        {thumbnail?.thumbnailUrl ? (
+          <img src={thumbnail.thumbnailUrl} alt="" className="h-full w-full object-cover image-alpha-grid" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-[10px] text-gray-600">
+            <ImageIcon className="h-4 w-4" />
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs font-medium text-gray-200">{image.name}</div>
+        <div className="mt-0.5 text-[10px] uppercase tracking-wide text-gray-500">
+          {isActive ? 'Active image' : 'Preview'}
         </div>
-      )}
+      </div>
     </button>
+  );
+};
+
+const WorkspaceImagePreviewModal: React.FC<{
+  images: IndexedImage[];
+  initialIndex: number;
+  onClose: () => void;
+}> = ({ images, initialIndex, onClose }) => {
+  const [index, setIndex] = useState(() => Math.min(Math.max(initialIndex, 0), Math.max(images.length - 1, 0)));
+  const current = images[index];
+  const thumbnail = useResolvedThumbnail(current ?? null);
+  const hasMultiple = images.length > 1;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        setIndex((currentIndex) => Math.max(0, currentIndex - 1));
+      }
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        setIndex((currentIndex) => Math.min(images.length - 1, currentIndex + 1));
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [images.length, onClose]);
+
+  if (!current) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-4">
+      <div className="flex max-h-[92vh] w-full max-w-6xl flex-col overflow-hidden rounded-lg border border-gray-700 bg-gray-900 shadow-2xl">
+        <div className="flex items-center justify-between gap-3 border-b border-gray-700 px-4 py-3">
+          <div className="min-w-0">
+            <h2 className="truncate text-base font-semibold text-gray-100">{current.name}</h2>
+            {hasMultiple && <p className="text-xs text-gray-500">{index + 1}/{images.length}</p>}
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-800 hover:text-gray-100"
+            aria-label="Close image preview"
+            title="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+        <div className="relative flex min-h-0 flex-1 items-center justify-center bg-black">
+          {hasMultiple && (
+            <button
+              onClick={() => setIndex((currentIndex) => Math.max(0, currentIndex - 1))}
+              disabled={index === 0}
+              className="absolute left-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-gray-900/80 p-2 text-gray-100 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+              aria-label="Previous image"
+              title="Previous"
+            >
+              <ChevronLeft size={24} />
+            </button>
+          )}
+          {thumbnail?.thumbnailUrl ? (
+            <img
+              src={thumbnail.thumbnailUrl}
+              alt={current.name}
+              className="max-h-[78vh] max-w-full object-contain image-alpha-grid"
+            />
+          ) : (
+            <div className="p-8 text-sm text-gray-400">Image preview is not available.</div>
+          )}
+          {hasMultiple && (
+            <button
+              onClick={() => setIndex((currentIndex) => Math.min(images.length - 1, currentIndex + 1))}
+              disabled={index === images.length - 1}
+              className="absolute right-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-gray-900/80 p-2 text-gray-100 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+              aria-label="Next image"
+              title="Next"
+            >
+              <ChevronRight size={24} />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -144,6 +239,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const [loadFailure, setLoadFailure] = useState<ComfyUIViewLoadFailure | null>(null);
   const [connectionMessage, setConnectionMessage] = useState<string>('');
   const [activeInspectorTab, setActiveInspectorTab] = useState<'image' | 'metadata' | 'workflow'>('image');
+  const [workspacePreviewIndex, setWorkspacePreviewIndex] = useState<number | null>(null);
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(() => {
     if (typeof window === 'undefined') {
       return false;
@@ -547,14 +643,14 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
               </div>
 
               {normalizedNavigationImages.length > 1 && (
-                <div className="flex gap-2 overflow-x-auto pb-1">
-                  {visibleNavigationImages.map((candidate) => (
+                <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
+                  {visibleNavigationImages.map((candidate, visibleIndex) => (
                     <WorkspaceThumbnailButton
                       key={candidate.id}
                       image={candidate}
                       isActive={candidate.id === image.id}
                       directoryPath={directoryPathByImageId[candidate.id]}
-                      onClick={() => onSelectImage?.(candidate)}
+                      onClick={() => setWorkspacePreviewIndex(visibleIndex)}
                       onDragStart={startImageFileDrag}
                     />
                   ))}
@@ -704,6 +800,13 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
           )}
         </aside>
       </div>
+      {workspacePreviewIndex !== null && (
+        <WorkspaceImagePreviewModal
+          images={visibleNavigationImages}
+          initialIndex={workspacePreviewIndex}
+          onClose={() => setWorkspacePreviewIndex(null)}
+        />
+      )}
     </div>
   );
 };

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -73,6 +73,7 @@ const DEFAULT_VIEW_STATE: ComfyUIViewState = {
 };
 
 const PANEL_COLLAPSED_STORAGE_KEY = 'image-metahub-comfyui-workspace-panel-collapsed';
+const THUMB_RAIL_COLLAPSED_STORAGE_KEY = 'image-metahub-comfyui-workspace-thumb-rail-collapsed';
 const THUMB_RAIL_WIDTH_STORAGE_KEY = 'image-metahub-comfyui-workspace-thumb-rail-width';
 const ASSET_CONTEXT_MENU_WIDTH = 224;
 const ASSET_CONTEXT_MENU_HEIGHT = 260;
@@ -399,6 +400,12 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
       return 108;
     }
     return clampThumbRailWidth(Number(window.localStorage.getItem(THUMB_RAIL_WIDTH_STORAGE_KEY)) || 108);
+  });
+  const [isThumbRailCollapsed, setIsThumbRailCollapsed] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    return window.localStorage.getItem(THUMB_RAIL_COLLAPSED_STORAGE_KEY) === 'true';
   });
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(() => {
     if (typeof window === 'undefined') {
@@ -762,6 +769,19 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     window.electronAPI.startFileDrag({ directoryPath: dragDirectoryPath, relativePath });
   }, []);
 
+  const toggleThumbRailCollapsed = useCallback(() => {
+    setIsThumbRailCollapsed((current) => {
+      const next = !current;
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(THUMB_RAIL_COLLAPSED_STORAGE_KEY, String(next));
+      }
+      window.requestAnimationFrame(() => {
+        void syncBounds();
+      });
+      return next;
+    });
+  }, [syncBounds]);
+
   const openWorkspacePreview = useCallback((visibleIndex: number) => {
     const selectedImage = visibleNavigationImages[visibleIndex];
     if (selectedImage) {
@@ -813,16 +833,15 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     if (selectedImages.has(contextImage.id)) {
       return selectedWorkspaceImages;
     }
-    return [...selectedWorkspaceImages, contextImage].slice(0, 4);
+    return [...selectedWorkspaceImages, contextImage];
   }, [selectedImages, selectedWorkspaceImages]);
 
   const openCompareMode = useCallback((targetImages: IndexedImage[]) => {
-    const comparableImages = targetImages.slice(0, 4);
-    if (comparableImages.length < 2 || comparableImages.length > 4) {
+    if (targetImages.length < 2 || targetImages.length > 4) {
       setAssetActionMessage('Select 2 to 4 images to compare.');
       return;
     }
-    onOpenCompare?.(comparableImages);
+    onOpenCompare?.(targetImages);
     setAssetContextMenu(null);
   }, [onOpenCompare]);
 
@@ -988,26 +1007,46 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
       <div className="flex min-h-0 flex-1">
         <aside
           className="flex min-h-0 shrink-0 flex-col border-r border-gray-800 bg-gray-900/95"
-          style={{ width: thumbRailWidth }}
+          style={{ width: isThumbRailCollapsed ? 44 : thumbRailWidth }}
         >
           <div className="border-b border-gray-800 p-2">
-            <div className="flex items-center gap-1 rounded-md border border-gray-800 bg-gray-950 px-2 py-1.5">
-              <Folder className="h-3.5 w-3.5 shrink-0 text-gray-500" />
-              <select
-                value={selectedDirectoryId || ''}
-                onChange={(event) => onSelectDirectory?.(event.target.value || null)}
-                className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 outline-none"
-                title="Change workspace folder"
-                aria-label="Change workspace folder"
+            {isThumbRailCollapsed ? (
+              <button
+                onClick={toggleThumbRailCollapsed}
+                className="flex h-8 w-full items-center justify-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-gray-100"
+                title="Show thumbnails"
+                aria-label="Show thumbnails"
               >
-                <option value="">All folders</option>
-                {directories.map((directory) => (
-                  <option key={directory.id} value={directory.id}>
-                    {directory.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            ) : (
+              <div className="flex items-center gap-1 rounded-md border border-gray-800 bg-gray-950 px-2 py-1.5">
+                <Folder className="h-3.5 w-3.5 shrink-0 text-gray-500" />
+                <select
+                  value={selectedDirectoryId || ''}
+                  onChange={(event) => onSelectDirectory?.(event.target.value || null)}
+                  className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 outline-none"
+                  title="Change workspace folder"
+                  aria-label="Change workspace folder"
+                >
+                  <option value="">All folders</option>
+                  {directories.map((directory) => (
+                    <option key={directory.id} value={directory.id}>
+                      {directory.name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={toggleThumbRailCollapsed}
+                  className="rounded p-1 text-gray-500 hover:bg-gray-800 hover:text-gray-100"
+                  title="Hide thumbnails"
+                  aria-label="Hide thumbnails"
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            )}
+            {!isThumbRailCollapsed && (
             <div className="mt-2 flex flex-wrap items-center gap-1">
               <span className="mr-auto rounded border border-gray-800 px-1.5 py-1 text-[10px] font-medium text-gray-400">
                 {selectedWorkspaceCount}
@@ -1091,8 +1130,10 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 <X className="h-3.5 w-3.5" />
               </button>
             </div>
+            )}
           </div>
 
+          {!isThumbRailCollapsed && (
           <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2">
             {visibleNavigationImages.map((candidate, visibleIndex) => (
               <WorkspaceThumbnailButton
@@ -1113,8 +1154,10 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
               />
             ))}
           </div>
+          )}
         </aside>
 
+        {!isThumbRailCollapsed && (
         <div
           className="w-1 cursor-ew-resize bg-gray-800 hover:bg-purple-500/50"
           onPointerDown={beginThumbRailResize}
@@ -1123,6 +1166,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
           onPointerCancel={endThumbRailResize}
           title="Resize thumbnail rail"
         />
+        )}
 
         <div className="relative min-w-0 flex-1 bg-black">
           <div ref={browserHostRef} className="absolute inset-0" />

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -3,21 +3,32 @@ import {
   AlertTriangle,
   ArrowLeft,
   ArrowRight,
+  CheckSquare,
   ChevronLeft,
   ChevronRight,
   CheckCircle,
   Clipboard,
+  Download,
   ExternalLink,
+  Folder,
+  GitCompare,
+  Heart,
   ImageIcon,
   Info,
   Loader2,
+  Package,
   Play,
+  RefreshCw,
   Rocket,
+  Square,
+  Star,
   SlidersHorizontal,
+  Tag,
+  Trash2,
   Workflow,
   X,
 } from 'lucide-react';
-import { BaseMetadata, ComfyUIViewLoadFailure, ComfyUIViewState, IndexedImage } from '../types';
+import { BaseMetadata, ComfyUIViewLoadFailure, ComfyUIViewState, Directory, ImageRating, IndexedImage } from '../types';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
@@ -25,6 +36,11 @@ import { type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGener
 import ComfyUIWorkflowWorkspace from './ComfyUIWorkflowWorkspace';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
+import { useThumbnail } from '../hooks/useThumbnail';
+import { formatImageForComfyUI } from '../utils/comfyUIFormatter';
+import { FileOperations } from '../services/fileOperations';
+import { useImageStore } from '../store/useImageStore';
+import TagManagerModal from './TagManagerModal';
 
 interface ComfyUIWorkspaceProps {
   image: IndexedImage | null;
@@ -34,12 +50,16 @@ interface ComfyUIWorkspaceProps {
   currentIndex?: number;
   isActive: boolean;
   suspendBrowser?: boolean;
-  onSelectImage?: (image: IndexedImage) => void;
   onNavigatePrevious?: () => void;
   onNavigateNext?: () => void;
   onGenerationStateChange?: (isGenerating: boolean) => void;
   onOpenQueue: () => void;
   onOpenSettings: () => void;
+  directories?: Directory[];
+  selectedDirectoryId?: string;
+  onSelectDirectory?: (directoryId: string | null) => void;
+  onInspectImage?: (image: IndexedImage) => void;
+  onOpenCompare?: (images: IndexedImage[]) => void;
 }
 
 const DEFAULT_VIEW_STATE: ComfyUIViewState = {
@@ -49,9 +69,15 @@ const DEFAULT_VIEW_STATE: ComfyUIViewState = {
   canGoBack: false,
   canGoForward: false,
   visible: false,
+  lastLoadFailed: false,
 };
 
 const PANEL_COLLAPSED_STORAGE_KEY = 'image-metahub-comfyui-workspace-panel-collapsed';
+const THUMB_RAIL_WIDTH_STORAGE_KEY = 'image-metahub-comfyui-workspace-thumb-rail-width';
+const ASSET_CONTEXT_MENU_WIDTH = 224;
+const ASSET_CONTEXT_MENU_HEIGHT = 260;
+const clampThumbRailWidth = (width: number) => Math.min(Math.max(Math.round(width) || 108, 76), 360);
+const OPEN_BATCH_EXPORT_EVENT = 'imagemetahub:open-batch-export';
 
 const formatValue = (value: unknown): string => {
   if (value === null || value === undefined || value === '') {
@@ -72,39 +98,63 @@ const MetadataLine: React.FC<{ label: string; value: unknown }> = ({ label, valu
 const WorkspaceThumbnailButton: React.FC<{
   image: IndexedImage;
   isActive: boolean;
+  isSelected: boolean;
   directoryPath?: string;
-  onClick: () => void;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onToggleSelected: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onToggleFavorite: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onContextMenu: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onDragStart: (event: React.DragEvent<HTMLElement>, image: IndexedImage, directoryPath?: string) => void;
-}> = ({ image, isActive, directoryPath, onClick, onDragStart }) => {
+}> = ({ image, isActive, isSelected, directoryPath, onClick, onToggleSelected, onToggleFavorite, onContextMenu, onDragStart }) => {
+  useThumbnail(image);
   const thumbnail = useResolvedThumbnail(image);
 
   return (
-    <button
-      onClick={onClick}
-      className={`flex h-16 w-full shrink-0 items-center gap-3 overflow-hidden rounded-md border bg-gray-950 p-1.5 text-left transition-colors ${
-        isActive ? 'border-purple-400 ring-1 ring-purple-400/60' : 'border-gray-700 hover:border-gray-500'
-      }`}
-      title={`Preview ${image.name}`}
-      aria-label={`Preview ${image.name}`}
-      draggable={Boolean(directoryPath && window.electronAPI?.startFileDrag)}
-      onDragStart={(event) => onDragStart(event, image, directoryPath)}
-    >
-      <div className="h-12 w-12 shrink-0 overflow-hidden rounded border border-gray-800 bg-black">
+    <div className="group relative aspect-square w-full shrink-0">
+      <button
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        className={`h-full w-full overflow-hidden rounded-md border bg-black transition-colors ${
+          isSelected
+            ? 'border-blue-400 ring-2 ring-blue-400/70'
+            : isActive
+              ? 'border-purple-400 ring-1 ring-purple-400/60'
+              : 'border-gray-700 hover:border-gray-500'
+        }`}
+        title={`Preview ${image.name}`}
+        aria-label={`Preview ${image.name}`}
+        draggable={Boolean(directoryPath && window.electronAPI?.startFileDrag)}
+        onDragStart={(event) => onDragStart(event, image, directoryPath)}
+      >
         {thumbnail?.thumbnailUrl ? (
           <img src={thumbnail.thumbnailUrl} alt="" className="h-full w-full object-cover image-alpha-grid" />
         ) : (
-          <div className="flex h-full w-full items-center justify-center text-[10px] text-gray-600">
-            <ImageIcon className="h-4 w-4" />
+          <div className="flex h-full w-full items-center justify-center text-gray-600">
+            <ImageIcon className="h-5 w-5" />
           </div>
         )}
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-xs font-medium text-gray-200">{image.name}</div>
-        <div className="mt-0.5 text-[10px] uppercase tracking-wide text-gray-500">
-          {isActive ? 'Active image' : 'Preview'}
-        </div>
-      </div>
-    </button>
+      </button>
+      <button
+        onClick={onToggleSelected}
+        className={`absolute left-1.5 top-1.5 rounded bg-gray-950/80 p-1 shadow transition-opacity ${
+          isSelected ? 'text-blue-300 opacity-100' : 'text-gray-300 opacity-0 group-hover:opacity-100'
+        }`}
+        title={isSelected ? 'Deselect image' : 'Select image'}
+        aria-label={isSelected ? 'Deselect image' : 'Select image'}
+      >
+        {isSelected ? <CheckSquare className="h-4 w-4" /> : <Square className="h-4 w-4" />}
+      </button>
+      <button
+        onClick={onToggleFavorite}
+        className={`absolute right-1.5 top-1.5 rounded bg-gray-950/80 p-1 shadow transition-opacity ${
+          image.isFavorite ? 'text-pink-300 opacity-100' : 'text-gray-300 opacity-0 group-hover:opacity-100 hover:text-pink-300'
+        }`}
+        title={image.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+        aria-label={image.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+      >
+        <Heart className={`h-4 w-4 ${image.isFavorite ? 'fill-current' : ''}`} />
+      </button>
+    </div>
   );
 };
 
@@ -112,11 +162,57 @@ const WorkspaceImagePreviewModal: React.FC<{
   images: IndexedImage[];
   initialIndex: number;
   onClose: () => void;
-}> = ({ images, initialIndex, onClose }) => {
+  onInspectImage?: (image: IndexedImage) => void;
+}> = ({ images, initialIndex, onClose, onInspectImage }) => {
   const [index, setIndex] = useState(() => Math.min(Math.max(initialIndex, 0), Math.max(images.length - 1, 0)));
+  const [modalSize, setModalSize] = useState(() => ({
+    width: Math.min(Math.round(window.innerWidth * 0.82), 1400),
+    height: Math.min(Math.round(window.innerHeight * 0.86), 980),
+  }));
+  const modalResizeRef = useRef<{ startX: number; startY: number; startWidth: number; startHeight: number } | null>(null);
   const current = images[index];
-  const thumbnail = useResolvedThumbnail(current ?? null);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
   const hasMultiple = images.length > 1;
+
+  useEffect(() => {
+    if (current) {
+      onInspectImage?.(current);
+    }
+  }, [current, onInspectImage]);
+
+  useEffect(() => {
+    let objectUrl: string | null = null;
+    let isDisposed = false;
+
+    const loadImage = async () => {
+      if (!current?.handle) {
+        setImageUrl(null);
+        return;
+      }
+
+      try {
+        const file = await current.handle.getFile();
+        if (isDisposed) {
+          return;
+        }
+        objectUrl = URL.createObjectURL(file);
+        setImageUrl(objectUrl);
+      } catch {
+        if (!isDisposed) {
+          setImageUrl(null);
+        }
+      }
+    };
+
+    void loadImage();
+
+    return () => {
+      isDisposed = true;
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [current]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -139,9 +235,43 @@ const WorkspaceImagePreviewModal: React.FC<{
     return null;
   }
 
+  const beginModalResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    modalResizeRef.current = {
+      startX: event.clientX,
+      startY: event.clientY,
+      startWidth: modalSize.width,
+      startHeight: modalSize.height,
+    };
+  };
+
+  const handleModalResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    const resizeState = modalResizeRef.current;
+    if (!resizeState) {
+      return;
+    }
+
+    setModalSize({
+      width: Math.min(Math.max(520, resizeState.startWidth + event.clientX - resizeState.startX), window.innerWidth - 32),
+      height: Math.min(Math.max(420, resizeState.startHeight + event.clientY - resizeState.startY), window.innerHeight - 32),
+    });
+  };
+
+  const endModalResize = () => {
+    modalResizeRef.current = null;
+  };
+
   return (
-    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-4">
-      <div className="flex max-h-[92vh] w-full max-w-6xl flex-col overflow-hidden rounded-lg border border-gray-700 bg-gray-900 shadow-2xl">
+    <div
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-4"
+      onMouseDown={onClose}
+    >
+      <div
+        className="relative flex flex-col overflow-hidden rounded-lg border border-gray-700 bg-gray-900 shadow-2xl"
+        style={{ width: modalSize.width, height: modalSize.height }}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
         <div className="flex items-center justify-between gap-3 border-b border-gray-700 px-4 py-3">
           <div className="min-w-0">
             <h2 className="truncate text-base font-semibold text-gray-100">{current.name}</h2>
@@ -168,11 +298,11 @@ const WorkspaceImagePreviewModal: React.FC<{
               <ChevronLeft size={24} />
             </button>
           )}
-          {thumbnail?.thumbnailUrl ? (
+          {imageUrl ? (
             <img
-              src={thumbnail.thumbnailUrl}
+              src={imageUrl}
               alt={current.name}
-              className="max-h-[78vh] max-w-full object-contain image-alpha-grid"
+              className="h-full max-h-full max-w-full object-contain image-alpha-grid"
             />
           ) : (
             <div className="p-8 text-sm text-gray-400">Image preview is not available.</div>
@@ -189,6 +319,14 @@ const WorkspaceImagePreviewModal: React.FC<{
             </button>
           )}
         </div>
+        <div
+          className="absolute bottom-0 right-0 h-5 w-5 cursor-nwse-resize border-b-2 border-r-2 border-gray-500/80"
+          onPointerDown={beginModalResize}
+          onPointerMove={handleModalResize}
+          onPointerUp={endModalResize}
+          onPointerCancel={endModalResize}
+          title="Resize preview"
+        />
       </div>
     </div>
   );
@@ -206,6 +344,12 @@ const getBounds = (element: HTMLElement) => {
 
 const getWorkflowMetadata = (image: IndexedImage | null): BaseMetadata | null =>
   (image?.metadata?.normalizedMetadata as BaseMetadata | undefined) ?? null;
+
+type WorkspaceAssetContextMenu = {
+  image: IndexedImage;
+  x: number;
+  y: number;
+} | null;
 
 const getSameOriginUrl = (candidateUrl: string, configuredUrl: string): string => {
   try {
@@ -226,20 +370,36 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   currentIndex = -1,
   isActive,
   suspendBrowser = false,
-  onSelectImage,
   onNavigatePrevious,
   onNavigateNext,
   onGenerationStateChange,
   onOpenQueue,
   onOpenSettings,
+  directories = [],
+  selectedDirectoryId = '',
+  onSelectDirectory,
+  onInspectImage,
+  onOpenCompare,
 }) => {
   const browserHostRef = useRef<HTMLDivElement>(null);
   const resizeStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const thumbRailResizeStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const lastSelectedThumbIndexRef = useRef<number | null>(null);
   const [viewState, setViewState] = useState<ComfyUIViewState>(DEFAULT_VIEW_STATE);
   const [loadFailure, setLoadFailure] = useState<ComfyUIViewLoadFailure | null>(null);
   const [connectionMessage, setConnectionMessage] = useState<string>('');
   const [activeInspectorTab, setActiveInspectorTab] = useState<'image' | 'metadata' | 'workflow'>('image');
   const [workspacePreviewIndex, setWorkspacePreviewIndex] = useState<number | null>(null);
+  const [assetContextMenu, setAssetContextMenu] = useState<WorkspaceAssetContextMenu>(null);
+  const [assetActionMessage, setAssetActionMessage] = useState<string>('');
+  const [isTagManagerOpen, setIsTagManagerOpen] = useState(false);
+  const [isRatingMenuOpen, setIsRatingMenuOpen] = useState(false);
+  const [thumbRailWidth, setThumbRailWidth] = useState(() => {
+    if (typeof window === 'undefined') {
+      return 108;
+    }
+    return clampThumbRailWidth(Number(window.localStorage.getItem(THUMB_RAIL_WIDTH_STORAGE_KEY)) || 108);
+  });
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(() => {
     if (typeof window === 'undefined') {
       return false;
@@ -254,6 +414,13 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const setComfyUIWorkspaceLastUrl = useSettingsStore((state) => state.setComfyUIWorkspaceLastUrl);
   const panelWidth = useSettingsStore((state) => state.comfyUIWorkspacePanelWidth);
   const setPanelWidth = useSettingsStore((state) => state.setComfyUIWorkspacePanelWidth);
+  const removeImages = useImageStore((state) => state.removeImages);
+  const selectedImages = useImageStore((state) => state.selectedImages);
+  const toggleImageSelection = useImageStore((state) => state.toggleImageSelection);
+  const clearImageSelection = useImageStore((state) => state.clearImageSelection);
+  const bulkToggleFavorite = useImageStore((state) => state.bulkToggleFavorite);
+  const toggleFavorite = useImageStore((state) => state.toggleFavorite);
+  const bulkSetImageRating = useImageStore((state) => state.bulkSetImageRating);
 
   const { generateWithComfyUI, isGenerating, generateStatus } = useGenerateWithComfyUI();
   const { copyToComfyUI, isCopying, copyStatus } = useCopyToComfyUI();
@@ -267,21 +434,48 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const canNavigatePrevious = currentIndex > 0;
   const canNavigateNext = currentIndex >= 0 && currentIndex < normalizedNavigationImages.length - 1;
   const visibleNavigationImages = useMemo(() => {
-    if (normalizedNavigationImages.length <= 24 || currentIndex < 0) {
+    if (normalizedNavigationImages.length <= 140) {
       return normalizedNavigationImages;
     }
 
-    const startIndex = Math.max(0, currentIndex - 11);
-    const endIndex = Math.min(normalizedNavigationImages.length, startIndex + 24);
-    const adjustedStartIndex = Math.max(0, endIndex - 24);
+    const visibleIndexes = new Set<number>();
+    const lastIndex = normalizedNavigationImages.length - 1;
 
-    return normalizedNavigationImages.slice(adjustedStartIndex, endIndex);
+    for (let index = 0; index < 60; index += 1) {
+      visibleIndexes.add(index);
+      visibleIndexes.add(lastIndex - index);
+    }
+
+    if (currentIndex >= 0) {
+      const startIndex = Math.max(0, currentIndex - 20);
+      const endIndex = Math.min(normalizedNavigationImages.length, currentIndex + 21);
+      for (let index = startIndex; index < endIndex; index += 1) {
+        visibleIndexes.add(index);
+      }
+    }
+
+    return Array.from(visibleIndexes)
+      .sort((a, b) => a - b)
+      .map((index) => normalizedNavigationImages[index])
+      .filter((candidate): candidate is IndexedImage => Boolean(candidate));
   }, [currentIndex, normalizedNavigationImages]);
+  const selectedWorkspaceImages = useMemo(
+    () => visibleNavigationImages.filter((candidate) => selectedImages.has(candidate.id)),
+    [selectedImages, visibleNavigationImages],
+  );
+  const selectedWorkspaceIds = useMemo(
+    () => selectedWorkspaceImages.map((candidate) => candidate.id),
+    [selectedWorkspaceImages],
+  );
+  const selectedWorkspaceCount = selectedWorkspaceImages.length;
+  const allSelectedWorkspaceFavorites = selectedWorkspaceCount > 0 && selectedWorkspaceImages.every((candidate) => candidate.isFavorite);
   const isElectron = typeof window !== 'undefined' && Boolean(window.electronAPI?.comfyUIViewOpen);
   const targetUrl = comfyUIWorkspaceLastUrl
     ? getSameOriginUrl(comfyUIWorkspaceLastUrl, comfyUIServerUrl)
     : comfyUIServerUrl;
-  const shouldShowBrowser = isActive && !suspendBrowser;
+  const hasBrowserLoadFailure = Boolean(loadFailure || viewState.lastLoadFailed);
+  const shouldShowBrowser = isActive && !suspendBrowser && workspacePreviewIndex === null && !hasBrowserLoadFailure;
+  const shouldShowBrowserFallback = suspendBrowser || hasBrowserLoadFailure || !viewState.visible;
 
   useEffect(() => {
     onGenerationStateChange?.(isGenerating);
@@ -290,6 +484,20 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
       onGenerationStateChange?.(false);
     };
   }, [isGenerating, onGenerationStateChange]);
+
+  useEffect(() => {
+    if (!assetContextMenu) {
+      return;
+    }
+
+    const close = () => setAssetContextMenu(null);
+    window.addEventListener('click', close);
+    window.addEventListener('blur', close);
+    return () => {
+      window.removeEventListener('click', close);
+      window.removeEventListener('blur', close);
+    };
+  }, [assetContextMenu]);
 
   const togglePanelCollapsed = useCallback(() => {
     setIsPanelCollapsed((current) => {
@@ -334,8 +542,11 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     if (result?.success && result.state) {
       setViewState(result.state);
       setLoadFailure(null);
+      setConnectionMessage('');
     } else if (result?.error) {
-      setConnectionMessage(result.error);
+      if (!result.error.includes('ERR_ABORTED')) {
+        setConnectionMessage(result.error);
+      }
     }
   }, [isElectron, shouldShowBrowser, targetUrl]);
 
@@ -387,8 +598,12 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
       }
     });
     const unsubscribeFailure = window.electronAPI?.onComfyUIViewLoadFailed?.((failure) => {
+      if (failure.errorCode === -3) {
+        return;
+      }
       setLoadFailure(failure);
       setComfyUIConnectionStatus('error');
+      window.electronAPI?.comfyUIViewHide?.();
     });
 
     window.electronAPI?.comfyUIViewGetState?.().then((result) => {
@@ -415,6 +630,21 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     const result = await window.electronAPI?.openExternalUrl?.(targetUrl);
     if (!result?.success) {
       setConnectionMessage(result?.error || 'Failed to open ComfyUI externally.');
+    }
+  };
+
+  const reloadEmbeddedView = async () => {
+    setConnectionMessage('');
+    setLoadFailure(null);
+    setViewState((current) => ({ ...current, lastLoadFailed: false, visible: false }));
+    const bounds = browserHostRef.current ? getBounds(browserHostRef.current) : undefined;
+    await window.electronAPI?.comfyUIViewReload?.();
+    const result = await window.electronAPI?.comfyUIViewOpen?.({ url: targetUrl, bounds });
+    if (result?.state) {
+      setViewState(result.state);
+    }
+    if (!result?.success) {
+      setConnectionMessage(result?.error || 'Failed to reload ComfyUI.');
     }
   };
 
@@ -483,6 +713,32 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     void syncBounds();
   };
 
+  const beginThumbRailResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    thumbRailResizeStateRef.current = {
+      startX: event.clientX,
+      startWidth: thumbRailWidth,
+    };
+  };
+
+  const handleThumbRailResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    const resizeState = thumbRailResizeStateRef.current;
+    if (!resizeState) {
+      return;
+    }
+    const nextWidth = clampThumbRailWidth(resizeState.startWidth + event.clientX - resizeState.startX);
+    setThumbRailWidth(nextWidth);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(THUMB_RAIL_WIDTH_STORAGE_KEY, String(nextWidth));
+    }
+  };
+
+  const endThumbRailResize = () => {
+    thumbRailResizeStateRef.current = null;
+    void syncBounds();
+  };
+
   const inspectorTabs = [
     { id: 'image' as const, label: 'Image', icon: ImageIcon },
     { id: 'metadata' as const, label: 'Metadata', icon: Info },
@@ -505,6 +761,207 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     event.dataTransfer.effectAllowed = 'copy';
     window.electronAPI.startFileDrag({ directoryPath: dragDirectoryPath, relativePath });
   }, []);
+
+  const openWorkspacePreview = useCallback((visibleIndex: number) => {
+    const selectedImage = visibleNavigationImages[visibleIndex];
+    if (selectedImage) {
+      onInspectImage?.(selectedImage);
+    }
+    setWorkspacePreviewIndex(visibleIndex);
+  }, [onInspectImage, visibleNavigationImages]);
+
+  const updateThumbSelection = useCallback((event: React.MouseEvent, contextImage: IndexedImage, visibleIndex: number) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.shiftKey && lastSelectedThumbIndexRef.current !== null) {
+      const start = Math.min(lastSelectedThumbIndexRef.current, visibleIndex);
+      const end = Math.max(lastSelectedThumbIndexRef.current, visibleIndex);
+      const rangeIds = visibleNavigationImages.slice(start, end + 1).map((candidate) => candidate.id);
+      useImageStore.setState((state) => {
+        const next = new Set(state.selectedImages);
+        rangeIds.forEach((id) => next.add(id));
+        return { selectedImages: next };
+      });
+    } else {
+      toggleImageSelection(contextImage.id);
+    }
+
+    lastSelectedThumbIndexRef.current = visibleIndex;
+  }, [toggleImageSelection, visibleNavigationImages]);
+
+  const handleThumbnailClick = useCallback((event: React.MouseEvent<HTMLButtonElement>, contextImage: IndexedImage, visibleIndex: number) => {
+    if (event.ctrlKey || event.metaKey || event.shiftKey) {
+      updateThumbSelection(event, contextImage, visibleIndex);
+      return;
+    }
+
+    openWorkspacePreview(visibleIndex);
+  }, [openWorkspacePreview, updateThumbSelection]);
+
+  const getContextTargetImages = useCallback((contextImage?: IndexedImage | null) => {
+    if (contextImage && selectedImages.has(contextImage.id) && selectedWorkspaceImages.length > 0) {
+      return selectedWorkspaceImages;
+    }
+    return contextImage ? [contextImage] : selectedWorkspaceImages;
+  }, [selectedImages, selectedWorkspaceImages]);
+
+  const getCompareTargetImages = useCallback((contextImage?: IndexedImage | null) => {
+    if (!contextImage) {
+      return selectedWorkspaceImages;
+    }
+    if (selectedImages.has(contextImage.id)) {
+      return selectedWorkspaceImages;
+    }
+    return [...selectedWorkspaceImages, contextImage].slice(0, 4);
+  }, [selectedImages, selectedWorkspaceImages]);
+
+  const openCompareMode = useCallback((targetImages: IndexedImage[]) => {
+    const comparableImages = targetImages.slice(0, 4);
+    if (comparableImages.length < 2 || comparableImages.length > 4) {
+      setAssetActionMessage('Select 2 to 4 images to compare.');
+      return;
+    }
+    onOpenCompare?.(comparableImages);
+    setAssetContextMenu(null);
+  }, [onOpenCompare]);
+
+  const exportImages = useCallback((targetImages: IndexedImage[]) => {
+    const imageIds = targetImages.map((candidate) => candidate.id);
+    if (imageIds.length === 0) {
+      return;
+    }
+    window.dispatchEvent(new CustomEvent(OPEN_BATCH_EXPORT_EVENT, {
+      detail: {
+        imageIds,
+        preferredSource: imageIds.length > 1 ? 'selected' : 'selected',
+      },
+    }));
+    setAssetContextMenu(null);
+  }, []);
+
+  const deleteImages = useCallback(async (targetImages: IndexedImage[]) => {
+    if (targetImages.length === 0) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      targetImages.length === 1
+        ? `Delete "${targetImages[0].name}"? This sends the file to the recycle bin.`
+        : `Delete ${targetImages.length} selected images? This sends the files to the recycle bin.`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    const results = await Promise.all(targetImages.map((candidate) => FileOperations.deleteFile(candidate)));
+    const deletedIds = targetImages
+      .filter((_, index) => results[index]?.success)
+      .map((candidate) => candidate.id);
+
+    if (deletedIds.length > 0) {
+      removeImages(deletedIds);
+      useImageStore.setState((state) => ({
+        selectedImages: new Set(Array.from(state.selectedImages).filter((id) => !deletedIds.includes(id))),
+      }));
+    }
+
+    const failedCount = results.length - deletedIds.length;
+    setAssetActionMessage(failedCount > 0 ? `Deleted ${deletedIds.length}; ${failedCount} failed.` : `Deleted ${deletedIds.length} image${deletedIds.length === 1 ? '' : 's'}.`);
+    setAssetContextMenu(null);
+  }, [removeImages]);
+
+  const setSelectedRating = useCallback((rating: ImageRating | null) => {
+    if (selectedWorkspaceIds.length === 0) {
+      return;
+    }
+    void bulkSetImageRating(selectedWorkspaceIds, rating);
+    setIsRatingMenuOpen(false);
+  }, [bulkSetImageRating, selectedWorkspaceIds]);
+
+  const showAssetContextMenu = useCallback((event: React.MouseEvent, contextImage: IndexedImage) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const thumbBounds = event.currentTarget.getBoundingClientRect();
+    const browserBounds = browserHostRef.current?.getBoundingClientRect();
+    const maxXBeforeBrowser = (browserBounds?.left ?? window.innerWidth) - ASSET_CONTEXT_MENU_WIDTH - 1;
+    const preferredRightX = event.clientX;
+    const flippedLeftX = thumbBounds.left - ASSET_CONTEXT_MENU_WIDTH - 8;
+    const x = preferredRightX <= maxXBeforeBrowser
+      ? preferredRightX
+      : Math.max(0, Math.min(flippedLeftX, maxXBeforeBrowser));
+
+    setAssetContextMenu({
+      image: contextImage,
+      x,
+      y: Math.max(8, Math.min(event.clientY, window.innerHeight - ASSET_CONTEXT_MENU_HEIGHT - 8)),
+    });
+  }, []);
+
+  const inspectAsset = useCallback((contextImage: IndexedImage) => {
+    onInspectImage?.(contextImage);
+    setActiveInspectorTab('image');
+    setAssetContextMenu(null);
+  }, [onInspectImage]);
+
+  const exportAssetImage = useCallback((contextImage: IndexedImage) => {
+    exportImages(getContextTargetImages(contextImage));
+  }, [exportImages, getContextTargetImages]);
+
+  const exportAssetWorkflow = useCallback(async (contextImage: IndexedImage) => {
+    setAssetContextMenu(null);
+    if (!window.electronAPI?.showSaveDialog || !window.electronAPI?.writeFile) {
+      setAssetActionMessage('Workflow export is only available in the desktop app.');
+      return;
+    }
+
+    try {
+      const defaultName = `${contextImage.name.replace(/\.[^.]+$/, '') || 'workflow'}.json`;
+      const saveResult = await window.electronAPI.showSaveDialog({
+        title: 'Export ComfyUI workflow',
+        defaultPath: defaultName,
+        filters: [{ name: 'ComfyUI workflow', extensions: ['json'] }],
+      });
+      if (!saveResult.success || saveResult.canceled || !saveResult.path) {
+        return;
+      }
+
+      const workflowJson = formatImageForComfyUI(contextImage);
+      const writeResult = await window.electronAPI.writeFile(saveResult.path, workflowJson);
+      setAssetActionMessage(writeResult.success ? 'Workflow exported.' : writeResult.error || 'Failed to export workflow.');
+    } catch (error) {
+      setAssetActionMessage(error instanceof Error ? error.message : String(error));
+    }
+  }, []);
+
+  const deleteAsset = useCallback(async (contextImage: IndexedImage) => {
+    await deleteImages(getContextTargetImages(contextImage));
+  }, [deleteImages, getContextTargetImages]);
+
+  const handleBulkFavorite = useCallback(() => {
+    if (selectedWorkspaceIds.length === 0) {
+      return;
+    }
+    void bulkToggleFavorite(selectedWorkspaceIds, !allSelectedWorkspaceFavorites);
+  }, [allSelectedWorkspaceFavorites, bulkToggleFavorite, selectedWorkspaceIds]);
+
+  const handleBulkTag = useCallback(() => {
+    if (selectedWorkspaceIds.length > 0) {
+      setIsTagManagerOpen(true);
+    }
+  }, [selectedWorkspaceIds.length]);
+
+  const handleBulkExport = useCallback(() => {
+    exportImages(selectedWorkspaceImages);
+  }, [exportImages, selectedWorkspaceImages]);
+
+  const handleBulkDelete = useCallback(() => {
+    void deleteImages(selectedWorkspaceImages);
+  }, [deleteImages, selectedWorkspaceImages]);
+
+  const handleBulkCompare = useCallback(() => {
+    openCompareMode(selectedWorkspaceImages);
+  }, [openCompareMode, selectedWorkspaceImages]);
 
   if (!isElectron) {
     return (
@@ -529,10 +986,148 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-gray-950">
       <div className="flex min-h-0 flex-1">
+        <aside
+          className="flex min-h-0 shrink-0 flex-col border-r border-gray-800 bg-gray-900/95"
+          style={{ width: thumbRailWidth }}
+        >
+          <div className="border-b border-gray-800 p-2">
+            <div className="flex items-center gap-1 rounded-md border border-gray-800 bg-gray-950 px-2 py-1.5">
+              <Folder className="h-3.5 w-3.5 shrink-0 text-gray-500" />
+              <select
+                value={selectedDirectoryId || ''}
+                onChange={(event) => onSelectDirectory?.(event.target.value || null)}
+                className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 outline-none"
+                title="Change workspace folder"
+                aria-label="Change workspace folder"
+              >
+                <option value="">All folders</option>
+                {directories.map((directory) => (
+                  <option key={directory.id} value={directory.id}>
+                    {directory.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-1">
+              <span className="mr-auto rounded border border-gray-800 px-1.5 py-1 text-[10px] font-medium text-gray-400">
+                {selectedWorkspaceCount}
+              </span>
+              <button
+                onClick={handleBulkExport}
+                disabled={selectedWorkspaceCount === 0}
+                className="rounded p-1.5 text-gray-400 hover:bg-gray-800 hover:text-white disabled:cursor-not-allowed disabled:text-gray-700"
+                title="Export selected"
+                aria-label="Export selected"
+              >
+                <Package className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={handleBulkFavorite}
+                disabled={selectedWorkspaceCount === 0}
+                className="rounded p-1.5 text-gray-400 hover:bg-gray-800 hover:text-pink-300 disabled:cursor-not-allowed disabled:text-gray-700"
+                title={allSelectedWorkspaceFavorites ? 'Remove selected from favorites' : 'Favorite selected'}
+                aria-label={allSelectedWorkspaceFavorites ? 'Remove selected from favorites' : 'Favorite selected'}
+              >
+                <Heart className={`h-3.5 w-3.5 ${allSelectedWorkspaceFavorites ? 'fill-current text-pink-300' : ''}`} />
+              </button>
+              <button
+                onClick={handleBulkTag}
+                disabled={selectedWorkspaceCount === 0}
+                className="rounded p-1.5 text-gray-400 hover:bg-gray-800 hover:text-blue-300 disabled:cursor-not-allowed disabled:text-gray-700"
+                title="Tag selected"
+                aria-label="Tag selected"
+              >
+                <Tag className="h-3.5 w-3.5" />
+              </button>
+              <div className="relative">
+                <button
+                  onClick={() => setIsRatingMenuOpen((open) => !open)}
+                  disabled={selectedWorkspaceCount === 0}
+                  className="rounded p-1.5 text-gray-400 hover:bg-gray-800 hover:text-yellow-300 disabled:cursor-not-allowed disabled:text-gray-700"
+                  title="Rate selected"
+                  aria-label="Rate selected"
+                >
+                  <Star className="h-3.5 w-3.5" />
+                </button>
+                {isRatingMenuOpen && selectedWorkspaceCount > 0 && (
+                  <div className="absolute left-0 top-full z-[100] mt-1 w-24 overflow-hidden rounded-md border border-gray-700 bg-gray-900 py-1 shadow-xl">
+                    {[0, 1, 2, 3, 4, 5].map((rating) => (
+                      <button
+                        key={rating}
+                        onClick={() => setSelectedRating(rating === 0 ? null : (rating as ImageRating))}
+                        className="block w-full px-2 py-1 text-left text-xs text-gray-200 hover:bg-gray-800"
+                      >
+                        {rating === 0 ? 'Clear' : `${rating} star${rating === 1 ? '' : 's'}`}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <button
+                onClick={handleBulkCompare}
+                disabled={selectedWorkspaceCount < 2 || selectedWorkspaceCount > 4}
+                className="rounded p-1.5 text-gray-400 hover:bg-gray-800 hover:text-purple-300 disabled:cursor-not-allowed disabled:text-gray-700"
+                title="Compare selected"
+                aria-label="Compare selected"
+              >
+                <GitCompare className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={handleBulkDelete}
+                disabled={selectedWorkspaceCount === 0}
+                className="rounded p-1.5 text-gray-400 hover:bg-gray-800 hover:text-red-300 disabled:cursor-not-allowed disabled:text-gray-700"
+                title="Delete selected"
+                aria-label="Delete selected"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={clearImageSelection}
+                disabled={selectedWorkspaceCount === 0}
+                className="rounded p-1.5 text-gray-400 hover:bg-gray-800 hover:text-white disabled:cursor-not-allowed disabled:text-gray-700"
+                title="Clear selection"
+                aria-label="Clear selection"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          </div>
+
+          <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2">
+            {visibleNavigationImages.map((candidate, visibleIndex) => (
+              <WorkspaceThumbnailButton
+                key={candidate.id}
+                image={candidate}
+                isActive={candidate.id === image?.id}
+                isSelected={selectedImages.has(candidate.id)}
+                directoryPath={directoryPathByImageId[candidate.id]}
+                onClick={(event) => handleThumbnailClick(event, candidate, visibleIndex)}
+                onToggleSelected={(event) => updateThumbSelection(event, candidate, visibleIndex)}
+                onToggleFavorite={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void toggleFavorite(candidate.id);
+                }}
+                onContextMenu={(event) => showAssetContextMenu(event, candidate)}
+                onDragStart={startImageFileDrag}
+              />
+            ))}
+          </div>
+        </aside>
+
+        <div
+          className="w-1 cursor-ew-resize bg-gray-800 hover:bg-purple-500/50"
+          onPointerDown={beginThumbRailResize}
+          onPointerMove={handleThumbRailResize}
+          onPointerUp={endThumbRailResize}
+          onPointerCancel={endThumbRailResize}
+          title="Resize thumbnail rail"
+        />
+
         <div className="relative min-w-0 flex-1 bg-black">
           <div ref={browserHostRef} className="absolute inset-0" />
-          {(suspendBrowser || loadFailure || !viewState.visible) && (
-            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-gray-950 text-center">
+          {shouldShowBrowserFallback && (
+            <div className="absolute inset-0 flex items-center justify-center bg-gray-950 text-center">
               <div className="max-w-sm px-6">
                 {suspendBrowser ? (
                   <Loader2 className="mx-auto h-9 w-9 animate-spin text-purple-300" />
@@ -545,8 +1140,33 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 <p className="mt-2 text-sm text-gray-400">
                   {suspendBrowser
                     ? 'Image MetaHub is generating through the API and temporarily hides the embedded ComfyUI UI to reduce memory pressure.'
-                    : 'Start ComfyUI or open it externally. The browser stays attached to this workspace once the endpoint responds.'}
+                    : `Start ComfyUI and make sure it is reachable at ${targetUrl || 'the configured server URL'}.`}
                 </p>
+                {!suspendBrowser && (
+                  <div className="mt-5 flex flex-wrap justify-center gap-2">
+                    <button
+                      onClick={reloadEmbeddedView}
+                      className="inline-flex items-center gap-2 rounded-md border border-purple-500/40 bg-purple-500/15 px-3 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-500/25"
+                    >
+                      <RefreshCw className="h-4 w-4" />
+                      Refresh
+                    </button>
+                    <button
+                      onClick={onOpenSettings}
+                      className="inline-flex items-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-sm font-semibold text-gray-200 hover:bg-gray-800"
+                    >
+                      <SlidersHorizontal className="h-4 w-4" />
+                      Settings
+                    </button>
+                    <button
+                      onClick={openExternally}
+                      className="inline-flex items-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-sm font-semibold text-gray-200 hover:bg-gray-800"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      Open externally
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -606,6 +1226,9 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 <button onClick={openExternally} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open externally">
                   <ExternalLink className="h-4 w-4" />
                 </button>
+                <button onClick={reloadEmbeddedView} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Refresh ComfyUI">
+                  <RefreshCw className="h-4 w-4" />
+                </button>
                 <button onClick={togglePanelCollapsed} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Hide image inspector">
                   <ChevronRight className="h-4 w-4" />
                 </button>
@@ -641,21 +1264,6 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                   Next
                 </button>
               </div>
-
-              {normalizedNavigationImages.length > 1 && (
-                <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
-                  {visibleNavigationImages.map((candidate, visibleIndex) => (
-                    <WorkspaceThumbnailButton
-                      key={candidate.id}
-                      image={candidate}
-                      isActive={candidate.id === image.id}
-                      directoryPath={directoryPathByImageId[candidate.id]}
-                      onClick={() => setWorkspacePreviewIndex(visibleIndex)}
-                      onDragStart={startImageFileDrag}
-                    />
-                  ))}
-                </div>
-              )}
 
               <div className="grid grid-cols-3 gap-1 rounded-lg border border-gray-800 bg-gray-950/80 p-1">
                 {inspectorTabs.map((tab) => {
@@ -742,6 +1350,12 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 </div>
               )}
 
+              {assetActionMessage && (
+                <div className="rounded-md border border-blue-700/40 bg-blue-500/10 px-3 py-2 text-xs text-blue-100">
+                  {assetActionMessage}
+                </div>
+              )}
+
               {activeInspectorTab === 'metadata' && (
                 metadata ? (
                   <div className="space-y-3">
@@ -804,9 +1418,64 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
         <WorkspaceImagePreviewModal
           images={visibleNavigationImages}
           initialIndex={workspacePreviewIndex}
+          onInspectImage={onInspectImage}
           onClose={() => setWorkspacePreviewIndex(null)}
         />
       )}
+      {assetContextMenu && (
+        <div
+          className="fixed z-[95] w-56 overflow-hidden rounded-lg border border-gray-700 bg-gray-900 py-1 text-sm text-gray-100 shadow-2xl"
+          style={{ left: assetContextMenu.x, top: assetContextMenu.y }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <button
+            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-800"
+            onClick={() => inspectAsset(assetContextMenu.image)}
+          >
+            <Info className="h-4 w-4" />
+            Inspect Asset
+          </button>
+          <button
+            className={`flex w-full items-center gap-2 px-3 py-2 text-left ${
+              getCompareTargetImages(assetContextMenu.image).length >= 2 && getCompareTargetImages(assetContextMenu.image).length <= 4
+                ? 'hover:bg-gray-800'
+                : 'cursor-not-allowed text-gray-500'
+            }`}
+            disabled={getCompareTargetImages(assetContextMenu.image).length < 2 || getCompareTargetImages(assetContextMenu.image).length > 4}
+            onClick={() => openCompareMode(getCompareTargetImages(assetContextMenu.image))}
+          >
+            <GitCompare className="h-4 w-4" />
+            Compare Mode
+          </button>
+          <div className="my-1 border-t border-gray-700" />
+          <button
+            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-800"
+            onClick={() => exportAssetImage(assetContextMenu.image)}
+          >
+            <Download className="h-4 w-4" />
+            Export Image
+          </button>
+          <button
+            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-800"
+            onClick={() => exportAssetWorkflow(assetContextMenu.image)}
+          >
+            <Workflow className="h-4 w-4" />
+            Export Workflow
+          </button>
+          <button
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-red-300 hover:bg-red-950/40"
+            onClick={() => deleteAsset(assetContextMenu.image)}
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete
+          </button>
+        </div>
+      )}
+      <TagManagerModal
+        isOpen={isTagManagerOpen}
+        onClose={() => setIsTagManagerOpen(false)}
+        selectedImageIds={selectedWorkspaceIds}
+      />
     </div>
   );
 };

--- a/components/GenerationQueueSidebar.tsx
+++ b/components/GenerationQueueSidebar.tsx
@@ -160,6 +160,22 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
       return;
     }
 
+    if (item.provider === 'comfyui' && item.status === 'waiting' && item.providerJobId && comfyUIServerUrl) {
+      const client = new ComfyUIApiClient({ serverUrl: comfyUIServerUrl });
+      try {
+        const result = await client.deleteQueueItems([item.providerJobId]);
+        if (!result.success) {
+          setJobStatus(item.id, item.status, { error: result.error || 'Failed to cancel ComfyUI job.' });
+          return;
+        }
+      } catch (error) {
+        setJobStatus(item.id, item.status, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      }
+    }
+
     if (item.status === 'waiting') {
       setJobStatus(item.id, 'canceled', { error: undefined });
       return;

--- a/components/GenerationQueueSidebar.tsx
+++ b/components/GenerationQueueSidebar.tsx
@@ -99,6 +99,11 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
   };
 
   const handleRetry = async (item: GenerationQueueItem) => {
+    if (!item.imageId) {
+      alert('This queue item cannot be retried because it was not started from an Image MetaHub image.');
+      return;
+    }
+
     const image = findImage(item.imageId);
     if (!image) {
       alert('Image no longer available for retry.');
@@ -126,6 +131,32 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
   const handleCancel = async (item: GenerationQueueItem, event?: React.MouseEvent<HTMLButtonElement>) => {
     event?.stopPropagation();
     if (item.status !== 'processing' && item.status !== 'waiting') {
+      return;
+    }
+
+    if (item.provider === 'comfyui' && item.origin === 'comfyui-external') {
+      if (!comfyUIServerUrl || !item.providerJobId) {
+        setJobStatus(item.id, 'failed', { error: 'Cannot cancel ComfyUI job without a prompt id.' });
+        return;
+      }
+
+      const client = new ComfyUIApiClient({ serverUrl: comfyUIServerUrl });
+      try {
+        const result = item.status === 'waiting'
+          ? await client.deleteQueueItems([item.providerJobId])
+          : await client.interrupt();
+
+        if (!result.success) {
+          setJobStatus(item.id, item.status, { error: result.error || 'Failed to cancel ComfyUI job.' });
+          return;
+        }
+
+        setJobStatus(item.id, 'canceled', { error: undefined });
+      } catch (error) {
+        setJobStatus(item.id, item.status, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
       return;
     }
 
@@ -278,7 +309,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
                       {statusLabel[item.status]}
                     </span>
                     <span className="text-[10px] uppercase tracking-wide text-gray-500">
-                      {item.provider === 'a1111' ? 'A1111' : 'ComfyUI'}
+                      {item.provider === 'a1111' ? 'A1111' : item.origin === 'comfyui-external' ? 'ComfyUI External' : 'ComfyUI'}
                     </span>
                   </div>
                   <p className="text-sm font-semibold text-gray-200 break-all">{item.imageName}</p>
@@ -295,7 +326,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
                       {item.status === 'waiting' ? <CircleX size={16} /> : <CircleStop size={16} />}
                     </button>
                   )}
-                  {(item.status === 'failed' || item.status === 'canceled') && (
+                  {(item.status === 'failed' || item.status === 'canceled') && item.origin !== 'comfyui-external' && (
                     <button
                       onClick={(event) => handleRetryClick(item, event)}
                       className="text-gray-400 hover:text-blue-300 transition-colors"

--- a/components/settings/IntegrationsSettingsPanel.tsx
+++ b/components/settings/IntegrationsSettingsPanel.tsx
@@ -23,9 +23,11 @@ export const IntegrationsSettingsPanel: React.FC = () => {
   const comfyUIEnabled = useSettingsStore((state) => state.comfyUIEnabled);
   const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
   const comfyUILastConnectionStatus = useSettingsStore((state) => state.comfyUILastConnectionStatus);
+  const comfyUIQueueMonitoringEnabled = useSettingsStore((state) => state.comfyUIQueueMonitoringEnabled);
   const setComfyUIEnabled = useSettingsStore((state) => state.setComfyUIEnabled);
   const setComfyUIServerUrl = useSettingsStore((state) => state.setComfyUIServerUrl);
   const setComfyUIConnectionStatus = useSettingsStore((state) => state.setComfyUIConnectionStatus);
+  const setComfyUIQueueMonitoringEnabled = useSettingsStore((state) => state.setComfyUIQueueMonitoringEnabled);
 
   const [isTestingA1111Connection, setIsTestingA1111Connection] = useState(false);
   const [isTestingComfyUIConnection, setIsTestingComfyUIConnection] = useState(false);
@@ -182,6 +184,12 @@ export const IntegrationsSettingsPanel: React.FC = () => {
           <SettingRow
             label="Show in viewer"
             control={<SettingSwitch checked={comfyUIEnabled} onChange={setComfyUIEnabled} />}
+          />
+
+          <SettingRow
+            label="Detect ComfyUI generations"
+            description="Show generations started in ComfyUI, including the embedded workspace, in the Image MetaHub queue."
+            control={<SettingSwitch checked={comfyUIQueueMonitoringEnabled} onChange={setComfyUIQueueMonitoringEnabled} />}
           />
 
           <div className="space-y-2 rounded-xl border border-gray-800 bg-gray-950/60 px-4 py-3">

--- a/electron.mjs
+++ b/electron.mjs
@@ -1006,7 +1006,8 @@ function configureComfyUIViewHandlers(view) {
       errorDescription,
       url: validatedURL,
     });
-    updateComfyUIViewState({ isLoading: false, lastLoadFailed: true });
+    view.setVisible(false);
+    updateComfyUIViewState({ isLoading: false, lastLoadFailed: true, visible: false });
   });
 }
 
@@ -1079,7 +1080,14 @@ async function openComfyUIView({ url, bounds } = {}) {
 
   const currentUrl = view.webContents.getURL();
   if (!currentUrl || comfyUIViewState.lastLoadFailed || !isComfyNavigationAllowed(currentUrl)) {
-    await view.webContents.loadURL(parsed.toString());
+    try {
+      await view.webContents.loadURL(parsed.toString());
+    } catch (error) {
+      const message = error?.message || '';
+      if (!message.includes('ERR_ABORTED') && error?.code !== 'ERR_ABORTED') {
+        throw error;
+      }
+    }
   }
 
   return { success: true, state: updateComfyUIViewState({ visible: true }) };

--- a/hooks/useComfyUIQueueMonitor.ts
+++ b/hooks/useComfyUIQueueMonitor.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { ComfyUIApiClient, ComfyUIProgressUpdate, normalizeLoopbackServerUrl } from '../services/comfyUIApiClient';
+import { ComfyUIApiClient, normalizeLoopbackServerUrl } from '../services/comfyUIApiClient';
 import { GeneratedQueueOutput, useGenerationQueueStore } from '../store/useGenerationQueueStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 
@@ -14,7 +14,13 @@ type ComfyUIHistoryImage = {
   type?: unknown;
 };
 
+type ComfyUIMonitorMessage = {
+  type?: string;
+  data?: Record<string, unknown>;
+};
+
 const POLL_INTERVAL_MS = 1500;
+const MONITOR_CLIENT_ID = 'image-metahub-monitor';
 
 const isHistoryImage = (value: unknown): value is ComfyUIHistoryImage =>
   Boolean(value && typeof value === 'object' && 'filename' in value);
@@ -136,6 +142,67 @@ const extractHistoryOutputs = (
   return images;
 };
 
+const getPromptHistory = (history: Record<string, unknown>, promptId: string): Record<string, unknown> | null => {
+  const promptHistory = history[promptId];
+  return promptHistory && typeof promptHistory === 'object'
+    ? promptHistory as Record<string, unknown>
+    : null;
+};
+
+const stringifyMessage = (value: unknown): string | null => {
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim();
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const message = stringifyMessage(entry);
+      if (message) {
+        return message;
+      }
+    }
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return stringifyMessage(record.exception_message) ||
+      stringifyMessage(record.exception_type) ||
+      stringifyMessage(record.message) ||
+      stringifyMessage(record.error);
+  }
+  return null;
+};
+
+const getHistoryFailureMessage = (promptHistory: Record<string, unknown>): string | null => {
+  const status = promptHistory.status;
+  const statusRecord = status && typeof status === 'object' ? status as Record<string, unknown> : null;
+  const statusText = typeof statusRecord?.status_str === 'string' ? statusRecord.status_str.toLowerCase() : '';
+  const completed = statusRecord?.completed;
+
+  if (statusText && statusText !== 'success') {
+    return stringifyMessage(statusRecord?.messages) || `ComfyUI ${statusText}`;
+  }
+
+  if (completed === false && statusText) {
+    return stringifyMessage(statusRecord?.messages) || `ComfyUI ${statusText}`;
+  }
+
+  return stringifyMessage(promptHistory.execution_error) ||
+    stringifyMessage(promptHistory.error) ||
+    stringifyMessage(promptHistory.exception);
+};
+
+const getWebSocketUrl = (serverUrl: string): string | null => {
+  try {
+    const resolvedServerUrl = normalizeLoopbackServerUrl(serverUrl);
+    const url = new URL(resolvedServerUrl);
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    url.pathname = '/ws';
+    url.search = `clientId=${encodeURIComponent(MONITOR_CLIENT_ID)}`;
+    return url.toString();
+  } catch {
+    return null;
+  }
+};
+
 const getTrackedExternalPromptIds = () =>
   useGenerationQueueStore
     .getState()
@@ -160,7 +227,21 @@ export function useComfyUIQueueMonitor() {
     const markHistoryIfAvailable = async (promptId: string) => {
       try {
         const history = await client.getHistory(promptId) as Record<string, unknown>;
-        if (isDisposed || !history[promptId]) {
+        const promptHistory = getPromptHistory(history, promptId);
+        if (isDisposed || !promptHistory) {
+          return;
+        }
+
+        const failureMessage = getHistoryFailureMessage(promptHistory);
+        if (failureMessage) {
+          useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+            providerJobId: promptId,
+            status: 'failed',
+            progress: 1,
+            error: failureMessage,
+            completedAt: Date.now(),
+            currentNode: null,
+          });
           return;
         }
 
@@ -219,20 +300,42 @@ export function useComfyUIQueueMonitor() {
     };
 
     const connectWebSocket = () => {
-      const resolvedServerUrl = normalizeLoopbackServerUrl(serverUrl);
-      const wsUrl = `${resolvedServerUrl.replace(/^http/, 'ws')}/ws?clientId=image-metahub-monitor`;
-      const socket = new WebSocket(wsUrl);
+      const wsUrl = getWebSocketUrl(serverUrl);
+      if (!wsUrl) {
+        return null;
+      }
+
+      let socket: WebSocket;
+      try {
+        socket = new WebSocket(wsUrl);
+      } catch {
+        return null;
+      }
 
       socket.onmessage = (event) => {
         try {
-          const message = JSON.parse(event.data) as ComfyUIProgressUpdate;
-          const promptId = message.data?.prompt_id || activePromptIdRef.current;
+          const message = JSON.parse(event.data) as ComfyUIMonitorMessage;
+          const promptId = typeof message.data?.prompt_id === 'string'
+            ? message.data.prompt_id
+            : activePromptIdRef.current;
           if (!promptId) {
             return;
           }
 
+          if (message.type === 'execution_error' || message.type === 'execution_interrupted') {
+            useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+              providerJobId: promptId,
+              status: 'failed',
+              progress: 1,
+              error: stringifyMessage(message.data) || (message.type === 'execution_interrupted' ? 'ComfyUI generation interrupted.' : 'ComfyUI generation failed.'),
+              completedAt: Date.now(),
+              currentNode: null,
+            });
+            return;
+          }
+
           if (message.type === 'executing') {
-            if (message.data.node === null) {
+            if (message.data?.node === null) {
               void markHistoryIfAvailable(promptId);
               return;
             }
@@ -241,13 +344,13 @@ export function useComfyUIQueueMonitor() {
             useGenerationQueueStore.getState().upsertExternalComfyUIJob({
               providerJobId: promptId,
               status: 'processing',
-              currentNode: message.data.node || null,
+              currentNode: typeof message.data?.node === 'string' ? message.data.node : null,
             });
           }
 
           if (message.type === 'progress') {
-            const value = message.data.value || 0;
-            const max = message.data.max || 1;
+            const value = typeof message.data?.value === 'number' ? message.data.value : 0;
+            const max = typeof message.data?.max === 'number' ? message.data.max : 1;
             useGenerationQueueStore.getState().upsertExternalComfyUIJob({
               providerJobId: promptId,
               status: 'processing',

--- a/hooks/useComfyUIQueueMonitor.ts
+++ b/hooks/useComfyUIQueueMonitor.ts
@@ -1,0 +1,295 @@
+import { useEffect, useRef } from 'react';
+import { ComfyUIApiClient, ComfyUIProgressUpdate, normalizeLoopbackServerUrl } from '../services/comfyUIApiClient';
+import { GeneratedQueueOutput, useGenerationQueueStore } from '../store/useGenerationQueueStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+
+type ComfyUIQueueEntry = {
+  promptId: string;
+  prompt?: string;
+};
+
+type ComfyUIHistoryImage = {
+  filename?: unknown;
+  subfolder?: unknown;
+  type?: unknown;
+};
+
+const POLL_INTERVAL_MS = 1500;
+
+const isHistoryImage = (value: unknown): value is ComfyUIHistoryImage =>
+  Boolean(value && typeof value === 'object' && 'filename' in value);
+
+const getPromptIdFromQueueEntry = (entry: unknown): string | null => {
+  if (Array.isArray(entry)) {
+    const candidate = entry.find((value) => typeof value === 'string' && value.length > 8);
+    return typeof candidate === 'string' ? candidate : null;
+  }
+
+  if (entry && typeof entry === 'object') {
+    const record = entry as Record<string, unknown>;
+    const candidate = record.prompt_id || record.promptId || record.id;
+    return typeof candidate === 'string' ? candidate : null;
+  }
+
+  return null;
+};
+
+const getPromptGraphFromQueueEntry = (entry: unknown): unknown => {
+  if (Array.isArray(entry)) {
+    return entry.find((value) => value && typeof value === 'object' && !Array.isArray(value));
+  }
+
+  if (entry && typeof entry === 'object') {
+    const record = entry as Record<string, unknown>;
+    return record.prompt || record.workflow;
+  }
+
+  return null;
+};
+
+const extractPromptPreview = (entry: unknown): string | undefined => {
+  const graph = getPromptGraphFromQueueEntry(entry);
+  if (!graph || typeof graph !== 'object') {
+    return undefined;
+  }
+
+  for (const node of Object.values(graph as Record<string, unknown>)) {
+    if (!node || typeof node !== 'object') {
+      continue;
+    }
+    const record = node as { class_type?: unknown; inputs?: Record<string, unknown> };
+    const classType = typeof record.class_type === 'string' ? record.class_type.toLowerCase() : '';
+    const text = record.inputs?.text;
+    if (classType.includes('cliptextencode') && typeof text === 'string' && text.trim()) {
+      return text.trim();
+    }
+  }
+
+  return undefined;
+};
+
+const parseQueueEntries = (queue: Record<string, unknown>, key: 'queue_running' | 'queue_pending'): ComfyUIQueueEntry[] => {
+  const entries = queue[key];
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  return entries
+    .map((entry): ComfyUIQueueEntry | null => {
+      const promptId = getPromptIdFromQueueEntry(entry);
+      if (!promptId) {
+        return null;
+      }
+
+      return {
+        promptId,
+        prompt: extractPromptPreview(entry),
+      };
+    })
+    .filter((entry): entry is ComfyUIQueueEntry => Boolean(entry));
+};
+
+const extractHistoryOutputs = (
+  history: Record<string, unknown>,
+  promptId: string,
+  client: ComfyUIApiClient
+): GeneratedQueueOutput[] => {
+  const promptHistory = history[promptId];
+  if (!promptHistory || typeof promptHistory !== 'object') {
+    return [];
+  }
+
+  const outputs = (promptHistory as { outputs?: unknown }).outputs;
+  if (!outputs || typeof outputs !== 'object') {
+    return [];
+  }
+
+  const images: GeneratedQueueOutput[] = [];
+  Object.values(outputs as Record<string, unknown>).forEach((nodeOutput, nodeIndex) => {
+    const nodeImages = (nodeOutput as { images?: unknown }).images;
+    if (!Array.isArray(nodeImages)) {
+      return;
+    }
+
+    nodeImages.filter(isHistoryImage).forEach((image, imageIndex) => {
+      if (typeof image.filename !== 'string') {
+        return;
+      }
+
+      const subfolder = typeof image.subfolder === 'string' ? image.subfolder : '';
+      const type = typeof image.type === 'string' ? image.type : 'output';
+      const relativePath = subfolder ? `${subfolder}/${image.filename}` : image.filename;
+      images.push({
+        id: `comfyui_external_${promptId}_${nodeIndex}_${imageIndex}`,
+        kind: 'remote-url',
+        url: client.getViewUrl({
+          filename: image.filename,
+          subfolder,
+          type,
+        }),
+        relativePath,
+        name: image.filename,
+      });
+    });
+  });
+
+  return images;
+};
+
+const getTrackedExternalPromptIds = () =>
+  useGenerationQueueStore
+    .getState()
+    .items.filter((item) => item.provider === 'comfyui' && item.origin === 'comfyui-external' && item.providerJobId)
+    .map((item) => item.providerJobId!);
+
+export function useComfyUIQueueMonitor() {
+  const comfyUIEnabled = useSettingsStore((state) => state.comfyUIEnabled);
+  const monitoringEnabled = useSettingsStore((state) => state.comfyUIQueueMonitoringEnabled);
+  const serverUrl = useSettingsStore((state) => state.comfyUIServerUrl);
+  const activePromptIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!comfyUIEnabled || !monitoringEnabled || !serverUrl) {
+      return;
+    }
+
+    let isDisposed = false;
+    let intervalId: number | null = null;
+    const client = new ComfyUIApiClient({ serverUrl });
+
+    const markHistoryIfAvailable = async (promptId: string) => {
+      try {
+        const history = await client.getHistory(promptId) as Record<string, unknown>;
+        if (isDisposed || !history[promptId]) {
+          return;
+        }
+
+        const outputs = extractHistoryOutputs(history, promptId, client);
+        useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+          providerJobId: promptId,
+          status: 'done',
+          progress: 1,
+          generatedOutputs: outputs,
+          completedAt: Date.now(),
+          currentNode: null,
+        });
+      } catch {
+        // History may not exist yet; the next poll/WebSocket event will try again.
+      }
+    };
+
+    const pollQueue = async () => {
+      try {
+        const queue = await client.getQueue() as Record<string, unknown>;
+        if (isDisposed) {
+          return;
+        }
+
+        const running = parseQueueEntries(queue, 'queue_running');
+        const pending = parseQueueEntries(queue, 'queue_pending');
+        const activePromptIds = new Set([...running, ...pending].map((entry) => entry.promptId));
+
+        pending.forEach((entry) => {
+          useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+            providerJobId: entry.promptId,
+            status: 'waiting',
+            progress: 0,
+            prompt: entry.prompt,
+          });
+        });
+
+        running.forEach((entry) => {
+          activePromptIdRef.current = entry.promptId;
+          useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+            providerJobId: entry.promptId,
+            status: 'processing',
+            progress: 0,
+            prompt: entry.prompt,
+          });
+        });
+
+        await Promise.all(
+          getTrackedExternalPromptIds()
+            .filter((promptId) => !activePromptIds.has(promptId))
+            .map(markHistoryIfAvailable)
+        );
+      } catch {
+        // Keep the monitor quiet when ComfyUI is offline or restarting.
+      }
+    };
+
+    const connectWebSocket = () => {
+      const resolvedServerUrl = normalizeLoopbackServerUrl(serverUrl);
+      const wsUrl = `${resolvedServerUrl.replace(/^http/, 'ws')}/ws?clientId=image-metahub-monitor`;
+      const socket = new WebSocket(wsUrl);
+
+      socket.onmessage = (event) => {
+        try {
+          const message = JSON.parse(event.data) as ComfyUIProgressUpdate;
+          const promptId = message.data?.prompt_id || activePromptIdRef.current;
+          if (!promptId) {
+            return;
+          }
+
+          if (message.type === 'executing') {
+            if (message.data.node === null) {
+              void markHistoryIfAvailable(promptId);
+              return;
+            }
+
+            activePromptIdRef.current = promptId;
+            useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+              providerJobId: promptId,
+              status: 'processing',
+              currentNode: message.data.node || null,
+            });
+          }
+
+          if (message.type === 'progress') {
+            const value = message.data.value || 0;
+            const max = message.data.max || 1;
+            useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+              providerJobId: promptId,
+              status: 'processing',
+              currentStep: value,
+              totalSteps: max,
+              progress: max > 0 ? value / max : 0,
+            });
+          }
+        } catch {
+          // Ignore malformed WebSocket messages from custom ComfyUI builds.
+        }
+      };
+
+      socket.onerror = () => {
+        socket.close();
+      };
+
+      socket.onclose = () => {
+        if (!isDisposed) {
+          window.setTimeout(() => {
+            if (!isDisposed) {
+              ws = connectWebSocket();
+            }
+          }, 3000);
+        }
+      };
+
+      return socket;
+    };
+
+    let ws: WebSocket | null = connectWebSocket();
+    void pollQueue();
+    intervalId = window.setInterval(pollQueue, POLL_INTERVAL_MS);
+
+    return () => {
+      isDisposed = true;
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+      }
+      ws?.close();
+      ws = null;
+      activePromptIdRef.current = null;
+    };
+  }, [comfyUIEnabled, monitoringEnabled, serverUrl]);
+}

--- a/hooks/useGenerationQueueRunner.ts
+++ b/hooks/useGenerationQueueRunner.ts
@@ -16,10 +16,12 @@ type ImageLookup = {
 
 const terminalStatuses = new Set(['done', 'failed', 'canceled']);
 
-const findImage = ({ images, filteredImages }: ImageLookup, imageId: string) =>
-  images.find((img) => img.id === imageId) ||
-  filteredImages.find((img) => img.id === imageId) ||
-  null;
+const findImage = ({ images, filteredImages }: ImageLookup, imageId?: string) =>
+  imageId
+    ? images.find((img) => img.id === imageId) ||
+      filteredImages.find((img) => img.id === imageId) ||
+      null
+    : null;
 
 export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup) {
   const items = useGenerationQueueStore((state) => state.items);
@@ -51,6 +53,11 @@ export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup
 
       const activeItem = state.items.find((item) => item.id === activeJobId);
       if (!activeItem) {
+        state.setActiveJob(provider, null);
+        return;
+      }
+
+      if (activeItem.origin === 'comfyui-external') {
         state.setActiveJob(provider, null);
         return;
       }

--- a/services/comfyUIApiClient.ts
+++ b/services/comfyUIApiClient.ts
@@ -620,7 +620,7 @@ export class ComfyUIApiClient {
       const timeoutId = setTimeout(() => controller.abort(), this.config.timeout);
 
       const response = await fetch(`${this.config.serverUrl}/queue`, {
-        method: 'DELETE',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/services/comfyUIApiClient.ts
+++ b/services/comfyUIApiClient.ts
@@ -610,6 +610,37 @@ export class ComfyUIApiClient {
     }
   }
 
+  async deleteQueueItems(promptIds: string[]): Promise<{ success: boolean; error?: string }> {
+    if (promptIds.length === 0) {
+      return { success: true };
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.config.timeout);
+
+      const response = await fetch(`${this.config.serverUrl}/queue`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ delete: promptIds }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return { success: false, error: errorText || `Failed to delete queue items: ${response.status}` };
+      }
+
+      return { success: true };
+    } catch (error: unknown) {
+      return { success: false, error: getErrorMessage(error) };
+    }
+  }
+
   /**
    * Connect to ComfyUI WebSocket for real-time progress updates
    */

--- a/services/generationQueueExecutors.ts
+++ b/services/generationQueueExecutors.ts
@@ -4,6 +4,7 @@ import { BaseMetadata, IndexedImage } from '../types';
 import {
   GeneratedQueueOutput,
   GenerationQueueItem,
+  useGenerationQueueStore,
 } from '../store/useGenerationQueueStore';
 import {
   hasPromptMetadata,
@@ -232,6 +233,8 @@ export async function executeComfyUIQueueJob(
   if (!result.success || !result.prompt_id) {
     throw new Error(result.error || 'Failed to queue workflow');
   }
+
+  useGenerationQueueStore.getState().updateJob(job.id, { providerJobId: result.prompt_id });
 
   context.startTracking(context.serverUrl, result.prompt_id, prepared.workflow.client_id);
   try {

--- a/store/useGenerationQueueStore.ts
+++ b/store/useGenerationQueueStore.ts
@@ -5,6 +5,7 @@ import { ComfyUISourceImagePolicy, ComfyUIWorkflowMode } from '../services/comfy
 
 export type GenerationProvider = 'a1111' | 'comfyui';
 export type GenerationStatus = 'waiting' | 'processing' | 'done' | 'failed' | 'canceled';
+export type GenerationOrigin = 'metahub' | 'comfyui-external';
 
 export type A1111QueuePayload = {
   provider: 'a1111';
@@ -39,7 +40,8 @@ export interface GeneratedQueueOutput {
 export interface GenerationQueueItem {
   id: string;
   provider: GenerationProvider;
-  imageId: string;
+  origin?: GenerationOrigin;
+  imageId?: string;
   imageName: string;
   prompt?: string;
   status: GenerationStatus;
@@ -60,7 +62,8 @@ export interface GenerationQueueItem {
 
 type CreateJobInput = {
   provider: GenerationProvider;
-  imageId: string;
+  origin?: GenerationOrigin;
+  imageId?: string;
   imageName: string;
   prompt?: string;
   totalImages?: number;
@@ -71,6 +74,19 @@ interface GenerationQueueState {
   items: GenerationQueueItem[];
   activeJobs: Record<GenerationProvider, string | null>;
   createJob: (input: CreateJobInput) => string;
+  upsertExternalComfyUIJob: (input: {
+    providerJobId: string;
+    status: GenerationStatus;
+    imageName?: string;
+    prompt?: string;
+    progress?: number;
+    currentStep?: number;
+    totalSteps?: number;
+    currentNode?: string | null;
+    error?: string;
+    generatedOutputs?: GeneratedQueueOutput[];
+    completedAt?: number;
+  }) => string;
   updateJob: (id: string, updates: Partial<GenerationQueueItem>) => void;
   setJobStatus: (id: string, status: GenerationStatus, updates?: Partial<GenerationQueueItem>) => void;
   setActiveJob: (provider: GenerationProvider, id: string | null) => void;
@@ -113,6 +129,7 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
     const item: GenerationQueueItem = {
       id,
       provider: input.provider,
+      origin: input.origin || 'metahub',
       imageId: input.imageId,
       imageName: input.imageName,
       prompt: input.prompt,
@@ -139,11 +156,91 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
 
     return id;
   },
+  upsertExternalComfyUIJob: (input) => {
+    const now = Date.now();
+    const shortPromptId = input.providerJobId.slice(0, 8);
+    const imageName = input.imageName || `ComfyUI job ${shortPromptId}`;
+    const existing = get().items.find(
+      (item) => item.provider === 'comfyui' && item.providerJobId === input.providerJobId
+    );
+
+    if (existing) {
+      if (existing.status === 'canceled') {
+        return existing.id;
+      }
+
+      if (existing.status === 'done' && input.status !== 'done' && input.status !== 'failed') {
+        return existing.id;
+      }
+
+      set((state) => ({
+        items: state.items.map((item) =>
+          item.id === existing.id
+            ? {
+                ...item,
+                origin: item.origin || 'metahub',
+                status: input.status,
+                imageName: input.imageName || item.imageName,
+                prompt: input.prompt ?? item.prompt,
+                progress: input.progress ?? item.progress,
+                currentStep: input.currentStep ?? item.currentStep,
+                totalSteps: input.totalSteps ?? item.totalSteps,
+                currentNode: input.currentNode === undefined ? item.currentNode : input.currentNode,
+                error: input.error,
+                generatedOutputs: input.generatedOutputs ?? item.generatedOutputs,
+                completedAt: input.completedAt ?? item.completedAt,
+                updatedAt: now,
+              }
+            : item
+        ),
+      }));
+      return existing.id;
+    }
+
+    const id = createQueueId();
+    const item: GenerationQueueItem = {
+      id,
+      provider: 'comfyui',
+      origin: 'comfyui-external',
+      imageName,
+      prompt: input.prompt,
+      status: input.status,
+      progress: input.progress ?? 0,
+      currentStep: input.currentStep,
+      totalSteps: input.totalSteps,
+      currentNode: input.currentNode,
+      providerJobId: input.providerJobId,
+      error: input.error,
+      generatedOutputs: input.generatedOutputs,
+      completedAt: input.completedAt,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    set((state) => {
+      const nextItems = [item, ...state.items];
+      const removedItems = nextItems.slice(MAX_ITEMS);
+      revokeGeneratedOutputUrls(removedItems);
+
+      return {
+        items: nextItems.slice(0, MAX_ITEMS),
+      };
+    });
+
+    return id;
+  },
   updateJob: (id, updates) => {
     set((state) => ({
-      items: state.items.map((item) =>
-        item.id === id ? { ...item, ...updates, updatedAt: Date.now() } : item
-      ),
+      items: state.items
+        .filter((item) => {
+          if (!updates.providerJobId || item.id === id) {
+            return true;
+          }
+          return !(item.provider === 'comfyui' && item.origin === 'comfyui-external' && item.providerJobId === updates.providerJobId);
+        })
+        .map((item) =>
+          item.id === id ? { ...item, ...updates, updatedAt: Date.now() } : item
+        ),
     }));
   },
   setJobStatus: (id, status, updates) => {
@@ -162,7 +259,7 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
   getNextWaitingJobId: (provider) => {
     const { items } = get();
     const next = items
-      .filter((item) => item.provider === provider && item.status === 'waiting')
+      .filter((item) => item.provider === provider && item.status === 'waiting' && item.origin !== 'comfyui-external')
       .sort((a, b) => a.createdAt - b.createdAt)[0];
     return next?.id ?? null;
   },

--- a/store/useGenerationQueueStore.ts
+++ b/store/useGenerationQueueStore.ts
@@ -173,13 +173,20 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
         return existing.id;
       }
 
+      const nextStatus =
+        existing.origin !== 'comfyui-external' &&
+        existing.status === 'processing' &&
+        input.status === 'waiting'
+          ? existing.status
+          : input.status;
+
       set((state) => ({
         items: state.items.map((item) =>
           item.id === existing.id
             ? {
                 ...item,
                 origin: item.origin || 'metahub',
-                status: input.status,
+                status: nextStatus,
                 imageName: input.imageName || item.imageName,
                 prompt: input.prompt ?? item.prompt,
                 progress: input.progress ?? item.progress,

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -133,6 +133,7 @@ interface SettingsState {
   comfyUIEnabled: boolean;
   comfyUIServerUrl: string;
   comfyUILastConnectionStatus: 'unknown' | 'connected' | 'error';
+  comfyUIQueueMonitoringEnabled: boolean;
   comfyUIWorkspaceLastUrl: string;
   comfyUIWorkspacePanelWidth: number;
   comfyUIWorkspaceAutoOpenSelectedImage: boolean;
@@ -174,6 +175,7 @@ interface SettingsState {
   setComfyUIEnabled: (value: boolean) => void;
   setComfyUIServerUrl: (url: string) => void;
   setComfyUIConnectionStatus: (status: 'unknown' | 'connected' | 'error') => void;
+  setComfyUIQueueMonitoringEnabled: (value: boolean) => void;
   setComfyUIWorkspaceLastUrl: (url: string) => void;
   setComfyUIWorkspacePanelWidth: (width: number) => void;
   setComfyUIWorkspaceAutoOpenSelectedImage: (value: boolean) => void;
@@ -228,6 +230,7 @@ export const useSettingsStore = create<SettingsState>()(
       comfyUIEnabled: true,
       comfyUIServerUrl: 'http://127.0.0.1:8188',
       comfyUILastConnectionStatus: 'unknown',
+      comfyUIQueueMonitoringEnabled: true,
       comfyUIWorkspaceLastUrl: '',
       comfyUIWorkspacePanelWidth: 360,
       comfyUIWorkspaceAutoOpenSelectedImage: true,
@@ -297,6 +300,7 @@ export const useSettingsStore = create<SettingsState>()(
       setComfyUIEnabled: (value) => set({ comfyUIEnabled: !!value }),
       setComfyUIServerUrl: (url) => set({ comfyUIServerUrl: url }),
       setComfyUIConnectionStatus: (status) => set({ comfyUILastConnectionStatus: status }),
+      setComfyUIQueueMonitoringEnabled: (value) => set({ comfyUIQueueMonitoringEnabled: !!value }),
       setComfyUIWorkspaceLastUrl: (url) => set({ comfyUIWorkspaceLastUrl: url }),
       setComfyUIWorkspacePanelWidth: (width) => set({ comfyUIWorkspacePanelWidth: Math.min(Math.max(Math.round(width) || 360, 280), 560) }),
       setComfyUIWorkspaceAutoOpenSelectedImage: (value) => set({ comfyUIWorkspaceAutoOpenSelectedImage: !!value }),
@@ -337,6 +341,7 @@ export const useSettingsStore = create<SettingsState>()(
         comfyUIEnabled: true,
         comfyUIServerUrl: 'http://127.0.0.1:8188',
         comfyUILastConnectionStatus: 'unknown',
+        comfyUIQueueMonitoringEnabled: true,
         comfyUIWorkspaceLastUrl: '',
         comfyUIWorkspacePanelWidth: 360,
         comfyUIWorkspaceAutoOpenSelectedImage: true,
@@ -425,6 +430,10 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.comfyUIEnabled !== 'boolean') {
           state.comfyUIEnabled = true;
+        }
+
+        if (state && typeof state.comfyUIQueueMonitoringEnabled !== 'boolean') {
+          state.comfyUIQueueMonitoringEnabled = true;
         }
 
         if (state && typeof state.comfyUIWorkspaceLastUrl !== 'string') {

--- a/types.ts
+++ b/types.ts
@@ -54,6 +54,7 @@ export interface ComfyUIViewState {
   canGoBack: boolean;
   canGoForward: boolean;
   visible: boolean;
+  lastLoadFailed?: boolean;
 }
 
 export interface ComfyUIViewResult {


### PR DESCRIPTION
## Summary

- Adds global ComfyUI queue monitoring so Image MetaHub can surface ComfyUI jobs started outside the app.
- Adds the ComfyUI queue monitoring settings toggle and external job handling/cancel behavior in the generation queue.
- Reworks the embedded ComfyUI workspace thumbnail rail with folder switching, vertical thumbnails, preview modal behavior, context menu actions, bulk selection/actions, compare mode, favorite-on-hover, and collapsible thumbnail sidebar.
- Improves embedded ComfyUI fallback behavior when the BrowserView fails to load or ComfyUI is offline.

## Validation

- `npm test -- --run __tests__/useGenerationQueueStore.test.ts __tests__/useSettingsStore.persistence.test.ts`
- `npm run build`

## Notes

Build completed with existing Vite/browser compatibility and chunk-size warnings. No new blocking validation failures were observed.