### PR TITLE
performance improvement

### DIFF
--- a/services/deduplicationEngine.ts
+++ b/services/deduplicationEngine.ts
@@ -123,10 +123,15 @@ export function suggestDuplicates(
   }
 
   // Filter out user-marked images from algorithm processing
-  const userMarkedIds = new Set([
-    ...userMarkedBest.map(img => img.id),
-    ...userArchived.map(img => img.id),
-  ]);
+  // Optimization: Populate Set directly in a loop to avoid O(N) allocation overhead of mapped arrays and spread operators
+  // Impact: Reduces garbage collection pressure and intermediate memory usage for large clusters
+  const userMarkedIds = new Set<string>();
+  for (const img of userMarkedBest) {
+    userMarkedIds.add(img.id);
+  }
+  for (const img of userArchived) {
+    userMarkedIds.add(img.id);
+  }
 
   const remainingImages = images.filter(img => !userMarkedIds.has(img.id));
 
@@ -178,9 +183,15 @@ export function batchSuggestDuplicates(
 
   for (const cluster of clusters) {
     // Get images for this cluster
-    const clusterImages = cluster.imageIds
-      .map(id => imagesMap.get(id))
-      .filter((img): img is IndexedImage => img !== undefined);
+    // Optimization: Avoid chained map/filter allocating intermediate arrays
+    // Impact: Improves processing speed and memory efficiency during batch deduplication
+    const clusterImages: IndexedImage[] = [];
+    for (const id of cluster.imageIds) {
+      const img = imagesMap.get(id);
+      if (img !== undefined) {
+        clusterImages.push(img);
+      }
+    }
 
     // Skip if no images found
     if (clusterImages.length === 0) {


### PR DESCRIPTION
### What
Replaced chained `.map()`, `.filter()`, and array spreading with explicit `for...of` loops in `services/deduplicationEngine.ts` when processing sets of duplicate and clustered images.

### Why
Initializing a `Set` with mapped arrays (`new Set([...a.map(), ...b.map()])`) and chaining `.map().filter()` causes JavaScript to allocate intermediate O(N) arrays in memory that are immediately discarded. In the context of a deduplication engine processing thousands of images, this creates significant garbage collection pauses and spikes memory usage.

### Impact
- Eliminates O(N) array allocation overhead during cluster processing
- Reduces Garbage Collection (GC) pauses
- Lowers intermediate memory footprint, making the deduplication algorithm scale better for very large datasets

### Measurement
Run `pnpm lint` and `pnpm test` to verify changes. The test suite passes.

---
*PR created automatically by Jules for task [2912334685160493082](https://jules.google.com/task/2912334685160493082) started by @LuqP2*