### PR TITLE
Add media playback diagnostics and macOS safe mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ComfyUI Workflow Actions**: Added richer ComfyUI workflow entry points across the main app, image viewer, grid, and embedded workspace, including workflow action coverage and desktop IPC support for workspace preview behavior.
 - **ComfyUI Workspace Metadata Copying**: Added copy actions for workspace metadata fields and clearer image dimension display in the ComfyUI Workspace context panel.
+- **Media Playback Diagnostics**: Added audio/video playback event diagnostics and imh-media protocol logging to help investigate early Electron Helper crashes on macOS.
 
 ### Improved
 
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Workspace Bulk Action UX**: Added clearer disabled-state tooltips for ComfyUI Workspace bulk actions so users can tell what selection is required.
 - **Accessibility**: Added missing accessible labels to icon-only controls across the ComfyUI Workspace, directory list, preview/sidebar, image viewer, automation rules, sidebar, and batch export surfaces.
 - **Hotkey Reset Safety**: Added a confirmation dialog before resetting all custom hotkeys.
+- **macOS Media Safe Mode**: Documented the opt-in `IMH_MEDIA_SAFE_MODE=1` launch mode for testing GPU-related media playback crashes without affecting normal launches.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,16 @@ npm run cli:index -- path/to/folder --out index.jsonl --recursive
 
 For release work, see [RELEASE-GUIDE.md](RELEASE-GUIDE.md) and [RELEASE-AUTOMATION.md](RELEASE-AUTOMATION.md).
 
+## Troubleshooting
+
+On macOS, if audio or video playback crashes the Electron Helper, launch Image MetaHub from Terminal with the opt-in media safe mode:
+
+```bash
+IMH_MEDIA_SAFE_MODE=1 open -a "Image MetaHub"
+```
+
+This disables hardware acceleration plus accelerated video decode/compositing switches for that launch only. The lower-level `IMH_DISABLE_GPU=1` flag is also available when you want to test GPU acceleration separately.
+
 ## Privacy
 
 Image MetaHub is designed to stay local:

