### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2023-10-24 - Array spread operator bottleneck
 **Learning:** Using the array spread operator (`[...prev, new]`) inside a loop over a large array can cause an $O(N^2)$ performance bottleneck due to repeatedly creating new arrays and copying elements.
 **Action:** When building aggregated lists inside a loop, mutate the existing array via `.push()` to maintain $O(1)$ amortized insertion time and overall $O(N)$ loop complexity.
+## 2024-05-11 - Mocking window.confirm in Vitest
+**Learning:** When tests trigger browser interactions like `window.confirm`, Vitest may hang or fail if they are not properly mocked.
+**Action:** Use `vi.spyOn(window, 'confirm').mockReturnValue(true)` to mock the interaction during tests, and ensure you call `mockRestore()` after the assertions to clean up the environment for subsequent tests.

--- a/services/comfyUIVisualWorkflow.ts
+++ b/services/comfyUIVisualWorkflow.ts
@@ -289,6 +289,8 @@ function buildHybridLayout(
   }
 
   let placedInPass = true;
+  const occupiedPositions = Array.from(hybridLayout.values());
+
   while (unresolved.size > 0 && placedInPass) {
     placedInPass = false;
 
@@ -320,8 +322,9 @@ function buildHybridLayout(
       const position = resolveHybridCollision({
         x: average(xCandidates),
         y: average(yCandidates),
-      }, Array.from(hybridLayout.values()));
+      }, occupiedPositions);
       hybridLayout.set(nodeId, position);
+      occupiedPositions.push(position);
       unresolved.delete(nodeId);
       placedInPass = true;
     }
@@ -377,7 +380,12 @@ function buildAutoLayout(prompt: ComfyUIPromptGraph, edges: VisualWorkflowEdge[]
   const columns = new Map<number, string[]>();
   for (const nodeId of nodeIds) {
     const depth = getDepth(nodeId);
-    columns.set(depth, [...(columns.get(depth) || []), nodeId]);
+    const existing = columns.get(depth);
+    if (existing) {
+      existing.push(nodeId);
+    } else {
+      columns.set(depth, [nodeId]);
+    }
   }
 
   const layout = new Map<string, { x: number; y: number }>();


### PR DESCRIPTION
This PR improves the performance of the visual workflow graph builder by addressing inefficient array aggregations in loop constraints.

**What:**
- Refactored `buildAutoLayout` to replace the array spread operator (`[...prev, new]`) with `.push()` when grouping columns by depth.
- Improved `buildHybridLayout` collision detection by pre-calculating the `occupiedPositions` array and mutating it directly via `.push()` when elements are mapped, instead of calling `Array.from(hybridLayout.values())` repeatedly.

**Why:**
The previous logic repeatedly created new arrays inside while/for loops when constructing node adjacency representations, causing performance to degrade non-linearly (O(N^2)) as the complexity and size of ComfyUI workflow structures increased.

**Impact:**
- Significantly reduces memory allocation and garbage collection overhead.
- Improves render and parsing time for very large and interconnected visual workflows.

**Measurement:**
- Run `pnpm test` and `pnpm lint` to verify that layout deterministic outcomes and types remain unchanged. All tests pass successfully.

---
*PR created automatically by Jules for task [7361675555307408478](https://jules.google.com/task/7361675555307408478) started by @LuqP2*