### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,6 @@
 ## 2026-05-17 - Eliminate Array.map() O(N) Allocation Overhead for new Set()
 **Learning:** Initializing a `Set` with a mapped array, such as `new Set(images.map(img => img.id))`, creates an unnecessary intermediate array of strings that immediately gets garbage collected. This increases memory usage and GC pauses.
 **Action:** Replace `new Set(array.map(item => item.prop))` with an explicit `for` loop that iterates over the original array and adds elements directly to the `Set`. This avoids the temporary array allocation and speeds up data operations.
+## $(date +%Y-%m-%d) - Eliminate Array.map() O(N) allocation overhead for Map/Set initialization
+**Learning:** Initializing a `Map` or `Set` using `.map()` on a large array (e.g., `new Map(arr.map(item => [item.id, item]))`) causes an O(N) temporary array of tuples to be allocated and immediately discarded, triggering garbage collection pauses.
+**Action:** Replace `.map()` with a pre-instantiated `Map` or `Set` and populate it directly using a `for` loop to scale at O(1) intermediate memory.

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -1405,7 +1405,15 @@ export const useImageStore = create<ImageState>((set, get) => {
                 return;
             }
 
-            const imagesById = new Map(currentState.images.map(image => [image.id, image]));
+            // Optimization: Replaced `new Map(currentState.images.map(...))` with a `for` loop
+            // to eliminate the O(N) allocation of an intermediate tuple array `[[id, image], ...]`.
+            // Impact: Reduces garbage collection pauses on the main thread during search/filter worker completions,
+            // scaling O(1) in intermediate memory instead of O(N) where N is the total image count.
+            const imagesById = new Map<string, IndexedImage>();
+            for (let i = 0; i < currentState.images.length; i++) {
+                const img = currentState.images[i];
+                imagesById.set(img.id, img);
+            }
             const filteredImages = payload.filteredIds
                 .map(id => imagesById.get(id))
                 .filter((image): image is IndexedImage => Boolean(image));


### PR DESCRIPTION
This replaces `new Map(currentState.images.map(image => [image.id, image]))` with an explicit `for` loop, eliminating the creation of an intermediate tuple array of size N that triggers garbage collection pauses on the main thread during search/filter completions.

---
*PR created automatically by Jules for task [3888917839373931359](https://jules.google.com/task/3888917839373931359) started by @LuqP2*