### PR TITLE
🎨 Palette: Add ARIA labels to Collections Workspace actions

### DIFF
--- a/components/CollectionsWorkspace.tsx
+++ b/components/CollectionsWorkspace.tsx
@@ -258,6 +258,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                       disabled={globalIndex <= 0}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
                       title="Move up"
+                      aria-label="Move up"
                     >
                       <ArrowUp className="h-3.5 w-3.5" />
                     </button>
@@ -270,6 +271,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                       disabled={globalIndex === -1 || globalIndex >= collections.length - 1}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
                       title="Move down"
+                      aria-label="Move down"
                     >
                       <ArrowDown className="h-3.5 w-3.5" />
                     </button>
@@ -281,6 +283,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                       }}
                       className="rounded-md border border-gray-700 p-1.5 text-gray-300 transition-colors hover:bg-gray-800"
                       title="Collection settings"
+                      aria-label="Collection settings"
                     >
                       <Pencil className="h-3.5 w-3.5" />
                     </button>
@@ -292,6 +295,7 @@ const CollectionsWorkspace: React.FC<CollectionsWorkspaceProps> = ({
                       }}
                       className="rounded-md border border-red-900/40 p-1.5 text-red-300 transition-colors hover:bg-red-900/20"
                       title="Delete collection"
+                      aria-label="Delete collection"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the icon-only action buttons (Move Up, Move Down, Edit, Delete) in the `CollectionsWorkspace` component.
🎯 **Why:** To fulfill the WCAG 2.5.3 Label in Name standard, ensuring that icon-only interactive elements are fully accessible to screen readers by providing an explicit label that matches their existing `title` tooltips.
♿ **Accessibility:** Screen reader users can now easily identify the function of the "Move up", "Move down", "Collection settings", and "Delete collection" actions on collection cards.

---
*PR created automatically by Jules for task [6581185372318145127](https://jules.google.com/task/6581185372318145127) started by @LuqP2*