### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2026-05-20 - Eliminate Array.map() O(N) allocation overhead for Map/Set initialization
 **Learning:** Initializing a `Map` or `Set` using `.map()` on a large array (e.g., `new Map(arr.map(item => [item.id, item]))`) causes an O(N) temporary array of tuples to be allocated and immediately discarded, triggering garbage collection pauses.
 **Action:** Replace `.map()` with a pre-instantiated `Map` or `Set` and populate it directly using a `for` loop to scale at O(1) intermediate memory.
+## 2024-05-24 - Avoid temporary array allocations during Set/Map initialization
+**Learning:** Using `.map()` inside `new Set()` or `new Map()` (e.g., `new Set(arr.map(x => x.id))`) causes JavaScript to allocate a temporary array of mapped values or tuples in memory, which is immediately discarded. This increases garbage collection pressure, especially for large datasets.
+**Action:** Replace `new Set(arr.map(...))` or `new Map(arr.map(...))` with direct loops (e.g., `const s = new Set(); for (const x of arr) s.add(x.id);`). This executes slightly faster and skips intermediate array allocation entirely.

--- a/utils/slideshowPlaylist.ts
+++ b/utils/slideshowPlaylist.ts
@@ -36,8 +36,18 @@ export const buildSlideshowPlaylist = ({
   const selectedInScope = scopeImages.filter(
     (image) => selectedImageIds.has(image.id) && isSlideshowMedia(image)
   );
-  const usedIds = new Set(selectedInScope.map((image) => image.id));
-  const allImageLookup = new Map(allImages.map((image) => [image.id, image]));
+
+  // Optimization: Avoid creating temporary arrays using .map() before creating Set/Map
+  const usedIds = new Set<string>();
+  for (const image of selectedInScope) {
+    usedIds.add(image.id);
+  }
+
+  const allImageLookup = new Map<string, IndexedImage>();
+  for (const image of allImages) {
+    allImageLookup.set(image.id, image);
+  }
+
   const selectedOutOfScope: IndexedImage[] = [];
 
   for (const imageId of selectedImageIds) {


### PR DESCRIPTION
**What**: Replaced intermediate `.map()` array allocations when initializing a `Set` and a `Map` in `utils/slideshowPlaylist.ts` with direct `for...of` loops.
**Why**: Initializing a `Set` or `Map` using `.map()` on an array causes JavaScript to allocate a temporary `O(N)` array in memory, which is immediately discarded. This increases garbage collection pressure, which can cause micro-stutters.
**Impact**: Eliminates two unnecessary array allocations per `buildSlideshowPlaylist` call, reducing memory churn and improving execution speed.
**Measurement**: Verified functionality via `pnpm test slideshowPlaylist`, which continues to pass successfully.

---
*PR created automatically by Jules for task [12532037930947591227](https://jules.google.com/task/12532037930947591227) started by @LuqP2*