### PR TITLE
🎨 Palette: Improve accessibility with aria-labels on icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - WCAG 2.5.3 Label in Name Insight
+**Learning:** Adding an `aria-label` to a button that already has visible text (like the "Back" button) overrides the accessible name. This causes a WCAG 2.5.3 violation because voice control users who say "Click Back" won't be able to activate it if the `aria-label` is "Return to the stacked results".
+**Action:** Only apply `aria-label` to icon-only buttons. If a button has visible text, rely on that text for the accessible name, or ensure the visible text is fully contained within the `aria-label`.

--- a/components/ActiveFilters.tsx
+++ b/components/ActiveFilters.tsx
@@ -99,7 +99,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-gray-700 bg-gray-800/70 text-gray-200`}>
             <span className="opacity-70">Search</span>
             <span className="max-w-[180px] truncate">"{searchQuery}"</span>
-            <button onClick={() => setSearchQuery('')} className="rounded p-0.5 hover:bg-gray-700 hover:text-white">
+            <button onClick={() => setSearchQuery('')} aria-label="Clear search filter" className="rounded p-0.5 hover:bg-gray-700 hover:text-white">
               <X size={12} />
             </button>
           </div>
@@ -109,7 +109,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-yellow-700/50 bg-yellow-950/50 text-yellow-200`}>
             <Heart size={12} className="fill-current" />
             <span>Favorites only</span>
-            <button onClick={() => setFavoriteFilterMode('neutral')} className="rounded p-0.5 hover:bg-yellow-900/70">
+            <button onClick={() => setFavoriteFilterMode('neutral')} aria-label="Remove favorites only filter" className="rounded p-0.5 hover:bg-yellow-900/70">
               <X size={12} />
             </button>
           </div>
@@ -119,7 +119,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-rose-700/50 bg-rose-950/50 text-rose-200`}>
             <Heart size={12} />
             <span>Exclude favorites</span>
-            <button onClick={() => setFavoriteFilterMode('neutral')} className="rounded p-0.5 hover:bg-rose-900/70">
+            <button onClick={() => setFavoriteFilterMode('neutral')} aria-label="Remove exclude favorites filter" className="rounded p-0.5 hover:bg-rose-900/70">
               <X size={12} />
             </button>
           </div>
@@ -128,7 +128,7 @@ const ActiveFilters: React.FC = () => {
         {selectedRatings.map((rating) => (
           <div key={`rating-${rating}`} className={`${chipClass} border-gray-700 bg-gray-900/70 text-gray-200`}>
             <RatingValueIcons value={rating} size={11} starClassName="fill-current" />
-            <button onClick={() => setSelectedRatings(selectedRatings.filter((value) => value !== rating))} className="rounded p-0.5 hover:bg-gray-800">
+            <button onClick={() => setSelectedRatings(selectedRatings.filter((value) => value !== rating))} aria-label={`Remove rating ${rating} filter`} className="rounded p-0.5 hover:bg-gray-800">
               <X size={12} />
             </button>
           </div>
@@ -138,7 +138,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-emerald-700/50 bg-emerald-950/50 text-emerald-200`}>
             <CheckCircle size={12} />
             <span>Verified metrics</span>
-            <button onClick={() => removeAdvancedFilter('hasVerifiedTelemetry')} className="rounded p-0.5 hover:bg-emerald-900/70">
+            <button onClick={() => removeAdvancedFilter('hasVerifiedTelemetry')} aria-label="Remove verified metrics filter" className="rounded p-0.5 hover:bg-emerald-900/70">
               <X size={12} />
             </button>
           </div>
@@ -148,7 +148,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-cyan-700/50 bg-cyan-950/50 text-cyan-200`}>
             <CheckCircle size={12} />
             <span>Has telemetry</span>
-            <button onClick={() => removeAdvancedFilter('telemetryState')} className="rounded p-0.5 hover:bg-cyan-900/70">
+            <button onClick={() => removeAdvancedFilter('telemetryState')} aria-label="Remove has telemetry filter" className="rounded p-0.5 hover:bg-cyan-900/70">
               <X size={12} />
             </button>
           </div>
@@ -158,7 +158,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-gray-700/50 bg-gray-900/70 text-gray-200`}>
             <CheckCircle size={12} />
             <span>Missing telemetry</span>
