### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## $(date +%Y-%m-%d) - Eliminate Array.map() O(N) allocation overhead for Map/Set initialization
 **Learning:** Initializing a `Map` or `Set` using `.map()` on a large array (e.g., `new Map(arr.map(item => [item.id, item]))`) causes an O(N) temporary array of tuples to be allocated and immediately discarded, triggering garbage collection pauses.
 **Action:** Replace `.map()` with a pre-instantiated `Map` or `Set` and populate it directly using a `for` loop to scale at O(1) intermediate memory.
+## 2026-05-20 - Eliminate Array.map() O(N) allocation overhead for Map/Set initialization
+**Learning:** Initializing a `Map` or `Set` using `.map()` on a large array (e.g., `new Map(arr.map(item => [item.id, item]))`) causes an O(N) temporary array of tuples to be allocated and immediately discarded, triggering garbage collection pauses.
+**Action:** Replace `.map()` with a pre-instantiated `Map` or `Set` and populate it directly using a `for` loop to scale at O(1) intermediate memory.

--- a/services/automationRuleEngine.ts
+++ b/services/automationRuleEngine.ts
@@ -48,8 +48,16 @@ const getLoraName = (lora: string | LoRAInfo): string => {
   return lora?.name || lora?.model_name || '';
 };
 
-const makeValueSet = (values: Array<string | undefined | null>): Set<string> =>
-  new Set(values.map(normalize).filter(Boolean));
+const makeValueSet = (values: Array<string | undefined | null>): Set<string> => {
+  const set = new Set<string>();
+  for (const value of values) {
+    const normalized = normalize(value);
+    if (normalized) {
+      set.add(normalized);
+    }
+  }
+  return set;
+};
 
 const getImageModelSet = (image: IndexedImage): Set<string> =>
   makeValueSet([
@@ -636,7 +644,11 @@ export function applyAutomationRuleToImages(
 
     matchedImageIds.push(image.id);
     const currentAnnotation = annotations.get(image.id);
-    const existingTags = new Set((currentAnnotation?.tags ?? image.tags ?? []).map((tag) => tag.toLowerCase()));
+    const existingTags = new Set<string>();
+    const sourceTags = currentAnnotation?.tags ?? image.tags ?? [];
+    for (let i = 0; i < sourceTags.length; i++) {
+      existingTags.add(sourceTags[i].toLowerCase());
+    }
     const nextTags = [...existingTags];
 
     for (const tag of normalizedActionTags) {

--- a/services/comfyUIWorkflowBuilder.ts
+++ b/services/comfyUIWorkflowBuilder.ts
@@ -737,7 +737,7 @@ export function analyzeComfyWorkflow(source: IndexedImage | UnknownRecord, norma
     warnings.push('Workflow does not contain MetaHubSaveNode or SaveImage. A save node will be injected.');
   }
 
-  const modelFamilySet = new Set<string>();
+  const modelFamilySet = new Set<ComfyUIModelFamily>();
   for (let i = 0; i < modelTargets.length; i++) {
     if (modelTargets[i].family) {
       modelFamilySet.add(modelTargets[i].family);

--- a/services/comfyUIWorkflowBuilder.ts
+++ b/services/comfyUIWorkflowBuilder.ts
@@ -737,7 +737,13 @@ export function analyzeComfyWorkflow(source: IndexedImage | UnknownRecord, norma
     warnings.push('Workflow does not contain MetaHubSaveNode or SaveImage. A save node will be injected.');
   }
 
-  const compatibleModelFamilies = Array.from(new Set(modelTargets.map((target) => target.family))).filter(Boolean);
+  const modelFamilySet = new Set<string>();
+  for (let i = 0; i < modelTargets.length; i++) {
+    if (modelTargets[i].family) {
+      modelFamilySet.add(modelTargets[i].family);
+    }
+  }
+  const compatibleModelFamilies = Array.from(modelFamilySet);
   const parsedGraph = resolvePromptFromGraph(embedded.workflow, embedded.prompt);
   const generationType = normalizedMetadata?.generationType || parsedGraph.generationType;
 

--- a/services/comfyUIWorkflowNodes.ts
+++ b/services/comfyUIWorkflowNodes.ts
@@ -132,7 +132,10 @@ export const filterImagesByWorkflowNodes = (
     return images.filter((image) => (image.workflowNodes?.length || 0) > 0);
   }
 
-  const selected = new Set(selectedNodeTypes.map((value) => value.toLowerCase()));
+  const selected = new Set<string>();
+  for (let i = 0; i < selectedNodeTypes.length; i++) {
+    selected.add(selectedNodeTypes[i].toLowerCase());
+  }
   return images.filter((image) =>
     (image.workflowNodes || []).some((nodeType) => selected.has(nodeType.toLowerCase()))
   );

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -716,7 +716,14 @@ export function resolvePromptFromGraph(workflow: any, prompt: any): Record<strin
     // Merge with existing lora array from resolveAll
     const existingLoras = results.lora || [];
     results.loras = modifiers.loras; // Detailed lora info
-    results.lora = Array.from(new Set([...existingLoras, ...modifiers.loras.map(l => l.name)])); // Backward compatibility
+    const loraNameSet = new Set<string>();
+    for (let i = 0; i < existingLoras.length; i++) {
+      loraNameSet.add(existingLoras[i]);
+    }
+    for (let i = 0; i < modifiers.loras.length; i++) {
+      loraNameSet.add(modifiers.loras[i].name);
+    }
+    results.lora = Array.from(loraNameSet); // Backward compatibility
   }
   if (modifiers.vaes.length > 0) {
     results.vaes = modifiers.vaes;

--- a/services/similarImageSearch.ts
+++ b/services/similarImageSearch.ts
@@ -481,7 +481,10 @@ export const getModelPromptOverlapGroups = (
   return Array.from(imagesByPrompt.entries())
     .map(([normalizedPrompt, sourceImages]) => {
       const promptImages = globalImagesByPrompt.get(normalizedPrompt) || [];
-      const sourceImageIds = new Set(sourceImages.map((image) => image.id));
+      const sourceImageIds = new Set<string>();
+      for (let i = 0; i < sourceImages.length; i++) {
+        sourceImageIds.add(sourceImages[i].id);
+      }
       const alternateCheckpoints = new Set<string>();
 
       for (const image of promptImages) {

--- a/services/workers/searchFilterWorker.ts
+++ b/services/workers/searchFilterWorker.ts
@@ -180,10 +180,14 @@ self.onmessage = (event: MessageEvent<WorkerMessage>) => {
 };
 
 function computeResults(criteria: SearchWorkerCriteria): Omit<CompletePayload, 'criteriaKey'> {
-  const visibleDirectoryIds = new Set(criteria.visibleDirectories.map(directory => directory.id));
-  const directoryPathMap = new Map(
-    criteria.visibleDirectories.map(directory => [directory.id, normalizePath(directory.path)])
-  );
+  const visibleDirectoryIds = new Set<string>();
+  const directoryPathMap = new Map<string, string>();
+  for (let i = 0; i < criteria.visibleDirectories.length; i++) {
+    const dir = criteria.visibleDirectories[i];
+    visibleDirectoryIds.add(dir.id);
+    directoryPathMap.set(dir.id, normalizePath(dir.path));
+  }
+
   const excludedFolders = criteria.excludedFolders.map(normalizePath);
   const selectedFolders = criteria.selectedFolders.map(normalizePath);
   const selectedRatings = new Set(criteria.selectedRatings);


### PR DESCRIPTION
This PR eliminates unnecessary intermediate array allocations when initializing large Maps and Sets across various services.

**What:**
Refactored several usages of `new Set(arr.map(...))` and `new Map(arr.map(...))` to instead instantiate an empty Set/Map and populate it directly using a `for` loop.

**Why:**
Chaining `.map()` before passing the result to a `Set` or `Map` constructor forces the JavaScript engine to allocate a temporary array containing all the mapped values (or tuples for Maps). This temporary array is immediately discarded, creating unnecessary garbage collection pauses, which is particularly bad in hot paths like the `searchFilterWorker` processing large collections of images.

**Impact:**
Reduces memory allocation complexity from O(N) intermediate array space to O(1) inside these loops.

**Measurement:**
Run `pnpm test` and `pnpm lint` to verify that behavior remains identical while performance improves at scale.

---
*PR created automatically by Jules for task [3100142061571020961](https://jules.google.com/task/3100142061571020961) started by @LuqP2*