### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2024-05-24 - Avoid temporary array allocations during Set/Map initialization
 **Learning:** Using `.map()` inside `new Set()` or `new Map()` (e.g., `new Set(arr.map(x => x.id))`) causes JavaScript to allocate a temporary array of mapped values or tuples in memory, which is immediately discarded. This increases garbage collection pressure, especially for large datasets.
 **Action:** Replace `new Set(arr.map(...))` or `new Map(arr.map(...))` with direct loops (e.g., `const s = new Set(); for (const x of arr) s.add(x.id);`). This executes slightly faster and skips intermediate array allocation entirely.
+## 2026-05-26 - Eliminate Array.map() O(N) allocation overhead for Map/Set initialization
+**Learning:** Initializing a `Map` or `Set` using `.map()` on a large array (e.g., `new Set(arr.map(item => item.id))`) causes an O(N) temporary array of elements to be allocated and immediately discarded, triggering garbage collection pauses.
+**Action:** Replace `.map()` with a pre-instantiated `Map` or `Set` and populate it directly using a `for` loop to scale at O(1) intermediate memory.

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -161,12 +161,24 @@ const renameIndexedRootInStore = (oldPath: string, newPath: string, newName: str
     remapImage(image) ?? image
   );
 
-  const nextSelectedImages = new Set(Array.from(store.selectedImages).map(replaceImageId));
+  const nextSelectedImages = new Set<string>();
+  for (const id of store.selectedImages) {
+    nextSelectedImages.add(replaceImageId(id));
+  }
+
   const nextClipboard = store.clipboard
     ? { ...store.clipboard, imageIds: store.clipboard.imageIds.map(replaceImageId) }
     : null;
-  const nextSelectedFolders = new Set(Array.from(store.selectedFolders).map(remapPathPrefix));
-  const nextExcludedFolders = new Set(Array.from(store.excludedFolders).map(remapPathPrefix));
+
+  const nextSelectedFolders = new Set<string>();
+  for (const folder of store.selectedFolders) {
+    nextSelectedFolders.add(remapPathPrefix(folder));
+  }
+
+  const nextExcludedFolders = new Set<string>();
+  for (const folder of store.excludedFolders) {
+    nextExcludedFolders.add(remapPathPrefix(folder));
+  }
 
   const nextAnnotations = new Map<string, any>();
   store.annotations.forEach((annotation, imageId) => {


### PR DESCRIPTION
**What:** 
Replaced `new Set(Array.from(store.set).map(...))` with pre-instantiated `Set`s populated directly via `for...of` loops in `components/DirectoryList.tsx`.

**Why:** 
Calling `.map()` to instantiate a `Set` or `Map` creates a temporary array that gets instantly discarded after the collection is built. In this case, `Array.from()` also created an intermediate array, meaning two O(N) arrays were allocated and destroyed for each updated Set during directory operations. This causes unnecessary garbage collection pauses and spikes memory usage on large stores.

**Impact:** 
Reduces intermediate array memory allocation to O(1) for these Set updates, minimizing GC overhead and slightly improving UI snappiness during directory interactions.

**Measurement:** 
Unit tests pass exactly as before. The Sets function identically but skip intermediate array allocation.

---
*PR created automatically by Jules for task [1439981024774514302](https://jules.google.com/task/1439981024774514302) started by @LuqP2*