-            <button onClick={() => removeAdvancedFilter('telemetryState')} className="rounded p-0.5 hover:bg-gray-800/70">
+            <button onClick={() => removeAdvancedFilter('telemetryState')} aria-label="Remove missing telemetry filter" className="rounded p-0.5 hover:bg-gray-800/70">
               <X size={12} />
             </button>
           </div>
@@ -168,7 +168,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-indigo-700/50 bg-indigo-950/50 text-indigo-200`}>
             <Settings size={12} />
             <span>{advancedFilters.dimension}</span>
-            <button onClick={() => removeAdvancedFilter('dimension')} className="rounded p-0.5 hover:bg-indigo-900/70">
+            <button onClick={() => removeAdvancedFilter('dimension')} aria-label="Remove dimension filter" className="rounded p-0.5 hover:bg-indigo-900/70">
               <X size={12} />
             </button>
           </div>
@@ -178,7 +178,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-indigo-700/50 bg-indigo-950/50 text-indigo-200`}>
             <Settings size={12} />
             <span>{formatRangeLabel('Steps', advancedFilters.steps)}</span>
-            <button onClick={() => removeAdvancedFilter('steps')} className="rounded p-0.5 hover:bg-indigo-900/70">
+            <button onClick={() => removeAdvancedFilter('steps')} aria-label="Remove steps filter" className="rounded p-0.5 hover:bg-indigo-900/70">
               <X size={12} />
             </button>
           </div>
@@ -188,7 +188,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-indigo-700/50 bg-indigo-950/50 text-indigo-200`}>
             <Settings size={12} />
             <span>{formatRangeLabel('CFG', advancedFilters.cfg)}</span>
-            <button onClick={() => removeAdvancedFilter('cfg')} className="rounded p-0.5 hover:bg-indigo-900/70">
+            <button onClick={() => removeAdvancedFilter('cfg')} aria-label="Remove CFG filter" className="rounded p-0.5 hover:bg-indigo-900/70">
               <X size={12} />
             </button>
           </div>
@@ -198,7 +198,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-indigo-700/50 bg-indigo-950/50 text-indigo-200`}>
             <Calendar size={12} />
             <span>{advancedFilters.date.from || '...'} - {advancedFilters.date.to || '...'}</span>
-            <button onClick={() => removeAdvancedFilter('date')} className="rounded p-0.5 hover:bg-indigo-900/70">
+            <button onClick={() => removeAdvancedFilter('date')} aria-label="Remove date filter" className="rounded p-0.5 hover:bg-indigo-900/70">
               <X size={12} />
             </button>
           </div>
@@ -208,7 +208,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-emerald-700/50 bg-emerald-950/50 text-emerald-200`}>
             <Settings size={12} />
             <span>{formatRangeLabel('Gen time', advancedFilters.generationTimeMs, 'ms')}</span>
-            <button onClick={() => removeAdvancedFilter('generationTimeMs')} className="rounded p-0.5 hover:bg-emerald-900/70">
+            <button onClick={() => removeAdvancedFilter('generationTimeMs')} aria-label="Remove generation time filter" className="rounded p-0.5 hover:bg-emerald-900/70">
               <X size={12} />
             </button>
           </div>
@@ -218,7 +218,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-cyan-700/50 bg-cyan-950/50 text-cyan-200`}>
             <Settings size={12} />
             <span>{formatRangeLabel('Speed', advancedFilters.stepsPerSecond, ' it/s')}</span>
-            <button onClick={() => removeAdvancedFilter('stepsPerSecond')} className="rounded p-0.5 hover:bg-cyan-900/70">
+            <button onClick={() => removeAdvancedFilter('stepsPerSecond')} aria-label="Remove speed filter" className="rounded p-0.5 hover:bg-cyan-900/70">
               <X size={12} />
             </button>
           </div>
