### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2533,6 +2533,7 @@ export default function App() {
                 onClick={() => setError(null)}
                 className="ml-4 p-1 hover:bg-red-800/50 rounded transition-colors"
                 title="Dismiss message"
+                aria-label="Dismiss message"
               >
                 <X size={16} />
               </button>

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -1307,22 +1307,22 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
                 </p>
               </div>
               <div className="flex shrink-0 items-center gap-1">
-                <button onClick={() => window.electronAPI?.comfyUIViewGoBack?.()} disabled={!viewState.canGoBack} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Back">
+                <button onClick={() => window.electronAPI?.comfyUIViewGoBack?.()} disabled={!viewState.canGoBack} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Back" aria-label="Back">
                   <ArrowLeft className="h-4 w-4" />
                 </button>
-                <button onClick={() => window.electronAPI?.comfyUIViewGoForward?.()} disabled={!viewState.canGoForward} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Forward">
+                <button onClick={() => window.electronAPI?.comfyUIViewGoForward?.()} disabled={!viewState.canGoForward} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100 disabled:opacity-40" title="Forward" aria-label="Forward">
                   <ArrowRight className="h-4 w-4" />
                 </button>
-                <button onClick={openExternally} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open externally">
+                <button onClick={openExternally} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open externally" aria-label="Open externally">
                   <ExternalLink className="h-4 w-4" />
                 </button>
-                <button onClick={reloadEmbeddedView} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Refresh ComfyUI">
+                <button onClick={reloadEmbeddedView} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Refresh ComfyUI" aria-label="Refresh ComfyUI">
                   <RefreshCw className="h-4 w-4" />
                 </button>
-                <button onClick={togglePanelCollapsed} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Hide image inspector">
+                <button onClick={togglePanelCollapsed} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Hide image inspector" aria-label="Hide image inspector">
                   <ChevronRight className="h-4 w-4" />
                 </button>
-                <button onClick={onOpenSettings} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open integration settings">
+                <button onClick={onOpenSettings} className="rounded p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100" title="Open integration settings" aria-label="Open integration settings">
                   <SlidersHorizontal className="h-4 w-4" />
                 </button>
               </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to multiple icon-only buttons throughout the app (error notice, ComfyUI workspace controls).
🎯 Why: Icon-only buttons without accessible names cannot be interpreted by screen readers. This ensures these controls are fully accessible to keyboard and screen reader users.
📸 Before/After: Visuals remain unchanged, but the DOM now includes `aria-label` attributes on these elements.
♿ Accessibility: Improved screen reader support for critical navigation and dismiss actions.

---
*PR created automatically by Jules for task [11676037135191308163](https://jules.google.com/task/11676037135191308163) started by @LuqP2*