--- a/README.md
+++ b/README.md
@@ -274,13 +274,13 @@ For release work, see [RELEASE-GUIDE.md](RELEASE-GUIDE.md) and [RELEASE-AUTOMATI
 
 ## Troubleshooting
 
-On macOS, if audio or video playback crashes the Electron Helper, launch Image MetaHub from Terminal with the opt-in media safe mode:
+On macOS, if audio or video playback crashes the Electron Helper, quit Image MetaHub first, then launch it from Terminal with the opt-in media safe mode:
 
 ```bash
-IMH_MEDIA_SAFE_MODE=1 open -a "Image MetaHub"
+IMH_MEDIA_SAFE_MODE=1 /Applications/Image\ MetaHub.app/Contents/MacOS/Image\ MetaHub
 ```
 
-This disables hardware acceleration plus accelerated video decode/compositing switches for that launch only. The lower-level `IMH_DISABLE_GPU=1` flag is also available when you want to test GPU acceleration separately.
+To confirm the flag was applied, `process-events.log` should include `mediaSafeModeEnabled: true` in the `app-startup` entry. This disables hardware acceleration plus accelerated video decode/compositing switches for that launch only. The lower-level `IMH_DISABLE_GPU=1` flag is also available when you want to test GPU acceleration separately.
 
 ## Privacy
 

--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Music } from 'lucide-react';
+import { type MediaDiagnosticsContext, useMediaDiagnostics } from '../hooks/useMediaDiagnostics';
 
 interface AudioPlayerProps {
   src: string;
@@ -10,6 +11,7 @@ interface AudioPlayerProps {
   onLoadedMetadata?: React.ReactEventHandler<HTMLAudioElement>;
   onCanPlay?: React.ReactEventHandler<HTMLAudioElement>;
   onPlaying?: React.ReactEventHandler<HTMLAudioElement>;
+  diagnostics?: Omit<MediaDiagnosticsContext, 'mediaKind' | 'src'>;
 }
 
 const AudioPlayer: React.FC<AudioPlayerProps> = ({
@@ -21,7 +23,15 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
   onLoadedMetadata,
   onCanPlay,
   onPlaying,
+  diagnostics,
 }) => {
+  const mediaDiagnostics = useMediaDiagnostics({
+    mediaKind: 'audio',
+    fileName: diagnostics?.fileName ?? title,
+    surface: diagnostics?.surface ?? 'audio-player',
+    src,
+  });
+
   return (
     <div
       data-media-element="true"
@@ -43,9 +53,25 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
         autoPlay={autoPlay}
         preload="metadata"
         className="w-full max-w-2xl"
-        onLoadedMetadata={onLoadedMetadata}
-        onCanPlay={onCanPlay}
-        onPlaying={onPlaying}
+        onLoadStart={mediaDiagnostics.onLoadStart}
+        onLoadedMetadata={(event) => {
+          mediaDiagnostics.onLoadedMetadata(event);
+          onLoadedMetadata?.(event);
+        }}
+        onCanPlay={(event) => {
+          mediaDiagnostics.onCanPlay(event);
+          onCanPlay?.(event);
+        }}
+        onPlay={mediaDiagnostics.onPlay}
+        onPlaying={(event) => {
+          mediaDiagnostics.onPlaying(event);
+          onPlaying?.(event);
+        }}
+        onError={mediaDiagnostics.onError}
+        onStalled={mediaDiagnostics.onStalled}
+        onSuspend={mediaDiagnostics.onSuspend}
+        onAbort={mediaDiagnostics.onAbort}
+        onEmptied={mediaDiagnostics.onEmptied}
       />
     </div>
   );

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -50,6 +50,7 @@ import AudioPlayer from './AudioPlayer';
 import ImageAdjustmentPanel from './ImageAdjustmentPanel';
 import { getRelativeImagePath, splitRelativePath } from '../utils/imagePaths';
 import { getFileExtension, isAudioFileName, isVideoFileName, SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
+import { type MediaDiagnosticsContext, useMediaDiagnostics } from '../hooks/useMediaDiagnostics';
 import {
   createProfilerOnRender,
   finishPerformanceFlow,
@@ -522,9 +523,16 @@ const VideoPlayer: React.FC<{
   onCanPlay?: React.ReactEventHandler<HTMLVideoElement>;
   onPlaying?: React.ReactEventHandler<HTMLVideoElement>;
   onEnded?: React.ReactEventHandler<HTMLVideoElement>;
-}> = ({ src, poster, onContextMenu, onLoadedMetadata, onCanPlay, onPlaying, onEnded }) => {
+  diagnostics?: Omit<MediaDiagnosticsContext, 'mediaKind' | 'src'>;
+}> = ({ src, poster, onContextMenu, onLoadedMetadata, onCanPlay, onPlaying, onEnded, diagnostics }) => {
   const videoRef = React.useRef<HTMLVideoElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const mediaDiagnostics = useMediaDiagnostics({
+    mediaKind: 'video',
+    fileName: diagnostics?.fileName ?? '',
+    surface: diagnostics?.surface ?? 'image-modal',
+    src,
+  });
   
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
@@ -621,15 +629,31 @@ const VideoPlayer: React.FC<{
         poster={poster}
         autoPlay
         playsInline
+        onLoadStart={mediaDiagnostics.onLoadStart}
         onTimeUpdate={handleTimeUpdate}
         onLoadedMetadata={(event) => {
+          mediaDiagnostics.onLoadedMetadata(event);
           handleLoadedMetadata();
           onLoadedMetadata?.(event);
         }}
-        onCanPlay={onCanPlay}
-        onPlaying={onPlaying}
-        onPlay={() => setIsPlaying(true)}
+        onCanPlay={(event) => {
+          mediaDiagnostics.onCanPlay(event);
+          onCanPlay?.(event);
+        }}
+        onPlaying={(event) => {
+          mediaDiagnostics.onPlaying(event);
+          onPlaying?.(event);
+        }}
+        onPlay={(event) => {
+          mediaDiagnostics.onPlay(event);
+          setIsPlaying(true);
+        }}
         onPause={() => setIsPlaying(false)}
+        onError={mediaDiagnostics.onError}
+        onStalled={mediaDiagnostics.onStalled}
+        onSuspend={mediaDiagnostics.onSuspend}
+        onAbort={mediaDiagnostics.onAbort}
+        onEmptied={mediaDiagnostics.onEmptied}
         onEnded={(event) => {
           setIsPlaying(false);
           onEnded?.(event);
@@ -2731,6 +2755,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   src={imageUrl}
                   title={image.name}
                   autoPlay
+                  diagnostics={{ fileName: image.name, surface: isSlideshowMode ? 'slideshow' : 'image-modal' }}
                   onContextMenu={handleContextMenu}
                   onLoadedMetadata={() => markPerformanceFlow(diagnosticsFlowId, 'audio-loadedmetadata', { imageId: image.id })}
                   onCanPlay={() => markPerformanceFlow(diagnosticsFlowId, 'audio-canplay', { imageId: image.id })}
@@ -2753,6 +2778,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   key={image.id}
                   src={imageUrl}
                   poster={preferredThumbnailUrl ?? undefined}
+                  diagnostics={{ fileName: image.name, surface: isSlideshowMode ? 'slideshow' : 'image-modal' }}
                   onContextMenu={handleContextMenu}
                   onLoadedMetadata={(event) => {
                     const duration = event.currentTarget.duration;

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -29,6 +29,7 @@ import { buildEffectiveMetadata, getEditableMetadataFields } from '../utils/edit
 import { MetadataEditorModal, type MetadataEditorDraft } from './MetadataEditorModal';
 import BatchExportModal from './BatchExportModal';
 import { hasCompactedRuntimeMetadata, hydrateImageRawMetadata } from '../services/rawMetadataHydration';
+import { useMediaDiagnostics } from '../hooks/useMediaDiagnostics';
 
 const formatLoRA = (lora: string | LoRAInfo): string => {
   if (typeof lora === 'string') {
@@ -196,6 +197,12 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const a1111GenerateLabel = singleVisibleProvider?.id === 'a1111' ? 'Generate' : 'Generate with A1111';
   const comfyGenerateLabel = singleVisibleProvider?.id === 'comfyui' ? 'Generate' : 'Generate with ComfyUI';
   const preferredThumbnailUrl = thumbnail?.thumbnailUrl ?? null;
+  const videoDiagnostics = useMediaDiagnostics({
+    mediaKind: 'video',
+    fileName: activeImage?.name ?? '',
+    surface: 'preview-sidebar',
+    src: imageUrl,
+  });
   const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
   const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
   const recentTagSuggestions = useMemo(() => getRecentTagChips({
@@ -474,6 +481,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 src={imageUrl}
                 title={activeImage.name}
                 compact
+                diagnostics={{ fileName: activeImage.name, surface: 'preview-sidebar' }}
               />
             ) : isVideo ? (
               <video
@@ -482,6 +490,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 controls
                 playsInline
                 poster={preferredThumbnailUrl ?? undefined}
+                {...videoDiagnostics}
               />
             ) : (
               <img src={imageUrl} alt={activeImage.name} className="max-w-full max-h-96 object-contain image-alpha-grid" />

--- a/electron.mjs
+++ b/electron.mjs
@@ -911,6 +911,12 @@ function sanitizeMediaPlaybackDiagnostics(payload = {}) {
   const safeFileName = payload.fileName ? path.basename(String(payload.fileName)) : null;
   const srcScheme = typeof payload.srcScheme === 'string' ? payload.srcScheme.slice(0, 32) : null;
   const eventName = typeof payload.eventName === 'string' ? payload.eventName.slice(0, 48) : null;
+  const safeErrorMessage = typeof payload.errorMessage === 'string'
+    ? payload.errorMessage
+      .replace(/[a-zA-Z][a-zA-Z\d+.-]*:\/\/\S+/g, '[redacted-url]')
+      .replace(/(?:[A-Za-z]:[\\/]|\/)(?:[^\s"'<>|?*]+[\\/])*[^\s"'<>|?*]*/g, '[redacted-path]')
+      .slice(0, 500)
+    : null;
 
   return {
     kind: 'media-playback-event',
@@ -923,7 +929,7 @@ function sanitizeMediaPlaybackDiagnostics(payload = {}) {
     readyState: Number.isFinite(payload.readyState) ? payload.readyState : null,
     networkState: Number.isFinite(payload.networkState) ? payload.networkState : null,
     errorCode: Number.isFinite(payload.errorCode) ? payload.errorCode : null,
-    errorMessage: typeof payload.errorMessage === 'string' ? payload.errorMessage.slice(0, 500) : null,
+    errorMessage: safeErrorMessage,
   };
 }
 

--- a/electron.mjs
+++ b/electron.mjs
@@ -119,6 +119,15 @@ const getSafeFileDetails = async (filePath) => {
   return { fileName, extension, mimeType, fileSize };
 };
 
+const redactDiagnosticText = (value, maxLength = 500) => {
+  if (typeof value !== 'string') return null;
+
+  return value
+    .replace(/[a-zA-Z][a-zA-Z\d+.-]*:\/\/\S+/g, '[redacted-url]')
+    .replace(/(?:[A-Za-z]:[\\/]|\/)(?:[^\s"'<>|?*]+[\\/])*[^\s"'<>|?*]*/g, '[redacted-path]')
+    .slice(0, maxLength);
+};
+
 const getMediaProtocolErrorType = (error) => {
   if (!error) return 'UNKNOWN_ERROR';
   if (error.code === 'ENOENT' || error.message?.includes('no such file')) return 'FILE_NOT_FOUND';
@@ -206,7 +215,7 @@ const registerMediaProtocol = () => {
         status: 'failed',
         errorType: getMediaProtocolErrorType(error),
         errorCode: error?.code ?? null,
-        errorMessage: error?.message ?? null,
+        errorMessage: redactDiagnosticText(error?.message),
         ...safeDetails,
       });
       callback({ error: -2 });
@@ -911,12 +920,7 @@ function sanitizeMediaPlaybackDiagnostics(payload = {}) {
   const safeFileName = payload.fileName ? path.basename(String(payload.fileName)) : null;
   const srcScheme = typeof payload.srcScheme === 'string' ? payload.srcScheme.slice(0, 32) : null;
   const eventName = typeof payload.eventName === 'string' ? payload.eventName.slice(0, 48) : null;
-  const safeErrorMessage = typeof payload.errorMessage === 'string'
-    ? payload.errorMessage
-      .replace(/[a-zA-Z][a-zA-Z\d+.-]*:\/\/\S+/g, '[redacted-url]')
-      .replace(/(?:[A-Za-z]:[\\/]|\/)(?:[^\s"'<>|?*]+[\\/])*[^\s"'<>|?*]*/g, '[redacted-path]')
-      .slice(0, 500)
-    : null;
+  const safeErrorMessage = redactDiagnosticText(payload.errorMessage);
 
   return {
     kind: 'media-playback-event',
@@ -4260,7 +4264,7 @@ function setupFileOperationHandlers() {
         status: 'failed',
         errorType: isFileNotFound ? 'FILE_NOT_FOUND' : (isPermissionError ? 'PERMISSION_ERROR' : 'UNKNOWN_ERROR'),
         errorCode: error.code,
-        errorMessage: error.message,
+        errorMessage: redactDiagnosticText(error.message),
         ...safeDetails,
       });
 

--- a/electron.mjs
+++ b/electron.mjs
@@ -36,10 +36,17 @@ const __dirname = path.dirname(__filename);
 // Simple development check
 const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 const gpuMitigationEnabled = process.env.IMH_DISABLE_GPU === '1' || process.env.IMH_DISABLE_GPU === 'true';
+const mediaSafeModeEnabled = process.platform === 'darwin' && (process.env.IMH_MEDIA_SAFE_MODE === '1' || process.env.IMH_MEDIA_SAFE_MODE === 'true');
 
-if (gpuMitigationEnabled) {
+if (gpuMitigationEnabled || mediaSafeModeEnabled) {
   app.disableHardwareAcceleration();
-  console.warn('[GPU] Hardware acceleration disabled via IMH_DISABLE_GPU.');
+  console.warn(`[GPU] Hardware acceleration disabled via ${mediaSafeModeEnabled ? 'IMH_MEDIA_SAFE_MODE' : 'IMH_DISABLE_GPU'}.`);
+}
+
+if (mediaSafeModeEnabled) {
+  app.commandLine.appendSwitch('disable-accelerated-video-decode');
+  app.commandLine.appendSwitch('disable-gpu-compositing');
+  console.warn('[Media] macOS media safe mode enabled via IMH_MEDIA_SAFE_MODE.');
 }
 
 app.commandLine.appendSwitch('js-flags', '--max-old-space-size=4096');
@@ -96,6 +103,29 @@ protocol.registerSchemesAsPrivileged([
 
 const getMimeTypeFromName = (name) => inferMimeTypeFromName(name);
 
+const getSafeFileDetails = async (filePath) => {
+  const fileName = path.basename(String(filePath || ''));
+  const extension = path.extname(fileName).toLowerCase();
+  const mimeType = getMimeTypeFromName(fileName) || null;
+  let fileSize = null;
+
+  try {
+    const stats = await fs.stat(filePath);
+    fileSize = stats.isFile() ? stats.size : null;
+  } catch {
+    fileSize = null;
+  }
+
+  return { fileName, extension, mimeType, fileSize };
+};
+
+const getMediaProtocolErrorType = (error) => {
+  if (!error) return 'UNKNOWN_ERROR';
+  if (error.code === 'ENOENT' || error.message?.includes('no such file')) return 'FILE_NOT_FOUND';
+  if (error.code === 'EACCES' || error.code === 'EPERM') return 'PERMISSION_ERROR';
+  return 'UNKNOWN_ERROR';
+};
+
 const buildMediaProtocolUrl = (filePath) => {
   const normalizedFilePath = path.resolve(filePath);
   return `${MEDIA_PROTOCOL_SCHEME}://local/?path=${encodeURIComponent(normalizedFilePath)}`;
@@ -131,28 +161,54 @@ const buildThumbnailProtocolUrl = (thumbnailId, extension = 'webp') => {
 
 const registerMediaProtocol = () => {
   protocol.registerFileProtocol(MEDIA_PROTOCOL_SCHEME, async (request, callback) => {
+    let safeDetails = { fileName: null, extension: null, mimeType: null, fileSize: null };
     try {
       const requestUrl = new URL(request.url);
       const requestedPath = requestUrl.searchParams.get('path');
       if (!requestedPath) {
+        logProcessEvent({
+          kind: 'imh-media-protocol',
+          status: 'failed',
+          errorType: 'MISSING_PATH',
+        });
         callback({ error: -6 });
         return;
       }
 
       const normalizedFilePath = path.resolve(requestedPath);
+      safeDetails = await getSafeFileDetails(normalizedFilePath);
       if (!isPathAllowed(normalizedFilePath)) {
         console.error('SECURITY VIOLATION: Attempted to load media outside of allowed directories.');
         console.error('  [imh-media] Requested path:', requestedPath);
         console.error('  [imh-media] Normalized path:', normalizedFilePath);
         console.error('  [imh-media] Allowed directories:', Array.from(allowedDirectoryPaths));
+        logProcessEvent({
+          kind: 'imh-media-protocol',
+          status: 'failed',
+          errorType: 'PERMISSION_DENIED',
+          ...safeDetails,
+        });
         callback({ error: -10 });
         return;
       }
 
       await fs.access(normalizedFilePath);
+      logProcessEvent({
+        kind: 'imh-media-protocol',
+        status: 'served',
+        ...safeDetails,
+      });
       callback({ path: normalizedFilePath });
     } catch (error) {
-      console.error('Error serving media protocol request:', request.url, error);
+      console.error('Error serving media protocol request:', error);
+      logProcessEvent({
+        kind: 'imh-media-protocol',
+        status: 'failed',
+        errorType: getMediaProtocolErrorType(error),
+        errorCode: error?.code ?? null,
+        errorMessage: error?.message ?? null,
+        ...safeDetails,
+      });
       callback({ error: -2 });
     }
   });
@@ -816,6 +872,7 @@ function registerProcessDiagnostics() {
     kind: 'app-startup',
     logs: getDiagnosticsLogPaths(),
     gpuMitigationEnabled,
+    mediaSafeModeEnabled,
     gpuFeatureStatus: app.getGPUFeatureStatus?.() ?? null,
   });
 
@@ -848,6 +905,26 @@ function registerProcessDiagnostics() {
       url: webContents?.getURL?.() ?? null,
     });
   });
+}
+
+function sanitizeMediaPlaybackDiagnostics(payload = {}) {
+  const safeFileName = payload.fileName ? path.basename(String(payload.fileName)) : null;
+  const srcScheme = typeof payload.srcScheme === 'string' ? payload.srcScheme.slice(0, 32) : null;
+  const eventName = typeof payload.eventName === 'string' ? payload.eventName.slice(0, 48) : null;
+
+  return {
+    kind: 'media-playback-event',
+    mediaKind: payload.mediaKind === 'audio' || payload.mediaKind === 'video' ? payload.mediaKind : 'unknown',
+    surface: typeof payload.surface === 'string' ? payload.surface.slice(0, 80) : null,
+    eventName,
+    fileName: safeFileName,
+    srcScheme,
+    currentTime: Number.isFinite(payload.currentTime) ? payload.currentTime : null,
+    readyState: Number.isFinite(payload.readyState) ? payload.readyState : null,
+    networkState: Number.isFinite(payload.networkState) ? payload.networkState : null,
+    errorCode: Number.isFinite(payload.errorCode) ? payload.errorCode : null,
+    errorMessage: typeof payload.errorMessage === 'string' ? payload.errorMessage.slice(0, 500) : null,
+  };
 }
 
 function attachWindowProcessDiagnostics(window) {
@@ -4124,23 +4201,45 @@ function setupFileOperationHandlers() {
     return { success: true, ...status };
   });
 
+  ipcMain.on('log-media-playback-event', (_event, payload) => {
+    logProcessEvent(sanitizeMediaPlaybackDiagnostics(payload));
+  });
+
   // Handle reading file content
   ipcMain.handle('resolve-media-url', async (event, filePath) => {
+    let safeDetails = { fileName: null, extension: null, mimeType: null, fileSize: null };
     try {
       if (!filePath) {
+        logProcessEvent({
+          kind: 'resolve-media-url',
+          status: 'failed',
+          errorType: 'MISSING_PATH',
+        });
         return { success: false, error: 'No file path provided' };
       }
 
       const normalizedFilePath = path.resolve(filePath);
+      safeDetails = await getSafeFileDetails(normalizedFilePath);
       if (!isPathAllowed(normalizedFilePath)) {
         console.error('SECURITY VIOLATION: Attempted to resolve media URL outside of allowed directories.');
         console.error('  [resolve-media-url] Requested path:', filePath);
         console.error('  [resolve-media-url] Normalized path:', normalizedFilePath);
         console.error('  [resolve-media-url] Allowed directories:', Array.from(allowedDirectoryPaths));
+        logProcessEvent({
+          kind: 'resolve-media-url',
+          status: 'failed',
+          errorType: 'PERMISSION_DENIED',
+          ...safeDetails,
+        });
         return { success: false, error: 'Access denied', errorType: 'PERMISSION_DENIED' };
       }
 
       await fs.access(normalizedFilePath);
+      logProcessEvent({
+        kind: 'resolve-media-url',
+        status: 'success',
+        ...safeDetails,
+      });
       return { success: true, url: buildMediaProtocolUrl(normalizedFilePath) };
     } catch (error) {
       const isFileNotFound = error.code === 'ENOENT' || error.message?.includes('no such file');
@@ -4149,6 +4248,15 @@ function setupFileOperationHandlers() {
       if (!isFileNotFound) {
         console.error('Error resolving media URL:', filePath, error);
       }
+
+      logProcessEvent({
+        kind: 'resolve-media-url',
+        status: 'failed',
+        errorType: isFileNotFound ? 'FILE_NOT_FOUND' : (isPermissionError ? 'PERMISSION_ERROR' : 'UNKNOWN_ERROR'),
+        errorCode: error.code,
+        errorMessage: error.message,
+        ...safeDetails,
+      });
 
       return {
         success: false,

--- a/hooks/useMediaDiagnostics.ts
+++ b/hooks/useMediaDiagnostics.ts
@@ -1,0 +1,74 @@
+import { type SyntheticEvent, useCallback, useMemo } from 'react';
+
+export const MEDIA_DIAGNOSTIC_EVENTS = [
+  'loadstart',
+  'loadedmetadata',
+  'canplay',
+  'play',
+  'playing',
+  'error',
+  'stalled',
+  'suspend',
+  'abort',
+  'emptied',
+] as const;
+
+export type MediaDiagnosticEventName = typeof MEDIA_DIAGNOSTIC_EVENTS[number];
+
+export interface MediaDiagnosticsContext {
+  mediaKind: 'audio' | 'video';
+  fileName: string;
+  surface: string;
+  src?: string | null;
+}
+
+const getSrcScheme = (src?: string | null): string | null => {
+  if (!src) return null;
+
+  const match = /^([a-zA-Z][a-zA-Z\d+.-]*):/.exec(src);
+  return match?.[1] ?? null;
+};
+
+const getMediaErrorMessage = (error: MediaError | null): string | null => {
+  if (!error) return null;
+  return error.message || null;
+};
+
+export function useMediaDiagnostics(context: MediaDiagnosticsContext) {
+  const logMediaEvent = useCallback(
+    (event: SyntheticEvent<HTMLMediaElement>) => {
+      const element = event.currentTarget;
+      const mediaError = element.error;
+
+      window.electronAPI?.logMediaPlaybackEvent?.({
+        mediaKind: context.mediaKind,
+        surface: context.surface,
+        eventName: event.type,
+        fileName: context.fileName,
+        srcScheme: getSrcScheme(context.src ?? element.currentSrc ?? element.src),
+        currentTime: Number.isFinite(element.currentTime) ? element.currentTime : null,
+        readyState: element.readyState,
+        networkState: element.networkState,
+        errorCode: mediaError?.code ?? null,
+        errorMessage: getMediaErrorMessage(mediaError),
+      });
+    },
+    [context.fileName, context.mediaKind, context.src, context.surface],
+  );
+
+  return useMemo(
+    () => ({
+      onLoadStart: logMediaEvent,
+      onLoadedMetadata: logMediaEvent,
+      onCanPlay: logMediaEvent,
+      onPlay: logMediaEvent,
+      onPlaying: logMediaEvent,
+      onError: logMediaEvent,
+      onStalled: logMediaEvent,
+      onSuspend: logMediaEvent,
+      onAbort: logMediaEvent,
+      onEmptied: logMediaEvent,
+    }),
+    [logMediaEvent],
+  );
+}

--- a/preload.js
+++ b/preload.js
@@ -223,6 +223,7 @@ const electronAPI = {
   startWatchingDirectory: (args) => ipcRenderer.invoke('start-watching-directory', args),
   stopWatchingDirectory: (args) => ipcRenderer.invoke('stop-watching-directory', args),
   getWatcherStatus: (args) => ipcRenderer.invoke('get-watcher-status', args),
+  logMediaPlaybackEvent: (payload) => ipcRenderer.send('log-media-playback-event', payload),
   onNewImagesDetected: (callback) => {
     const subscription = (event, data) => callback(data);
     ipcRenderer.on('new-images-detected', subscription);

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -7,16 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.16.1] - [Unreleased]
 
-### Improved
+### Added
 
 - **ComfyUI Workflow Actions**: Added richer ComfyUI workflow entry points across the main app, image viewer, grid, and embedded workspace, including workflow action coverage and desktop IPC support for workspace preview behavior.
 - **ComfyUI Workspace Metadata Copying**: Added copy actions for workspace metadata fields and clearer image dimension display in the ComfyUI Workspace context panel.
+- **Media Playback Diagnostics**: Added audio/video playback event diagnostics and imh-media protocol logging to help investigate early Electron Helper crashes on macOS.
+
+### Improved
+
 - **Large Library Performance**: Reduced temporary allocations and queue overhead in large libraries by avoiding `Array.shift()` hot paths, removing intermediate arrays during `Set`/`Map` construction, and optimizing lookup map initialization across store, thumbnail, lineage, and automation flows.
 - **ComfyUI Visual Workflow Performance**: Reworked visual workflow graph depth calculation to avoid recursive stack overflows on long workflows and reduced object iteration overhead for large ComfyUI graphs.
 - **Edited PNG Metadata Preservation**: Improved edited PNG saves so ComfyUI workflow metadata is preserved when image adjustment exports write PNG bytes.
 - **Workspace Bulk Action UX**: Added clearer disabled-state tooltips for ComfyUI Workspace bulk actions so users can tell what selection is required.
 - **Accessibility**: Added missing accessible labels to icon-only controls across the ComfyUI Workspace, directory list, preview/sidebar, image viewer, automation rules, sidebar, and batch export surfaces.
 - **Hotkey Reset Safety**: Added a confirmation dialog before resetting all custom hotkeys.
+- **macOS Media Safe Mode**: Documented the opt-in `IMH_MEDIA_SAFE_MODE=1` launch mode for testing GPU-related media playback crashes without affecting normal launches.
 
 ### Fixed
 
@@ -27,20 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ComfyUI Visual Workflow Upstreams**: Fixed visual workflow handling for missing upstream nodes.
 - **Bulk Delete Shortcut Handling**: Fixed duplicate confirmation dialogs and repeated delete attempts when deleting selected images with the Delete key.
 
-## [0.16.0] - 2026-05-13
+## [0.16.0] - 2026-05-12
 
 ### Added
 
 - **Image Adjustment Editing**: Added an adjustment panel in the Image Modal for brightness, contrast, saturation, and hue, with desktop Save As and Overwrite workflows that export PNG output while preserving generation metadata.
 - **Embedded ComfyUI Workspace**: Added a dedicated ComfyUI Workspace view with an embedded ComfyUI browser, image context panel, workflow metadata tabs, thumbnail navigation, copy/generate actions, and direct open actions from grid/table image contexts.
 - **ComfyUI Queue Detection**: Added optional monitoring for ComfyUI jobs started outside Image MetaHub, showing waiting/processing/done/failed status, progress, output previews, and cancel support in the generation queue.
-- **Release CI**: Added GitHub Actions coverage for test/lint/build validation plus RC artifact builds for macOS and Linux.
 
 ### Improved
 
 - **Large Library Memory Usage**: Reduced OOM risk in large ComfyUI libraries by compacting oversized raw metadata, streaming cache diffing across chunks, using lighter Electron file handles, increasing renderer heap headroom, and avoiding automatic table thumbnails in very large result sets.
 - **Large Library Cache Reconciliation**: Improved startup and manual cache checks for large folders by applying lightweight UI deltas and persisting chunked cache updates without rehydrating the entire library.
-- **ComfyUI Workspace UX**: Improved workspace navigation with library filter scoping, directory selection, selected-image auto-open behavior, metadata view options, timestamp-aware thumbnails, and safer embedded-browser visibility during generation.
 - **Cache Controls**: Clarified cache reset actions and added library cache clearing support from settings.
 - **Trial Migration**: Reset eligible non-Pro trial state for this release so users affected by earlier trial behavior can start fresh.
 - **Accessibility**: Added accessible labels to search, compare zoom controls, reset zoom, and generate variation icon-only controls.

--- a/types.ts
+++ b/types.ts
@@ -339,6 +339,18 @@ export interface ElectronAPI {
   startWatchingDirectory: (args: { directoryId: string; dirPath: string }) => Promise<{ success: boolean; error?: string }>;
   stopWatchingDirectory: (args: { directoryId: string }) => Promise<{ success: boolean }>;
   getWatcherStatus: (args: { directoryId: string }) => Promise<{ success: boolean; active: boolean }>;
+  logMediaPlaybackEvent: (payload: {
+    mediaKind: 'audio' | 'video';
+    surface: string;
+    eventName: string;
+    fileName: string;
+    srcScheme: string | null;
+    currentTime: number | null;
+    readyState: number | null;
+    networkState: number | null;
+    errorCode: number | null;
+    errorMessage: string | null;
+  }) => void;
   onNewImagesDetected: (callback: (data: { directoryId: string; files: Array<{ name: string; path: string; lastModified: number; contentModifiedMs?: number; size: number; type: string; forceReindex?: boolean }> }) => void) => () => void;
   onWatchedFilesRemoved: (callback: (data: WatchedFileRemovalPayload) => void) => () => void;
   onWatcherDebug: (callback: (data: { message: string }) => void) => () => void;


### PR DESCRIPTION
## Summary

- Adds shared audio/video playback event diagnostics for the preview sidebar, image modal, and slideshow surfaces.
- Persists media diagnostics through the existing process-events logging path without storing full media paths.
- Adds imh-media protocol and resolve-media-url diagnostics with basename, extension, MIME type, cheap file size, and error classification.
- Adds opt-in macOS media safe mode via `IMH_MEDIA_SAFE_MODE=1` and documents the direct `.app` binary launch flow.
- Redacts URL/path-like content from media error messages before writing diagnostics.

## Why

Issue #285 reports early Electron Helper crashes on macOS Tahoe 26.5 when playing audio or video with audio. These diagnostics should help distinguish media element failures, custom protocol/file serving issues, child process exits, and GPU/media pipeline problems while keeping the mitigation opt-in for v0.16.1.

## Validation

- `npm run build` passed.
- `npm test` passed once during the implementation pass.
- Later full-suite reruns intermittently timed out only in `__tests__/cli.test.ts` at its 5s `npx tsx cli.ts` startup limit; the isolated CLI test passed immediately afterward with `npx vitest run __tests__/cli.test.ts`.