### PR TITLE
Fix image modal freeze after watched deletion

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1348,11 +1348,29 @@ export default function App() {
     () => safeFilteredImages.map((image) => image.id),
     [safeFilteredImages]
   );
+  const filteredNavigationIndexById = useMemo(() => {
+    const indexById = new Map<string, number>();
+    filteredNavigationImageIds.forEach((imageId, index) => {
+      indexById.set(imageId, index);
+    });
+    return indexById;
+  }, [filteredNavigationImageIds]);
 
   const activeScopeNavigationImageIds = useMemo(
     () => safeActiveImageScope?.map((image) => image.id) ?? null,
     [safeActiveImageScope]
   );
+  const activeScopeNavigationIndexById = useMemo(() => {
+    if (!activeScopeNavigationImageIds) {
+      return null;
+    }
+
+    const indexById = new Map<string, number>();
+    activeScopeNavigationImageIds.forEach((imageId, index) => {
+      indexById.set(imageId, index);
+    });
+    return indexById;
+  }, [activeScopeNavigationImageIds]);
 
   const getImageByIdFromStore = useCallback((imageId: string) => {
     if (!imageId) {
@@ -1386,6 +1404,27 @@ export default function App() {
 
     return modal.navigationImageIds.filter((imageId) => imageLookup.has(imageId));
   }, [activeScopeNavigationImageIds, filteredNavigationImageIds, getImageByIdFromStore, imageLookup]);
+
+  const resolveModalNavigationIndex = useCallback((
+    modal: OpenImageModalState,
+    navigationImageIds: string[]
+  ) => {
+    if (modal.navigationSource === 'filtered') {
+      return filteredNavigationIndexById.get(modal.imageId) ?? -1;
+    }
+
+    if (modal.navigationSource === 'scope' && activeScopeNavigationIndexById) {
+      return activeScopeNavigationIndexById.get(modal.imageId) ?? -1;
+    }
+
+    return navigationImageIds.findIndex((imageId) => imageId === modal.imageId);
+  }, [activeScopeNavigationIndexById, filteredNavigationIndexById]);
+
+  const resolveModalNavigationImages = useCallback((modal: OpenImageModalState) => {
+    return resolveModalNavigationImageIds(modal)
+      .map((imageId) => getImageByIdFromStore(imageId))
+      .filter((candidate): candidate is IndexedImage => Boolean(candidate));
+  }, [getImageByIdFromStore, resolveModalNavigationImageIds]);
 
   useEffect(() => {
     if (openImageModals.length === 0) {
@@ -1587,7 +1626,7 @@ export default function App() {
     }
 
     const availableImageIds = resolveModalNavigationImageIds(targetModal);
-    const currentIndex = availableImageIds.findIndex((imageId) => imageId === targetModal.imageId);
+    const currentIndex = resolveModalNavigationIndex(targetModal, availableImageIds);
 
     if (currentIndex === -1) {
       return;
@@ -1613,7 +1652,7 @@ export default function App() {
       suppressSelectedImageModalOpenRef.current = nextImage.id;
       setSelectedImage(nextImage);
     }
-  }, [getImageByIdFromStore, openImageModals, resolveModalNavigationImageIds, setSelectedImage]);
+  }, [getImageByIdFromStore, openImageModals, resolveModalNavigationImageIds, resolveModalNavigationIndex, setSelectedImage]);
 
   const handleOpenImageModalInBackground = useCallback((
     image: IndexedImage,
@@ -2185,10 +2224,7 @@ export default function App() {
         }
 
         const navigationImageIds = resolveModalNavigationImageIds(modal);
-        const navigationImages = navigationImageIds
-          .map((imageId) => getImageByIdFromStore(imageId))
-          .filter((candidate): candidate is IndexedImage => Boolean(candidate));
-        const currentIndex = navigationImageIds.findIndex((imageId) => imageId === modal.imageId);
+        const currentIndex = resolveModalNavigationIndex(modal, navigationImageIds);
         const directoryPath = directoryPathById.get(image.directoryId);
         if (!directoryPath) {
           return null;
@@ -2197,7 +2233,6 @@ export default function App() {
         return {
           ...modal,
           image,
-          navigationImages,
           directoryPath,
           currentIndex: currentIndex === -1 ? 0 : currentIndex,
           totalImages: navigationImageIds.length,
@@ -2205,12 +2240,11 @@ export default function App() {
       })
       .filter(Boolean) as Array<OpenImageModalState & {
         image: IndexedImage;
-        navigationImages: IndexedImage[];
         directoryPath: string;
         currentIndex: number;
         totalImages: number;
       }>;
-  }, [directoryPathById, getImageByIdFromStore, openImageModals, resolveModalNavigationImageIds]);
+  }, [directoryPathById, getImageByIdFromStore, openImageModals, resolveModalNavigationImageIds, resolveModalNavigationIndex]);
 
   const footerWindowItems = useMemo(() => {
     return openImageModals
@@ -2841,8 +2875,8 @@ export default function App() {
             closeOnSlideshowExit={modal.closeOnSlideshowExit}
             diagnosticsFlowId={modal.diagnosticsFlowId}
             onSlideshowStartAcknowledged={() => handleSlideshowStartAcknowledged(modal.modalId)}
-            onFindSimilar={(image) => openFindSimilar(image, modal.navigationImages)}
-            onOpenComfyUIWorkflow={(image) => handleOpenComfyUIWorkflowFromImageModal(modal.modalId, image, modal.navigationImages)}
+            onFindSimilar={(image) => openFindSimilar(image, resolveModalNavigationImages(modal))}
+            onOpenComfyUIWorkflow={(image) => handleOpenComfyUIWorkflowFromImageModal(modal.modalId, image, resolveModalNavigationImages(modal))}
           />
         ))}
 

--- a/App.tsx
+++ b/App.tsx
@@ -916,13 +916,20 @@ export default function App() {
       }
 
       window.setTimeout(() => {
-        cacheManager.applyChunkedCacheDelta(
-          directory.path,
-          directory.name,
-          [],
-          removedIds,
-          removedNames,
-          useImageStore.getState().scanSubfolders,
+        const activeScanSubfolders = useImageStore.getState().scanSubfolders;
+        const cacheModes = Array.from(new Set([activeScanSubfolders, !activeScanSubfolders]));
+
+        Promise.all(
+          cacheModes.map((scanSubfoldersMode) =>
+            cacheManager.applyChunkedCacheDelta(
+              directory.path,
+              directory.name,
+              [],
+              removedIds,
+              removedNames,
+              scanSubfoldersMode,
+            )
+          )
         ).catch((error) => {
           console.error('Failed to update cache after watched file removal:', error);
         });

--- a/App.tsx
+++ b/App.tsx
@@ -915,13 +915,18 @@ export default function App() {
         }));
       }
 
-      await cacheManager.removeCachedImages(
-        directory.path,
-        directory.name,
-        removedIds,
-        removedNames,
-        useImageStore.getState().scanSubfolders,
-      );
+      window.setTimeout(() => {
+        cacheManager.applyChunkedCacheDelta(
+          directory.path,
+          directory.name,
+          [],
+          removedIds,
+          removedNames,
+          useImageStore.getState().scanSubfolders,
+        ).catch((error) => {
+          console.error('Failed to update cache after watched file removal:', error);
+        });
+      }, 0);
 
       const removedCount = Math.max(removedIds.length, removedNames.length);
       setNewImagesToast({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - [Unreleased]
+
+### Improved
+
+- **Image Modal Navigation Performance**: Improved rapid left/right arrow navigation in the image viewer by coalescing repeated key events, using cheaper navigation indexes, and temporarily keeping heavy sidebar rendering out of the hot path while keys are held.
+
+### Fixed
+
+- **Watched File Deletion Stability**: Fixed watched file deletions so cache pruning no longer blocks the renderer, updates both flat and recursive cache variants, and safely rewrites multi-chunk caches without overwriting chunks that are still being read.
+
 ## [0.16.1] - [2026-05-23]
 
 ### Added

--- a/__tests__/cache-manager.workflow-nodes.test.ts
+++ b/__tests__/cache-manager.workflow-nodes.test.ts
@@ -332,6 +332,80 @@ describe('cacheManager workflowNodes hydration', () => {
     expect(finalizeCacheWrite.mock.calls[0][0].record.chunkCount).toBe(1);
   });
 
+  it('writes chunked cache deltas to a temporary cache before replacing the source chunks', async () => {
+    const writeCacheChunk = vi.fn().mockResolvedValue({ success: true });
+    const finalizeCacheWrite = vi.fn().mockResolvedValue({ success: true });
+    const originalCacheId = 'D:/library-flat';
+    const firstChunk = Array.from({ length: 1024 }, (_, index) => ({
+      id: `dir-1::chunk-0-${index}.png`,
+      name: `chunk-0-${index}.png`,
+      metadataString: '',
+      metadata: {},
+      lastModified: 1,
+      models: [],
+      loras: [],
+      scheduler: '',
+    }));
+    const secondChunk = [
+      {
+        id: 'dir-1::chunk-1.png',
+        name: 'chunk-1.png',
+        metadataString: '',
+        metadata: {},
+        lastModified: 1,
+        models: [],
+        loras: [],
+        scheduler: '',
+      },
+    ];
+
+    window.electronAPI = {
+      getCacheSummary: vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          id: originalCacheId,
+          directoryPath: 'D:/library',
+          directoryName: 'Library',
+          lastScan: 1,
+          imageCount: 1025,
+          parserVersion: 7,
+          chunkCount: 2,
+        },
+      }),
+      getCacheChunk: vi.fn().mockImplementation(async ({ cacheId, chunkIndex }) => {
+        expect(cacheId).toBe(originalCacheId);
+        return {
+          success: true,
+          data: chunkIndex === 0 ? firstChunk : secondChunk,
+        };
+      }),
+      writeCacheChunk,
+      finalizeCacheWrite,
+    };
+    (cacheManager as any).isElectron = true;
+
+    await cacheManager.applyChunkedCacheDelta(
+      'D:/library',
+      'Library',
+      [],
+      ['dir-1::chunk-1.png'],
+      ['chunk-1.png'],
+      false
+    );
+
+    expect(window.electronAPI.getCacheChunk).toHaveBeenCalledTimes(2);
+    expect(writeCacheChunk).toHaveBeenCalled();
+    for (const call of writeCacheChunk.mock.calls) {
+      expect(call[0].cacheId).not.toBe(originalCacheId);
+      expect(call[0].cacheId).toMatch(/^D:\/library-flat-delta-/);
+    }
+    expect(finalizeCacheWrite).toHaveBeenCalledWith(expect.objectContaining({
+      cacheId: originalCacheId,
+      sourceCacheId: writeCacheChunk.mock.calls[0][0].cacheId,
+    }));
+    expect(finalizeCacheWrite.mock.calls[0][0].record.imageCount).toBe(1024);
+  });
+
   it('migrates inline metadata before appending new cache chunks', async () => {
     const writeCacheChunk = vi.fn().mockResolvedValue({ success: true });
     const finalizeCacheWrite = vi.fn().mockResolvedValue({ success: true });

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -223,6 +223,7 @@ const DETAILS_SIDEBAR_DEFAULT_HEIGHT = 320;
 const DETAILS_SIDEBAR_MIN_WIDTH = 300;
 const DETAILS_SIDEBAR_MIN_HEIGHT = 240;
 const DETAILS_SIDEBAR_MAX_RATIO = 0.7;
+const RAPID_KEYBOARD_NAVIGATION_IDLE_MS = 140;
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
@@ -778,6 +779,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const [showDetails, setShowDetails] = useState(true);
   const [showPerformance, setShowPerformance] = useState(true);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [isRapidKeyboardNavigating, setIsRapidKeyboardNavigating] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<'details' | 'workflow'>('details');
   const [sidebarWidth, setSidebarWidth] = useState(DETAILS_SIDEBAR_DEFAULT_WIDTH);
   const [sidebarHeight, setSidebarHeight] = useState(DETAILS_SIDEBAR_DEFAULT_HEIGHT);
@@ -808,6 +810,12 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const modalWindowRef = useRef<ModalWindowState>(modalWindow);
   const liveModalWindowRef = useRef<ModalWindowState>(modalWindow);
   const modalPaintFrameRef = useRef<number | null>(null);
+  const keyboardNavigationFrameRef = useRef<number | null>(null);
+  const pendingKeyboardNavigationRef = useRef<'next' | 'previous' | null>(null);
+  const keyboardNavigationIdleTimeoutRef = useRef<number | null>(null);
+  const isRapidKeyboardNavigatingRef = useRef(false);
+  const onWindowStateChangeRef = useRef(onWindowStateChange);
+  const lastReportedWindowStateRef = useRef<ModalWindowState | null>(null);
   const slideshowTimeoutRef = useRef<number | null>(null);
   const restoredModalWindowRef = useRef<ModalWindowState | null>(null);
   const isMinimizeAnimatingRef = useRef(false);
@@ -973,7 +981,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const previewKeymap = useSettingsStore((state) => state.keymap.preview as Record<string, string> | undefined);
   const toggleFullscreenKeybinding = previewKeymap?.toggleFullscreenInViewer || 'alt+enter';
   const isWindowInteractionActive = modalInteraction.mode !== 'idle';
-  const showSidebar = !isFullViewportModal && !isSidebarCollapsed;
+  const showSidebar = !isFullViewportModal && !isSidebarCollapsed && !isRapidKeyboardNavigating;
   const showSidebarOnBottom = showSidebar && detailsPlacement === 'bottom';
   const showSidebarOnRight = showSidebar && detailsPlacement === 'right';
   const imageFullPath = directoryPath
@@ -1205,11 +1213,28 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [isActive, onSlideshowStartAcknowledged, setFullscreenMode, startSlideshow, totalImages]);
 
   useEffect(() => {
+    onWindowStateChangeRef.current = onWindowStateChange;
+  }, [onWindowStateChange]);
+
+  useEffect(() => {
     modalWindowRef.current = modalWindow;
     liveModalWindowRef.current = modalWindow;
     applyModalWindowStyles(modalWindow);
-    onWindowStateChange?.(modalWindow);
-  }, [applyModalWindowStyles, modalWindow, onWindowStateChange]);
+
+    const lastReported = lastReportedWindowStateRef.current;
+    if (
+      lastReported &&
+      lastReported.x === modalWindow.x &&
+      lastReported.y === modalWindow.y &&
+      lastReported.width === modalWindow.width &&
+      lastReported.height === modalWindow.height
+    ) {
+      return;
+    }
+
+    lastReportedWindowStateRef.current = modalWindow;
+    onWindowStateChangeRef.current?.(modalWindow);
+  }, [applyModalWindowStyles, modalWindow]);
 
   useEffect(() => {
     return () => {
@@ -2288,6 +2313,46 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }
   }, [currentIndex, image, isIndexing, onClose, onImageDeleted, onNavigateNext, onNavigatePrevious, totalImages]);
 
