### PR TITLE
Improve grid selection and adjustment discovery

### DIFF
--- a/__tests__/GridToolbar.test.tsx
+++ b/__tests__/GridToolbar.test.tsx
@@ -130,4 +130,33 @@ describe('GridToolbar', () => {
 
     expect(onStartSlideshow).toHaveBeenCalledTimes(1);
   });
+
+  it('clears selected images from the toolbar', () => {
+    const images = [
+      { id: 'img-1', name: 'alpha.png' },
+      { id: 'img-2', name: 'beta.png' },
+    ] as any;
+
+    useImageStore.setState({ selectedImages: new Set(['img-1', 'img-2']) } as any);
+
+    render(
+      <GridToolbar
+        selectedImages={useImageStore.getState().selectedImages}
+        images={images}
+        directories={[]}
+        filteredImageActionCount={0}
+        onDeleteSelected={vi.fn()}
+        onGenerateA1111={vi.fn()}
+        onGenerateComfyUI={vi.fn()}
+        onCompare={vi.fn()}
+        onBatchExport={vi.fn()}
+        onStartSlideshow={vi.fn()}
+        slideshowImageCount={0}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear selection' }));
+
+    expect(useImageStore.getState().selectedImages).toEqual(new Set());
+  });
 });

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -777,6 +777,59 @@ describe('ImageGrid selection opening behavior', () => {
     expect(useImageStore.getState().selectedImages).toEqual(new Set());
   });
 
