### PR TITLE
🎨 Palette: Add aria-label to modal Close buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-14 - DirectoryList Icon Buttons Missing ARIA Labels
 **Learning:** Several interactive icon-only buttons in the DirectoryList component (toggle subfolders, refresh, exclude/include, clear selection) lack `aria-label` attributes, affecting screen reader accessibility.
 **Action:** Add descriptive `aria-label` attributes to all icon-only buttons in DirectoryList to ensure they meet the WCAG 2.5.3 Label in Name standard.
+
+## 2026-05-21 - Modal Close Icon Buttons Missing ARIA Labels
+**Learning:** Several modal components (TransferImagesModal, RenameImageModal, ProOnlyModal) lack `aria-label` attributes on their "Close" icon-only buttons, affecting screen reader accessibility. Although they have a `title` attribute, `aria-label` is standard for screen readers.
+**Action:** Always add descriptive `aria-label` attributes to icon-only buttons, especially "Close" buttons in modals, to ensure they meet the WCAG 2.5.3 Label in Name standard.

--- a/components/ProOnlyModal.tsx
+++ b/components/ProOnlyModal.tsx
@@ -160,6 +160,7 @@ const ProOnlyModal: React.FC<ProOnlyModalProps> = ({
             onClick={onClose}
             className="p-2 hover:bg-gray-800 rounded-lg transition-colors"
             title="Close"
+            aria-label="Close pro feature modal"
           >
             <X className="w-5 h-5 text-gray-400" />
           </button>

--- a/components/RenameImageModal.tsx
+++ b/components/RenameImageModal.tsx
@@ -66,6 +66,7 @@ const RenameImageModal: React.FC<RenameImageModalProps> = ({ image, isOpen, onCl
             onClick={onClose}
             className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-800 hover:text-white"
             title="Close"
+            aria-label="Close rename modal"
           >
             <X className="h-4 w-4" />
           </button>

--- a/components/TransferImagesModal.tsx
+++ b/components/TransferImagesModal.tsx
@@ -218,6 +218,7 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
             onClick={onClose}
             className="p-2 hover:bg-gray-800 rounded-lg transition-colors"
             title="Close"
+            aria-label="Close transfer modal"
             disabled={isSubmitting}
           >
             <X className="w-4 h-4 text-gray-400" />


### PR DESCRIPTION
🎨 Palette: Added missing `aria-label`s to modal close buttons

💡 What: Added `aria-label="Close..."` to the icon-only (X) buttons in `TransferImagesModal`, `RenameImageModal`, and `ProOnlyModal`.
🎯 Why: While these buttons had `title` attributes, proper screen reader support requires `aria-label` for icon-only interactive elements.
📸 Before/After: Visual appearance is unchanged.
♿ Accessibility: Improved screen reader navigation for critical modal components.

---
*PR created automatically by Jules for task [12395330301034980572](https://jules.google.com/task/12395330301034980572) started by @LuqP2*