### PR TITLE
performance improvement

### DIFF
--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -761,7 +761,7 @@ export function useImageLoader() {
                     return;
                 }
 
-                const directory = idleReconcileQueueRef.current.shift();
+                const directory = idleReconcileQueueRef.current.pop();
                 if (!directory) {
                     continue;
                 }
@@ -781,7 +781,7 @@ export function useImageLoader() {
             return;
         }
 
-        idleReconcileQueueRef.current = directories.slice();
+        idleReconcileQueueRef.current = directories.slice().reverse();
         idleReconcileTimerRef.current = setTimeout(() => {
             idleReconcileTimerRef.current = null;
             void runIdleReconcileQueue();

--- a/services/thumbnailManager.ts
+++ b/services/thumbnailManager.ts
@@ -735,40 +735,55 @@ class ThumbnailManager {
   }
 
   private processQueues(): void {
+    let takenHigh1 = 0;
     while (
       this.activeWorkers < MAX_CONCURRENT_THUMBNAILS &&
       this.activeHighPriorityWorkers < MAX_CONCURRENT_HIGH_PRIORITY_THUMBNAILS &&
-      this.highPriorityQueue.length > 0
+      takenHigh1 < this.highPriorityQueue.length
     ) {
-      const job = this.highPriorityQueue.shift();
+      const job = this.highPriorityQueue[takenHigh1];
       if (!job) {
         break;
       }
+      takenHigh1++;
       this.startJob(job, 'high');
     }
+    if (takenHigh1 > 0) {
+      this.highPriorityQueue.splice(0, takenHigh1);
+    }
 
+    let takenLow = 0;
     while (
       this.backgroundPauseCount === 0 &&
       this.activeWorkers < MAX_CONCURRENT_THUMBNAILS &&
       this.activeBackgroundWorkers < MAX_CONCURRENT_BACKGROUND_THUMBNAILS &&
-      this.backgroundQueue.length > 0
+      takenLow < this.backgroundQueue.length
     ) {
-      const job = this.backgroundQueue.shift();
+      const job = this.backgroundQueue[takenLow];
       if (!job) {
         break;
       }
+      takenLow++;
       this.startJob(job, 'low');
     }
+    if (takenLow > 0) {
+      this.backgroundQueue.splice(0, takenLow);
+    }
 
+    let takenHigh2 = 0;
     while (
       this.activeWorkers < MAX_CONCURRENT_THUMBNAILS &&
-      this.highPriorityQueue.length > 0
+      takenHigh2 < this.highPriorityQueue.length
     ) {
-      const job = this.highPriorityQueue.shift();
+      const job = this.highPriorityQueue[takenHigh2];
       if (!job) {
         break;
       }
+      takenHigh2++;
       this.startJob(job, 'high');
+    }
+    if (takenHigh2 > 0) {
+      this.highPriorityQueue.splice(0, takenHigh2);
     }
   }
 


### PR DESCRIPTION
What: Replaced `.shift()` with index tracking and batched `.splice()` in `services/thumbnailManager.ts` and utilized `.pop()` combined with `.reverse()` array initiation in `hooks/useImageLoader.ts`.
Why: Using `.shift()` on arrays causes a recalculation and re-indexing of all subsequent items resulting in O(N^2) time complexity.
Impact: Reduces O(N^2) re-indexing time to O(N) or O(1) in multiple asynchronous queue consumptions across the application.
Measurement: Verify by ensuring thumbnail generation continues to work as expected without locking or blocking UI logic. Run tests with `pnpm test`.

---
*PR created automatically by Jules for task [2910384908628472676](https://jules.google.com/task/2910384908628472676) started by @LuqP2*