### PR TITLE
fix(toolbar): make favorite action deterministic for mixed selections

### DIFF
--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -81,7 +81,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   const [isTagModalOpen, setIsTagModalOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const collectionActionsRef = useRef<HTMLDivElement>(null);
-  const toggleFavorite = useImageStore((state) => state.toggleFavorite);
+  const bulkToggleFavorite = useImageStore((state) => state.bulkToggleFavorite);
   const clearImageSelection = useImageStore((state) => state.clearImageSelection);
   const collections = useImageStore((state) => state.collections);
   const { canUseComparison, canUseA1111, canUseComfyUI, showProModal, canUseBulkTagging } = useFeatureAccess();
@@ -157,7 +157,13 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   };
 
   const handleToggleFavorites = () => {
-    selectedImagesList.forEach(img => toggleFavorite(img.id));
+    if (selectedImagesList.length === 0) return;
+
+    const nextFavoriteState = !allFavorites;
+    void bulkToggleFavorite(
+      selectedImagesList.map((img) => img.id),
+      nextFavoriteState,
+    );
   };
 
   const handleCompare = () => {


### PR DESCRIPTION
### Motivation
- Mixed selections containing both favorited and non-favorited images toggled each item individually which produced alternating states instead of converging to a clear all-on/all-off result.

### Description
- Replace per-image `toggleFavorite` calls with a single `bulkToggleFavorite` call in `components/GridToolbar.tsx` to apply a uniform target state to the entire selection.
- Compute the target state as `!allFavorites` so the action will favorite all when any are not favorited and unfavorite all when all are already favorited.
- Keep UI behavior unchanged beyond the deterministic batch favorite/unfavorite operation.

### Testing
- Ran `npm test -- GridToolbar` and `__tests__/GridToolbar.test.tsx` passed (4 tests) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb5456384832f96928e05070e2db0)