+  it('includes the previewed image when command-click starts a selection', () => {
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png' }),
+      createImage({ id: 'img-2', name: 'beta.png' }),
+    ];
+
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(),
+      isStackingEnabled: false,
+      focusedImageIndex: 0,
+      previewImage: images[0],
+      selectedImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<SelectionHarness images={images} />);
+
+    fireEvent.click(screen.getByAltText('beta.png'), { metaKey: true });
+
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
+  });
+
+  it('selects an image range with shift-click from the preview anchor', () => {
+    const images = [
+      createImage({ id: 'img-1', name: 'alpha.png' }),
+      createImage({ id: 'img-2', name: 'beta.png' }),
+      createImage({ id: 'img-3', name: 'gamma.png' }),
+    ];
+
+    useImageStore.setState({
+      images,
+      filteredImages: images,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(),
+      isStackingEnabled: false,
+      focusedImageIndex: 0,
+      previewImage: images[0],
+      selectedImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<SelectionHarness images={images} />);
+
+    fireEvent.click(screen.getByAltText('gamma.png'), { shiftKey: true });
+
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2', 'img-3']));
+  });
+
   it('clears checked images when clicking empty grid space without modifiers', () => {
     const images = [
       createImage({ id: 'img-1', name: 'alpha.png' }),

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -803,6 +803,31 @@ describe('ImageGrid selection opening behavior', () => {
     expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
   });
 
+  it('does not include a hidden preview anchor when command-click starts a selection', () => {
+    const hiddenImage = createImage({ id: 'img-hidden', name: 'hidden.png' });
+    const visibleImage = createImage({ id: 'img-visible', name: 'visible.png' });
+    const visibleImages = [visibleImage];
+
+    useImageStore.setState({
+      images: [hiddenImage, visibleImage],
+      filteredImages: visibleImages,
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+      selectedImages: new Set(),
+      isStackingEnabled: false,
+      focusedImageIndex: null,
+      previewImage: hiddenImage,
+      selectedImage: null,
+      transferProgress: null,
+      filterAndSortImages: vi.fn(),
+    } as any);
+
+    render(<SelectionHarness images={visibleImages} />);
+
+    fireEvent.click(screen.getByAltText('visible.png'), { metaKey: true });
+
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-visible']));
+  });
+
   it('selects an image range with shift-click from the preview anchor', () => {
     const images = [
       createImage({ id: 'img-1', name: 'alpha.png' }),

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -12,7 +12,8 @@ import {
   RefreshCw,
   Plus,
   Play,
-  Workflow
+  Workflow,
+  X
 } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
@@ -81,6 +82,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const collectionActionsRef = useRef<HTMLDivElement>(null);
   const toggleFavorite = useImageStore((state) => state.toggleFavorite);
+  const clearImageSelection = useImageStore((state) => state.clearImageSelection);
   const collections = useImageStore((state) => state.collections);
   const { canUseComparison, canUseA1111, canUseComfyUI, showProModal, canUseBulkTagging } = useFeatureAccess();
   const { isReparsing, reparseImages } = useReparseMetadata();
@@ -313,6 +315,17 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
             {selectedCount > 0 && (
               <>
                 <span className="text-[11px] text-gray-400 mr-2 whitespace-nowrap">{selectedCount} selected</span>
+
+                <Tooltip label="Clear selection">
+                  <button
+                    onClick={clearImageSelection}
+                    className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
+                    title="Clear selection"
+                    aria-label="Clear selection"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </Tooltip>
 
                 {/* Copy to Clipboard */}
                 <Tooltip label="Copy to Clipboard">

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -465,8 +465,8 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
           }
 
           if (doubleClickToOpen) {
-            if (e.ctrlKey || e.metaKey) {
-              toggleImageSelection(image.id);
+            if (e.ctrlKey || e.metaKey || e.shiftKey) {
+              onImageClick(image, e);
             } else {
               setPreviewImage(image);
             }

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -3010,18 +3010,33 @@ const ImageModal: React.FC<ImageModalProps> = ({
             </div>
           )}
           <div className="p-6 space-y-4 overflow-y-auto flex-1">
-          {canEditImage && isAdjustmentPanelOpen && (
-            <ImageAdjustmentPanel
-              adjustments={imageAdjustments}
-              onChange={setImageAdjustments}
-              onReset={() => setImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS)}
-              onSaveAs={() => void handleSaveEditedImageAs()}
-              onOverwrite={() => void handleOverwriteEditedImage()}
-              canOverwrite={canOverwriteEditedImage}
-              overwriteUnavailableReason="Overwrite is only available for PNG images. Use Save As to create an edited PNG copy."
-              isSaving={isSavingEditedImage}
-              disabled={!isFullImageSourceReady}
-            />
+          {canEditImage && (
+            <>
+              {!isAdjustmentPanelOpen && (
+                <button
+                  type="button"
+                  onClick={() => setIsAdjustmentPanelOpen(true)}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-sm font-medium text-cyan-100 transition-colors hover:border-cyan-400/50 hover:bg-cyan-500/20"
+                >
+                  <SlidersHorizontal className="h-4 w-4" />
+                  Adjust Image
+                </button>
+              )}
+
+              {isAdjustmentPanelOpen && (
+                <ImageAdjustmentPanel
+                  adjustments={imageAdjustments}
+                  onChange={setImageAdjustments}
+                  onReset={() => setImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS)}
+                  onSaveAs={() => void handleSaveEditedImageAs()}
+                  onOverwrite={() => void handleOverwriteEditedImage()}
+                  canOverwrite={canOverwriteEditedImage}
+                  overwriteUnavailableReason="Overwrite is only available for PNG images. Use Save As to create an edited PNG copy."
+                  isSaving={isSavingEditedImage}
+                  disabled={!isFullImageSourceReady}
+                />
+              )}
+            </>
           )}
 
           {/* Annotations Section */}

--- a/hooks/useImageSelection.ts
+++ b/hooks/useImageSelection.ts
@@ -14,7 +14,14 @@ export function useImageSelection() {
     } = useImageStore();
 
     const handleImageSelection = useCallback((image: IndexedImage, event: React.MouseEvent) => {
-        const { activeImageScope, filteredImages, selectedImage, selectedImages } = useImageStore.getState();
+        const {
+            activeImageScope,
+            filteredImages,
+            focusedImageIndex,
+            previewImage,
+            selectedImage,
+            selectedImages,
+        } = useImageStore.getState();
         const selectionScope = activeImageScope ?? filteredImages;
 
         // Update focused index
@@ -23,9 +30,15 @@ export function useImageSelection() {
             setFocusedImageIndex(clickedIndex);
         }
 
-        if (event.shiftKey && selectedImage) {
-            const lastSelectedIndex = selectionScope.findIndex(img => img.id === selectedImage.id);
-            const clickedIndex = selectionScope.findIndex(img => img.id === image.id);
+        const selectedImageAnchor = selectedImage ?? previewImage;
+        const focusedAnchor =
+            typeof focusedImageIndex === 'number' && focusedImageIndex >= 0
+                ? selectionScope[focusedImageIndex]
+                : null;
+        const selectionAnchor = selectedImageAnchor ?? focusedAnchor ?? null;
+
+        if (event.shiftKey && selectionAnchor) {
+            const lastSelectedIndex = selectionScope.findIndex(img => img.id === selectionAnchor.id);
             if (lastSelectedIndex !== -1 && clickedIndex !== -1) {
                 const start = Math.min(lastSelectedIndex, clickedIndex);
                 const end = Math.max(lastSelectedIndex, clickedIndex);
@@ -38,6 +51,11 @@ export function useImageSelection() {
         }
 
         if (event.ctrlKey || event.metaKey) {
+            if (selectedImages.size === 0 && selectionAnchor && selectionAnchor.id !== image.id) {
+                useImageStore.setState({ selectedImages: new Set([selectionAnchor.id, image.id]) });
+                return;
+            }
+
             toggleImageSelection(image.id);
         } else {
             setSelectedImage(image);

--- a/hooks/useImageSelection.ts
+++ b/hooks/useImageSelection.ts
@@ -30,18 +30,29 @@ export function useImageSelection() {
             setFocusedImageIndex(clickedIndex);
         }
 
-        const selectedImageAnchor = selectedImage ?? previewImage;
         const focusedAnchor =
             typeof focusedImageIndex === 'number' && focusedImageIndex >= 0
                 ? selectionScope[focusedImageIndex]
                 : null;
-        const selectionAnchor = selectedImageAnchor ?? focusedAnchor ?? null;
+        const anchorCandidates = [selectedImage, previewImage, focusedAnchor].filter(
+            (candidate): candidate is IndexedImage => Boolean(candidate)
+        );
+        let selectionAnchor: IndexedImage | null = null;
+        let selectionAnchorIndex = -1;
+
+        for (const candidate of anchorCandidates) {
+            const candidateIndex = selectionScope.findIndex(img => img.id === candidate.id);
+            if (candidateIndex !== -1) {
+                selectionAnchor = candidate;
+                selectionAnchorIndex = candidateIndex;
+                break;
+            }
+        }
 
         if (event.shiftKey && selectionAnchor) {
-            const lastSelectedIndex = selectionScope.findIndex(img => img.id === selectionAnchor.id);
-            if (lastSelectedIndex !== -1 && clickedIndex !== -1) {
-                const start = Math.min(lastSelectedIndex, clickedIndex);
-                const end = Math.max(lastSelectedIndex, clickedIndex);
+            if (selectionAnchorIndex !== -1 && clickedIndex !== -1) {
+                const start = Math.min(selectionAnchorIndex, clickedIndex);
+                const end = Math.max(selectionAnchorIndex, clickedIndex);
                 const rangeIds = selectionScope.slice(start, end + 1).map(img => img.id);
                 const newSelection = new Set(selectedImages);
                 rangeIds.forEach(id => newSelection.add(id));


### PR DESCRIPTION
## Summary

- Improves grid multi-selection behavior so Cmd/Ctrl-click and Shift-click use the current preview/focus as the selection anchor.
- Adds a clear-selection action to the grid toolbar.
- Makes image adjustments easier to discover by adding an `Adjust Image` entry inside the image details panel.
- Adds focused regression coverage for the grid selection and toolbar clearing flows.

## Context

Refs #283 and #284.

The macOS MP4 playback/crash report in #285 is intentionally not handled here; that needs a separate media/Electron investigation and Mac RC validation.

## Validation

- `npm test -- ImageGrid.contextMenu GridToolbar ImageAdjustmentPanel`
- `npx tsc -b`