@@ -228,7 +228,7 @@ const ActiveFilters: React.FC = () => {
           <div className={`${chipClass} border-cyan-700/50 bg-cyan-950/50 text-cyan-200`}>
             <Settings size={12} />
             <span>{formatRangeLabel('VRAM', advancedFilters.vramPeakMb, ' MB')}</span>
-            <button onClick={() => removeAdvancedFilter('vramPeakMb')} className="rounded p-0.5 hover:bg-cyan-900/70">
+            <button onClick={() => removeAdvancedFilter('vramPeakMb')} aria-label="Remove VRAM filter" className="rounded p-0.5 hover:bg-cyan-900/70">
               <X size={12} />
             </button>
           </div>
@@ -315,7 +315,7 @@ const FacetChip: React.FC<FacetChipProps> = ({ label, value, tone, onRemove }) =
   <div className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] font-medium ${toneClasses[tone]}`}>
     <span className="opacity-70">{label}</span>
     <span className="max-w-[180px] truncate">{value}</span>
-    <button onClick={onRemove} className="rounded p-0.5 hover:bg-black/10">
+    <button onClick={onRemove} aria-label={`Remove ${label} filter`} className="rounded p-0.5 hover:bg-black/10">
       <X size={12} />
     </button>
   </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -390,7 +390,7 @@ const Header: React.FC<HeaderProps> = ({
               <button
                 onClick={() => setStackingEnabled(!isStackingEnabled)}
                 className={`${utilityButtonClassName} shrink-0 ${isStackingEnabled ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : ''}`}
-                title={isStackingEnabled ? 'Disable stacking' : 'Stack items by identical prompt'}
+                title={isStackingEnabled ? 'Disable stacking' : 'Stack items by identical prompt'} aria-label={isStackingEnabled ? 'Disable stacking' : 'Stack items by identical prompt'}
               >
                 {isStackingEnabled ? <Layers2 size={16} /> : <Layers size={16} />}
               </button>
@@ -467,7 +467,7 @@ const Header: React.FC<HeaderProps> = ({
             <button
               onClick={() => setEnableSafeMode(!enableSafeMode)}
               className={`${utilityButtonClassName} h-8 w-8 border-transparent bg-transparent ${enableSafeMode ? 'border-accent/40 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/20 hover:text-accent' : 'text-gray-500 hover:text-gray-200'}`}
-              title={enableSafeMode ? 'Safe Mode on' : 'Safe Mode off'}
+              title={enableSafeMode ? 'Safe Mode on' : 'Safe Mode off'} aria-label={enableSafeMode ? 'Safe Mode on' : 'Safe Mode off'}
             >
               {enableSafeMode ? <Eye size={16} /> : <EyeOff size={16} />}
             </button>
@@ -476,7 +476,7 @@ const Header: React.FC<HeaderProps> = ({
               target="_blank"
               rel="noopener noreferrer"
               className={`${utilityButtonClassName} h-8 w-8 border-transparent bg-transparent`}
-              title="Report a bug or provide feedback"
+              title="Report a bug or provide feedback" aria-label="Report a bug or provide feedback"
             >
               <Bug size={16} />
             </a>
@@ -489,7 +489,7 @@ const Header: React.FC<HeaderProps> = ({
                 }
               }}
               className={`${utilityButtonClassName} relative h-8 w-8 border-transparent bg-transparent`}
-              title={canUseAnalytics ? 'Analytics (Pro)' : 'Analytics (Pro Feature) - start trial'}
+              title={canUseAnalytics ? 'Analytics (Pro)' : 'Analytics (Pro Feature) - start trial'} aria-label={canUseAnalytics ? 'Analytics (Pro)' : 'Analytics (Pro Feature) - start trial'}
             >
               <BarChart3 size={16} />
               <div className="absolute -right-0.5 -top-0.5">
@@ -499,7 +499,7 @@ const Header: React.FC<HeaderProps> = ({
             <button
               onClick={onOpenSettings}
               className={`${utilityButtonClassName} h-8 w-8 border-transparent bg-transparent`}
-              title="Open Settings"
+              title="Open Settings" aria-label="Open Settings"
             >
               <Settings size={16} />
             </button>


### PR DESCRIPTION
Adds `aria-label` attributes to all icon-only buttons in the UI that lacked them, primarily the various "remove filter" buttons in `ActiveFilters` and the utility icon buttons (Safe Mode, Settings, etc.) in `Header`. Acknowledged and avoided overriding accessible names for buttons that already have descriptive visible text.

---
*PR created automatically by Jules for task [10555551551060638151](https://jules.google.com/task/10555551551060638151) started by @LuqP2*