### PR TITLE
Preserve metadata when saving edited PNGs

### DIFF
--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -109,4 +109,30 @@ describe('imageEditingService', () => {
     expect(text).toContain('Image MetaHub');
     expect(text).toContain('model.safetensors');
   });
+
+  it('preserves embedded ComfyUI workflow chunks when saving edited PNG bytes', () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x00,
+      0x49, 0x45, 0x4e, 0x44,
+      0xae, 0x42, 0x60, 0x82,
+    ]);
+    const workflow = { nodes: [{ id: 1, type: 'KSampler' }] };
+    const prompt = { '1': { class_type: 'KSampler', inputs: { seed: 123 } } };
+
+    const output = embedMetaHubMetadataInPngBytes(pngBytes, {
+      prompt: 'a test prompt',
+      model: 'model.safetensors',
+      models: ['model.safetensors'],
+    }, DEFAULT_IMAGE_ADJUSTMENTS, {
+      workflow,
+      prompt,
+    });
+    const text = new TextDecoder().decode(output);
+
+    expect(text).toContain('workflow');
+    expect(text).toContain('prompt_api');
+    expect(text).toContain('KSampler');
+    expect(text).toContain('"seed":123');
+  });
 });

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -93,6 +93,27 @@ const formatValue = (value: unknown): string => {
   return String(value);
 };
 
+const getImageDimensionsLabel = (image: IndexedImage): string => {
+  const metadata = image.metadata?.normalizedMetadata as BaseMetadata | undefined;
+  const width = Number(metadata?.width);
+  const height = Number(metadata?.height);
+  if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+    return `${Math.round(width)}x${Math.round(height)}`;
+  }
+
+  const dimensions = typeof image.dimensions === 'string' ? image.dimensions.trim() : '';
+  if (dimensions) {
+    return dimensions.replace(/\s+/g, '');
+  }
+
+  return '';
+};
+
+const getImagePrompt = (image: IndexedImage): string => {
+  const metadata = image.metadata?.normalizedMetadata as BaseMetadata | undefined;
+  return (metadata?.prompt || image.prompt || '').trim();
+};
+
 const hasMetadataValue = (value: unknown): boolean => (
   value !== null && value !== undefined && value !== ''
 );
@@ -189,6 +210,7 @@ const WorkspaceThumbnailButton: React.FC<{
 }> = ({ image, isActive, isSelected, directoryPath, onClick, onToggleSelected, onToggleFavorite, onContextMenu, onDragStart }) => {
   useThumbnail(image);
   const thumbnail = useResolvedThumbnail(image);
+  const dimensionsLabel = getImageDimensionsLabel(image);
 
   return (
     <div className="group w-full shrink-0">
@@ -236,6 +258,14 @@ const WorkspaceThumbnailButton: React.FC<{
         >
           <Heart className={`h-4 w-4 ${image.isFavorite ? 'fill-current' : ''}`} />
         </button>
+        {dimensionsLabel && (
+          <div
+            className="pointer-events-none absolute bottom-1.5 left-1.5 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[10px] leading-none text-gray-100 shadow"
+            title={`Dimensions: ${dimensionsLabel}`}
+          >
+            {dimensionsLabel}
+          </div>
+        )}
       </div>
       <div className="mt-1 truncate text-[11px] leading-4 text-gray-400" title={image.name}>
         {image.name}
@@ -909,6 +939,12 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
         setAssetActionMessage(`Failed to copy ${label}.`);
       });
   }, []);
