### PR TITLE
feat: Add skip delete confirmation setting

### DIFF
--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -449,6 +449,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const setComfyUIWorkspaceLastUrl = useSettingsStore((state) => state.setComfyUIWorkspaceLastUrl);
   const panelWidth = useSettingsStore((state) => state.comfyUIWorkspacePanelWidth);
   const setPanelWidth = useSettingsStore((state) => state.setComfyUIWorkspacePanelWidth);
+  const skipDeleteConfirmation = useSettingsStore((state) => state.skipDeleteConfirmation);
   const removeImages = useImageStore((state) => state.removeImages);
   const selectedImages = useImageStore((state) => state.selectedImages);
   const toggleImageSelection = useImageStore((state) => state.toggleImageSelection);
@@ -897,13 +898,15 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
       return;
     }
 
-    const confirmed = window.confirm(
-      targetImages.length === 1
-        ? `Delete "${targetImages[0].name}"? This sends the file to the recycle bin.`
-        : `Delete ${targetImages.length} selected images? This sends the files to the recycle bin.`,
-    );
-    if (!confirmed) {
-      return;
+    if (!skipDeleteConfirmation) {
+      const confirmed = window.confirm(
+        targetImages.length === 1
+          ? `Delete "${targetImages[0].name}"? This sends the file to the recycle bin.`
+          : `Delete ${targetImages.length} selected images? This sends the files to the recycle bin.`,
+      );
+      if (!confirmed) {
+        return;
+      }
     }
 
     const results = await Promise.all(targetImages.map((candidate) => FileOperations.deleteFile(candidate)));
@@ -921,7 +924,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     const failedCount = results.length - deletedIds.length;
     setAssetActionMessage(failedCount > 0 ? `Deleted ${deletedIds.length}; ${failedCount} failed.` : `Deleted ${deletedIds.length} image${deletedIds.length === 1 ? '' : 's'}.`);
     setAssetContextMenu(null);
-  }, [removeImages]);
+  }, [removeImages, skipDeleteConfirmation]);
 
   const setSelectedRating = useCallback((rating: ImageRating | null) => {
     if (selectedWorkspaceIds.length === 0) {

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -790,6 +790,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const enableAnimations = useSettingsStore((state) => state.enableAnimations);
   const slideshowIntervalSeconds = useSettingsStore((state) => state.slideshowIntervalSeconds);
   const slideshowShowFilename = useSettingsStore((state) => state.slideshowShowFilename);
+  const skipDeleteConfirmation = useSettingsStore((state) => state.skipDeleteConfirmation);
   const modalProfilerOnRender = useMemo(() => createProfilerOnRender('ImageModal'), []);
   const hasMarkedModalShellRef = useRef(false);
   const hasMarkedPreviewVisibleRef = useRef(false);
@@ -2194,7 +2195,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
       return;
     }
 
-    if (window.confirm('Are you sure you want to delete this image? This action cannot be undone.')) {
+    if (skipDeleteConfirmation || window.confirm('Are you sure you want to delete this image? This action cannot be undone.')) {
       const idToDelete = image.id;
       const imageToDelete = image;
 
@@ -2219,7 +2220,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         alert(`Failed to delete file: ${result.error}`);
       }
     }
-  }, [currentIndex, image, isIndexing, onClose, onImageDeleted, onNavigateNext, onNavigatePrevious, totalImages]);
+  }, [currentIndex, image, isIndexing, onClose, onImageDeleted, onNavigateNext, onNavigatePrevious, skipDeleteConfirmation, totalImages]);
 
   useEffect(() => {
     if (!isActive) {

--- a/components/settings/LibrarySettingsPanel.tsx
+++ b/components/settings/LibrarySettingsPanel.tsx
@@ -61,6 +61,9 @@ export const LibrarySettingsPanel: React.FC<{ onClose: () => void }> = ({ onClos
   const maxConcurrency = hardwareConcurrency
     ? Math.max(1, Math.min(16, Math.floor(hardwareConcurrency)))
     : 16;
+  const skipDeleteConfirmation = useSettingsStore((state) => state.skipDeleteConfirmation);
+  const setSkipDeleteConfirmation = useSettingsStore((state) => state.setSkipDeleteConfirmation);
+
   const selectedStartupVerificationMode = startupVerificationModeDetails[startupVerificationMode];
 
   useEffect(() => {
@@ -162,6 +165,17 @@ export const LibrarySettingsPanel: React.FC<{ onClose: () => void }> = ({ onClos
           label="File monitoring"
           description="Watch indexed folders for new or modified images."
           control={<SettingSwitch checked={globalAutoWatch} onChange={() => toggleGlobalAutoWatch()} />}
+        />
+
+        <SettingRow
+          label="Skip delete confirmation"
+          description="Bypass the confirmation dialog when deleting images to the recycle bin."
+          control={
+            <SettingSwitch
+              checked={skipDeleteConfirmation}
+              onChange={(value) => setSkipDeleteConfirmation(value)}
+            />
+          }
         />
 
         <div className="space-y-3 rounded-xl border border-gray-800 bg-gray-950/60 px-4 py-3">

--- a/hooks/useImageSelection.ts
+++ b/hooks/useImageSelection.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
 import { IndexedImage } from '../types';
 import { FileOperations } from '../services/fileOperations';
 
@@ -46,10 +47,11 @@ export function useImageSelection() {
 
     const handleDeleteSelectedImages = useCallback(async () => {
         const { selectedImages, images, directories } = useImageStore.getState();
+        const { skipDeleteConfirmation } = useSettingsStore.getState();
         if (selectedImages.size === 0) return;
 
         const confirmMessage = `Are you sure you want to delete ${selectedImages.size} image(s)?`;
-        if (!window.confirm(confirmMessage)) return;
+        if (!skipDeleteConfirmation && !window.confirm(confirmMessage)) return;
 
         const imagesToDelete = Array.from(selectedImages);
         const deletedIdsHandledLocally: string[] = [];

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -113,6 +113,7 @@ interface SettingsState {
   globalAutoWatch: boolean;
   startupVerificationMode: StartupVerificationMode;
   doubleClickToOpen: boolean;
+  skipDeleteConfirmation: boolean;
   tagSuggestionLimit: number;
   recentTagChipLimit: number;
   sensitiveTags: string[];
@@ -159,6 +160,7 @@ interface SettingsState {
   toggleGlobalAutoWatch: () => void;
   setStartupVerificationMode: (value: StartupVerificationMode) => void;
   setDoubleClickToOpen: (value: boolean) => void;
+  setSkipDeleteConfirmation: (value: boolean) => void;
   setTagSuggestionLimit: (value: number) => void;
   setRecentTagChipLimit: (value: number) => void;
   setSensitiveTags: (tags: string[]) => void;
@@ -210,6 +212,7 @@ export const useSettingsStore = create<SettingsState>()(
       globalAutoWatch: true,
       startupVerificationMode: 'off',
       doubleClickToOpen: false,
+      skipDeleteConfirmation: false,
       tagSuggestionLimit: DEFAULT_TAG_SUGGESTION_LIMIT,
       recentTagChipLimit: DEFAULT_RECENT_TAG_CHIP_LIMIT,
       sensitiveTags: ['nsfw', 'private', 'hidden'],
@@ -263,6 +266,7 @@ export const useSettingsStore = create<SettingsState>()(
       toggleGlobalAutoWatch: () => set((state) => ({ globalAutoWatch: !state.globalAutoWatch })),
       setStartupVerificationMode: (value) => set({ startupVerificationMode: value }),
       setDoubleClickToOpen: (value) => set({ doubleClickToOpen: !!value }),
+      setSkipDeleteConfirmation: (value) => set({ skipDeleteConfirmation: !!value }),
       setTagSuggestionLimit: (value) => set({ tagSuggestionLimit: sanitizeTagUiLimit(value, DEFAULT_TAG_SUGGESTION_LIMIT) }),
       setRecentTagChipLimit: (value) => set({ recentTagChipLimit: sanitizeTagUiLimit(value, DEFAULT_RECENT_TAG_CHIP_LIMIT) }),
       setSensitiveTags: (tags) => {
@@ -325,6 +329,7 @@ export const useSettingsStore = create<SettingsState>()(
         globalAutoWatch: true,
         startupVerificationMode: 'off',
         doubleClickToOpen: false,
+        skipDeleteConfirmation: false,
         tagSuggestionLimit: DEFAULT_TAG_SUGGESTION_LIMIT,
         recentTagChipLimit: DEFAULT_RECENT_TAG_CHIP_LIMIT,
         sensitiveTags: ['nsfw', 'private', 'hidden'],


### PR DESCRIPTION
Adds a new `skipDeleteConfirmation` setting. When enabled, it bypasses the `window.confirm` dialog when deleting images to the recycle bin, speeding up the deletion flow.

---
*PR created automatically by Jules for task [12899450297234324036](https://jules.google.com/task/12899450297234324036) started by @LuqP2*