### PR TITLE
🎨 Palette: Add confirmation dialog for resetting hotkeys

### DIFF
--- a/components/HotkeySettings.tsx
+++ b/components/HotkeySettings.tsx
@@ -119,7 +119,12 @@ export const HotkeySettings = () => {
   }, [recording, handleKeyDown]);
 
   const handleResetAll = () => {
-    // Add confirmation dialog here
+    const confirmed = window.confirm(
+      'Are you sure you want to reset all hotkeys to their default values?\n\nThis action cannot be undone.'
+    );
+    if (!confirmed) {
+      return;
+    }
     resetKeymap();
   };
 


### PR DESCRIPTION
Added a micro-UX improvement to the hotkey settings panel by introducing a confirmation dialog when the user clicks the "Reset All" button. Previously, clicking this button immediately wiped all custom hotkey configurations without warning. This aligns with the Palette persona's goal of preventing accidental destructive actions.

---
*PR created automatically by Jules for task [7886009217111588808](https://jules.google.com/task/7886009217111588808) started by @LuqP2*