+  const scheduleKeyboardNavigation = useCallback((direction: 'next' | 'previous', isRepeatedKey = false) => {
+    pendingKeyboardNavigationRef.current = direction;
+
+    if (isRepeatedKey) {
+      if (!isRapidKeyboardNavigatingRef.current) {
+        isRapidKeyboardNavigatingRef.current = true;
+        setIsRapidKeyboardNavigating(true);
+      }
+
+      if (keyboardNavigationIdleTimeoutRef.current !== null) {
+        window.clearTimeout(keyboardNavigationIdleTimeoutRef.current);
+      }
+
+      keyboardNavigationIdleTimeoutRef.current = window.setTimeout(() => {
+        keyboardNavigationIdleTimeoutRef.current = null;
+        isRapidKeyboardNavigatingRef.current = false;
+        setIsRapidKeyboardNavigating(false);
+      }, RAPID_KEYBOARD_NAVIGATION_IDLE_MS);
+    }
+
+    if (keyboardNavigationFrameRef.current !== null) {
+      return;
+    }
+
+    keyboardNavigationFrameRef.current = window.requestAnimationFrame(() => {
+      keyboardNavigationFrameRef.current = null;
+      const nextDirection = pendingKeyboardNavigationRef.current;
+      pendingKeyboardNavigationRef.current = null;
+
+      if (nextDirection === 'next') {
+        onNavigateNext?.();
+        return;
+      }
+
+      if (nextDirection === 'previous') {
+        onNavigatePrevious?.();
+      }
+    });
+  }, [onNavigateNext, onNavigatePrevious]);
+
   useEffect(() => {
     if (!isActive) {
       return;
@@ -2374,14 +2439,14 @@ const ImageModal: React.FC<ImageModalProps> = ({
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
         event.stopPropagation();
-        onNavigatePrevious?.();
+        scheduleKeyboardNavigation('previous', event.repeat);
         return;
       }
 
       if (event.key === 'ArrowRight') {
         event.preventDefault();
         event.stopPropagation();
-        onNavigateNext?.();
+        scheduleKeyboardNavigation('next', event.repeat);
         return;
       }
     };
@@ -2408,9 +2473,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
     isRenaming,
     isSlideshowMode,
     onClose,
-    onNavigateNext,
-    onNavigatePrevious,
     previewKeymap,
+    scheduleKeyboardNavigation,
     toggleFullscreen,
     toggleFullscreenKeybinding,
   ]);
@@ -2419,6 +2483,16 @@ const ImageModal: React.FC<ImageModalProps> = ({
     return () => {
       clearMediaOverlayHideTimer();
       clearSlideshowTimer();
+      if (keyboardNavigationFrameRef.current !== null) {
+        window.cancelAnimationFrame(keyboardNavigationFrameRef.current);
+        keyboardNavigationFrameRef.current = null;
+      }
+      if (keyboardNavigationIdleTimeoutRef.current !== null) {
+        window.clearTimeout(keyboardNavigationIdleTimeoutRef.current);
+        keyboardNavigationIdleTimeoutRef.current = null;
+      }
+      isRapidKeyboardNavigatingRef.current = false;
+      pendingKeyboardNavigationRef.current = null;
     };
   }, [clearMediaOverlayHideTimer, clearSlideshowTimer]);
 
@@ -2586,6 +2660,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
     >
       <div
         ref={modalShellRef}
+        role="dialog"
+        aria-modal={isFullViewportModal ? 'true' : 'false'}
+        aria-label={`Image viewer: ${image.name}`}
         className={`${
           isFullViewportModal
             ? 'fixed inset-0 z-[9999] h-screen w-screen rounded-none bg-black'

--- a/electron.mjs
+++ b/electron.mjs
@@ -3318,8 +3318,37 @@ function setupFileOperationHandlers() {
     }
   });
 
-  ipcMain.handle('finalize-cache-write', async (event, { cacheId, record }) => {
+  ipcMain.handle('finalize-cache-write', async (event, { cacheId, sourceCacheId, record }) => {
     try {
+      const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
+      const safeSourceCacheId = sourceCacheId?.replace(/[^a-zA-Z0-9-_]/g, '_');
+      if (safeSourceCacheId && safeSourceCacheId !== safeCacheId) {
+        const rootPath = await getCacheRootPath();
+        const cacheDir = path.join(rootPath, 'json_cache');
+        await fs.mkdir(cacheDir, { recursive: true });
+
+        const files = await fs.readdir(cacheDir).catch(error => {
+          if (error.code === 'ENOENT') return [];
+          throw error;
+        });
+
+        await Promise.all(
+          files
+            .filter(file => file.startsWith(`${safeCacheId}_`))
+            .map(file => fs.unlink(path.join(cacheDir, file)).catch(err => {
+              if (err.code !== 'ENOENT') throw err;
+            }))
+        );
+
+        for (const file of files.filter(file => file.startsWith(`${safeSourceCacheId}_`))) {
+          const suffix = file.slice(safeSourceCacheId.length);
+          await fs.rename(
+            path.join(cacheDir, file),
+            path.join(cacheDir, `${safeCacheId}${suffix}`)
+          );
+        }
+      }
+
       const mainCachePath = await getCacheFilePath(cacheId);
       // Add parser version to cache record
       const recordWithVersion = { ...record, parserVersion: PARSER_VERSION };

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - [Unreleased]
+
+### Improved
+
+- **Image Modal Navigation Performance**: Improved rapid left/right arrow navigation in the image viewer by coalescing repeated key events, using cheaper navigation indexes, and temporarily keeping heavy sidebar rendering out of the hot path while keys are held.
+
+### Fixed
+
+- **Watched File Deletion Stability**: Fixed watched file deletions so cache pruning no longer blocks the renderer, updates both flat and recursive cache variants, and safely rewrites multi-chunk caches without overwriting chunks that are still being read.
+
 ## [0.16.1] - [Unreleased]
 
 ### Added

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -730,6 +730,7 @@ class CacheManager {
     if (imagesToUpsert.length === 0 && removedImageIds.length === 0 && removedImageNames.length === 0) return;
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
+    const outputCacheId = `${cacheId}-delta-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const summary = await this.getCacheSummary(directoryPath, scanSubfolders);
     if (!summary) {
       if (imagesToUpsert.length > 0) {
@@ -759,7 +760,7 @@ class CacheManager {
 
       const chunk = outputBuffer.splice(0, outputBuffer.length);
       const result = await window.electronAPI.writeCacheChunk({
-        cacheId,
+        cacheId: outputCacheId,
         chunkIndex: outputChunkIndex,
         data: chunk,
       });
@@ -806,6 +807,7 @@ class CacheManager {
 
     const finalizeResult = await window.electronAPI.finalizeCacheWrite({
       cacheId,
+      sourceCacheId: outputCacheId,
       record: {
         id: cacheId,
         directoryPath,

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -3715,7 +3715,9 @@ export const useImageStore = create<ImageState>((set, get) => {
 
             return resolveSmartCollectionImageIds(collection, state.images).length;
         },
-        setFocusedImageIndex: (index) => set({ focusedImageIndex: index }),
+        setFocusedImageIndex: (index) => set((state) => (
+            state.focusedImageIndex === index ? state : { focusedImageIndex: index }
+        )),
         setClipboard: (clipboard) => set({ clipboard }),
         setFullscreenMode: (isFullscreen) => set({ isFullscreenMode: isFullscreen }),
 

--- a/types.ts
+++ b/types.ts
@@ -295,7 +295,7 @@ export interface ElectronAPI {
   writeJsonCacheData: (args: { cacheId: string; data: any }) => Promise<{ success: boolean; error?: string }>;
   prepareCacheWrite: (args: { cacheId: string }) => Promise<{ success: boolean; error?: string }>;
   writeCacheChunk: (args: { cacheId: string; chunkIndex: number; data: any }) => Promise<{ success: boolean; error?: string }>;
-  finalizeCacheWrite: (args: { cacheId: string; record: any }) => Promise<{ success: boolean; error?: string }>;
+  finalizeCacheWrite: (args: { cacheId: string; record: any; sourceCacheId?: string }) => Promise<{ success: boolean; error?: string }>;
   clearCacheData: (cacheId: string) => Promise<{ success: boolean; error?: string }>;
   resolveThumbnailCacheBatch: (args: {
     candidates: ThumbnailCacheCandidate[];


### PR DESCRIPTION
## Summary
- defer watched-removal cache updates so file watcher deletions do not block the renderer
- coalesce image modal arrow-key navigation and avoid rebuilding full navigation image lists on each modal render
- suppress heavy modal sidebar rendering during repeated keyboard navigation and prevent grid focus updates while the modal is open

## Verification
- `npx tsc --noEmit`
- `npx vitest run`