### PR TITLE
Add Image Library Group By separators

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -62,6 +62,7 @@ import { type SettingsFocusSection, type SettingsTab, type SettingsTabInput, res
 import { buildSlideshowPlaylist } from './utils/slideshowPlaylist';
 import { getModelPromptOverlapGroups, type ModelPromptOverlapGroup } from './services/similarImageSearch';
 import { resolveWatchedRemovalIdsForDirectory, type WatchedFilesRemovedPayload } from './utils/watcherRemovalUtils';
+import { groupImages, type ImageGroup, type ImageGroupingSortOrder } from './utils/imageGrouping';
 
 interface OpenImageModalState {
   modalId: string;
@@ -336,6 +337,8 @@ export default function App() {
     setItemsPerPage,
     viewMode,
     toggleViewMode,
+    groupBy,
+    setGroupBy,
     theme,
     setLastViewedVersion,
     globalAutoWatch,
@@ -345,6 +348,7 @@ export default function App() {
 
   // --- Local UI State ---
   const [currentPage, setCurrentPage] = useState(1);
+  const [pendingJumpGroupRequest, setPendingJumpGroupRequest] = useState<{ groupId: string; requestId: number } | null>(null);
   const [searchInputValue, setSearchInputValue] = useState(searchQuery);
   const previousSearchQueryRef = useRef(searchQuery);
   const pendingSearchFlowIdRef = useRef<string | null>(null);
@@ -871,6 +875,12 @@ export default function App() {
 
     return () => unsubscribe();
   }, [directories, excludedFolders, includeSubfolders, processNewWatchedFiles, selectedFolders, sortOrder]);
+
+  useEffect(() => {
+    if (sortOrder === 'random' && groupBy !== 'none') {
+      setGroupBy('none');
+    }
+  }, [groupBy, setGroupBy, sortOrder]);
 
   useEffect(() => {
     if (!window.electronAPI?.onWatchedFilesRemoved) return;
@@ -2145,6 +2155,19 @@ export default function App() {
     },
     [displayImages, currentPage, itemsPerPage]
   );
+  const effectiveLibraryGroupBy = libraryView === 'library' && sortOrder !== 'random' ? groupBy : 'none';
+  const imageGroupingSortOrder = sortOrder as ImageGroupingSortOrder;
+  const currentLibraryGroups = useMemo<ImageGroup[]>(
+    () => effectiveLibraryGroupBy === 'none'
+      ? []
+      : groupImages(paginatedImages, effectiveLibraryGroupBy, { sortOrder: imageGroupingSortOrder }).groups,
+    [effectiveLibraryGroupBy, imageGroupingSortOrder, paginatedImages]
+  );
+
+  useEffect(() => {
+    setPendingJumpGroupRequest(null);
+  }, [currentPage, effectiveLibraryGroupBy, viewMode]);
+
   const totalPages = itemsPerPage === -1
     ? 1
     : Math.ceil(displayImages.length / itemsPerPage);
@@ -2413,6 +2436,8 @@ export default function App() {
           sortOrder={sortOrder}
           onSortOrderChange={imageStoreSetSortOrder}
           onReshuffle={reshuffle}
+          groupBy={sortOrder === 'random' ? 'none' : groupBy}
+          onGroupByChange={setGroupBy}
         >
           <DirectoryList
             directories={safeDirectories}
@@ -2615,6 +2640,9 @@ export default function App() {
                     onStartSlideshow={handleStartSlideshow}
                     slideshowImageCount={slideshowImageCount}
                     slideshowSourceLabel={slideshowSourceLabel}
+                    groups={libraryView === 'library' ? currentLibraryGroups : []}
+                    groupBy={effectiveLibraryGroupBy}
+                    onJumpToGroup={(groupId) => setPendingJumpGroupRequest({ groupId, requestId: Date.now() })}
                   />
                 )}
 
@@ -2636,6 +2664,9 @@ export default function App() {
                           onImageRenamed={handleImageRenamed}
                           onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
                           onOpenComfyUIWorkspace={(image) => openComfyUIWorkflowInWorkspace(image, displayImages)}
+                          groupBy={effectiveLibraryGroupBy}
+                          groupSortOrder={imageGroupingSortOrder}
+                          jumpToGroupRequest={pendingJumpGroupRequest}
                         />
                       ) : (
                         <ImageTable
@@ -2646,6 +2677,9 @@ export default function App() {
                           onImageRenamed={handleImageRenamed}
                           onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
                           onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
+                          groupBy={effectiveLibraryGroupBy}
+                          groupSortOrder={imageGroupingSortOrder}
+                          jumpToGroupRequest={pendingJumpGroupRequest}
                         />
                   )
                 ) : libraryView === 'model' ? (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ComfyUI Workflow Actions**: Added richer ComfyUI workflow entry points across the main app, image viewer, grid, and embedded workspace, including workflow action coverage and desktop IPC support for workspace preview behavior.
 - **ComfyUI Workspace Metadata Copying**: Added copy actions for workspace metadata fields and clearer image dimension display in the ComfyUI Workspace context panel.
+- **Image Library Grouping**: Added Library Group By separators for date, name, and inferred generation sessions, plus Jump To navigation with calendar badges for date/session groups.
 - **Media Playback Diagnostics**: Added audio/video playback event diagnostics and imh-media protocol logging to help investigate early Electron Helper crashes on macOS.
 
 ### Improved

--- a/__tests__/GridToolbar.test.tsx
+++ b/__tests__/GridToolbar.test.tsx
@@ -159,4 +159,84 @@ describe('GridToolbar', () => {
 
     expect(useImageStore.getState().selectedImages).toEqual(new Set());
   });
+
+  it('opens jump menu and jumps to the selected group', async () => {
+    const onJumpToGroup = vi.fn();
+
+    render(
+      <GridToolbar
+        selectedImages={new Set()}
+        images={[]}
+        directories={[]}
+        filteredImageActionCount={0}
+        onDeleteSelected={vi.fn()}
+        onGenerateA1111={vi.fn()}
+        onGenerateComfyUI={vi.fn()}
+        onCompare={vi.fn()}
+        onBatchExport={vi.fn()}
+        onStartSlideshow={vi.fn()}
+        slideshowImageCount={0}
+        groups={[
+          { id: 'session-1', label: 'May 21, 09:00-09:30', count: 4, startImageId: 'img-1' },
+          { id: 'session-2', label: 'May 21, 14:00-14:15', count: 2, startImageId: 'img-5' },
+        ]}
+        onJumpToGroup={onJumpToGroup}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Jump to group' }));
+    fireEvent.change(screen.getByPlaceholderText('Find group...'), { target: { value: '14:00' } });
+    fireEvent.click(await screen.findByText('May 21, 14:00-14:15'));
+
+    expect(onJumpToGroup).toHaveBeenCalledWith('session-2');
+  });
+
+  it('uses a calendar jump menu for session groups and marks session counts by day', async () => {
+    const onJumpToGroup = vi.fn();
+
+    render(
+      <GridToolbar
+        selectedImages={new Set()}
+        images={[]}
+        directories={[]}
+        filteredImageActionCount={0}
+        onDeleteSelected={vi.fn()}
+        onGenerateA1111={vi.fn()}
+        onGenerateComfyUI={vi.fn()}
+        onCompare={vi.fn()}
+        onBatchExport={vi.fn()}
+        onStartSlideshow={vi.fn()}
+        slideshowImageCount={0}
+        groupBy="session"
+        groups={[
+          {
+            id: 'session-1',
+            label: 'May 21, 09:00-09:30',
+            count: 4,
+            startImageId: 'img-1',
+            dateKey: '2026-05-21',
+            startTime: new Date(2026, 4, 21, 9, 0).getTime(),
+          },
+          {
+            id: 'session-2',
+            label: 'May 21, 14:00-14:15',
+            count: 2,
+            startImageId: 'img-5',
+            dateKey: '2026-05-21',
+            startTime: new Date(2026, 4, 21, 14, 0).getTime(),
+          },
+        ]}
+        onJumpToGroup={onJumpToGroup}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Jump to group' }));
+
+    expect(screen.getByText(/2026/)).toBeTruthy();
+    expect(screen.getByTitle('2 sessions')).toBeTruthy();
+
+    fireEvent.click(await screen.findByText('May 21, 14:00-14:15'));
+
+    expect(onJumpToGroup).toHaveBeenCalledWith('session-2');
+  });
 });

--- a/__tests__/imageGrouping.test.ts
+++ b/__tests__/imageGrouping.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { IndexedImage } from '../types';
+import { groupImages } from '../utils/imageGrouping';
+
+const makeImage = (id: string, name: string, lastModified: number, models: string[] = []): IndexedImage => ({
+  id,
+  name,
+  handle: { name } as FileSystemFileHandle,
+  metadata: {},
+  metadataString: '',
+  lastModified,
+  models,
+  loras: [],
+  scheduler: '',
+});
+
+describe('imageGrouping', () => {
+  it('groups images by local date while preserving incoming order', () => {
+    const firstDay = new Date(2026, 4, 20, 18, 30).getTime();
+    const nextDay = new Date(2026, 4, 21, 9, 15).getTime();
+
+    const result = groupImages([
+      makeImage('a', 'a.png', firstDay),
+      makeImage('b', 'b.png', firstDay + 1000),
+      makeImage('c', 'c.png', nextDay),
+    ], 'date');
+
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups.map((group) => group.count)).toEqual([2, 1]);
+    expect(result.items.map((item) => item.type === 'group-header' ? item.group.id : item.image.id)).toEqual([
+      'date-2026-05-20',
+      'a',
+      'b',
+      'date-2026-05-21',
+      'c',
+    ]);
+  });
+
+  it('groups names by first normalized letter and puts numeric or symbol names under #', () => {
+    const result = groupImages([
+      makeImage('a', 'apple.png', 1),
+      makeImage('b', 'Banana.png', 2),
+      makeImage('c', '2-cats.png', 3),
+      makeImage('d', '_draft.png', 4),
+    ], 'name');
+
+    expect(result.groups.map((group) => group.label)).toEqual(['A', 'B', '#']);
+    expect(result.groups.map((group) => group.count)).toEqual([1, 1, 2]);
+  });
+
+  it('splits sessions after gaps greater than 45 minutes', () => {
+    const base = new Date(2026, 4, 21, 9, 0).getTime();
+    const minute = 60 * 1000;
+
+    const result = groupImages([
+      makeImage('first-a', 'first-a.png', base, ['model-a']),
+      makeImage('first-b', 'first-b.png', base + 10 * minute, ['model-a']),
+      makeImage('second-a', 'second-a.png', base + 60 * minute, ['model-b']),
+      makeImage('third-a', 'third-a.png', base + 150 * minute, ['model-c']),
+    ], 'session', { sortOrder: 'date-asc' });
+
+    expect(result.groups).toHaveLength(3);
+    expect(result.groups.map((group) => group.count)).toEqual([2, 1, 1]);
+    expect(result.groups[0].startImageId).toBe('first-a');
+    expect(result.groups[0].subtitle).toBe('Dominant model: model-a');
+  });
+
+  it('keeps stable session group ids for the same filtered input', () => {
+    const base = new Date(2026, 4, 21, 9, 0).getTime();
+    const images = [
+      makeImage('a', 'a.png', base),
+      makeImage('b', 'b.png', base + 5 * 60 * 1000),
+    ];
+
+    expect(groupImages(images, 'session').groups.map((group) => group.id)).toEqual(
+      groupImages(images, 'session').groups.map((group) => group.id),
+    );
+  });
+
+  it('orders sessions from the explicit sort order instead of endpoint timestamps', () => {
+    const base = new Date(2026, 4, 21, 9, 0).getTime();
+    const minute = 60 * 1000;
+    const nameSortedImages = [
+      makeImage('middle', 'alpha.png', base + 90 * minute),
+      makeImage('newest', 'beta.png', base + 180 * minute),
+      makeImage('oldest', 'zeta.png', base),
+    ];
+
+    expect(groupImages(nameSortedImages, 'session', { sortOrder: 'date-asc' }).groups.map((group) => group.startImageId)).toEqual([
+      'oldest',
+      'middle',
+      'newest',
+    ]);
+    expect(groupImages(nameSortedImages, 'session', { sortOrder: 'asc' }).groups.map((group) => group.startImageId)).toEqual([
+      'newest',
+      'middle',
+      'oldest',
+    ]);
+  });
+});

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -8,12 +8,15 @@ import {
   Sparkles,
   Trash2,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   Tag,
   RefreshCw,
   Plus,
   Play,
   Workflow,
-  X
+  X,
+  Search
 } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
@@ -24,6 +27,7 @@ import ActiveFilters from './ActiveFilters';
 import TagManagerModal from './TagManagerModal';
 import { useReparseMetadata } from '../hooks/useReparseMetadata';
 import Tooltip from './Tooltip';
+import type { ImageGroup, ImageGroupByMode } from '../utils/imageGrouping';
 
 const OPEN_BATCH_EXPORT_EVENT = 'imagemetahub:open-batch-export';
 
@@ -44,7 +48,30 @@ interface GridToolbarProps {
   onStartSlideshow: () => void;
   slideshowImageCount: number;
   slideshowSourceLabel?: string;
+  groups?: ImageGroup[];
+  groupBy?: ImageGroupByMode;
+  onJumpToGroup?: (groupId: string) => void;
 }
+
+const formatCalendarDateKey = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const getGroupDateKey = (group: ImageGroup): string | null => {
+  if (group.dateKey) {
+    return group.dateKey;
+  }
+  if (typeof group.startTime === 'number') {
+    return formatCalendarDateKey(new Date(group.startTime));
+  }
+  return null;
+};
+
+const sameCalendarMonth = (left: Date, right: Date): boolean =>
+  left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth();
 
 const showNotification = (message: string, type: 'success' | 'error' = 'success') => {
   const notification = document.createElement('div');
@@ -74,13 +101,21 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   onStartSlideshow,
   slideshowImageCount,
   slideshowSourceLabel = 'current view',
+  groups = [],
+  groupBy = 'none',
+  onJumpToGroup,
 }) => {
   const [generateDropdownOpen, setGenerateDropdownOpen] = useState(false);
   const [isCollectionActionsOpen, setIsCollectionActionsOpen] = useState(false);
   const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
+  const [isJumpMenuOpen, setIsJumpMenuOpen] = useState(false);
+  const [jumpQuery, setJumpQuery] = useState('');
+  const [selectedJumpDateKey, setSelectedJumpDateKey] = useState<string | null>(null);
+  const [jumpCalendarMonth, setJumpCalendarMonth] = useState(() => new Date());
   const [isTagModalOpen, setIsTagModalOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const collectionActionsRef = useRef<HTMLDivElement>(null);
+  const jumpMenuRef = useRef<HTMLDivElement>(null);
   const bulkToggleFavorite = useImageStore((state) => state.bulkToggleFavorite);
   const clearImageSelection = useImageStore((state) => state.clearImageSelection);
   const collections = useImageStore((state) => state.collections);
@@ -116,6 +151,9 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       if (collectionActionsRef.current && !collectionActionsRef.current.contains(event.target as Node)) {
         setIsCollectionActionsOpen(false);
         setIsAddToCollectionSubmenuOpen(false);
+      }
+      if (jumpMenuRef.current && !jumpMenuRef.current.contains(event.target as Node)) {
+        setIsJumpMenuOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
@@ -252,6 +290,67 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   const canUseFilteredCollectionActions =
     filteredImageActionCount > 0 &&
     (Boolean(onCreateCollectionFromFiltered) || Boolean(onAddCurrentFilteredToCollection));
+  const canJumpToGroups = groups.length > 0 && Boolean(onJumpToGroup);
+  const useCalendarJump = groupBy === 'date' || groupBy === 'session';
+  const groupsByDate = useMemo(() => {
+    const next = new Map<string, ImageGroup[]>();
+    for (const group of groups) {
+      const key = getGroupDateKey(group);
+      if (!key) {
+        continue;
+      }
+      const dateGroups = next.get(key) ?? [];
+      dateGroups.push(group);
+      next.set(key, dateGroups);
+    }
+    return next;
+  }, [groups]);
+  const calendarDateKeys = useMemo(() => Array.from(groupsByDate.keys()).sort(), [groupsByDate]);
+  const activeJumpDateKey = selectedJumpDateKey && groupsByDate.has(selectedJumpDateKey)
+    ? selectedJumpDateKey
+    : calendarDateKeys[0] ?? null;
+  const calendarGroups = activeJumpDateKey ? groupsByDate.get(activeJumpDateKey) ?? [] : [];
+  const calendarMonthDays = useMemo(() => {
+    const monthStart = new Date(jumpCalendarMonth.getFullYear(), jumpCalendarMonth.getMonth(), 1);
+    const gridStart = new Date(monthStart);
+    gridStart.setDate(monthStart.getDate() - monthStart.getDay());
+
+    return Array.from({ length: 42 }, (_, index) => {
+      const date = new Date(gridStart);
+      date.setDate(gridStart.getDate() + index);
+      return date;
+    });
+  }, [jumpCalendarMonth]);
+  const visibleJumpGroups = useMemo(() => {
+    const normalizedQuery = jumpQuery.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return groups;
+    }
+
+    return groups.filter((group) =>
+      `${group.label} ${group.subtitle ?? ''}`.toLowerCase().includes(normalizedQuery)
+    );
+  }, [groups, jumpQuery]);
+
+  useEffect(() => {
+    if (!isJumpMenuOpen || !useCalendarJump || calendarDateKeys.length === 0) {
+      return;
+    }
+
+    const targetKey = activeJumpDateKey ?? calendarDateKeys[0];
+    if (!targetKey) {
+      return;
+    }
+
+    const [year, monthIndex, day] = targetKey.split('-').map(Number);
+    const targetDate = new Date(year, monthIndex - 1, day || 1);
+    if (!sameCalendarMonth(jumpCalendarMonth, targetDate)) {
+      setJumpCalendarMonth(targetDate);
+    }
+    if (selectedJumpDateKey !== targetKey) {
+      setSelectedJumpDateKey(targetKey);
+    }
+  }, [activeJumpDateKey, calendarDateKeys, isJumpMenuOpen, jumpCalendarMonth, selectedJumpDateKey, useCalendarJump]);
 
   const hasActiveFilters = 
       selectedModels.length > 0 ||
@@ -275,7 +374,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       selectedRatings.length > 0 ||
       (advancedFilters && Object.keys(advancedFilters).length > 0);
 
-  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions && slideshowImageCount === 0) {
+  if (selectedCount === 0 && !hasActiveFilters && !canUseFilteredCollectionActions && slideshowImageCount === 0 && !canJumpToGroups) {
     return null;
   }
 
@@ -562,6 +661,158 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                   )}
                 </div>
                 {hasActiveFilters && <div className="w-px h-6 bg-gray-600 mx-2 flex-shrink-0" />}
+              </>
+            )}
+
+            {canJumpToGroups && (
+              <>
+                {(selectedCount > 0 || canUseFilteredCollectionActions || slideshowImageCount > 0) && (
+                  <div className="w-px h-4 bg-gray-700 mx-1" />
+                )}
+                <div className="relative" ref={jumpMenuRef}>
+                  <Tooltip label="Jump to group">
+                    <button
+                      onClick={() => setIsJumpMenuOpen((open) => !open)}
+                      className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors flex items-center gap-0.5"
+                      title="Jump to group"
+                      aria-label="Jump to group"
+                    >
+                      <Search className="w-4 h-4" />
+                      <ChevronDown className="w-3 h-3" />
+                    </button>
+                  </Tooltip>
+
+                  {isJumpMenuOpen && (
+                    <div className="absolute left-0 top-full mt-1 w-72 rounded-lg border border-gray-700 bg-gray-800 p-2 shadow-xl z-50">
+                      {useCalendarJump ? (
+                        <>
+                          <div className="mb-2 flex items-center justify-between">
+                            <button
+                              onClick={() => setJumpCalendarMonth((date) => new Date(date.getFullYear(), date.getMonth() - 1, 1))}
+                              className="rounded p-1 text-gray-400 hover:bg-gray-700 hover:text-white"
+                              aria-label="Previous month"
+                            >
+                              <ChevronLeft className="h-4 w-4" />
+                            </button>
+                            <div className="text-sm font-medium text-gray-200">
+                              {jumpCalendarMonth.toLocaleDateString(undefined, { month: 'long', year: 'numeric' })}
+                            </div>
+                            <button
+                              onClick={() => setJumpCalendarMonth((date) => new Date(date.getFullYear(), date.getMonth() + 1, 1))}
+                              className="rounded p-1 text-gray-400 hover:bg-gray-700 hover:text-white"
+                              aria-label="Next month"
+                            >
+                              <ChevronRight className="h-4 w-4" />
+                            </button>
+                          </div>
+
+                          <div className="mb-2 grid grid-cols-7 gap-1 text-center text-[10px] uppercase text-gray-500">
+                            {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, index) => (
+                              <div key={`${day}-${index}`}>{day}</div>
+                            ))}
+                          </div>
+
+                          <div className="grid grid-cols-7 gap-1">
+                            {calendarMonthDays.map((date) => {
+                              const dateKey = formatCalendarDateKey(date);
+                              const dateGroups = groupsByDate.get(dateKey) ?? [];
+                              const markerCount = groupBy === 'session'
+                                ? dateGroups.length
+                                : dateGroups.reduce((total, group) => total + group.count, 0);
+                              const isSelected = dateKey === activeJumpDateKey;
+                              const inMonth = sameCalendarMonth(date, jumpCalendarMonth);
+
+                              return (
+                                <button
+                                  key={dateKey}
+                                  onClick={() => markerCount > 0 && setSelectedJumpDateKey(dateKey)}
+                                  disabled={markerCount === 0}
+                                  className={`relative h-8 rounded-md text-xs transition-colors ${
+                                    isSelected
+                                      ? 'bg-blue-600 text-white'
+                                      : markerCount > 0
+                                      ? 'bg-gray-700 text-gray-100 hover:bg-gray-600'
+                                      : 'text-gray-600'
+                                  } ${inMonth ? '' : 'opacity-40'}`}
+                                  title={markerCount > 0 ? `${markerCount} ${groupBy === 'session' ? 'session' : 'image'}${markerCount === 1 ? '' : 's'}` : undefined}
+                                >
+                                  {date.getDate()}
+                                  {markerCount > 0 && (
+                                    <span className={`absolute -right-1 -top-1 min-w-[16px] rounded-full px-1 text-[10px] leading-4 ${
+                                      isSelected ? 'bg-white text-blue-700' : 'bg-blue-500 text-white'
+                                    }`}>
+                                      {markerCount}
+                                    </span>
+                                  )}
+                                </button>
+                              );
+                            })}
+                          </div>
+
+                          <div className="mt-3 max-h-52 overflow-y-auto border-t border-gray-700 pt-2">
+                            {calendarGroups.length === 0 ? (
+                              <div className="px-2 py-3 text-sm text-gray-500">No groups on this day</div>
+                            ) : (
+                              calendarGroups.map((group) => (
+                                <button
+                                  key={group.id}
+                                  onClick={() => {
+                                    onJumpToGroup?.(group.id);
+                                    setIsJumpMenuOpen(false);
+                                  }}
+                                  className="flex w-full items-start justify-between gap-3 rounded-md px-2 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                                >
+                                  <span className="min-w-0">
+                                    <span className="block truncate font-medium">{group.label}</span>
+                                    {group.subtitle && (
+                                      <span className="block truncate text-xs text-gray-400">{group.subtitle}</span>
+                                    )}
+                                  </span>
+                                  <span className="shrink-0 rounded bg-gray-700 px-1.5 py-0.5 text-xs text-gray-300">{group.count}</span>
+                                </button>
+                              ))
+                            )}
+                          </div>
+                        </>
+                      ) : (
+                        <>
+                          <input
+                            value={jumpQuery}
+                            onChange={(event) => setJumpQuery(event.target.value)}
+                            placeholder="Find group..."
+                            className="mb-2 w-full rounded-md border border-gray-600 bg-gray-900 px-2 py-1.5 text-sm text-gray-200 placeholder:text-gray-500 focus:border-blue-500 focus:outline-none"
+                            autoFocus
+                          />
+                          <div className="max-h-72 overflow-y-auto">
+                            {visibleJumpGroups.length === 0 ? (
+                              <div className="px-2 py-3 text-sm text-gray-500">No matching groups</div>
+                            ) : (
+                              visibleJumpGroups.map((group) => (
+                                <button
+                                  key={group.id}
+                                  onClick={() => {
+                                    onJumpToGroup?.(group.id);
+                                    setIsJumpMenuOpen(false);
+                                    setJumpQuery('');
+                                  }}
+                                  className="flex w-full items-start justify-between gap-3 rounded-md px-2 py-2 text-left text-sm text-gray-200 transition-colors hover:bg-gray-700 hover:text-white"
+                                >
+                                  <span className="min-w-0">
+                                    <span className="block truncate font-medium">{group.label}</span>
+                                    {group.subtitle && (
+                                      <span className="block truncate text-xs text-gray-400">{group.subtitle}</span>
+                                    )}
+                                  </span>
+                                  <span className="shrink-0 rounded bg-gray-700 px-1.5 py-0.5 text-xs text-gray-300">{group.count}</span>
+                                </button>
+                              ))
+                            )}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
               </>
             )}
 

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1,4 +1,4 @@
-import { FixedSizeGrid as Grid, GridChildComponentProps, areEqual } from 'react-window';
+import { VariableSizeGrid as Grid, GridChildComponentProps, areEqual } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
@@ -41,6 +41,7 @@ import { thumbnailManager } from '../services/thumbnailManager';
 import { getContextMenuRatingTargetIds } from '../utils/ratingSelection';
 import { getRenameBasename, renameIndexedImage } from '../services/imageRenameService';
 import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
+import { groupImages, type ImageGroup, type ImageGroupByMode, type ImageGroupingSortOrder } from '../utils/imageGrouping';
 import {
   beginPerformanceFlow,
   createProfilerOnRender,
@@ -136,8 +137,11 @@ const abbreviatePathForDisplay = (relativePath: string): string => {
 const getWarmupImage = (item: IndexedImage | ImageStack): IndexedImage =>
   isImageStack(item) ? item.coverImage : item;
 
+const isImageRenderItem = (item: GridRenderItem): item is IndexedImage | ImageStack =>
+  !('type' in item);
+
 const collectWarmupImages = (
-  items: (IndexedImage | ImageStack)[],
+  items: GridRenderItem[],
   startIndex: number,
   endIndex: number
 ): IndexedImage[] => {
@@ -150,7 +154,10 @@ const collectWarmupImages = (
   const images: IndexedImage[] = [];
 
   for (let index = safeStart; index <= safeEnd; index++) {
-    images.push(getWarmupImage(items[index]));
+    const item = items[index];
+    if (isImageRenderItem(item)) {
+      images.push(getWarmupImage(item));
+    }
   }
 
   return images;
@@ -709,6 +716,7 @@ function isImageStack(item: IndexedImage | ImageStack): item is ImageStack {
 }
 
 const GAP_SIZE = 16;
+const GROUP_HEADER_HEIGHT = 52;
 const ITEM_HEIGHT_RATIO = 1.0;
 const CARD_HEIGHT_RATIO = 1.2;
 const FILENAME_HEIGHT = 40;
@@ -722,7 +730,7 @@ const clampIndex = (index: number, itemCount: number): number =>
 const KEYBOARD_NAVIGATION_KEYS = ['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'];
 
 interface CellData {
-  items: (IndexedImage | ImageStack)[];
+  items: GridRenderItem[];
   columnCount: number;
   onImageClick: (image: IndexedImage, event: React.MouseEvent) => void;
   onStackClick: (stack: ImageStack) => void;
@@ -743,6 +751,123 @@ interface CellData {
   blurSensitiveImages?: boolean;
   toggleImageSelection: (imageId: string, multiSelect: boolean) => void;
 }
+
+type GridRenderItem =
+  | IndexedImage
+  | ImageStack
+  | { type: 'group-header'; group: ImageGroup }
+  | { type: 'group-spacer'; groupId: string; index: number };
+
+const GroupHeader: React.FC<{ group: ImageGroup }> = ({ group }) => (
+  <div
+    className="flex h-full w-full items-center justify-between gap-3 border-y border-gray-700/70 bg-gray-900/95 px-5 text-gray-200"
+    data-group-id={group.id}
+  >
+    <div className="min-w-0">
+      <div className="truncate text-sm font-semibold">{group.label}</div>
+      {group.subtitle && <div className="truncate text-xs text-gray-500">{group.subtitle}</div>}
+    </div>
+    <div className="shrink-0 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-xs text-gray-400">
+      {group.count} item{group.count === 1 ? '' : 's'}
+    </div>
+  </div>
+);
+
+const expandGroupedItemsForColumns = (items: GridRenderItem[], columnCount: number): GridRenderItem[] => {
+  if (columnCount <= 1) {
+    return items;
+  }
+
+  const expanded: GridRenderItem[] = [];
+  for (const item of items) {
+    if (!isImageRenderItem(item) && item.type === 'group-header') {
+      const remainder = expanded.length % columnCount;
+      if (remainder !== 0) {
+        for (let index = remainder; index < columnCount; index += 1) {
+          expanded.push({ type: 'group-spacer', groupId: `${item.group.id}-pre`, index });
+        }
+      }
+    }
+
+    expanded.push(item);
+    if (!isImageRenderItem(item) && item.type === 'group-header') {
+      for (let index = 1; index < columnCount; index += 1) {
+        expanded.push({ type: 'group-spacer', groupId: item.group.id, index });
+      }
+    }
+  }
+  return expanded;
+};
+
+const getVirtualRowHeight = (
+  items: GridRenderItem[],
+  rowIndex: number,
+  columnCount: number,
+  imageSize: number,
+  showFilenames: boolean,
+): number => {
+  const rowStartIndex = rowIndex * columnCount;
+  const rowFirstItem = items[rowStartIndex];
+  return rowFirstItem && !isImageRenderItem(rowFirstItem) && rowFirstItem.type === 'group-header'
+    ? GROUP_HEADER_HEIGHT
+    : getItemHeight(imageSize, showFilenames) + GAP_SIZE;
+};
+
+const getVirtualRowTop = (
+  items: GridRenderItem[],
+  targetRowIndex: number,
+  columnCount: number,
+  imageSize: number,
+  showFilenames: boolean,
+): number => {
+  let top = 0;
+  for (let rowIndex = 0; rowIndex < targetRowIndex; rowIndex += 1) {
+    top += getVirtualRowHeight(items, rowIndex, columnCount, imageSize, showFilenames);
+  }
+  return top;
+};
+
+const getVirtualRowAtOffset = (
+  items: GridRenderItem[],
+  offset: number,
+  columnCount: number,
+  imageSize: number,
+  showFilenames: boolean,
+): number => {
+  const rowCount = Math.max(1, Math.ceil(items.length / columnCount));
+  let top = 0;
+
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+    const rowHeight = getVirtualRowHeight(items, rowIndex, columnCount, imageSize, showFilenames);
+    const bottom = top + rowHeight;
+    if (offset < bottom) {
+      return rowIndex;
+    }
+    top = bottom;
+  }
+
+  return rowCount - 1;
+};
+
+const getVirtualPageTargetIndex = (
+  items: GridRenderItem[],
+  currentIndex: number,
+  direction: 1 | -1,
+  viewportHeight: number,
+  columnCount: number,
+  imageSize: number,
+  showFilenames: boolean,
+): number => {
+  const currentRow = currentIndex >= 0 ? Math.floor(currentIndex / columnCount) : direction > 0 ? 0 : Math.max(0, Math.ceil(items.length / columnCount) - 1);
+  const currentColumn = currentIndex >= 0 ? currentIndex % columnCount : 0;
+  const currentTop = getVirtualRowTop(items, currentRow, columnCount, imageSize, showFilenames);
+  const targetOffset = direction > 0
+    ? currentTop + viewportHeight
+    : Math.max(0, currentTop - viewportHeight);
+  const targetRow = getVirtualRowAtOffset(items, targetOffset, columnCount, imageSize, showFilenames);
+
+  return clampIndex((targetRow * columnCount) + currentColumn, items.length);
+};
 
 const Cell = React.memo(({ columnIndex, rowIndex, style, data }: GridChildComponentProps<CellData>) => {
   const {
@@ -775,6 +900,29 @@ const Cell = React.memo(({ columnIndex, rowIndex, style, data }: GridChildCompon
   }
 
   const item = items[index];
+
+  if (!isImageRenderItem(item)) {
+    if (item.type === 'group-spacer') {
+      return <div style={style} />;
+    }
+
+    if (columnIndex !== 0) {
+      return <div style={style} />;
+    }
+
+    return (
+      <div
+        style={{
+          ...style,
+          left: 0,
+          width: '100%',
+          height: GROUP_HEADER_HEIGHT,
+        }}
+      >
+        <GroupHeader group={item.group} />
+      </div>
+    );
+  }
 
   if (isImageStack(item)) {
     const isSensitive = enableSafeMode &&
@@ -886,6 +1034,9 @@ interface ImageGridProps {
   onOpenComfyUIWorkspace?: (image: IndexedImage) => void;
   markedBestIds?: Set<string>;      // IDs of images marked as best
   markedArchivedIds?: Set<string>;  // IDs of images marked for archive
+  groupBy?: ImageGroupByMode;
+  groupSortOrder?: ImageGroupingSortOrder;
+  jumpToGroupRequest?: { groupId: string; requestId: number } | null;
 }
 
 const InnerGridElement = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => (
@@ -907,6 +1058,9 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   onOpenComfyUIWorkspace,
   markedBestIds,
   markedArchivedIds,
+  groupBy = 'none',
+  groupSortOrder = 'date-desc',
+  jumpToGroupRequest = null,
 }) => {
   const imageSize = useSettingsStore((state) => state.imageSize);
   const itemsPerPage = useSettingsStore((state) => state.itemsPerPage);
@@ -917,7 +1071,22 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const setViewingStackPrompt = useImageStore((state) => state.setViewingStackPrompt);
   const setSearchQuery = useImageStore((state) => state.setSearchQuery);
   const { stackedItems } = useImageStacking(images, isStackingEnabled);
-  const itemsToRender = isStackingEnabled ? stackedItems : images;
+  const effectiveGroupBy = !isStackingEnabled ? groupBy : 'none';
+  const groupedImages = useMemo(
+    () => groupImages(images, effectiveGroupBy, { sortOrder: groupSortOrder }),
+    [effectiveGroupBy, groupSortOrder, images]
+  );
+  const itemsToRender: GridRenderItem[] = useMemo(() => {
+    if (isStackingEnabled) {
+      return stackedItems;
+    }
+
+    if (effectiveGroupBy === 'none') {
+      return images;
+    }
+
+    return groupedImages.items.map((item) => item.type === 'group-header' ? item : item.image);
+  }, [effectiveGroupBy, groupedImages.items, images, isStackingEnabled, stackedItems]);
   const isInfinite = itemsPerPage === -1;
   const gridScopeRef = useRef<HTMLDivElement>(null);
   const gridScrollRef = useRef<HTMLDivElement>(null);
@@ -1025,7 +1194,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     return Math.max(1, measuredColumnCount || columnCountRef.current || 1);
   }, [imageSize, isInfinite]);
 
-  const getRenderedIndexForImageIndex = useCallback((imageIndex: number | null): number => {
+  const getRenderedIndexInItems = useCallback((imageIndex: number | null, renderItems: GridRenderItem[]): number => {
     if (imageIndex == null || imageIndex < 0) {
       return -1;
     }
@@ -1035,17 +1204,38 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       return -1;
     }
 
-    return itemsToRender.findIndex((item) =>
-      isImageStack(item)
+    return renderItems.findIndex((item) =>
+      isImageRenderItem(item) && (isImageStack(item)
         ? item.images.some((stackImage) => stackImage.id === focusedImage.id)
-        : item.id === focusedImage.id
+        : item.id === focusedImage.id)
     );
-  }, [images, itemsToRender]);
+  }, [images]);
 
   const getImageIndexForRenderedItem = useCallback((item: IndexedImage | ImageStack): number => {
     const itemImage = getWarmupImage(item);
     return images.findIndex((image) => image.id === itemImage.id);
   }, [images]);
+
+  const resolveImageRenderItem = useCallback((
+    renderItems: GridRenderItem[],
+    startIndex: number,
+    direction: 1 | -1,
+  ): { item: IndexedImage | ImageStack; index: number } | null => {
+    if (renderItems.length === 0) {
+      return null;
+    }
+
+    let index = clampIndex(startIndex, renderItems.length);
+    while (index >= 0 && index < renderItems.length) {
+      const item = renderItems[index];
+      if (item && isImageRenderItem(item)) {
+        return { item, index };
+      }
+      index += direction;
+    }
+
+    return null;
+  }, []);
 
   useEffect(() => {
     focusedImageIndexRef.current = focusedImageIndex;
@@ -1446,23 +1636,35 @@ const ImageGrid: React.FC<ImageGridProps> = ({
 
       if (isInfinite) {
         const columnCount = columnCountRef.current;
+        const virtualItems = expandGroupedItemsForColumns(itemsToRender, columnCount);
         const colWidth = imageSize + GAP_SIZE;
         const itemHeight = getItemHeight(imageSize, showFilenameArea);
-        const rowHeight = itemHeight + GAP_SIZE;
-
-        const minRow = Math.max(0, Math.floor((box.top - GAP_SIZE) / rowHeight));
-        const maxRow = Math.floor((box.bottom - GAP_SIZE) / rowHeight);
+        const rowCount = Math.ceil(virtualItems.length / columnCount);
+        let currentRowTop = 0;
         
         const minCol = Math.max(0, Math.floor((box.left - GAP_SIZE) / colWidth));
         const maxCol = Math.min(columnCount - 1, Math.floor((box.right - GAP_SIZE) / colWidth));
 
-        for (let r = minRow; r <= maxRow; r++) {
+        for (let r = 0; r < rowCount; r++) {
+            const rowHeight = getVirtualRowHeight(virtualItems, r, columnCount, imageSize, showFilenameArea);
+            const rowBottom = currentRowTop + rowHeight;
+            if (rowBottom < box.top) {
+              currentRowTop = rowBottom;
+              continue;
+            }
+            if (currentRowTop > box.bottom) {
+              break;
+            }
+
             for (let c = minCol; c <= maxCol; c++) {
                 const index = r * columnCount + c;
-                if (index >= 0 && index < itemsToRender.length) {
-                    const item = itemsToRender[index];
+                if (index >= 0 && index < virtualItems.length) {
+                    const item = virtualItems[index];
+                    if (!isImageRenderItem(item)) {
+                      continue;
+                    }
                     const itemLeft = c * colWidth + GAP_SIZE;
-                    const itemTop = r * rowHeight + GAP_SIZE;
+                    const itemTop = currentRowTop + GAP_SIZE;
                     const itemRight = itemLeft + imageSize;
                     const itemBottom = itemTop + itemHeight;
 
@@ -1478,6 +1680,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                     }
                 }
             }
+            currentRowTop = rowBottom;
         }
       } else {
         imageCardsRef.current.forEach((element, imageId) => {
@@ -1568,17 +1771,17 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       if (KEYBOARD_NAVIGATION_KEYS.includes(e.key)) {
         e.preventDefault();
 
-        const itemCount = itemsToRender.length;
+        const columnCount = getActiveColumnCount();
+        const keyboardItems = expandGroupedItemsForColumns(itemsToRender, columnCount);
+        const itemCount = keyboardItems.length;
         if (itemCount === 0) {
           return;
         }
 
-        const currentRenderedIndex = getRenderedIndexForImageIndex(focusedImageIndexRef.current);
+        const currentRenderedIndex = getRenderedIndexInItems(focusedImageIndexRef.current, keyboardItems);
         let nextRenderedIndex = 0;
 
         if (currentRenderedIndex >= 0) {
-          const columnCount = getActiveColumnCount();
-
           if (!isInfinite && e.key === 'ArrowRight' && currentRenderedIndex >= itemCount - 1) {
             if (currentPage < totalPages) {
               pendingKeyboardPreviewRef.current = null;
@@ -1616,14 +1819,15 @@ const ImageGrid: React.FC<ImageGridProps> = ({
           }
         }
 
-        const resolvedRenderedIndex = clampIndex(nextRenderedIndex, itemCount);
-        const nextItem = itemsToRender[resolvedRenderedIndex];
-        const previewTarget: IndexedImage | undefined = nextItem
-          ? isImageStack(nextItem)
-            ? nextItem.coverImage
-            : nextItem
+        const movementDirection: 1 | -1 =
+          e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'End' ? -1 : 1;
+        const resolvedRenderItem = resolveImageRenderItem(keyboardItems, nextRenderedIndex, movementDirection);
+        const previewTarget: IndexedImage | undefined = resolvedRenderItem
+          ? isImageStack(resolvedRenderItem.item)
+            ? resolvedRenderItem.item.coverImage
+            : resolvedRenderItem.item
           : undefined;
-        const resolvedImageIndex = nextItem ? getImageIndexForRenderedItem(nextItem) : -1;
+        const resolvedImageIndex = resolvedRenderItem ? getImageIndexForRenderedItem(resolvedRenderItem.item) : -1;
 
         if (previewTarget && resolvedImageIndex >= 0) {
           focusedImageIndexRef.current = resolvedImageIndex;
@@ -1637,24 +1841,20 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         }
       } else if (e.key === 'PageDown') {
         e.preventDefault();
-        const itemCount = itemsToRender.length;
+        const columnCount = getActiveColumnCount();
+        const keyboardItems = expandGroupedItemsForColumns(itemsToRender, columnCount);
+        const itemCount = keyboardItems.length;
         if (isInfinite && itemCount > 0) {
-          const columnCount = getActiveColumnCount();
-          const rowHeight = getItemHeight(imageSize, showFilenameArea) + GAP_SIZE;
-          const viewportHeight = getGridScrollElement()?.clientHeight ?? rowHeight;
-          const visibleRows = Math.max(1, Math.floor(viewportHeight / rowHeight));
-          const currentRenderedIndex = getRenderedIndexForImageIndex(focusedImageIndexRef.current);
-          const nextRenderedIndex = clampIndex(
-            (currentRenderedIndex >= 0 ? currentRenderedIndex : 0) + (columnCount * visibleRows),
-            itemCount,
-          );
-          const nextItem = itemsToRender[nextRenderedIndex];
-          const previewTarget = nextItem
-            ? isImageStack(nextItem)
-              ? nextItem.coverImage
-              : nextItem
+          const viewportHeight = getGridScrollElement()?.clientHeight ?? getVirtualRowHeight(keyboardItems, 0, columnCount, imageSize, showFilenameArea);
+          const currentRenderedIndex = getRenderedIndexInItems(focusedImageIndexRef.current, keyboardItems);
+          const nextRenderedIndex = getVirtualPageTargetIndex(keyboardItems, currentRenderedIndex, 1, viewportHeight, columnCount, imageSize, showFilenameArea);
+          const resolvedRenderItem = resolveImageRenderItem(keyboardItems, nextRenderedIndex, 1);
+          const previewTarget = resolvedRenderItem
+            ? isImageStack(resolvedRenderItem.item)
+              ? resolvedRenderItem.item.coverImage
+              : resolvedRenderItem.item
             : undefined;
-          const resolvedImageIndex = nextItem ? getImageIndexForRenderedItem(nextItem) : -1;
+          const resolvedImageIndex = resolvedRenderItem ? getImageIndexForRenderedItem(resolvedRenderItem.item) : -1;
 
           if (previewTarget && resolvedImageIndex >= 0) {
             focusedImageIndexRef.current = resolvedImageIndex;
@@ -1670,24 +1870,20 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         }
       } else if (e.key === 'PageUp') {
         e.preventDefault();
-        const itemCount = itemsToRender.length;
+        const columnCount = getActiveColumnCount();
+        const keyboardItems = expandGroupedItemsForColumns(itemsToRender, columnCount);
+        const itemCount = keyboardItems.length;
         if (isInfinite && itemCount > 0) {
-          const columnCount = getActiveColumnCount();
-          const rowHeight = getItemHeight(imageSize, showFilenameArea) + GAP_SIZE;
-          const viewportHeight = getGridScrollElement()?.clientHeight ?? rowHeight;
-          const visibleRows = Math.max(1, Math.floor(viewportHeight / rowHeight));
-          const currentRenderedIndex = getRenderedIndexForImageIndex(focusedImageIndexRef.current);
-          const nextRenderedIndex = clampIndex(
-            (currentRenderedIndex >= 0 ? currentRenderedIndex : 0) - (columnCount * visibleRows),
-            itemCount,
-          );
-          const nextItem = itemsToRender[nextRenderedIndex];
-          const previewTarget = nextItem
-            ? isImageStack(nextItem)
-              ? nextItem.coverImage
-              : nextItem
+          const viewportHeight = getGridScrollElement()?.clientHeight ?? getVirtualRowHeight(keyboardItems, 0, columnCount, imageSize, showFilenameArea);
+          const currentRenderedIndex = getRenderedIndexInItems(focusedImageIndexRef.current, keyboardItems);
+          const nextRenderedIndex = getVirtualPageTargetIndex(keyboardItems, currentRenderedIndex, -1, viewportHeight, columnCount, imageSize, showFilenameArea);
+          const resolvedRenderItem = resolveImageRenderItem(keyboardItems, nextRenderedIndex, -1);
+          const previewTarget = resolvedRenderItem
+            ? isImageStack(resolvedRenderItem.item)
+              ? resolvedRenderItem.item.coverImage
+              : resolvedRenderItem.item
             : undefined;
-          const resolvedImageIndex = nextItem ? getImageIndexForRenderedItem(nextItem) : -1;
+          const resolvedImageIndex = resolvedRenderItem ? getImageIndexForRenderedItem(resolvedRenderItem.item) : -1;
 
           if (previewTarget && resolvedImageIndex >= 0) {
             focusedImageIndexRef.current = resolvedImageIndex;
@@ -1717,7 +1913,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('keyup', handleKeyUp);
     };
-  }, [flushKeyboardPreview, getActiveColumnCount, getGridScrollElement, getImageIndexForRenderedItem, getRenderedIndexForImageIndex, imageSize, isInfinite, itemsToRender, setFocusedImageIndex, setPreviewImage, onImageClick, focusedImageIndex, images, currentPage, totalPages, onPageChange, showFilenameArea]);
+  }, [flushKeyboardPreview, getActiveColumnCount, getGridScrollElement, getImageIndexForRenderedItem, getRenderedIndexInItems, imageSize, isInfinite, itemsToRender, resolveImageRenderItem, setFocusedImageIndex, setPreviewImage, onImageClick, focusedImageIndex, images, currentPage, totalPages, onPageChange, showFilenameArea]);
 
   useEffect(() => {
     return () => {
@@ -1731,13 +1927,16 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       return;
     }
 
-    const renderedIndex = getRenderedIndexForImageIndex(focusedImageIndex);
+    const columnCount = Math.max(1, columnCountRef.current);
+    const activeItems = isInfinite
+      ? expandGroupedItemsForColumns(itemsToRender, columnCount)
+      : itemsToRender;
+    const renderedIndex = getRenderedIndexInItems(focusedImageIndex, activeItems);
     if (renderedIndex < 0) {
       return;
     }
 
     if (isInfinite) {
-      const columnCount = Math.max(1, columnCountRef.current);
       virtualGridRef.current?.scrollToItem({
         rowIndex: Math.floor(renderedIndex / columnCount),
         columnIndex: renderedIndex % columnCount,
@@ -1747,7 +1946,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     }
 
     const focusedItem = itemsToRender[renderedIndex];
-    if (!focusedItem) {
+    if (!focusedItem || !isImageRenderItem(focusedItem)) {
       return;
     }
 
@@ -1758,7 +1957,44 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         inline: 'nearest',
       });
     }
-  }, [focusedImageIndex, getRenderedIndexForImageIndex, isInfinite, itemsToRender]);
+  }, [focusedImageIndex, getRenderedIndexInItems, isInfinite, itemsToRender]);
+
+  useEffect(() => {
+    if (!jumpToGroupRequest || effectiveGroupBy === 'none') {
+      return;
+    }
+
+    const targetGroup = groupedImages.groups.find((group) => group.id === jumpToGroupRequest.groupId);
+    if (!targetGroup) {
+      return;
+    }
+
+    const targetImageIndex = images.findIndex((image) => image.id === targetGroup.startImageId);
+    if (targetImageIndex >= 0) {
+      focusedImageIndexRef.current = targetImageIndex;
+      setFocusedImageIndex(targetImageIndex);
+      setPreviewImage(images[targetImageIndex]);
+    }
+
+    const virtualItems = expandGroupedItemsForColumns(itemsToRender, Math.max(1, columnCountRef.current));
+    const renderedIndex = virtualItems.findIndex((item) => !isImageRenderItem(item) && item.type === 'group-header' && item.group.id === jumpToGroupRequest.groupId);
+    if (renderedIndex < 0) {
+      return;
+    }
+
+    if (isInfinite) {
+      const columnCount = Math.max(1, columnCountRef.current);
+      virtualGridRef.current?.scrollToItem({
+        rowIndex: Math.floor(renderedIndex / columnCount),
+        columnIndex: 0,
+        align: 'start',
+      });
+      return;
+    }
+
+    const header = gridScopeRef.current?.querySelector<HTMLElement>(`[data-group-id="${CSS.escape(jumpToGroupRequest.groupId)}"]`);
+    header?.scrollIntoView({ block: 'start', inline: 'nearest' });
+  }, [effectiveGroupBy, groupedImages.groups, images, isInfinite, itemsToRender, jumpToGroupRequest, setFocusedImageIndex, setPreviewImage]);
 
   // Add global mouseup listener to handle selection end even outside the grid
   useEffect(() => {
@@ -2366,12 +2602,13 @@ const ImageGrid: React.FC<ImageGridProps> = ({
               {({ height, width }) => {
                 const columnCount = Math.floor(width / (imageSize + GAP_SIZE));
                 const safeColumnCount = columnCount > 0 ? columnCount : 1;
-                const rowCount = Math.ceil(itemsToRender.length / safeColumnCount);
+                const virtualItems = expandGroupedItemsForColumns(itemsToRender, safeColumnCount);
+                const rowCount = Math.ceil(virtualItems.length / safeColumnCount);
                 
                 columnCountRef.current = safeColumnCount;
 
                 const cellData: CellData = {
-                    items: itemsToRender,
+                    items: virtualItems,
                     columnCount: safeColumnCount,
                     onImageClick,
                     onStackClick: handleStackClick,
@@ -2395,14 +2632,15 @@ const ImageGrid: React.FC<ImageGridProps> = ({
 
                 return (
                   <Grid
+                    key={`${safeColumnCount}:${imageSize}:${showFilenameArea}:${virtualItems.length}:${groupedImages.groups.map((group) => `${group.id}:${group.count}`).join('|')}`}
                     ref={virtualGridRef}
                     columnCount={safeColumnCount}
-                    columnWidth={imageSize + GAP_SIZE}
+                    columnWidth={() => imageSize + GAP_SIZE}
                     height={height}
                     overscanColumnCount={1}
                     overscanRowCount={4}
                     rowCount={rowCount}
-                    rowHeight={getItemHeight(imageSize, showFilenameArea) + GAP_SIZE}
+                    rowHeight={(rowIndex) => getVirtualRowHeight(virtualItems, rowIndex, safeColumnCount, imageSize, showFilenameArea)}
                     width={width}
                     outerRef={gridScrollRef}
                     className="no-scrollbar-if-needed"
@@ -2410,7 +2648,16 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                     itemKey={({ columnIndex, rowIndex, data }) => {
                       const itemIndex = rowIndex * safeColumnCount + columnIndex;
                       const item = (data as CellData).items[itemIndex];
-                      return item ? item.id : `empty-${rowIndex}-${columnIndex}`;
+                      if (!item) {
+                        return `empty-${rowIndex}-${columnIndex}`;
+                      }
+                      if (!isImageRenderItem(item)) {
+                        if (item.type === 'group-spacer') {
+                          return `${item.groupId}-spacer-${item.index}`;
+                        }
+                        return columnIndex === 0 ? item.group.id : `${item.group.id}-empty-${columnIndex}`;
+                      }
+                      return item.id;
                     }}
                     style={{ overflowX: 'hidden' }}
                     innerElementType={InnerGridElement}
@@ -2430,18 +2677,18 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                       const itemsRenderedStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
                       const visibleStartIndex = (visibleRowStartIndex * safeColumnCount) + visibleColumnStartIndex;
                       const visibleStopIndex = Math.min(
-                        itemsToRender.length - 1,
+                        virtualItems.length - 1,
                         (visibleRowStopIndex * safeColumnCount) + visibleColumnStopIndex
                       );
                       const aheadStopIndex = Math.min(
-                        itemsToRender.length - 1,
+                        virtualItems.length - 1,
                         (((overscanRowStopIndex + 1) * safeColumnCount) - 1)
                       );
-                      const primaryImages = collectWarmupImages(itemsToRender, visibleStartIndex, visibleStopIndex);
-                      const secondaryImages = collectWarmupImages(itemsToRender, visibleStopIndex + 1, aheadStopIndex);
+                      const primaryImages = collectWarmupImages(virtualItems, visibleStartIndex, visibleStopIndex);
+                      const secondaryImages = collectWarmupImages(virtualItems, visibleStopIndex + 1, aheadStopIndex);
                       const visibleImageKey = getWarmupWindowImageKey(primaryImages);
                       const aheadImageKey = getWarmupWindowImageKey(secondaryImages);
-                      const windowKey = `${visibleStartIndex}:${visibleStopIndex}:${aheadStopIndex}:${itemsToRender.length}:${safeColumnCount}:${visibleImageKey}:${aheadImageKey}`;
+                      const windowKey = `${visibleStartIndex}:${visibleStopIndex}:${aheadStopIndex}:${virtualItems.length}:${safeColumnCount}:${visibleImageKey}:${aheadImageKey}`;
 
                       if (lastWarmupWindowRef.current === windowKey) {
                         return;
@@ -2499,7 +2746,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                         columnCount: safeColumnCount,
                         primaryCount: primaryImages.length,
                         secondaryCount: secondaryImages.length,
-                        itemCount: itemsToRender.length,
+                        itemCount: virtualItems.length,
                       });
                     }}
                   >
@@ -2568,6 +2815,17 @@ const ImageGrid: React.FC<ImageGridProps> = ({
           data-grid-background
         >
           {itemsToRender.map((item, index) => {
+            if (!isImageRenderItem(item)) {
+              if (item.type === 'group-spacer') {
+                return null;
+              }
+              return (
+                <div key={item.group.id} className="basis-full" data-group-id={item.group.id}>
+                  <GroupHeader group={item.group} />
+                </div>
+              );
+            }
+
             if (isImageStack(item)) {
                const isSensitive = enableSafeMode &&
                 sensitiveTagSet && sensitiveTagSet.size > 0 &&

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { FixedSizeList as List } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -19,6 +19,7 @@ import { useReparseMetadata } from '../hooks/useReparseMetadata';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 import RenameImageModal from './RenameImageModal';
 import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
+import { groupImages, type ImageGroupByMode, type ImageGroupingSortOrder, type ImageGroupRenderItem } from '../utils/imageGrouping';
 
 interface ImageTableProps {
   images: IndexedImage[];
@@ -30,6 +31,9 @@ interface ImageTableProps {
   onImageRenamed?: (oldImageId: string, newImageId: string) => void;
   onFindSimilar?: (image: IndexedImage) => void;
   onOpenComfyUIWorkspace?: (image: IndexedImage) => void;
+  groupBy?: ImageGroupByMode;
+  groupSortOrder?: ImageGroupingSortOrder;
+  jumpToGroupRequest?: { groupId: string; requestId: number } | null;
 }
 
 type SortField = 'filename' | 'model' | 'steps' | 'cfg' | 'size' | 'seed';
@@ -75,6 +79,9 @@ const ImageTable: React.FC<ImageTableProps> = ({
   onImageRenamed,
   onFindSimilar,
   onOpenComfyUIWorkspace,
+  groupBy = 'none',
+  groupSortOrder = 'date-desc',
+  jumpToGroupRequest = null,
 }) => {
   const directories = useImageStore((state) => state.directories);
   const transferProgress = useImageStore((state) => state.transferProgress);
@@ -89,6 +96,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
   const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
   const [renameImage, setRenameImage] = useState<IndexedImage | null>(null);
   const [transferStatusText, setTransferStatusText] = useState<string>('');
+  const listRef = useRef<React.ElementRef<typeof List>>(null);
   const bulkSetImageRating = useImageStore((state) => state.bulkSetImageRating);
   const collections = useImageStore((state) => state.collections);
   const createCollection = useImageStore((state) => state.createCollection);
@@ -421,6 +429,10 @@ const ImageTable: React.FC<ImageTableProps> = ({
     () => applySorting(images, sortField, sortDirection),
     [images, sortField, sortDirection, applySorting]
   );
+  const groupedRows = useMemo<ImageGroupRenderItem[]>(
+    () => groupImages(sortedImages, groupBy, { sortOrder: groupSortOrder }).items,
+    [groupBy, groupSortOrder, sortedImages]
+  );
   const enableRowThumbnails = sortedImages.length <= 5000;
 
   const columnWidths = [
@@ -437,7 +449,28 @@ const ImageTable: React.FC<ImageTableProps> = ({
 
   // Row renderer for virtualized list
   const Row = ({ index, style }: { index: number; style: React.CSSProperties }) => {
-    const image = sortedImages[index];
+    const item = groupedRows[index];
+    if (!item) {
+      return <div style={style} />;
+    }
+
+    if (item.type === 'group-header') {
+      return (
+        <div style={style} data-group-id={item.group.id}>
+          <div className="flex h-full items-center justify-between gap-3 border-y border-gray-700/70 bg-gray-900/95 px-4 text-gray-200">
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold">{item.group.label}</div>
+              {item.group.subtitle && <div className="truncate text-xs text-gray-500">{item.group.subtitle}</div>}
+            </div>
+            <div className="shrink-0 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-xs text-gray-400">
+              {item.group.count} item{item.group.count === 1 ? '' : 's'}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    const image = item.image;
     return (
       <div style={style}>
         <ImageTableRow
@@ -454,6 +487,19 @@ const ImageTable: React.FC<ImageTableProps> = ({
 
   const ROW_HEIGHT = 64; // Height of each table row in pixels
   const HEADER_HEIGHT = 48; // Height of table header
+
+  useEffect(() => {
+    if (!jumpToGroupRequest || groupBy === 'none') {
+      return;
+    }
+
+    const targetIndex = groupedRows.findIndex((item) => item.type === 'group-header' && item.group.id === jumpToGroupRequest.groupId);
+    if (targetIndex < 0) {
+      return;
+    }
+
+    listRef.current?.scrollToItem(targetIndex, 'start');
+  }, [groupBy, groupedRows, jumpToGroupRequest]);
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
@@ -512,11 +558,15 @@ const ImageTable: React.FC<ImageTableProps> = ({
               {({ height, width }: { height: number; width: number }) => (
                 <List
                   height={height}
-                  itemCount={sortedImages.length}
+                  itemCount={groupedRows.length}
                   itemSize={ROW_HEIGHT}
+                  ref={listRef}
                   width={width}
                   overscanCount={5}
-                  itemKey={(index) => sortedImages[index]?.id ?? index}
+                  itemKey={(index) => {
+                    const item = groupedRows[index];
+                    return item?.type === 'group-header' ? item.group.id : item?.image.id ?? index;
+                  }}
                 >
                   {Row}
                 </List>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import AutomationRulesModal from './AutomationRulesModal';
 import { useImageStore } from '../store/useImageStore';
 import type { AdvancedFilters as AdvancedFilterState, ImageRating } from '../types';
 import { createProfilerOnRender } from '../utils/performanceDiagnostics';
+import type { ImageGroupByMode } from '../utils/imageGrouping';
 
 interface SidebarProps {
   searchQuery: string;
@@ -48,6 +49,8 @@ interface SidebarProps {
   sortOrder: string;
   onSortOrderChange: (value: string) => void;
   onReshuffle?: () => void;
+  groupBy: ImageGroupByMode;
+  onGroupByChange: (value: ImageGroupByMode) => void;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -82,7 +85,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   onIncludeFolder,
   sortOrder,
   onSortOrderChange,
-  onReshuffle
+  onReshuffle,
+  groupBy,
+  onGroupByChange
 }) => {
   const [isGenerationParametersExpanded, setIsGenerationParametersExpanded] = useState(true);
   const [isAutomationRulesOpen, setIsAutomationRulesOpen] = useState(false);
@@ -320,6 +325,23 @@ const Sidebar: React.FC<SidebarProps> = ({
           )}
           </div>
         </div>
+
+        {sortOrder !== 'random' && (
+          <div className="px-4 py-3 border-b border-gray-700">
+            <label htmlFor="sidebar-group-by" className="block text-gray-400 text-xs font-medium mb-2">Group By</label>
+            <select
+              id="sidebar-group-by"
+              value={groupBy}
+              onChange={(event) => onGroupByChange(event.target.value as ImageGroupByMode)}
+              className="w-full bg-gray-700 text-gray-200 border border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="none">None</option>
+              <option value="date">Date</option>
+              <option value="name">Name</option>
+              <option value="session">Session</option>
+            </select>
+          </div>
+        )}
 
         <div className="px-3 py-2 border-b border-gray-700">
           <div className={`grid gap-2 ${onAddFolder ? 'grid-cols-2' : 'grid-cols-1'}`}>

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ComfyUI Workflow Actions**: Added richer ComfyUI workflow entry points across the main app, image viewer, grid, and embedded workspace, including workflow action coverage and desktop IPC support for workspace preview behavior.
 - **ComfyUI Workspace Metadata Copying**: Added copy actions for workspace metadata fields and clearer image dimension display in the ComfyUI Workspace context panel.
+- **Image Library Grouping**: Added Library Group By separators for date, name, and inferred generation sessions, plus Jump To navigation with calendar badges for date/session groups.
 - **Media Playback Diagnostics**: Added audio/video playback event diagnostics and imh-media protocol logging to help investigate early Electron Helper crashes on macOS.
 
 ### Improved

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -63,6 +63,7 @@ const electronStorage: StateStorage = {
 };
 
 import { Keymap } from '../types';
+import type { ImageGroupByMode } from '../utils/imageGrouping';
 
 const detectDefaultIndexingConcurrency = (): number => {
   if (typeof navigator !== 'undefined' && typeof navigator.hardwareConcurrency === 'number') {
@@ -103,6 +104,7 @@ interface SettingsState {
   cachePath: string | null;
   autoUpdate: boolean;
   viewMode: 'grid' | 'list';
+  groupBy: ImageGroupByMode;
   theme: 'light' | 'dark' | 'system' | 'dracula' | 'nord' | 'ocean';
   keymap: Keymap;
   lastViewedVersion: string | null;
@@ -148,6 +150,7 @@ interface SettingsState {
   setCachePath: (path: string) => void;
   toggleAutoUpdate: () => void;
   toggleViewMode: () => void;
+  setGroupBy: (value: ImageGroupByMode) => void;
   setTheme: (theme: 'light' | 'dark' | 'system' | 'dracula' | 'nord' | 'ocean') => void;
   updateKeybinding: (scope: string, action: string, keybinding: string) => void;
   resetKeymap: () => void;
@@ -200,6 +203,7 @@ export const useSettingsStore = create<SettingsState>()(
       cachePath: null, // Default cache path, null means use app data dir
       autoUpdate: true, // Check for updates by default
       viewMode: 'grid',
+      groupBy: 'none',
       theme: 'system', // Default to system theme
       keymap: getDefaultKeymap(),
       lastViewedVersion: null,
@@ -249,6 +253,7 @@ export const useSettingsStore = create<SettingsState>()(
       setCachePath: (path) => set({ cachePath: path }),
       toggleAutoUpdate: () => set((state) => ({ autoUpdate: !state.autoUpdate })),
       toggleViewMode: () => set((state) => ({ viewMode: state.viewMode === 'grid' ? 'list' : 'grid' })),
+      setGroupBy: (value) => set({ groupBy: value }),
       setTheme: (theme) => set({ theme }),
       setLastViewedVersion: (version) => set({ lastViewedVersion: version }),
       setIndexingConcurrency: (value) =>
@@ -325,6 +330,7 @@ export const useSettingsStore = create<SettingsState>()(
         cachePath: null,
         autoUpdate: true,
         viewMode: 'grid',
+        groupBy: 'none',
         theme: 'system',
         keymap: getDefaultKeymap(),
         lastViewedVersion: null,
@@ -386,6 +392,16 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.showFilenames !== 'boolean') {
           state.showFilenames = false;
+        }
+
+        if (
+          state &&
+          state.groupBy !== 'none' &&
+          state.groupBy !== 'date' &&
+          state.groupBy !== 'name' &&
+          state.groupBy !== 'session'
+        ) {
+          state.groupBy = 'none';
         }
 
         if (state && typeof state.showFullFilePath !== 'boolean') {

--- a/utils/imageGrouping.ts
+++ b/utils/imageGrouping.ts
@@ -1,0 +1,213 @@
+import type { IndexedImage } from '../types';
+import { formatLocalDateKey } from './dateFilterUtils';
+
+export type ImageGroupByMode = 'none' | 'date' | 'name' | 'session';
+export type ImageGroupingSortOrder = 'asc' | 'desc' | 'date-asc' | 'date-desc' | 'random';
+
+export interface ImageGroupingOptions {
+  sortOrder?: ImageGroupingSortOrder;
+}
+
+export interface ImageGroup {
+  id: string;
+  label: string;
+  subtitle?: string;
+  count: number;
+  startImageId: string;
+  dateKey?: string;
+  startTime?: number;
+  endTime?: number;
+}
+
+export type ImageGroupRenderItem =
+  | { type: 'group-header'; group: ImageGroup }
+  | { type: 'image'; image: IndexedImage };
+
+export interface GroupedImagesResult {
+  groups: ImageGroup[];
+  items: ImageGroupRenderItem[];
+}
+
+export const SESSION_GAP_MS = 45 * 60 * 1000;
+
+const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
+
+const formatDateLabel = (timestamp: number): string =>
+  new Date(timestamp).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+const formatTimeLabel = (timestamp: number): string =>
+  new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+const getDominantModel = (images: IndexedImage[]): string | undefined => {
+  const counts = new Map<string, number>();
+
+  for (const image of images) {
+    for (const model of image.models ?? []) {
+      const normalized = typeof model === 'string' ? model.trim() : '';
+      if (!normalized) {
+        continue;
+      }
+      counts.set(normalized, (counts.get(normalized) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((left, right) => right[1] - left[1] || collator.compare(left[0], right[0]))[0]?.[0];
+};
+
+const makeGroup = (
+  id: string,
+  label: string,
+  images: IndexedImage[],
+  subtitle?: string,
+  extra?: Pick<ImageGroup, 'dateKey' | 'startTime' | 'endTime'>,
+): ImageGroup => ({
+  id,
+  label,
+  subtitle,
+  count: images.length,
+  startImageId: images[0]?.id ?? '',
+  ...extra,
+});
+
+const flattenGroups = (
+  groupedEntries: Array<{ group: ImageGroup; images: IndexedImage[] }>,
+): GroupedImagesResult => ({
+  groups: groupedEntries.map((entry) => entry.group),
+  items: groupedEntries.flatMap((entry) => [
+    { type: 'group-header' as const, group: entry.group },
+    ...entry.images.map((image) => ({ type: 'image' as const, image })),
+  ]),
+});
+
+const groupByDate = (images: IndexedImage[]): GroupedImagesResult => {
+  const entries = new Map<string, IndexedImage[]>();
+
+  for (const image of images) {
+    const key = formatLocalDateKey(image.lastModified);
+    const bucket = entries.get(key) ?? [];
+    bucket.push(image);
+    entries.set(key, bucket);
+  }
+
+  return flattenGroups(
+    Array.from(entries.entries()).map(([key, groupImages]) => ({
+      group: makeGroup(`date-${key}`, formatDateLabel(groupImages[0].lastModified), groupImages, undefined, {
+        dateKey: key,
+        startTime: groupImages[0].lastModified,
+        endTime: groupImages[groupImages.length - 1].lastModified,
+      }),
+      images: groupImages,
+    })),
+  );
+};
+
+const getNameGroupKey = (name: string): string => {
+  const first = name.trim().charAt(0).toUpperCase();
+  return /^[A-Z]$/.test(first) ? first : '#';
+};
+
+const groupByName = (images: IndexedImage[]): GroupedImagesResult => {
+  const entries = new Map<string, IndexedImage[]>();
+
+  for (const image of images) {
+    const key = getNameGroupKey(image.name);
+    const bucket = entries.get(key) ?? [];
+    bucket.push(image);
+    entries.set(key, bucket);
+  }
+
+  return flattenGroups(
+    Array.from(entries.entries()).map(([key, groupImages]) => ({
+      group: makeGroup(`name-${key}`, key, groupImages),
+      images: groupImages,
+    })),
+  );
+};
+
+const getSessionSortDirection = (sortOrder?: ImageGroupingSortOrder): 'asc' | 'desc' =>
+  sortOrder === 'date-asc' ? 'asc' : 'desc';
+
+const groupBySession = (images: IndexedImage[], options: ImageGroupingOptions = {}): GroupedImagesResult => {
+  if (images.length === 0) {
+    return { groups: [], items: [] };
+  }
+
+  const sessionDirection = getSessionSortDirection(options.sortOrder);
+  const sorted = [...images].sort((left, right) => left.lastModified - right.lastModified || collator.compare(left.name, right.name));
+  const sessions: IndexedImage[][] = [];
+  let currentSession: IndexedImage[] = [sorted[0]];
+
+  for (let index = 1; index < sorted.length; index += 1) {
+    const image = sorted[index];
+    const previousImage = sorted[index - 1];
+
+    if (image.lastModified - previousImage.lastModified > SESSION_GAP_MS) {
+      sessions.push(currentSession);
+      currentSession = [image];
+      continue;
+    }
+
+    currentSession.push(image);
+  }
+
+  sessions.push(currentSession);
+
+  const orderedSessions = sessionDirection === 'desc'
+    ? [...sessions].reverse()
+    : sessions;
+
+  return flattenGroups(
+    orderedSessions.map((session) => {
+      const chronologicalStart = session[0];
+      const chronologicalEnd = session[session.length - 1];
+      const start = chronologicalStart.lastModified;
+      const end = chronologicalEnd.lastModified;
+      const dominantModel = getDominantModel(session);
+      const label = `${formatDateLabel(start)} ${formatTimeLabel(start)}-${formatTimeLabel(end)}`;
+      const subtitle = dominantModel ? `Dominant model: ${dominantModel}` : undefined;
+      const orderedSessionImages = sessionDirection === 'desc'
+        ? [...session].reverse()
+        : session;
+
+      return {
+        group: makeGroup(`session-${start}-${chronologicalStart.id}`, label, orderedSessionImages, subtitle, {
+          dateKey: formatLocalDateKey(start),
+          startTime: start,
+          endTime: end,
+        }),
+        images: orderedSessionImages,
+      };
+    }),
+  );
+};
+
+export const groupImages = (
+  images: IndexedImage[],
+  groupBy: ImageGroupByMode,
+  options: ImageGroupingOptions = {},
+): GroupedImagesResult => {
+  if (groupBy === 'none' || images.length === 0) {
+    return {
+      groups: [],
+      items: images.map((image) => ({ type: 'image', image })),
+    };
+  }
+
+  if (groupBy === 'date') {
+    return groupByDate(images);
+  }
+
+  if (groupBy === 'name') {
+    return groupByName(images);
+  }
+
+  return groupBySession(images, options);
+};


### PR DESCRIPTION
## Summary
- Add persisted Image Library grouping by date, name, and inferred generation session
- Add grouped headers in grid/table views and Jump To navigation
- Use calendar Jump To for date/session groups, including session-count badges by day
- Document the feature in the 0.16.1 changelog

## Validation
- `npx tsc --noEmit`
- `npx vitest run __tests__/imageGrouping.test.ts __tests__/GridToolbar.test.tsx`
- `npm run build`