### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Eliminate Array.shift() O(N^2) Overhead in BFS Queues
+**Learning:** Using `Array.shift()` to dequeue items in Breadth-First Search (BFS) loops introduces an $O(N^2)$ complexity due to array re-indexing on every shift. This is a common performance anti-pattern in graph traversal code.
+**Action:** Replace `const item = queue.shift()` with an index pointer: `let queueIndex = 0; while (queueIndex < queue.length) { const item = queue[queueIndex++]; }`. This reduces queue operations to $O(1)$ and speeds up graph analysis in ComfyUI workflows and cache eviction routines.

--- a/services/comfyUIWorkflowBuilder.ts
+++ b/services/comfyUIWorkflowBuilder.ts
@@ -324,9 +324,10 @@ function collectTextTargets(prompt: ComfyUIPromptGraph, startNodeIds: string[]):
   const targets: TextTarget[] = [];
   const visited = new Set<string>();
   const queue = [...startNodeIds];
+  let queueIndex = 0;
 
-  while (queue.length > 0) {
-    const nodeId = queue.shift()!;
+  while (queueIndex < queue.length) {
+    const nodeId = queue[queueIndex++]!;
     if (visited.has(nodeId)) {
       continue;
     }
@@ -358,9 +359,10 @@ function collectUpstreamModelTargets(prompt: ComfyUIPromptGraph, startNodeIds: s
   const targets: ModelTarget[] = [];
   const visited = new Set<string>();
   const queue = [...startNodeIds];
+  let queueIndex = 0;
 
-  while (queue.length > 0) {
-    const nodeId = queue.shift()!;
+  while (queueIndex < queue.length) {
+    const nodeId = queue[queueIndex++]!;
     if (visited.has(nodeId)) {
       continue;
     }
@@ -392,9 +394,10 @@ function collectUpstreamLoraTargets(prompt: ComfyUIPromptGraph, startNodeIds: st
   const targets: LoRATarget[] = [];
   const visited = new Set<string>();
   const queue = [...startNodeIds];
+  let queueIndex = 0;
 
-  while (queue.length > 0) {
-    const nodeId = queue.shift()!;
+  while (queueIndex < queue.length) {
+    const nodeId = queue[queueIndex++]!;
     if (visited.has(nodeId)) {
       continue;
     }
@@ -438,9 +441,10 @@ function collectUpstreamAssetTargets(
   const maskTargets: AssetTarget[] = [];
   const visited = new Set<string>();
   const queue = [...startNodeIds];
+  let queueIndex = 0;
 
-  while (queue.length > 0) {
-    const nodeId = queue.shift()!;
+  while (queueIndex < queue.length) {
+    const nodeId = queue[queueIndex++]!;
     if (visited.has(nodeId)) {
       continue;
     }
@@ -492,9 +496,10 @@ function hasDownstreamCandidate(
 ): boolean {
   const queue = [...(consumerMap[startNodeId] || [])];
   const visited = new Set<string>();
+  let queueIndex = 0;
 
-  while (queue.length > 0) {
-    const nodeId = queue.shift()!;
+  while (queueIndex < queue.length) {
+    const nodeId = queue[queueIndex++]!;
     if (visited.has(nodeId)) {
       continue;
     }
@@ -526,8 +531,9 @@ function findTerminalImageProducer(prompt: ComfyUIPromptGraph, samplerNodeIds: s
 
   const reachableFromSampler = new Set<string>();
   const queue = [...samplerNodeIds];
-  while (queue.length > 0) {
-    const nodeId = queue.shift()!;
+  let queueIndex = 0;
+  while (queueIndex < queue.length) {
+    const nodeId = queue[queueIndex++]!;
     if (reachableFromSampler.has(nodeId)) {
       continue;
     }

--- a/services/mediaSourceCache.ts
+++ b/services/mediaSourceCache.ts
@@ -393,8 +393,9 @@ class MediaSourceCache {
       .filter(([, entry]) => Boolean(entry.url) && entry.kind === kind)
       .sort((a, b) => a[1].lastAccess - b[1].lastAccess);
 
-    while (sortedEntries.length > maxEntries) {
-      const [cacheKey, entry] = sortedEntries.shift()!;
+    let evictIndex = 0;
+    while (sortedEntries.length - evictIndex > maxEntries) {
+      const [cacheKey, entry] = sortedEntries[evictIndex++]!;
       this.entries.delete(cacheKey);
       if (entry.revokeOnEvict && entry.url) {
         URL.revokeObjectURL(entry.url);

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -450,9 +450,10 @@ function detectComfyLineageFromGraph(
   let hasMaskInput = false;
   let hasInpaintMarkers = false;
   let hasOutpaintMarkers = false;
+  let queueIndex = 0;
 
-  while (queue.length > 0) {
-    const nodeId = queue.shift()!;
+  while (queueIndex < queue.length) {
+    const nodeId = queue[queueIndex++]!;
     if (visited.has(nodeId)) {
       continue;
     }


### PR DESCRIPTION
## What
Replaced uses of `Array.shift()` in BFS graph traversals and cache eviction routines with an index-pointer loop logic.

## Why
In queue-consumption loops, using `Array.shift()` causes an $O(N)$ penalty per iteration since the entire underlying array must be re-indexed in memory after the first element is popped. This yields an overall worst-case complexity of $O(N^2)$ for parsing very wide ComfyUI workflows or for evicting massive data caches. 

## Impact
Reduces queue operations from $O(N^2)$ to $O(N)$, resulting in faster parsing of large workflow graphs and faster bulk cache eviction without blocking the main thread.

## Measurement
Verify the changes by analyzing the runtime speed of workflow traversals in ComfyUI or large batch cache pruning in `services/mediaSourceCache.ts`, which should now scale linearly with graph width or array length. Running `pnpm test` confirms all downstream graph traversal assumptions hold identically.

---
*PR created automatically by Jules for task [11604076715514533667](https://jules.google.com/task/11604076715514533667) started by @LuqP2*