### PR TITLE
performance improvement

### DIFF
--- a/components/FindSimilarModal.tsx
+++ b/components/FindSimilarModal.tsx
@@ -174,7 +174,16 @@ export default function FindSimilarModal({
       return;
     }
 
-    setSelectedIds(new Set(execution.results.filter((result) => result.preselected).map((result) => result.image.id)));
+    // Optimization: Replaced `.filter().map()` with a `for` loop
+    // to eliminate the O(N) allocation of intermediate arrays.
+    // Impact: Reduces garbage collection pauses during modal updates.
+    const nextSelectedIds = new Set<string>();
+    for (const result of execution.results) {
+      if (result.preselected) {
+        nextSelectedIds.add(result.image.id);
+      }
+    }
+    setSelectedIds(nextSelectedIds);
   }, [execution]);
 
   if (!isOpen || !sourceImage || !availability || !sourceDetails || !execution || typeof document === 'undefined') {

--- a/hooks/useComfyUIQueueMonitor.ts
+++ b/hooks/useComfyUIQueueMonitor.ts
@@ -297,7 +297,17 @@ export function useComfyUIQueueMonitor() {
 
         const running = parseQueueEntries(queue, 'queue_running');
         const pending = parseQueueEntries(queue, 'queue_pending');
-        const activePromptIds = new Set([...running, ...pending].map((entry) => entry.promptId));
+
+        // Optimization: Replaced spread operator and `.map()` with `for` loops
+        // to eliminate the O(N) allocation of intermediate arrays.
+        // Impact: Reduces garbage collection pauses during polling.
+        const activePromptIds = new Set<string>();
+        for (const entry of running) {
+          activePromptIds.add(entry.promptId);
+        }
+        for (const entry of pending) {
+          activePromptIds.add(entry.promptId);
+        }
 
         pending.forEach((entry) => {
           nodeLabelsRef.current.set(entry.promptId, entry.nodeLabels);


### PR DESCRIPTION
What: 
Replaced `.filter().map()` and `[...a, ...b].map()` with direct `for` loops when populating `Set` variables in `FindSimilarModal.tsx` and `useComfyUIQueueMonitor.ts`. Added required Bolt-specific documentation explaining the optimization.

Why:
Chaining `.map()` before passing it to `new Set()` allocates a temporary `O(N)` array in memory that is only needed momentarily. In high-frequency components or polling systems, this creates unnecessary garbage collection pressure and pauses on the main thread.

Impact:
Reduces garbage collection allocation overhead to `O(1)` during these routines. Skips creating throwaway arrays containing strings.

Measurement:
Verify that the components render normally. Running tests via `pnpm test FindSimilarModal` and `pnpm test comfyui` confirm the loop rewrite didn't change functional logic.

---
*PR created automatically by Jules for task [15951030785622461076](https://jules.google.com/task/15951030785622461076) started by @LuqP2*