### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/components/AutomationRulesModal.tsx
+++ b/components/AutomationRulesModal.tsx
@@ -642,7 +642,7 @@ const ConditionRowEditor: React.FC<ConditionRowEditorProps> = ({ row, valueSourc
         {operatorOptions.map((operator) => <option key={operator} value={operator}>{OPERATOR_LABELS[operator]}</option>)}
       </select>
 
-      <button type="button" onClick={onRemove} className="h-9 rounded-lg border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-rose-300" title="Remove condition">
+      <button type="button" onClick={onRemove} className="h-9 rounded-lg border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-rose-300" title="Remove condition" aria-label="Remove condition">
         <X className="mx-auto h-4 w-4" />
       </button>
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -492,7 +492,7 @@ const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPromp
       <div className="flex justify-between items-start">
         <p className="font-semibold text-gray-400 text-xs uppercase tracking-wider">{label}</p>
         {onCopy && (
-            <button onClick={() => onCopy(displayValue)} className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-white" title={`Copy ${label}`}>
+            <button onClick={() => onCopy(displayValue)} className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-white" title={`Copy ${label}`} aria-label={`Copy ${label}`}>
                 <Copy className="w-4 h-4" />
             </button>
         )}

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -100,7 +100,7 @@ const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPromp
       <div className="flex justify-between items-start">
         <p className="font-semibold text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">{label}</p>
         {onCopy && (
-            <button onClick={() => onCopy(displayValue)} className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-gray-50" title={`Copy ${label}`}>
+            <button onClick={() => onCopy(displayValue)} className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-gray-50" title={`Copy ${label}`} aria-label={`Copy ${label}`}>
                 <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path d="M7 3a1 1 0 011-1h6a1 1 0 110 2H8a1 1 0 01-1-1zM5 5a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2H5z"></path></svg>
             </button>
         )}


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons in `ImagePreviewSidebar`, `ImageModal`, and `AutomationRulesModal` components.
🎯 Why: To improve screen reader accessibility according to WCAG 2.5.3 Label in Name guidelines, ensuring icon-only interactive elements have descriptive accessible names.
♿ Accessibility: Improved screen reader navigation by ensuring these buttons explicitly announce their actions.

---
*PR created automatically by Jules for task [7722859390359626163](https://jules.google.com/task/7722859390359626163) started by @LuqP2*