### PR TITLE
Polish ComfyUI workspace thumbnails and queue UX

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -100,6 +100,7 @@ interface BatchExportRequestState {
 const SIDEBAR_WIDTH_STORAGE_KEY = 'image-metahub-sidebar-width';
 const RIGHT_SIDEBAR_WIDTH_STORAGE_KEY = 'image-metahub-right-sidebar-width';
 const OPEN_BATCH_EXPORT_EVENT = 'imagemetahub:open-batch-export';
+const COMFYUI_WORKSPACE_APPLY_FILTERS_STORAGE_KEY = 'image-metahub-comfyui-workspace-apply-library-filters';
 const SIDEBAR_DEFAULT_WIDTH = 320;
 const SIDEBAR_MIN_WIDTH = 280;
 const SIDEBAR_MAX_WIDTH = 640;
@@ -395,6 +396,12 @@ export default function App() {
   const [comfyUIWorkspaceImageId, setComfyUIWorkspaceImageId] = useState<string | null>(null);
   const [comfyUIWorkspaceNavigationImageIds, setComfyUIWorkspaceNavigationImageIds] = useState<string[] | null>(null);
   const [comfyUIWorkspaceDirectoryId, setComfyUIWorkspaceDirectoryId] = useState<string>('');
+  const [comfyUIWorkspaceApplyLibraryFilters, setComfyUIWorkspaceApplyLibraryFilters] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    return window.localStorage.getItem(COMFYUI_WORKSPACE_APPLY_FILTERS_STORAGE_KEY) === 'true';
+  });
   const [isComfyUIWorkspaceGenerating, setIsComfyUIWorkspaceGenerating] = useState(false);
   const [newImagesToast, setNewImagesToast] = useState<{ message: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
@@ -1682,8 +1689,11 @@ export default function App() {
 
     setActiveImageModalId(activeModalId);
     setSelectedImage(image);
+    if (libraryView === 'comfyui') {
+      setLibraryView('library');
+    }
     setGeneratedOutputPreview(null);
-  }, [beginModalOpenFlow, getImageByIdFromStore, openImageModals, safeActiveImageScope, safeFilteredImages, setSelectedImage]);
+  }, [beginModalOpenFlow, getImageByIdFromStore, libraryView, openImageModals, safeActiveImageScope, safeFilteredImages, setSelectedImage]);
 
   const resolveGeneratedOutputImageId = useCallback((output: GeneratedQueueOutput): string | undefined => {
     if (output.imageId && getImageByIdFromStore(output.imageId)) {
@@ -1832,6 +1842,7 @@ export default function App() {
       : libraryView === 'node'
       ? nodeViewResultImages
       : safeFilteredImages;
+  const comfyUIWorkspaceSourceImages = comfyUIWorkspaceApplyLibraryFilters ? displayImages : safeImages;
 
   useEffect(() => {
     if (libraryView !== 'comfyui') {
@@ -1851,8 +1862,8 @@ export default function App() {
 
     const effectiveDirectoryId = shouldIgnoreDirectoryScope ? '' : comfyUIWorkspaceDirectoryId;
     const scopedImages = effectiveDirectoryId
-      ? displayImages.filter((image) => image.directoryId === effectiveDirectoryId)
-      : displayImages;
+      ? comfyUIWorkspaceSourceImages.filter((image) => image.directoryId === effectiveDirectoryId)
+      : comfyUIWorkspaceSourceImages;
     const scopedImageIds = scopedImages.map((image) => image.id);
 
     setComfyUIWorkspaceNavigationImageIds(scopedImageIds);
@@ -1868,7 +1879,7 @@ export default function App() {
 
       return preferredImage?.id ?? null;
     });
-  }, [comfyUIWorkspaceDirectoryId, comfyUIWorkspaceImageId, displayImages, imageLookup, libraryView, previewImage, selectedImage]);
+  }, [comfyUIWorkspaceDirectoryId, comfyUIWorkspaceImageId, comfyUIWorkspaceSourceImages, imageLookup, libraryView, previewImage, selectedImage]);
 
   const openFindSimilar = useCallback((
     sourceImage: IndexedImage,
@@ -1951,12 +1962,21 @@ export default function App() {
     setComfyUIWorkspaceDirectoryId(nextDirectoryId);
 
     const nextImages = nextDirectoryId
-      ? displayImages.filter((candidate) => candidate.directoryId === nextDirectoryId)
-      : displayImages;
+      ? comfyUIWorkspaceSourceImages.filter((candidate) => candidate.directoryId === nextDirectoryId)
+      : comfyUIWorkspaceSourceImages;
 
     setComfyUIWorkspaceNavigationImageIds(nextImages.map((candidate) => candidate.id));
     setComfyUIWorkspaceImageId(nextImages[0]?.id ?? null);
-  }, [displayImages]);
+  }, [comfyUIWorkspaceSourceImages]);
+  const handleComfyUIWorkspaceApplyLibraryFiltersChange = useCallback((applyFilters: boolean) => {
+    setComfyUIWorkspaceApplyLibraryFilters(applyFilters);
+    window.localStorage.setItem(COMFYUI_WORKSPACE_APPLY_FILTERS_STORAGE_KEY, String(applyFilters));
+  }, []);
+  const handleComfyUIWorkspaceViewFullMetadata = useCallback((image: IndexedImage) => {
+    setComfyUIWorkspaceImageId(image.id);
+    setSelectedImage(image);
+    setLibraryView('library');
+  }, [setSelectedImage]);
   const handleComfyUIWorkspaceNavigate = useCallback((direction: 'next' | 'previous') => {
     if (comfyUIWorkspaceCurrentIndex === -1) {
       return;
@@ -2645,7 +2665,10 @@ export default function App() {
                     directories={safeDirectories}
                     selectedDirectoryId={comfyUIWorkspaceDirectoryId}
                     onSelectDirectory={handleComfyUIWorkspaceDirectoryChange}
+                    applyLibraryFilters={comfyUIWorkspaceApplyLibraryFilters}
+                    onApplyLibraryFiltersChange={handleComfyUIWorkspaceApplyLibraryFiltersChange}
                     onInspectImage={(image) => setComfyUIWorkspaceImageId(image.id)}
+                    onViewFullMetadata={handleComfyUIWorkspaceViewFullMetadata}
                     onOpenCompare={handleOpenFindSimilarCompare}
                   />
                 ) : (

--- a/App.tsx
+++ b/App.tsx
@@ -110,6 +110,11 @@ const RIGHT_SIDEBAR_MAX_WIDTH = 640;
 const SIDEBAR_COLLAPSED_CONTENT_OFFSET = 48;
 const MAIN_CONTENT_MIN_WIDTH = 560;
 
+const getImageTimestamp = (image: IndexedImage): number => image.contentModifiedMs ?? image.lastModified ?? 0;
+
+const sortImagesNewestFirst = (images: IndexedImage[]): IndexedImage[] =>
+  [...images].sort((a, b) => getImageTimestamp(b) - getImageTimestamp(a) || a.name.localeCompare(b.name));
+
 const sanitizePreferredWidth = (
   width: number,
   fallbackWidth: number,
@@ -1948,11 +1953,11 @@ export default function App() {
       .map((imageId) => imageLookup.get(imageId) ?? null)
       .filter((candidate): candidate is IndexedImage => Boolean(candidate));
 
-    if (comfyUIWorkspaceImage && !resolvedImages.some((candidate) => candidate.id === comfyUIWorkspaceImage.id)) {
-      return [comfyUIWorkspaceImage, ...resolvedImages];
-    }
+    const nextImages = comfyUIWorkspaceImage && !resolvedImages.some((candidate) => candidate.id === comfyUIWorkspaceImage.id)
+      ? [comfyUIWorkspaceImage, ...resolvedImages]
+      : resolvedImages;
 
-    return resolvedImages;
+    return sortImagesNewestFirst(nextImages);
   }, [comfyUIWorkspaceImage, comfyUIWorkspaceNavigationImageIds, imageLookup]);
   const comfyUIWorkspaceCurrentIndex = useMemo(() => {
     if (!comfyUIWorkspaceImage) {

--- a/App.tsx
+++ b/App.tsx
@@ -67,7 +67,7 @@ interface OpenImageModalState {
   modalId: string;
   imageId: string;
   navigationImageIds: string[];
-  navigationSource: 'filtered' | 'cluster' | 'scope' | 'slideshow';
+  navigationSource: 'filtered' | 'cluster' | 'scope' | 'slideshow' | 'comfyui';
   zIndex: number;
   initialWindowOffset: number;
   isMinimized: boolean;
@@ -1352,6 +1352,10 @@ export default function App() {
       return modal.navigationImageIds.filter((imageId) => Boolean(getImageByIdFromStore(imageId)));
     }
 
+    if (modal.navigationSource === 'comfyui') {
+      return modal.navigationImageIds.filter((imageId) => Boolean(getImageByIdFromStore(imageId)));
+    }
+
     return modal.navigationImageIds.filter((imageId) => imageLookup.has(imageId));
   }, [activeScopeNavigationImageIds, filteredNavigationImageIds, getImageByIdFromStore, imageLookup]);
 
@@ -1957,6 +1961,53 @@ export default function App() {
 
     return comfyUIWorkspaceNavigationImages.findIndex((candidate) => candidate.id === comfyUIWorkspaceImage.id);
   }, [comfyUIWorkspaceImage, comfyUIWorkspaceNavigationImages]);
+  const handleOpenComfyUIWorkspaceImageModal = useCallback((image: IndexedImage, navigationImages: IndexedImage[]) => {
+    const navigationImageIds = navigationImages.length > 0
+      ? navigationImages.map((entry) => entry.id)
+      : [image.id];
+    const modalId = `image-modal-${Date.now()}-${image.id}`;
+    const existingModalForImage = openImageModals.find((modal) => modal.imageId === image.id);
+    const activeModalId = existingModalForImage?.modalId ?? modalId;
+
+    setOpenImageModals((current) => {
+      const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;
+      const nextZIndex = highestZIndex + 1;
+      const existingModal = current.find((modal) => modal.imageId === image.id);
+
+      if (existingModal) {
+        return current.map((modal) =>
+          modal.modalId === existingModal.modalId
+            ? {
+                ...modal,
+                navigationImageIds,
+                navigationSource: 'comfyui',
+                zIndex: nextZIndex,
+                isMinimized: false,
+              }
+            : modal
+        );
+      }
+
+      return [
+        ...current,
+        {
+          modalId,
+          imageId: image.id,
+          navigationImageIds,
+          navigationSource: 'comfyui',
+          zIndex: nextZIndex,
+          initialWindowOffset: current.length * 28,
+          isMinimized: false,
+          diagnosticsFlowId: beginModalOpenFlow(image.id, 'comfyui-workspace'),
+        },
+      ];
+    });
+
+    setComfyUIWorkspaceImageId(image.id);
+    setActiveImageModalId(activeModalId);
+    suppressSelectedImageModalOpenRef.current = image.id;
+    setSelectedImage(image);
+  }, [beginModalOpenFlow, openImageModals, setSelectedImage]);
   const handleComfyUIWorkspaceDirectoryChange = useCallback((directoryId: string | null) => {
     const nextDirectoryId = directoryId || '';
     setComfyUIWorkspaceDirectoryId(nextDirectoryId);
@@ -2173,6 +2224,7 @@ export default function App() {
     !isSaveFilteredCollectionModalOpen &&
     !isA1111GenerateModalOpen &&
     !isComfyUIGenerateModalOpen &&
+    !hasActiveVisibleImageModal &&
     !generatedOutputPreview &&
     !proModalOpen;
   const libraryContentFocusClass = hasActiveVisibleImageModal
@@ -2668,6 +2720,7 @@ export default function App() {
                     applyLibraryFilters={comfyUIWorkspaceApplyLibraryFilters}
                     onApplyLibraryFiltersChange={handleComfyUIWorkspaceApplyLibraryFiltersChange}
                     onInspectImage={(image) => setComfyUIWorkspaceImageId(image.id)}
+                    onOpenImageModal={handleOpenComfyUIWorkspaceImageModal}
                     onViewFullMetadata={handleComfyUIWorkspaceViewFullMetadata}
                     onOpenCompare={handleOpenFindSimilarCompare}
                   />

--- a/App.tsx
+++ b/App.tsx
@@ -2217,6 +2217,9 @@ export default function App() {
   const hasActiveVisibleImageModal = openImageModalEntries.some(
     (modal) => !modal.isMinimized && modal.modalId === activeImageModalId
   );
+  const hasVisibleImageModal = openImageModalEntries.some(
+    (modal) => !modal.isMinimized
+  );
   const shouldShowEmbeddedComfyUIView =
     libraryView === 'comfyui' &&
     !isSettingsModalOpen &&
@@ -2229,7 +2232,7 @@ export default function App() {
     !isSaveFilteredCollectionModalOpen &&
     !isA1111GenerateModalOpen &&
     !isComfyUIGenerateModalOpen &&
-    !hasActiveVisibleImageModal &&
+    !hasVisibleImageModal &&
     !generatedOutputPreview &&
     !proModalOpen;
   const libraryContentFocusClass = hasActiveVisibleImageModal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Image Adjustment Editing**: Added an adjustment panel in the Image Modal for brightness, contrast, saturation, and hue, with desktop Save As and Overwrite workflows that export PNG output while preserving generation metadata.
 - **Embedded ComfyUI Workspace**: Added a dedicated ComfyUI Workspace view with an embedded ComfyUI browser, image context panel, workflow metadata tabs, thumbnail navigation, copy/generate actions, and direct open actions from grid/table image contexts.
+- **ComfyUI Queue Detection**: Added optional monitoring for ComfyUI jobs started outside Image MetaHub, showing waiting/processing/done/failed status, progress, output previews, and cancel support in the generation queue.
+
 
 ### Improved
 

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -92,10 +92,6 @@ const formatValue = (value: unknown): string => {
   return String(value);
 };
 
-const getImageTimestamp = (image: IndexedImage): number => {
-  return image.contentModifiedMs ?? image.lastModified ?? 0;
-};
-
 const MetadataLine: React.FC<{ label: string; value: unknown }> = ({ label, value }) => (
   <div className="rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2">
     <div className="text-[10px] uppercase tracking-wide text-gray-500">{label}</div>
@@ -466,8 +462,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const thumbnail = useResolvedThumbnail(image);
   const metadata = getWorkflowMetadata(image);
   const normalizedNavigationImages = useMemo(
-    () => (navigationImages.length > 0 ? [...navigationImages] : image ? [image] : [])
-      .sort((a, b) => getImageTimestamp(b) - getImageTimestamp(a) || a.name.localeCompare(b.name)),
+    () => (navigationImages.length > 0 ? navigationImages : image ? [image] : []),
     [image, navigationImages],
   );
   const currentPosition = currentIndex >= 0 ? currentIndex + 1 : 0;

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -62,6 +62,7 @@ interface ComfyUIWorkspaceProps {
   applyLibraryFilters?: boolean;
   onApplyLibraryFiltersChange?: (applyFilters: boolean) => void;
   onInspectImage?: (image: IndexedImage) => void;
+  onOpenImageModal?: (image: IndexedImage, navigationImages: IndexedImage[]) => void;
   onViewFullMetadata?: (image: IndexedImage) => void;
   onOpenCompare?: (images: IndexedImage[]) => void;
 }
@@ -409,6 +410,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   applyLibraryFilters = false,
   onApplyLibraryFiltersChange,
   onInspectImage,
+  onOpenImageModal,
   onViewFullMetadata,
   onOpenCompare,
 }) => {
@@ -822,9 +824,9 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     const selectedImage = visibleNavigationImages[visibleIndex];
     if (selectedImage) {
       inspectWorkspaceImage(selectedImage);
+      onOpenImageModal?.(selectedImage, visibleNavigationImages);
     }
-    setWorkspacePreviewIndex(visibleIndex);
-  }, [inspectWorkspaceImage, visibleNavigationImages]);
+  }, [inspectWorkspaceImage, onOpenImageModal, visibleNavigationImages]);
 
   const updateThumbSelection = useCallback((event: React.MouseEvent, contextImage: IndexedImage, visibleIndex: number) => {
     event.preventDefault();

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -91,6 +91,10 @@ const formatValue = (value: unknown): string => {
   return String(value);
 };
 
+const getImageTimestamp = (image: IndexedImage): number => {
+  return image.contentModifiedMs ?? image.lastModified ?? 0;
+};
+
 const MetadataLine: React.FC<{ label: string; value: unknown }> = ({ label, value }) => (
   <div className="rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2">
     <div className="text-[10px] uppercase tracking-wide text-gray-500">{label}</div>
@@ -115,50 +119,55 @@ const WorkspaceThumbnailButton: React.FC<{
   const thumbnail = useResolvedThumbnail(image);
 
   return (
-    <div className="group relative aspect-square w-full shrink-0">
-      <button
-        onClick={onClick}
-        onContextMenu={onContextMenu}
-        className={`h-full w-full overflow-hidden rounded-md border bg-black transition-colors ${
-          isSelected
-            ? 'border-blue-400 ring-2 ring-blue-400/70'
-            : isActive
-              ? 'border-purple-400 ring-1 ring-purple-400/60'
-              : 'border-gray-700 hover:border-gray-500'
-        }`}
-        title={`Preview ${image.name}`}
-        aria-label={`Preview ${image.name}`}
-        draggable={Boolean(directoryPath && window.electronAPI?.startFileDrag)}
-        onDragStart={(event) => onDragStart(event, image, directoryPath)}
-      >
-        {thumbnail?.thumbnailUrl ? (
-          <img src={thumbnail.thumbnailUrl} alt="" className="h-full w-full object-cover image-alpha-grid" />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-gray-600">
-            <ImageIcon className="h-5 w-5" />
-          </div>
-        )}
-      </button>
-      <button
-        onClick={onToggleSelected}
-        className={`absolute left-1.5 top-1.5 rounded bg-gray-950/80 p-1 shadow transition-opacity ${
-          isSelected ? 'text-blue-300 opacity-100' : 'text-gray-300 opacity-0 group-hover:opacity-100'
-        }`}
-        title={isSelected ? 'Deselect image' : 'Select image'}
-        aria-label={isSelected ? 'Deselect image' : 'Select image'}
-      >
-        {isSelected ? <CheckSquare className="h-4 w-4" /> : <Square className="h-4 w-4" />}
-      </button>
-      <button
-        onClick={onToggleFavorite}
-        className={`absolute right-1.5 top-1.5 rounded bg-gray-950/80 p-1 shadow transition-opacity ${
-          image.isFavorite ? 'text-pink-300 opacity-100' : 'text-gray-300 opacity-0 group-hover:opacity-100 hover:text-pink-300'
-        }`}
-        title={image.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-        aria-label={image.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-      >
-        <Heart className={`h-4 w-4 ${image.isFavorite ? 'fill-current' : ''}`} />
-      </button>
+    <div className="group w-full shrink-0">
+      <div className="relative aspect-square w-full">
+        <button
+          onClick={onClick}
+          onContextMenu={onContextMenu}
+          className={`h-full w-full overflow-hidden rounded-md border bg-black transition-colors ${
+            isSelected
+              ? 'border-blue-400 ring-2 ring-blue-400/70'
+              : isActive
+                ? 'border-purple-400 ring-1 ring-purple-400/60'
+                : 'border-gray-700 hover:border-gray-500'
+          }`}
+          title={`Preview ${image.name}`}
+          aria-label={`Preview ${image.name}`}
+          draggable={Boolean(directoryPath && window.electronAPI?.startFileDrag)}
+          onDragStart={(event) => onDragStart(event, image, directoryPath)}
+        >
+          {thumbnail?.thumbnailUrl ? (
+            <img src={thumbnail.thumbnailUrl} alt="" className="h-full w-full object-cover image-alpha-grid" />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-gray-600">
+              <ImageIcon className="h-5 w-5" />
+            </div>
+          )}
+        </button>
+        <button
+          onClick={onToggleSelected}
+          className={`absolute left-1.5 top-1.5 rounded bg-gray-950/80 p-1 shadow transition-opacity ${
+            isSelected ? 'text-blue-300 opacity-100' : 'text-gray-300 opacity-0 group-hover:opacity-100'
+          }`}
+          title={isSelected ? 'Deselect image' : 'Select image'}
+          aria-label={isSelected ? 'Deselect image' : 'Select image'}
+        >
+          {isSelected ? <CheckSquare className="h-4 w-4" /> : <Square className="h-4 w-4" />}
+        </button>
+        <button
+          onClick={onToggleFavorite}
+          className={`absolute right-1.5 top-1.5 rounded bg-gray-950/80 p-1 shadow transition-opacity ${
+            image.isFavorite ? 'text-pink-300 opacity-100' : 'text-gray-300 opacity-0 group-hover:opacity-100 hover:text-pink-300'
+          }`}
+          title={image.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+          aria-label={image.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+        >
+          <Heart className={`h-4 w-4 ${image.isFavorite ? 'fill-current' : ''}`} />
+        </button>
+      </div>
+      <div className="mt-1 truncate text-[11px] leading-4 text-gray-400" title={image.name}>
+        {image.name}
+      </div>
     </div>
   );
 };
@@ -455,7 +464,8 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const thumbnail = useResolvedThumbnail(image);
   const metadata = getWorkflowMetadata(image);
   const normalizedNavigationImages = useMemo(
-    () => (navigationImages.length > 0 ? navigationImages : image ? [image] : []),
+    () => (navigationImages.length > 0 ? [...navigationImages] : image ? [image] : [])
+      .sort((a, b) => getImageTimestamp(b) - getImageTimestamp(a) || a.name.localeCompare(b.name)),
     [image, navigationImages],
   );
   const currentPosition = currentIndex >= 0 ? currentIndex + 1 : 0;
@@ -803,13 +813,18 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     });
   }, [syncBounds]);
 
+  const inspectWorkspaceImage = useCallback((nextImage: IndexedImage) => {
+    onInspectImage?.(nextImage);
+    setActiveInspectorTab('metadata');
+  }, [onInspectImage]);
+
   const openWorkspacePreview = useCallback((visibleIndex: number) => {
     const selectedImage = visibleNavigationImages[visibleIndex];
     if (selectedImage) {
-      onInspectImage?.(selectedImage);
+      inspectWorkspaceImage(selectedImage);
     }
     setWorkspacePreviewIndex(visibleIndex);
-  }, [onInspectImage, visibleNavigationImages]);
+  }, [inspectWorkspaceImage, visibleNavigationImages]);
 
   const updateThumbSelection = useCallback((event: React.MouseEvent, contextImage: IndexedImage, visibleIndex: number) => {
     event.preventDefault();
@@ -939,10 +954,9 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   }, []);
 
   const inspectAsset = useCallback((contextImage: IndexedImage) => {
-    onInspectImage?.(contextImage);
-    setActiveInspectorTab('image');
+    inspectWorkspaceImage(contextImage);
     setAssetContextMenu(null);
-  }, [onInspectImage]);
+  }, [inspectWorkspaceImage]);
 
   const exportAssetImage = useCallback((contextImage: IndexedImage) => {
     exportImages(getContextTargetImages(contextImage));
@@ -1497,7 +1511,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
         <WorkspaceImagePreviewModal
           images={visibleNavigationImages}
           initialIndex={workspacePreviewIndex}
-          onInspectImage={onInspectImage}
+          onInspectImage={inspectWorkspaceImage}
           onViewFullMetadata={onViewFullMetadata}
           onClose={() => setWorkspacePreviewIndex(null)}
         />

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -10,6 +10,7 @@ import {
   Clipboard,
   Download,
   ExternalLink,
+  FileText,
   Folder,
   GitCompare,
   Heart,
@@ -58,7 +59,10 @@ interface ComfyUIWorkspaceProps {
   directories?: Directory[];
   selectedDirectoryId?: string;
   onSelectDirectory?: (directoryId: string | null) => void;
+  applyLibraryFilters?: boolean;
+  onApplyLibraryFiltersChange?: (applyFilters: boolean) => void;
   onInspectImage?: (image: IndexedImage) => void;
+  onViewFullMetadata?: (image: IndexedImage) => void;
   onOpenCompare?: (images: IndexedImage[]) => void;
 }
 
@@ -164,7 +168,8 @@ const WorkspaceImagePreviewModal: React.FC<{
   initialIndex: number;
   onClose: () => void;
   onInspectImage?: (image: IndexedImage) => void;
-}> = ({ images, initialIndex, onClose, onInspectImage }) => {
+  onViewFullMetadata?: (image: IndexedImage) => void;
+}> = ({ images, initialIndex, onClose, onInspectImage, onViewFullMetadata }) => {
   const [index, setIndex] = useState(() => Math.min(Math.max(initialIndex, 0), Math.max(images.length - 1, 0)));
   const [modalSize, setModalSize] = useState(() => ({
     width: Math.min(Math.round(window.innerWidth * 0.82), 1400),
@@ -278,14 +283,27 @@ const WorkspaceImagePreviewModal: React.FC<{
             <h2 className="truncate text-base font-semibold text-gray-100">{current.name}</h2>
             {hasMultiple && <p className="text-xs text-gray-500">{index + 1}/{images.length}</p>}
           </div>
-          <button
-            onClick={onClose}
-            className="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-800 hover:text-gray-100"
-            aria-label="Close image preview"
-            title="Close"
-          >
-            <X size={20} />
-          </button>
+          <div className="flex shrink-0 items-center gap-2">
+            {onViewFullMetadata && (
+              <button
+                onClick={() => onViewFullMetadata(current)}
+                className="inline-flex items-center gap-2 rounded bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-500"
+                aria-label="View full metadata"
+                title="View full metadata"
+              >
+                <FileText size={16} />
+                <span>View full metadata</span>
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-800 hover:text-gray-100"
+              aria-label="Close image preview"
+              title="Close"
+            >
+              <X size={20} />
+            </button>
+          </div>
         </div>
         <div className="relative flex min-h-0 flex-1 items-center justify-center bg-black">
           {hasMultiple && (
@@ -379,7 +397,10 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   directories = [],
   selectedDirectoryId = '',
   onSelectDirectory,
+  applyLibraryFilters = false,
+  onApplyLibraryFiltersChange,
   onInspectImage,
+  onViewFullMetadata,
   onOpenCompare,
 }) => {
   const browserHostRef = useRef<HTMLDivElement>(null);
@@ -1047,6 +1068,19 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
               </div>
             )}
             {!isThumbRailCollapsed && (
+            <>
+            <label
+              className="mt-2 flex cursor-pointer items-center justify-between gap-2 rounded-md border border-gray-800 bg-gray-950/70 px-2 py-1.5 text-[11px] text-gray-400"
+              title="Use the current Library filters for this thumbnail rail"
+            >
+              <span className="truncate">Apply Library Filters</span>
+              <input
+                type="checkbox"
+                checked={applyLibraryFilters}
+                onChange={(event) => onApplyLibraryFiltersChange?.(event.target.checked)}
+                className="h-3.5 w-3.5 accent-purple-500"
+              />
+            </label>
             <div className="mt-2 flex flex-wrap items-center gap-1">
               <span className="mr-auto rounded border border-gray-800 px-1.5 py-1 text-[10px] font-medium text-gray-400">
                 {selectedWorkspaceCount}
@@ -1130,6 +1164,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 <X className="h-3.5 w-3.5" />
               </button>
             </div>
+            </>
             )}
           </div>
 
@@ -1463,6 +1498,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
           images={visibleNavigationImages}
           initialIndex={workspacePreviewIndex}
           onInspectImage={onInspectImage}
+          onViewFullMetadata={onViewFullMetadata}
           onClose={() => setWorkspacePreviewIndex(null)}
         />
       )}

--- a/components/GenerationQueueSidebar.tsx
+++ b/components/GenerationQueueSidebar.tsx
@@ -406,7 +406,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
                   </div>
                   {item.currentNode && (
                     <div className="text-[11px] text-gray-500 truncate">
-                      {item.currentNode}
+                      Current node: {item.currentNode}
                     </div>
                   )}
                 </div>

--- a/hooks/useComfyUIQueueMonitor.ts
+++ b/hooks/useComfyUIQueueMonitor.ts
@@ -6,6 +6,7 @@ import { useSettingsStore } from '../store/useSettingsStore';
 type ComfyUIQueueEntry = {
   promptId: string;
   prompt?: string;
+  nodeLabels: Record<string, string>;
 };
 
 type ComfyUIHistoryImage = {
@@ -74,6 +75,25 @@ const extractPromptPreview = (entry: unknown): string | undefined => {
   return undefined;
 };
 
+const extractNodeLabels = (entry: unknown): Record<string, string> => {
+  const graph = getPromptGraphFromQueueEntry(entry);
+  if (!graph || typeof graph !== 'object') {
+    return {};
+  }
+
+  return Object.entries(graph as Record<string, unknown>).reduce<Record<string, string>>((labels, [nodeId, node]) => {
+    if (!node || typeof node !== 'object') {
+      return labels;
+    }
+
+    const record = node as { class_type?: unknown; _meta?: { title?: unknown } };
+    const title = typeof record._meta?.title === 'string' ? record._meta.title.trim() : '';
+    const classType = typeof record.class_type === 'string' ? record.class_type.trim() : '';
+    labels[String(nodeId)] = title || classType || `Node ${nodeId}`;
+    return labels;
+  }, {});
+};
+
 const parseQueueEntries = (queue: Record<string, unknown>, key: 'queue_running' | 'queue_pending'): ComfyUIQueueEntry[] => {
   const entries = queue[key];
   if (!Array.isArray(entries)) {
@@ -90,6 +110,7 @@ const parseQueueEntries = (queue: Record<string, unknown>, key: 'queue_running' 
       return {
         promptId,
         prompt: extractPromptPreview(entry),
+        nodeLabels: extractNodeLabels(entry),
       };
     })
     .filter((entry): entry is ComfyUIQueueEntry => Boolean(entry));
@@ -214,6 +235,7 @@ export function useComfyUIQueueMonitor() {
   const monitoringEnabled = useSettingsStore((state) => state.comfyUIQueueMonitoringEnabled);
   const serverUrl = useSettingsStore((state) => state.comfyUIServerUrl);
   const activePromptIdRef = useRef<string | null>(null);
+  const nodeLabelsRef = useRef<Map<string, Record<string, string>>>(new Map());
 
   useEffect(() => {
     if (!comfyUIEnabled || !monitoringEnabled || !serverUrl) {
@@ -271,6 +293,7 @@ export function useComfyUIQueueMonitor() {
         const activePromptIds = new Set([...running, ...pending].map((entry) => entry.promptId));
 
         pending.forEach((entry) => {
+          nodeLabelsRef.current.set(entry.promptId, entry.nodeLabels);
           useGenerationQueueStore.getState().upsertExternalComfyUIJob({
             providerJobId: entry.promptId,
             status: 'waiting',
@@ -281,6 +304,7 @@ export function useComfyUIQueueMonitor() {
 
         running.forEach((entry) => {
           activePromptIdRef.current = entry.promptId;
+          nodeLabelsRef.current.set(entry.promptId, entry.nodeLabels);
           useGenerationQueueStore.getState().upsertExternalComfyUIJob({
             providerJobId: entry.promptId,
             status: 'processing',
@@ -341,10 +365,16 @@ export function useComfyUIQueueMonitor() {
             }
 
             activePromptIdRef.current = promptId;
+            const nodeId = typeof message.data?.node === 'string' || typeof message.data?.node === 'number'
+              ? String(message.data.node)
+              : null;
+            const currentNode = nodeId
+              ? nodeLabelsRef.current.get(promptId)?.[nodeId] || `Node ${nodeId}`
+              : null;
             useGenerationQueueStore.getState().upsertExternalComfyUIJob({
               providerJobId: promptId,
               status: 'processing',
-              currentNode: typeof message.data?.node === 'string' ? message.data.node : null,
+              currentNode,
             });
           }
 
@@ -393,6 +423,7 @@ export function useComfyUIQueueMonitor() {
       ws?.close();
       ws = null;
       activePromptIdRef.current = null;
+      nodeLabelsRef.current.clear();
     };
   }, [comfyUIEnabled, monitoringEnabled, serverUrl]);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4122,13 +4122,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.16.tgz",
-      "integrity": "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==",
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -4553,9 +4556,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001750",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz",
-      "integrity": "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4122,16 +4122,13 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.16.tgz",
+      "integrity": "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "baseline-browser-mapping": "dist/cli.js"
       }
     },
     "node_modules/bidi-js": {
@@ -4556,9 +4553,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001750",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz",
+      "integrity": "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==",
       "dev": true,
       "funding": [
         {

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Image Adjustment Editing**: Added an adjustment panel in the Image Modal for brightness, contrast, saturation, and hue, with desktop Save As and Overwrite workflows that export PNG output while preserving generation metadata.
 - **Embedded ComfyUI Workspace**: Added a dedicated ComfyUI Workspace view with an embedded ComfyUI browser, image context panel, workflow metadata tabs, thumbnail navigation, copy/generate actions, and direct open actions from grid/table image contexts.
+- **ComfyUI Queue Detection**: Added optional monitoring for ComfyUI jobs started outside Image MetaHub, showing waiting/processing/done/failed status, progress, output previews, and cancel support in the generation queue.
+
 
 ### Improved
 


### PR DESCRIPTION
## Summary

- Makes the ComfyUI workspace thumbnail rail independent from Library filters by default, with an `Apply Library Filters` toggle.
- Sorts workspace thumbnails by most recent file first and shows the filename beneath each thumbnail.
- Opens the full Image Modal from workspace thumbnails while hiding the embedded ComfyUI BrowserView so the modal stays on top.
- Keeps the Image Inspector focused on metadata when inspecting images from the ComfyUI workspace.
- Improves ComfyUI queue current-node display by resolving node ids to node labels from the observed prompt graph.

## Validation

- `npm run build`

## Notes

Build completed with the existing Vite/browser compatibility and chunk-size warnings. No blocking validation failures were observed.