### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/components/BatchExportModal.tsx
+++ b/components/BatchExportModal.tsx
@@ -346,6 +346,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
             onClick={() => { void handleRequestClose(); }}
             className="p-2 hover:bg-gray-800 rounded-lg transition-colors"
             title={isExporting ? 'Cancel export' : 'Close'}
+            aria-label={isExporting ? 'Cancel export' : 'Close'}
             disabled={isCancelling}
           >
             <X className="w-4 h-4 text-gray-400" />

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -210,6 +210,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           onClick={onToggleCollapse}
           className="mt-4 mb-6 rounded-xl p-0 text-gray-400 transition-colors duration-200 hover:bg-gray-800/50 hover:text-gray-100"
           title="Expand sidebar"
+          aria-label="Expand sidebar"
         >
            <img src="logo1.png" alt="Expand" className="h-10 w-10 rounded-xl object-contain" />
         </button>
@@ -272,6 +273,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             onClick={onToggleCollapse}
             className="app-top-icon-button ml-auto h-8 w-8"
             title="Collapse sidebar"
+            aria-label="Collapse sidebar"
           >
             <ChevronLeft className="w-4 h-4" />
           </button>
@@ -311,6 +313,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 onClick={onReshuffle}
                 className="ml-2 p-2 text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-md border border-gray-600 transition-colors"
                 title="Reshuffle Random Order"
+                aria-label="Reshuffle Random Order"
             >
                 <RefreshCw className="h-5 w-5" />
             </button>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to icon-only buttons in `Sidebar.tsx` and `BatchExportModal.tsx`.
🎯 Why: Ensures that interactive elements relying solely on icons are accessible to screen readers, aligning with WCAG 2.5.3 (Label in Name) guidelines and our UX standards.
♿ Accessibility:
- Added `aria-label="Expand sidebar"` and `aria-label="Collapse sidebar"` to sidebar toggle buttons.
- Added `aria-label="Reshuffle Random Order"` to the reshuffle button in the sidebar.
- Added dynamic `aria-label` to the close/cancel button in the batch export modal.

---
*PR created automatically by Jules for task [14168437619358773397](https://jules.google.com/task/14168437619358773397) started by @LuqP2*