### PR TITLE
performance improvement

### DIFF
--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -634,9 +634,11 @@ class CacheManager {
   ): Promise<void> {
     if (!this.isElectron || !images || images.length === 0) return;
 
-    const updates = new Map(
-      sanitizeCacheMetadata(toCacheMetadata(images), { forceClone: true }).map((image) => [image.id, image])
-    );
+    const sanitizedUpdates = sanitizeCacheMetadata(toCacheMetadata(images), { forceClone: true });
+    const updates = new Map<string, CacheImageMetadata>();
+    for (const image of sanitizedUpdates) {
+      updates.set(image.id, image);
+    }
 
     const candidateModes = Array.from(new Set([scanSubfolders, !scanSubfolders]));
     for (const mode of candidateModes) {

--- a/services/fileTransferService.ts
+++ b/services/fileTransferService.ts
@@ -165,9 +165,10 @@ export async function transferIndexedImages({
     destinationRelativePath: joinRelativePath(destinationRelativePrefix, item.destinationRelativePath),
   }));
 
-  const sourceByPath = new Map(
-    sourceDescriptors.map(({ sourceKey, image }) => [sourceKey, image]),
-  );
+  const sourceByPath = new Map<string, IndexedImage>();
+  for (const { sourceKey, image } of sourceDescriptors) {
+    sourceByPath.set(sourceKey, image);
+  }
   const annotationsMap = new Map(useImageStore.getState().annotations);
 
   const persistenceTransfers: Array<{ sourceImageId: string; targetImageId: string }> = [];
@@ -197,16 +198,14 @@ export async function transferIndexedImages({
   }
 
   const transferredEntries = transferredItems.map(buildTransferredEntry);
-  const fileStatsMap = new Map(
-    transferredItems.map((item) => [
-      item.destinationRelativePath,
-      {
-        size: item.size,
-        type: item.type,
-        birthtimeMs: item.lastModified,
-      },
-    ]),
-  );
+  const fileStatsMap = new Map<string, { size?: number; type?: string; birthtimeMs?: number }>();
+  for (const item of transferredItems) {
+    fileStatsMap.set(item.destinationRelativePath, {
+      size: item.size,
+      type: item.type,
+      birthtimeMs: item.lastModified,
+    });
+  }
 
   const addImages = useImageStore.getState().addImages;
   const flushPendingImages = useImageStore.getState().flushPendingImages;


### PR DESCRIPTION
What: Replaced \`new Map(arr.map(...))\` with a pre-instantiated \`Map\` and a \`for\` loop in \`cacheManager.ts\` and \`fileTransferService.ts\`.
Why: Initializing a \`Map\` using \`.map()\` on a large array causes an O(N) temporary array of tuples to be allocated and immediately discarded, triggering garbage collection pauses.
Impact: Reduces intermediate memory allocation and GC pauses for tight loops during cache resolution and file transfers.
Measurement: Compare memory allocation overhead during bulk operations using Chrome DevTools Performance monitor.

---
*PR created automatically by Jules for task [5936492405476786088](https://jules.google.com/task/5936492405476786088) started by @LuqP2*