+
+  const copyAssetPrompt = useCallback((contextImage: IndexedImage) => {
+    const prompt = getImagePrompt(contextImage);
+    setAssetContextMenu(null);
+    copyInspectorValue('Prompt', prompt);
+  }, [copyInspectorValue]);
 
   const showInspectorFieldContextMenu = useCallback((
     event: React.MouseEvent<HTMLElement>,
@@ -1733,6 +1769,16 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
           >
             <GitCompare className="h-4 w-4" />
             Compare Mode
+          </button>
+          <button
+            className={`flex w-full items-center gap-2 px-3 py-2 text-left ${
+              getImagePrompt(assetContextMenu.image) ? 'hover:bg-gray-800' : 'cursor-not-allowed text-gray-500'
+            }`}
+            disabled={!getImagePrompt(assetContextMenu.image)}
+            onClick={() => copyAssetPrompt(assetContextMenu.image)}
+          >
+            <Copy className="h-4 w-4" />
+            Copy Prompt
           </button>
           <div className="my-1 border-t border-gray-700" />
           <button

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   CheckCircle,
   Clipboard,
+  Copy,
   Download,
   ExternalLink,
   FileText,
@@ -92,14 +93,88 @@ const formatValue = (value: unknown): string => {
   return String(value);
 };
 
-const MetadataLine: React.FC<{ label: string; value: unknown }> = ({ label, value }) => (
-  <div className="rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2">
-    <div className="text-[10px] uppercase tracking-wide text-gray-500">{label}</div>
-    <div className="mt-1 truncate font-mono text-xs text-gray-200" title={formatValue(value)}>
-      {formatValue(value)}
-    </div>
-  </div>
+const hasMetadataValue = (value: unknown): boolean => (
+  value !== null && value !== undefined && value !== ''
 );
+
+const MetadataLine: React.FC<{
+  label: string;
+  value: unknown;
+  onCopy?: (label: string, value: string) => void;
+  onContextMenu?: (event: React.MouseEvent<HTMLElement>, label: string, value: string) => void;
+}> = ({ label, value, onCopy, onContextMenu }) => {
+  const displayValue = formatValue(value);
+  const canCopy = hasMetadataValue(value);
+
+  return (
+    <div
+      className="group rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2"
+      onContextMenu={(event) => {
+        if (canCopy) {
+          onContextMenu?.(event, label, displayValue);
+        }
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[10px] uppercase tracking-wide text-gray-500">{label}</div>
+        {canCopy && onCopy && (
+          <button
+            type="button"
+            onClick={() => onCopy(label, displayValue)}
+            className="text-gray-500 opacity-0 transition-opacity hover:text-gray-100 group-hover:opacity-100 focus:opacity-100"
+            title={`Copy ${label}`}
+            aria-label={`Copy ${label}`}
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+      <div className="mt-1 truncate font-mono text-xs text-gray-200" title={formatValue(value)}>
+        {displayValue}
+      </div>
+    </div>
+  );
+};
+
+const MetadataTextBlock: React.FC<{
+  label: string;
+  value: unknown;
+  maxHeightClass: string;
+  onCopy: (label: string, value: string) => void;
+  onContextMenu: (event: React.MouseEvent<HTMLElement>, label: string, value: string) => void;
+}> = ({ label, value, maxHeightClass, onCopy, onContextMenu }) => {
+  const displayValue = formatValue(value);
+  const canCopy = hasMetadataValue(value);
+
+  return (
+    <div
+      className="group rounded-lg border border-gray-800 bg-gray-950/80 p-3"
+      onContextMenu={(event) => {
+        if (canCopy) {
+          onContextMenu(event, label, displayValue);
+        }
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[10px] uppercase tracking-wide text-gray-500">{label}</div>
+        {canCopy && (
+          <button
+            type="button"
+            onClick={() => onCopy(label, displayValue)}
+            className="text-gray-500 opacity-0 transition-opacity hover:text-gray-100 group-hover:opacity-100 focus:opacity-100"
+            title={`Copy ${label}`}
+            aria-label={`Copy ${label}`}
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+      <p className={`mt-2 overflow-y-auto whitespace-pre-wrap break-words text-xs text-gray-200 ${maxHeightClass}`}>
+        {displayValue}
+      </p>
+    </div>
+  );
+};
 
 const WorkspaceThumbnailButton: React.FC<{
   image: IndexedImage;
@@ -376,6 +451,13 @@ type WorkspaceAssetContextMenu = {
   y: number;
 } | null;
 
+type InspectorContextMenu = {
+  x: number;
+  y: number;
+  label: string;
+  value: string;
+} | null;
+
 const getSameOriginUrl = (candidateUrl: string, configuredUrl: string): string => {
   try {
     const candidate = new URL(candidateUrl);
@@ -420,6 +502,7 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
   const [activeInspectorTab, setActiveInspectorTab] = useState<'image' | 'metadata' | 'workflow'>('image');
   const [workspacePreviewIndex, setWorkspacePreviewIndex] = useState<number | null>(null);
   const [assetContextMenu, setAssetContextMenu] = useState<WorkspaceAssetContextMenu>(null);
+  const [inspectorContextMenu, setInspectorContextMenu] = useState<InspectorContextMenu>(null);
   const [assetActionMessage, setAssetActionMessage] = useState<string>('');
   const [isTagManagerOpen, setIsTagManagerOpen] = useState(false);
   const [isRatingMenuOpen, setIsRatingMenuOpen] = useState(false);
@@ -533,6 +616,20 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
       window.removeEventListener('blur', close);
     };
   }, [assetContextMenu]);
+
+  useEffect(() => {
+    if (!inspectorContextMenu) {
+      return;
+    }
+
+    const close = () => setInspectorContextMenu(null);
+    window.addEventListener('click', close);
+    window.addEventListener('blur', close);
+    return () => {
+      window.removeEventListener('click', close);
+      window.removeEventListener('blur', close);
+    };
+  }, [inspectorContextMenu]);
 
   const togglePanelCollapsed = useCallback(() => {
     setIsPanelCollapsed((current) => {
@@ -796,6 +893,70 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
     event.dataTransfer.effectAllowed = 'copy';
     window.electronAPI.startFileDrag({ directoryPath: dragDirectoryPath, relativePath });
   }, []);
+
+  const copyInspectorValue = useCallback((label: string, value: string) => {
+    const text = value.trim();
+    if (!text || text === 'Not found') {
+      return;
+    }
+
+    navigator.clipboard.writeText(text)
+      .then(() => {
+        setAssetActionMessage(`${label} copied.`);
+      })
+      .catch((error) => {
+        console.error(`Failed to copy ${label}:`, error);
+        setAssetActionMessage(`Failed to copy ${label}.`);
+      });
+  }, []);
+
+  const showInspectorFieldContextMenu = useCallback((
+    event: React.MouseEvent<HTMLElement>,
+    label: string,
+    value: string,
+  ) => {
+    const selection = window.getSelection()?.toString().trim();
+    event.preventDefault();
+    event.stopPropagation();
+    setAssetContextMenu(null);
+    setInspectorContextMenu({
+      x: event.clientX,
+      y: event.clientY,
+      label: selection ? 'Selection' : label,
+      value: selection || value,
+    });
+  }, []);
+
+  const showInspectorSelectionContextMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement | null;
+    if (target?.closest('button, input, textarea, select, [contenteditable="true"]')) {
+      return;
+    }
+
+    const selection = window.getSelection()?.toString().trim();
+    if (!selection) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    setAssetContextMenu(null);
+    setInspectorContextMenu({
+      x: event.clientX,
+      y: event.clientY,
+      label: 'Selection',
+      value: selection,
+    });
+  }, []);
+
+  const copyInspectorContextValue = useCallback(() => {
+    if (!inspectorContextMenu) {
+      return;
+    }
+
+    copyInspectorValue(inspectorContextMenu.label, inspectorContextMenu.value);
+    setInspectorContextMenu(null);
+  }, [copyInspectorValue, inspectorContextMenu]);
 
   const toggleThumbRailCollapsed = useCallback(() => {
     setIsThumbRailCollapsed((current) => {
@@ -1448,25 +1609,45 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
 
               {activeInspectorTab === 'metadata' && (
                 metadata ? (
-                  <div className="space-y-3">
+                  <div className="space-y-3" onContextMenu={showInspectorSelectionContextMenu}>
                   <div className="grid grid-cols-2 gap-2">
-                    <MetadataLine label="Model" value={metadata.model} />
-                    <MetadataLine label="Seed" value={metadata.seed} />
-                    <MetadataLine label="Steps" value={metadata.steps} />
-                    <MetadataLine label="CFG" value={(metadata as any).cfgScale ?? metadata.cfg_scale} />
-                    <MetadataLine label="Sampler" value={metadata.sampler} />
-                    <MetadataLine label="Scheduler" value={metadata.scheduler} />
+                    <MetadataLine label="Model" value={metadata.model} onCopy={copyInspectorValue} onContextMenu={showInspectorFieldContextMenu} />
+                    <MetadataLine label="Seed" value={metadata.seed} onCopy={copyInspectorValue} onContextMenu={showInspectorFieldContextMenu} />
+                    <MetadataLine label="Steps" value={metadata.steps} onCopy={copyInspectorValue} onContextMenu={showInspectorFieldContextMenu} />
+                    <MetadataLine label="CFG" value={(metadata as any).cfgScale ?? metadata.cfg_scale} onCopy={copyInspectorValue} onContextMenu={showInspectorFieldContextMenu} />
+                    <MetadataLine label="Sampler" value={metadata.sampler} onCopy={copyInspectorValue} onContextMenu={showInspectorFieldContextMenu} />
+                    <MetadataLine label="Scheduler" value={metadata.scheduler} onCopy={copyInspectorValue} onContextMenu={showInspectorFieldContextMenu} />
+                    <MetadataLine
+                      label="Dimensions"
+                      value={metadata.width && metadata.height ? `${metadata.width}x${metadata.height}` : undefined}
+                      onCopy={copyInspectorValue}
+                      onContextMenu={showInspectorFieldContextMenu}
+                    />
+                    <MetadataLine
+                      label="LoRAs"
+                      value={Array.isArray(metadata.loras) && metadata.loras.length > 0
+                        ? metadata.loras.map((lora) => typeof lora === 'string' ? lora : lora.name || lora.model_name || '').filter(Boolean).join(', ')
+                        : undefined}
+                      onCopy={copyInspectorValue}
+                      onContextMenu={showInspectorFieldContextMenu}
+                    />
                   </div>
 
-                  <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
-                    <div className="text-[10px] uppercase tracking-wide text-gray-500">Prompt</div>
-                    <p className="mt-2 max-h-40 overflow-y-auto whitespace-pre-wrap text-xs text-gray-200">{metadata.prompt || 'Not found'}</p>
-                  </div>
+                  <MetadataTextBlock
+                    label="Prompt"
+                    value={metadata.prompt}
+                    maxHeightClass="max-h-40"
+                    onCopy={copyInspectorValue}
+                    onContextMenu={showInspectorFieldContextMenu}
+                  />
 
-                  <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-3">
-                    <div className="text-[10px] uppercase tracking-wide text-gray-500">Negative prompt</div>
-                    <p className="mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs text-gray-200">{metadata.negativePrompt || 'Not found'}</p>
-                  </div>
+                  <MetadataTextBlock
+                    label="Negative prompt"
+                    value={metadata.negativePrompt}
+                    maxHeightClass="max-h-32"
+                    onCopy={copyInspectorValue}
+                    onContextMenu={showInspectorFieldContextMenu}
+                  />
                 </div>
                 ) : (
                   <div className="rounded-lg border border-gray-800 bg-gray-950/80 p-4 text-sm text-gray-400">
@@ -1512,6 +1693,21 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
           onViewFullMetadata={onViewFullMetadata}
           onClose={() => setWorkspacePreviewIndex(null)}
         />
+      )}
+      {inspectorContextMenu && (
+        <div
+          className="fixed z-[96] min-w-[160px] overflow-hidden rounded-lg border border-gray-700 bg-gray-900 py-1 text-sm text-gray-100 shadow-2xl"
+          style={{ left: inspectorContextMenu.x, top: inspectorContextMenu.y }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <button
+            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-800"
+            onClick={copyInspectorContextValue}
+          >
+            <Copy className="h-4 w-4" />
+            Copy {inspectorContextMenu.label}
+          </button>
+        </div>
       )}
       {assetContextMenu && (
         <div

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -762,6 +762,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
   const [isAdjustmentPanelOpen, setIsAdjustmentPanelOpen] = useState(false);
   const [imageAdjustments, setImageAdjustments] = useState<ImageAdjustments>(DEFAULT_IMAGE_ADJUSTMENTS);
+  const [isShowingOriginalForAdjustmentCompare, setIsShowingOriginalForAdjustmentCompare] = useState(false);
   const [isSavingEditedImage, setIsSavingEditedImage] = useState(false);
   const [isFullImageSourceReady, setIsFullImageSourceReady] = useState(false);
   const [modalWindow, setModalWindow] = useState<ModalWindowState>(() => {
@@ -958,6 +959,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     [imageAdjustments]
   );
   const hasAdjustmentChanges = hasImageAdjustments(imageAdjustments);
+  const shouldApplyAdjustmentFilter = canEditImage && hasAdjustmentChanges && !isShowingOriginalForAdjustmentCompare;
   const rawMetadataImage = hydratedRawMetadataImage?.id === liveImage.id ? hydratedRawMetadataImage : liveImage;
 
   const ensureFullRawMetadata = useCallback(async (): Promise<IndexedImage> => {
@@ -980,6 +982,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   useEffect(() => {
     setImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS);
+    setIsShowingOriginalForAdjustmentCompare(false);
     setIsAdjustmentPanelOpen(false);
     setHydratedRawMetadataImage(null);
     setIsHydratingRawMetadata(false);
@@ -1694,6 +1697,18 @@ const ImageModal: React.FC<ImageModalProps> = ({
     setIsDragging(false);
   }, []);
 
+  const showOriginalForAdjustmentCompare = useCallback((event: React.PointerEvent<HTMLImageElement>) => {
+    if (!hasAdjustmentChanges || event.button !== 0) {
+      return;
+    }
+
+    setIsShowingOriginalForAdjustmentCompare(true);
+  }, [hasAdjustmentChanges]);
+
+  const hideOriginalForAdjustmentCompare = useCallback(() => {
+    setIsShowingOriginalForAdjustmentCompare(false);
+  }, []);
+
   const handleDragStart = useCallback((e: React.DragEvent<HTMLImageElement>) => {
     if (!canDragExternally) {
       return;
@@ -1712,6 +1727,22 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }
     window.electronAPI?.startFileDrag({ directoryPath, relativePath });
   }, [canDragExternally, directoryPath, image.id, image.name]);
+
+  useEffect(() => {
+    if (!isShowingOriginalForAdjustmentCompare || typeof window === 'undefined') {
+      return;
+    }
+
+    window.addEventListener('pointerup', hideOriginalForAdjustmentCompare);
+    window.addEventListener('pointercancel', hideOriginalForAdjustmentCompare);
+    window.addEventListener('blur', hideOriginalForAdjustmentCompare);
+
+    return () => {
+      window.removeEventListener('pointerup', hideOriginalForAdjustmentCompare);
+      window.removeEventListener('pointercancel', hideOriginalForAdjustmentCompare);
+      window.removeEventListener('blur', hideOriginalForAdjustmentCompare);
+    };
+  }, [hideOriginalForAdjustmentCompare, isShowingOriginalForAdjustmentCompare]);
 
   const handleZoomIn = () => {
     setZoom(prev => Math.min(prev + 0.5, 5));
@@ -1754,7 +1785,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }) ?? null;
   }, [directories]);
 
-  const writeEditedImage = useCallback(async (targetPath: string, sourceMetadata?: BaseMetadata) => {
+  const writeEditedImage = useCallback(async (
+    targetPath: string,
+    sourceMetadata?: BaseMetadata,
+    sourceRawMetadata?: Record<string, unknown>,
+  ) => {
     if (!imageUrl || !isFullImageSourceReady) {
       throw new Error('The full image is still loading.');
     }
@@ -1771,7 +1806,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
       editableSource.revoke();
     }
 
-    const outputBytes = embedMetaHubMetadataInPngBytes(pngBytes, sourceMetadata, imageAdjustments);
+    const outputBytes = embedMetaHubMetadataInPngBytes(pngBytes, sourceMetadata, imageAdjustments, sourceRawMetadata);
     const result = await window.electronAPI.writeFile(targetPath, outputBytes);
     if (!result.success) {
       throw new Error(result.error || 'Failed to write edited image.');
@@ -1803,8 +1838,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
         return;
       }
 
-      const sourceMetadata = getUsableNormalizedMetadata(liveImage);
-      await writeEditedImage(saveResult.path, sourceMetadata);
+      const sourceImageWithMetadata = await ensureFullRawMetadata();
+      const sourceMetadata = getUsableNormalizedMetadata(sourceImageWithMetadata);
+      const sourceRawMetadata = sourceImageWithMetadata.metadata as Record<string, unknown>;
+      await writeEditedImage(saveResult.path, sourceMetadata, sourceRawMetadata);
 
       const targetDirectory = findDirectoryForAbsolutePath(saveResult.path);
       if (targetDirectory) {
@@ -1812,10 +1849,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
         if (indexedImage) {
           const savedMetadata = sourceMetadata
             ? {
-                ...liveImage.metadata,
+                ...indexedImage.metadata,
                 normalizedMetadata: sourceMetadata,
               }
-            : liveImage.metadata;
+            : indexedImage.metadata;
           const savedImage: IndexedImage = {
             ...indexedImage,
             metadata: savedMetadata,
@@ -1858,6 +1895,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     allImages,
     buildEditedDefaultPath,
     canEditImage,
+    ensureFullRawMetadata,
     findDirectoryForAbsolutePath,
     hasAdjustmentChanges,
     isSavingEditedImage,
@@ -1903,8 +1941,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
         throw new Error(joined.error || 'Failed to resolve the original image path.');
       }
 
-      const sourceMetadata = getUsableNormalizedMetadata(liveImage);
-      await writeEditedImage(joined.path, sourceMetadata);
+      const sourceImageWithMetadata = await ensureFullRawMetadata();
+      const sourceMetadata = getUsableNormalizedMetadata(sourceImageWithMetadata);
+      const sourceRawMetadata = sourceImageWithMetadata.metadata as Record<string, unknown>;
+      await writeEditedImage(joined.path, sourceMetadata, sourceRawMetadata);
 
       const reparsed = await reparseIndexedImage(liveImage, sourceDirectory.path);
       if (!reparsed) {
@@ -1913,10 +1953,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
       const preservedMetadata = sourceMetadata
         ? {
-            ...liveImage.metadata,
+            ...reparsed.metadata,
             normalizedMetadata: sourceMetadata,
           }
-        : liveImage.metadata;
+        : reparsed.metadata;
       const preservedMetadataImage: IndexedImage = {
         ...liveImage,
         ...reparsed,
@@ -1969,6 +2009,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     canEditImage,
     canOverwriteEditedImage,
     directories,
+    ensureFullRawMetadata,
     hasAdjustmentChanges,
     isSavingEditedImage,
     liveImage,
@@ -2748,12 +2789,17 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   }
                 }}
                 onContextMenu={handleContextMenu}
+                onPointerDown={showOriginalForAdjustmentCompare}
+                onPointerUp={hideOriginalForAdjustmentCompare}
+                onPointerCancel={hideOriginalForAdjustmentCompare}
+                onPointerLeave={hideOriginalForAdjustmentCompare}
                 onDragStart={handleDragStart}
                 style={{
                   transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
-                  filter: canEditImage ? adjustmentFilter : undefined,
+                  filter: shouldApplyAdjustmentFilter ? adjustmentFilter : undefined,
                   transition: isDragging ? 'none' : 'transform 0.1s ease-out',
                 }}
+                title={hasAdjustmentChanges ? 'Hold to compare with the original image' : undefined}
                 draggable={canDragExternally && zoom === 1}
               />
             )

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -305,43 +305,115 @@ const formatMetadataForA1111Compat = (metadata: BaseMetadata): string => {
 const buildMetaHubEditPayload = (
   metadata: BaseMetadata,
   adjustments: ImageAdjustments,
-) => ({
-  generator: 'Image MetaHub',
-  source_generator: typeof metadata.generator === 'string' ? metadata.generator : null,
-  edited_at: new Date().toISOString(),
-  edit: {
-    tool: 'image-adjustments',
-    adjustments,
-  },
-  prompt: metadata.prompt || '',
-  negativePrompt: metadata.negativePrompt || '',
-  seed: Number.isFinite(metadata.seed) ? metadata.seed : undefined,
-  steps: Number.isFinite(metadata.steps) ? metadata.steps : undefined,
-  cfg: Number.isFinite(metadata.cfg_scale ?? metadata.cfgScale) ? (metadata.cfg_scale ?? metadata.cfgScale) : undefined,
-  sampler_name: metadata.sampler || '',
-  scheduler: metadata.scheduler || '',
-  model: metadata.model || metadata.models?.[0] || '',
-  width: Number.isFinite(metadata.width) ? metadata.width : 0,
-  height: Number.isFinite(metadata.height) ? metadata.height : 0,
-  loras: toLoraPayload(metadata.loras),
-  imh_pro: {
-    notes: typeof metadata.notes === 'string' ? metadata.notes : '',
-    user_tags: Array.isArray(metadata.tags) ? metadata.tags.join(', ') : '',
-  },
-});
+  preservedWorkflow?: PreservedComfyWorkflow,
+) => {
+  const payload: Record<string, unknown> = {
+    generator: 'Image MetaHub',
+    source_generator: typeof metadata.generator === 'string' ? metadata.generator : null,
+    edited_at: new Date().toISOString(),
+    edit: {
+      tool: 'image-adjustments',
+      adjustments,
+    },
+    prompt: metadata.prompt || '',
+    negativePrompt: metadata.negativePrompt || '',
+    seed: Number.isFinite(metadata.seed) ? metadata.seed : undefined,
+    steps: Number.isFinite(metadata.steps) ? metadata.steps : undefined,
+    cfg: Number.isFinite(metadata.cfg_scale ?? metadata.cfgScale) ? (metadata.cfg_scale ?? metadata.cfgScale) : undefined,
+    sampler_name: metadata.sampler || '',
+    scheduler: metadata.scheduler || '',
+    model: metadata.model || metadata.models?.[0] || '',
+    width: Number.isFinite(metadata.width) ? metadata.width : 0,
+    height: Number.isFinite(metadata.height) ? metadata.height : 0,
+    loras: toLoraPayload(metadata.loras),
+    imh_pro: {
+      notes: typeof metadata.notes === 'string' ? metadata.notes : '',
+      user_tags: Array.isArray(metadata.tags) ? metadata.tags.join(', ') : '',
+    },
+  };
+
+  if (preservedWorkflow?.workflow !== undefined) {
+    payload.workflow = preservedWorkflow.workflow;
+  }
+  if (preservedWorkflow?.prompt !== undefined) {
+    payload.prompt_api = preservedWorkflow.prompt;
+  }
+
+  return payload;
+};
+
+type PreservedComfyWorkflow = {
+  workflow?: unknown;
+  prompt?: unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+);
+
+const parseMaybeRecord = (value: unknown): Record<string, unknown> | null => {
+  if (isRecord(value)) {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const stringifyPngTextValue = (value: unknown): string => (
+  typeof value === 'string' ? value : JSON.stringify(value)
+);
+
+const extractPreservedComfyWorkflow = (
+  rawMetadata?: Record<string, unknown>,
+): PreservedComfyWorkflow | undefined => {
+  if (!rawMetadata) {
+    return undefined;
+  }
+
+  const metaHubPayload = parseMaybeRecord(rawMetadata.imagemetahub_data);
+  const workflow = metaHubPayload?.workflow ?? rawMetadata.workflow;
+  const prompt = metaHubPayload?.prompt_api ?? metaHubPayload?.prompt ?? rawMetadata.prompt;
+
+  if (workflow === undefined && prompt === undefined) {
+    return undefined;
+  }
+
+  return { workflow, prompt };
+};
 
 export const embedMetaHubMetadataInPngBytes = (
   pngBytes: Uint8Array,
   metadata: BaseMetadata | undefined,
   adjustments: Partial<ImageAdjustments>,
+  rawMetadata?: Record<string, unknown>,
 ): Uint8Array => {
   if (!metadata) {
     return pngBytes;
   }
 
   const normalizedAdjustments = normalizeImageAdjustments(adjustments);
-  return appendChunksToPngBytes(pngBytes, [
+  const preservedWorkflow = extractPreservedComfyWorkflow(rawMetadata);
+  const chunks = [
     createPngTextChunk('parameters', formatMetadataForA1111Compat(metadata)),
-    createPngInternationalTextChunk('imagemetahub_data', JSON.stringify(buildMetaHubEditPayload(metadata, normalizedAdjustments))),
-  ]);
+    createPngInternationalTextChunk(
+      'imagemetahub_data',
+      JSON.stringify(buildMetaHubEditPayload(metadata, normalizedAdjustments, preservedWorkflow)),
+    ),
+  ];
+
+  if (preservedWorkflow?.workflow !== undefined) {
+    chunks.push(createPngInternationalTextChunk('workflow', stringifyPngTextValue(preservedWorkflow.workflow)));
+  }
+  if (preservedWorkflow?.prompt !== undefined) {
+    chunks.push(createPngInternationalTextChunk('prompt', stringifyPngTextValue(preservedWorkflow.prompt)));
+  }
+
+  return appendChunksToPngBytes(pngBytes, chunks);
 };


### PR DESCRIPTION
## Summary

- Preserve ComfyUI workflow metadata when saving edited PNG bytes.
- Add coverage for the metadata-preserving save path.
- Improve ComfyUI Workspace metadata field copy actions and image dimension display.

## Validation

- Not run in this PR creation pass; branch was already clean and pushed.
