### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,6 @@
 ## $(date +%Y-%m-%d) - Eliminate Array.map() O(N) allocation overhead for Map/Set initialization
 **Learning:** Initializing a `Map` or `Set` using `.map()` on a large array (e.g., `new Map(arr.map(item => [item.id, item]))`) causes an O(N) temporary array of tuples to be allocated and immediately discarded, triggering garbage collection pauses.
 **Action:** Replace `.map()` with a pre-instantiated `Map` or `Set` and populate it directly using a `for` loop to scale at O(1) intermediate memory.
+## $(date +%Y-%m-%d) - Eliminate Array.map() O(N) allocation overhead for Map/Set initialization
+**Learning:** Initializing a `Map` or `Set` using `.map()` on a large array (e.g., `new Map(arr.map(item => [item.id, item]))`) causes an O(N) temporary array of tuples to be allocated and immediately discarded, triggering garbage collection pauses.
+**Action:** Replace `.map()` with a pre-instantiated `Map` or `Set` and populate it directly using a `for` loop to scale at O(1) intermediate memory.

--- a/services/automationRuleEngine.ts
+++ b/services/automationRuleEngine.ts
@@ -615,7 +615,10 @@ export function applyAutomationRuleToImages(
   const collectionImageAdds = new Map<string, string[]>();
   const normalizedActionTags = normalizeList(rule.actions.addTags).map((tag) => tag.toLowerCase());
   const collectionIds = normalizeList(rule.actions.addToCollectionIds);
-  const collectionById = new Map(collections.map((collection) => [collection.id, collection]));
+  const collectionById = new Map<string, SmartCollection>();
+  for (const collection of collections) {
+    collectionById.set(collection.id, collection);
+  }
   const resolvedCollectionIds = new Map<string, Set<string>>();
   for (const collectionId of collectionIds) {
     const collection = collectionById.get(collectionId);

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -1150,7 +1150,10 @@ export function resolveSmartCollectionImageIds(collection: SmartCollection, imag
 }
 
 export function resolveSmartCollectionImages(collection: SmartCollection, images: IndexedImage[]): IndexedImage[] {
-  const imageLookup = new Map(images.map((image) => [image.id, image]));
+  const imageLookup = new Map<string, IndexedImage>();
+  for (const image of images) {
+    imageLookup.set(image.id, image);
+  }
   return resolveSmartCollectionImageIds(collection, images)
     .map((imageId) => imageLookup.get(imageId))
     .filter((image): image is IndexedImage => Boolean(image));

--- a/services/lineageRegistry.ts
+++ b/services/lineageRegistry.ts
@@ -307,7 +307,10 @@ export const buildLineageRegistrySnapshot = (
   librarySignature: string,
   onProgress?: (processed: number, total: number, message: string) => void
 ): LineageRegistrySnapshot => {
-  const imagesById = new Map(images.map((image) => [image.id, image]));
+  const imagesById = new Map<string, LightweightLineageImage>();
+  for (const image of images) {
+    imagesById.set(image.id, image);
+  }
   const index = buildLineageIndex(images);
   const resolvedByImageId: Record<string, ResolvedLineageEntry> = {};
   const derivedIdsBySourceId = new Map<string, string[]>();

--- a/services/thumbnailManager.ts
+++ b/services/thumbnailManager.ts
@@ -582,7 +582,10 @@ class ThumbnailManager {
     }
 
     const misses: IndexedImage[] = [];
-    const imagesById = new Map(images.map((image) => [image.id, image]));
+    const imagesById = new Map<string, IndexedImage>();
+    for (const image of images) {
+      imagesById.set(image.id, image);
+    }
 
     for (const candidate of candidates) {
       const image = imagesById.get(candidate.requestId);


### PR DESCRIPTION
What: Removed intermediate `Array.map()` calls during `Map` initializations in multiple service files.
Why: Initializing a `Map` or `Set` using `.map()` on a large array (e.g., `new Map(arr.map(item => [item.id, item]))`) causes an O(N) temporary array of tuples to be allocated and immediately discarded, triggering garbage collection pauses.
Impact: Reduces intermediate memory allocation from O(N) to O(1) during lookup map creation, lowering GC pressure.
Measurement: Verify the changes pass linting (`pnpm lint`) and tests (`pnpm test`).

---
*PR created automatically by Jules for task [16625841999549842159](https://jules.google.com/task/16625841999549842159) started by @LuqP2*