### PR TITLE
Add advanced compare modes

### DIFF
--- a/__tests__/ComparisonModal.interaction.test.tsx
+++ b/__tests__/ComparisonModal.interaction.test.tsx
@@ -1,18 +1,31 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ComparisonModal from '../components/ComparisonModal';
 import { useImageStore } from '../store/useImageStore';
 import type { IndexedImage } from '../types';
 
 vi.mock('../components/ComparisonPane', () => ({
-  default: ({ image, onHoverChange }: { image: IndexedImage; onHoverChange?: (isHovered: boolean) => void }) => (
+  default: ({
+    image,
+    onHoverChange,
+    onRemove,
+  }: {
+    image: IndexedImage;
+    onHoverChange?: (isHovered: boolean) => void;
+    onRemove?: () => void;
+  }) => (
     <div
       data-testid={`pane-${image.id}`}
       onMouseEnter={() => onHoverChange?.(true)}
       onMouseLeave={() => onHoverChange?.(false)}
     >
       {image.name}
+      {onRemove ? (
+        <button type="button" onClick={onRemove} aria-label={`Remove ${image.name} from comparison pane`}>
+          Remove pane
+        </button>
+      ) : null}
     </div>
   ),
 }));
@@ -118,5 +131,45 @@ describe('ComparisonModal interactions', () => {
     expect(screen.getByText('Metadata Delta')).toBeTruthy();
     expect(screen.getByText('Sensitivity')).toBeTruthy();
     expect(screen.getByText('Opacity')).toBeTruthy();
+  });
+
+  it('clears the visual delta panel when returning to side-by-side mode', async () => {
+    const first = createImage('img-1', 'first prompt');
+    const second = createImage('img-2', 'second prompt');
+
+    useImageStore.setState({
+      comparisonImages: [first, second],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+    } as any);
+
+    render(<ComparisonModal isOpen onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff Map' }));
+    expect(screen.getByText('Visual Delta')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Side-by-Side' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Visual Delta')).toBeNull();
+    });
+  });
+
+  it('removes one pane from a 3-image comparison without closing the modal', () => {
+    const first = createImage('img-1', 'first prompt');
+    const second = createImage('img-2', 'second prompt');
+    const third = createImage('img-3', 'third prompt');
+    const onClose = vi.fn();
+
+    useImageStore.setState({
+      comparisonImages: [first, second, third],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+    } as any);
+
+    render(<ComparisonModal isOpen onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove img-2.png from comparison pane' }));
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(useImageStore.getState().comparisonImages.map((image) => image.id)).toEqual(['img-1', 'img-3']);
   });
 });

--- a/__tests__/ComparisonModal.interaction.test.tsx
+++ b/__tests__/ComparisonModal.interaction.test.tsx
@@ -18,7 +18,21 @@ vi.mock('../components/ComparisonPane', () => ({
 }));
 
 vi.mock('../components/ComparisonOverlayView', () => ({
-  default: () => <div data-testid="overlay-view">overlay</div>,
+  default: ({ onVisualAnalysisChange }: { onVisualAnalysisChange?: (metrics: any) => void }) => {
+    React.useEffect(() => {
+      onVisualAnalysisChange?.({
+        width: 100,
+        height: 80,
+        changedPixels: 25,
+        totalPixels: 8000,
+        changedPercent: 0.3125,
+        averageDelta: 12,
+        strongestRegion: { x: 10, y: 10, width: 20, height: 20, score: 90 },
+      });
+    }, [onVisualAnalysisChange]);
+
+    return <div data-testid="overlay-view">overlay</div>;
+  },
 }));
 
 vi.mock('../components/ComparisonMetadataPanel', () => ({
@@ -84,5 +98,25 @@ describe('ComparisonModal interactions', () => {
 
     fireEvent.mouseLeave(screen.getByTestId('pane-img-2'));
     expect(screen.getByTestId('metadata-img-2').getAttribute('data-highlighted')).toBe('false');
+  });
+
+  it('enables advanced two-image modes and shows visual delta controls', () => {
+    const first = createImage('img-1', 'first prompt');
+    const second = createImage('img-2', 'second prompt');
+
+    useImageStore.setState({
+      comparisonImages: [first, second],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+    } as any);
+
+    render(<ComparisonModal isOpen onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff Map' }));
+
+    expect(screen.getByTestId('overlay-view')).toBeTruthy();
+    expect(screen.getByText('Visual Delta')).toBeTruthy();
+    expect(screen.getByText('Metadata Delta')).toBeTruthy();
+    expect(screen.getByText('Sensitivity')).toBeTruthy();
+    expect(screen.getByText('Opacity')).toBeTruthy();
   });
 });

--- a/__tests__/visualComparison.test.ts
+++ b/__tests__/visualComparison.test.ts
@@ -52,6 +52,17 @@ describe('visualComparison utilities', () => {
     expect(createHeatmapImageData(left, right, 5).metrics.changedPixels).toBe(1);
   });
 
+  it('does not count identical pixels as changed at zero threshold', () => {
+    const left = imageData(1, 1, [[80, 90, 100, 255]]);
+    const right = imageData(1, 1, [[80, 90, 100, 255]]);
+
+    const result = createHeatmapImageData(left, right, 0);
+
+    expect(result.metrics.changedPixels).toBe(0);
+    expect(result.metrics.changedPercent).toBe(0);
+    expect(result.imageData.data[3]).toBe(0);
+  });
+
   it('detects the strongest changed region', () => {
     const left = imageData(2, 2, [
       [0, 0, 0, 255], [0, 0, 0, 255],

--- a/__tests__/visualComparison.test.ts
+++ b/__tests__/visualComparison.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
   buildVisualComparisonFromImageData,
+  calculatePixelDelta,
   createEdgeDifferenceImageData,
   createHeatmapImageData,
 } from '../utils/visualComparison';
@@ -61,6 +62,14 @@ describe('visualComparison utilities', () => {
     expect(result.metrics.changedPixels).toBe(0);
     expect(result.metrics.changedPercent).toBe(0);
     expect(result.imageData.data[3]).toBe(0);
+  });
+
+  it('detects alpha-only pixel changes', () => {
+    const opaqueBlack = imageData(1, 1, [[0, 0, 0, 255]]);
+    const transparentBlack = imageData(1, 1, [[0, 0, 0, 0]]);
+
+    expect(calculatePixelDelta(opaqueBlack.data, transparentBlack.data, 0)).toBeGreaterThan(0);
+    expect(createHeatmapImageData(opaqueBlack, transparentBlack, 18).metrics.changedPixels).toBe(1);
   });
 
   it('detects the strongest changed region', () => {

--- a/__tests__/visualComparison.test.ts
+++ b/__tests__/visualComparison.test.ts
@@ -95,4 +95,20 @@ describe('visualComparison utilities', () => {
 
     expect(visibleAlphaValues.length).toBeGreaterThan(0);
   });
+
+  it('does not render flat zero-strength edges at zero threshold', () => {
+    const left = imageData(2, 2, [
+      [40, 40, 40, 255], [40, 40, 40, 255],
+      [40, 40, 40, 255], [40, 40, 40, 255],
+    ]);
+    const right = imageData(2, 2, [
+      [40, 40, 40, 255], [40, 40, 40, 255],
+      [40, 40, 40, 255], [40, 40, 40, 255],
+    ]);
+
+    const edgeMap = createEdgeDifferenceImageData(left, right, 0);
+    const visibleAlphaValues = Array.from(edgeMap.data).filter((_, index) => index % 4 === 3 && edgeMap.data[index] > 0);
+
+    expect(visibleAlphaValues).toHaveLength(0);
+  });
 });

--- a/__tests__/visualComparison.test.ts
+++ b/__tests__/visualComparison.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  buildVisualComparisonFromImageData,
+  createEdgeDifferenceImageData,
+  createHeatmapImageData,
+} from '../utils/visualComparison';
+
+class TestImageData {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+
+  constructor(dataOrWidth: Uint8ClampedArray | number, widthOrHeight: number, height?: number) {
+    if (typeof dataOrWidth === 'number') {
+      this.width = dataOrWidth;
+      this.height = widthOrHeight;
+      this.data = new Uint8ClampedArray(this.width * this.height * 4);
+      return;
+    }
+
+    this.data = dataOrWidth;
+    this.width = widthOrHeight;
+    this.height = height ?? 0;
+  }
+}
+
+const imageData = (width: number, height: number, pixels: Array<[number, number, number, number]>): ImageData =>
+  new ImageData(new Uint8ClampedArray(pixels.flat()), width, height);
+
+describe('visualComparison utilities', () => {
+  beforeAll(() => {
+    if (typeof ImageData === 'undefined') {
+      (globalThis as unknown as { ImageData: typeof ImageData }).ImageData = TestImageData as unknown as typeof ImageData;
+    }
+  });
+
+  it('returns zero visual delta for identical images', () => {
+    const left = imageData(1, 1, [[20, 40, 60, 255]]);
+    const result = buildVisualComparisonFromImageData(left, imageData(1, 1, [[20, 40, 60, 255]]), 18);
+
+    expect(result.metrics.changedPixels).toBe(0);
+    expect(result.metrics.changedPercent).toBe(0);
+    expect(result.metrics.averageDelta).toBe(0);
+    expect(result.metrics.strongestRegion).toBeNull();
+  });
+
+  it('respects the heatmap threshold', () => {
+    const left = imageData(1, 1, [[100, 100, 100, 255]]);
+    const right = imageData(1, 1, [[110, 110, 110, 255]]);
+
+    expect(createHeatmapImageData(left, right, 20).metrics.changedPixels).toBe(0);
+    expect(createHeatmapImageData(left, right, 5).metrics.changedPixels).toBe(1);
+  });
+
+  it('detects the strongest changed region', () => {
+    const left = imageData(2, 2, [
+      [0, 0, 0, 255], [0, 0, 0, 255],
+      [0, 0, 0, 255], [0, 0, 0, 255],
+    ]);
+    const right = imageData(2, 2, [
+      [0, 0, 0, 255], [0, 0, 0, 255],
+      [0, 0, 0, 255], [255, 255, 255, 255],
+    ]);
+    const result = buildVisualComparisonFromImageData(left, right, 18);
+
+    expect(result.metrics.changedPixels).toBe(1);
+    expect(result.metrics.strongestRegion).toMatchObject({ x: 1, y: 1 });
+  });
+
+  it('creates visible Sobel edge differences for simple shapes', () => {
+    const left = imageData(3, 3, [
+      [0, 0, 0, 255], [255, 255, 255, 255], [0, 0, 0, 255],
+      [0, 0, 0, 255], [255, 255, 255, 255], [0, 0, 0, 255],
+      [0, 0, 0, 255], [255, 255, 255, 255], [0, 0, 0, 255],
+    ]);
+    const right = imageData(3, 3, [
+      [0, 0, 0, 255], [0, 0, 0, 255], [0, 0, 0, 255],
+      [255, 255, 255, 255], [255, 255, 255, 255], [255, 255, 255, 255],
+      [0, 0, 0, 255], [0, 0, 0, 255], [0, 0, 0, 255],
+    ]);
+
+    const edgeMap = createEdgeDifferenceImageData(left, right, 20);
+    const visibleAlphaValues = Array.from(edgeMap.data).filter((_, index) => index % 4 === 3 && edgeMap.data[index] > 0);
+
+    expect(visibleAlphaValues.length).toBeGreaterThan(0);
+  });
+});

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -60,7 +60,13 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   );
 
   const updateSharedZoom = (zoom: number, x: number, y: number) => {
-    setSharedZoom({ zoom, x, y });
+    setSharedZoom((current) => {
+      const unchanged =
+        Math.abs(current.zoom - zoom) < 0.001 &&
+        Math.abs(current.x - x) < 0.5 &&
+        Math.abs(current.y - y) < 0.5;
+      return unchanged ? current : { zoom, x, y };
+    });
   };
 
   const handleZoomChange = (zoom: number, x: number, y: number) => {

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -113,6 +113,12 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   }, [supportsOverlayModes, viewMode]);
 
   useEffect(() => {
+    if (isAdvancedMode) return;
+    setVisualMetrics(null);
+    setHighlightDeltaRegion(false);
+  }, [isAdvancedMode]);
+
+  useEffect(() => {
     if (!isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -143,17 +149,6 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [imageCount, isOpen, viewMode]);
 
-  if (!isOpen || imageCount < 2) return null;
-
-  const viewModes: { id: ComparisonViewMode; label: string; hint: string; disabled?: boolean }[] = [
-    { id: 'side-by-side', label: imageCount > 2 ? 'Compare' : 'Side-by-Side', hint: imageCount > 2 ? 'Compare all selected images together' : 'Two panes with optional synced zoom' },
-    { id: 'slider', label: 'Slider', hint: 'Drag the divider to reveal each image', disabled: !supportsOverlayModes },
-    { id: 'hover', label: 'Hover', hint: 'Hover to toggle between the images', disabled: !supportsOverlayModes },
-    { id: 'difference-map', label: 'Diff Map', hint: 'Highlight changed pixels as a heatmap', disabled: !supportsOverlayModes },
-    { id: 'flicker', label: 'Flicker', hint: 'Alternate images in the same viewport', disabled: !supportsOverlayModes },
-    { id: 'loupe', label: 'Loupe', hint: 'Inspect Image A, diff, and Image B under the cursor', disabled: !supportsOverlayModes },
-    { id: 'edge-difference', label: 'Edges', hint: 'Compare structural outlines and silhouettes', disabled: !supportsOverlayModes },
-  ];
   const isSideBySide = viewMode === 'side-by-side';
   const metadataReference = comparisonImages[0]?.metadata?.normalizedMetadata ?? null;
   const leftMetadata = comparisonImages[0]?.metadata?.normalizedMetadata ?? null;
@@ -173,6 +168,18 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   const updateAdvancedSettings = (patch: Partial<ComparisonAdvancedSettings>) => {
     setAdvancedSettings((current) => ({ ...current, ...patch }));
   };
+
+  if (!isOpen || imageCount < 2) return null;
+
+  const viewModes: { id: ComparisonViewMode; label: string; hint: string; disabled?: boolean }[] = [
+    { id: 'side-by-side', label: imageCount > 2 ? 'Compare' : 'Side-by-Side', hint: imageCount > 2 ? 'Compare all selected images together' : 'Two panes with optional synced zoom' },
+    { id: 'slider', label: 'Slider', hint: 'Drag the divider to reveal each image', disabled: !supportsOverlayModes },
+    { id: 'hover', label: 'Hover', hint: 'Hover to toggle between the images', disabled: !supportsOverlayModes },
+    { id: 'difference-map', label: 'Diff Map', hint: 'Highlight changed pixels as a heatmap', disabled: !supportsOverlayModes },
+    { id: 'flicker', label: 'Flicker', hint: 'Alternate images in the same viewport', disabled: !supportsOverlayModes },
+    { id: 'loupe', label: 'Loupe', hint: 'Inspect Image A, diff, and Image B under the cursor', disabled: !supportsOverlayModes },
+    { id: 'edge-difference', label: 'Edges', hint: 'Compare structural outlines and silhouettes', disabled: !supportsOverlayModes },
+  ];
 
   return (
     <div className="fixed inset-0 z-[140] bg-black/85 backdrop-blur-sm flex flex-col">
@@ -434,6 +441,7 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
                   onHoverChange={(isHovered) =>
                     setActiveMetadataIndex((current) => (isHovered ? index : current === index ? null : current))
                   }
+                  onRemove={imageCount > 2 ? () => handleRemoveImage(index) : undefined}
                   className={`h-full rounded-xl border border-gray-800 overflow-hidden ${isOddLastGridItem ? 'md:col-span-2' : ''}`}
                   imageLabel={`Image ${index + 1}`}
                 />

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, FC, useMemo } from 'react';
 import { X, Repeat, ArrowLeft } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
-import { BaseMetadata, ComparisonLayoutMode, ComparisonModalProps, IndexedImage, ZoomState, ComparisonViewMode } from '../types';
+import { BaseMetadata, ComparisonAdvancedSettings, ComparisonLayoutMode, ComparisonModalProps, IndexedImage, ZoomState, ComparisonViewMode } from '../types';
 import ComparisonPane from './ComparisonPane';
 import ComparisonMetadataPanel from './ComparisonMetadataPanel';
 import ComparisonOverlayView from './ComparisonOverlayView';
+import { getFieldLabel, getMetadataDifferences } from '../utils/metadataComparison';
+import { VisualComparisonMetrics } from '../utils/visualComparison';
 
 export const getComparisonMetadataReference = (
   comparisonImages: IndexedImage[],
@@ -33,9 +35,25 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   const [layoutMode, setLayoutMode] = useState<ComparisonLayoutMode>('strip');
   const [metadataViewMode, setMetadataViewMode] = useState<'standard' | 'diff'>('standard');
   const [activeMetadataIndex, setActiveMetadataIndex] = useState<number | null>(null);
+  const [visualMetrics, setVisualMetrics] = useState<VisualComparisonMetrics | null>(null);
+  const [highlightDeltaRegion, setHighlightDeltaRegion] = useState(false);
+  const [advancedSettings, setAdvancedSettings] = useState<ComparisonAdvancedSettings>({
+    threshold: 18,
+    opacity: 65,
+    baseMode: 'left',
+    flickerSpeedMs: 700,
+    loupeSize: 220,
+    loupeZoom: 2,
+    showLabels: true,
+  });
 
   const imageCount = comparisonImages.length;
   const supportsOverlayModes = imageCount === 2;
+  const advancedModes = useMemo(
+    () => new Set<ComparisonViewMode>(['difference-map', 'flicker', 'loupe', 'edge-difference']),
+    []
+  );
+  const isAdvancedMode = advancedModes.has(viewMode);
   const directoryPathById = useMemo(
     () => new Map(directories.map((directory) => [directory.id, directory.path])),
     [directories]
@@ -84,6 +102,8 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   useEffect(() => {
     setExpandedMetadataIndexes(new Set());
     setActiveMetadataIndex(null);
+    setVisualMetrics(null);
+    setHighlightDeltaRegion(false);
   }, [comparisonImages]);
 
   useEffect(() => {
@@ -129,9 +149,30 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
     { id: 'side-by-side', label: imageCount > 2 ? 'Compare' : 'Side-by-Side', hint: imageCount > 2 ? 'Compare all selected images together' : 'Two panes with optional synced zoom' },
     { id: 'slider', label: 'Slider', hint: 'Drag the divider to reveal each image', disabled: !supportsOverlayModes },
     { id: 'hover', label: 'Hover', hint: 'Hover to toggle between the images', disabled: !supportsOverlayModes },
+    { id: 'difference-map', label: 'Diff Map', hint: 'Highlight changed pixels as a heatmap', disabled: !supportsOverlayModes },
+    { id: 'flicker', label: 'Flicker', hint: 'Alternate images in the same viewport', disabled: !supportsOverlayModes },
+    { id: 'loupe', label: 'Loupe', hint: 'Inspect Image A, diff, and Image B under the cursor', disabled: !supportsOverlayModes },
+    { id: 'edge-difference', label: 'Edges', hint: 'Compare structural outlines and silhouettes', disabled: !supportsOverlayModes },
   ];
   const isSideBySide = viewMode === 'side-by-side';
   const metadataReference = comparisonImages[0]?.metadata?.normalizedMetadata ?? null;
+  const leftMetadata = comparisonImages[0]?.metadata?.normalizedMetadata ?? null;
+  const rightMetadata = comparisonImages[1]?.metadata?.normalizedMetadata ?? null;
+  const metadataDifferences = useMemo(() => {
+    if (!leftMetadata || !rightMetadata) return [];
+    const priority = ['prompt', 'negativePrompt', 'seed', 'model', 'models', 'loras', 'cfg_scale', 'steps', 'sampler', 'scheduler', 'width', 'height'];
+    const differences = Array.from(getMetadataDifferences(leftMetadata, rightMetadata));
+    return differences.sort((left, right) => {
+      const leftIndex = priority.indexOf(left);
+      const rightIndex = priority.indexOf(right);
+      const normalizedLeft = leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex;
+      const normalizedRight = rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex;
+      return normalizedLeft - normalizedRight || left.localeCompare(right);
+    });
+  }, [leftMetadata, rightMetadata]);
+  const updateAdvancedSettings = (patch: Partial<ComparisonAdvancedSettings>) => {
+    setAdvancedSettings((current) => ({ ...current, ...patch }));
+  };
 
   return (
     <div className="fixed inset-0 z-[140] bg-black/85 backdrop-blur-sm flex flex-col">
@@ -247,6 +288,108 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
             <span>Back to Grid</span>
           </button>
         </div>
+
+        {isAdvancedMode && supportsOverlayModes && (
+          <div className="flex flex-wrap items-center gap-3 rounded-lg border border-gray-700/60 bg-gray-950/45 px-3 py-2">
+            {(viewMode === 'difference-map' || viewMode === 'edge-difference' || viewMode === 'loupe') && (
+              <>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Sensitivity
+                  <input
+                    type="range"
+                    min={0}
+                    max={80}
+                    value={advancedSettings.threshold}
+                    onChange={(event) => updateAdvancedSettings({ threshold: Number(event.target.value) })}
+                    className="w-28 accent-blue-500"
+                  />
+                  <span className="w-6 text-right text-gray-500">{advancedSettings.threshold}</span>
+                </label>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Opacity
+                  <input
+                    type="range"
+                    min={20}
+                    max={100}
+                    value={advancedSettings.opacity}
+                    onChange={(event) => updateAdvancedSettings({ opacity: Number(event.target.value) })}
+                    className="w-24 accent-blue-500"
+                  />
+                  <span className="w-8 text-right text-gray-500">{advancedSettings.opacity}%</span>
+                </label>
+                {viewMode !== 'loupe' && (
+                  <select
+                    value={advancedSettings.baseMode}
+                    onChange={(event) => updateAdvancedSettings({ baseMode: event.target.value as ComparisonAdvancedSettings['baseMode'] })}
+                    className="rounded-lg border border-gray-700 bg-gray-900 px-2 py-1 text-xs text-gray-200"
+                    title="Choose the base image below the visual difference layer"
+                  >
+                    <option value="left">Image A base</option>
+                    <option value="right">Image B base</option>
+                    <option value="diff">Diff only</option>
+                  </select>
+                )}
+              </>
+            )}
+
+            {viewMode === 'flicker' && (
+              <>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Speed
+                  <input
+                    type="range"
+                    min={150}
+                    max={1500}
+                    step={50}
+                    value={advancedSettings.flickerSpeedMs}
+                    onChange={(event) => updateAdvancedSettings({ flickerSpeedMs: Number(event.target.value) })}
+                    className="w-32 accent-blue-500"
+                  />
+                  <span className="w-12 text-right text-gray-500">{advancedSettings.flickerSpeedMs}ms</span>
+                </label>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  <input
+                    type="checkbox"
+                    checked={advancedSettings.showLabels}
+                    onChange={(event) => updateAdvancedSettings({ showLabels: event.target.checked })}
+                    className="accent-blue-500"
+                  />
+                  Labels
+                </label>
+              </>
+            )}
+
+            {viewMode === 'loupe' && (
+              <>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Size
+                  <input
+                    type="range"
+                    min={160}
+                    max={340}
+                    step={10}
+                    value={advancedSettings.loupeSize}
+                    onChange={(event) => updateAdvancedSettings({ loupeSize: Number(event.target.value) })}
+                    className="w-24 accent-blue-500"
+                  />
+                </label>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Zoom
+                  <input
+                    type="range"
+                    min={1.4}
+                    max={3.5}
+                    step={0.1}
+                    value={advancedSettings.loupeZoom}
+                    onChange={(event) => updateAdvancedSettings({ loupeZoom: Number(event.target.value) })}
+                    className="w-24 accent-blue-500"
+                  />
+                  <span className="w-8 text-right text-gray-500">{advancedSettings.loupeZoom.toFixed(1)}x</span>
+                </label>
+              </>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="flex-1 min-h-0 overflow-hidden">
@@ -260,6 +403,9 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
             sharedZoom={sharedZoom}
             onZoomChange={updateSharedZoom}
             onActiveImageChange={setActiveMetadataIndex}
+            advancedSettings={advancedSettings}
+            onVisualAnalysisChange={setVisualMetrics}
+            highlightedRegion={highlightDeltaRegion ? visualMetrics?.strongestRegion : null}
           />
         ) : (
           <div className="h-full overflow-auto bg-gray-950 p-2">
@@ -299,6 +445,57 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
       </div>
 
       <div className="bg-gray-900/50 border-t border-gray-700 p-4 overflow-y-auto max-h-[40vh]">
+        {supportsOverlayModes && visualMetrics && (
+          <div className="mx-auto mb-4 grid max-w-7xl grid-cols-1 gap-3 md:grid-cols-[1.1fr_1fr]">
+            <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wider text-amber-100">Visual Delta</h3>
+                <button
+                  type="button"
+                  onMouseEnter={() => setHighlightDeltaRegion(true)}
+                  onMouseLeave={() => setHighlightDeltaRegion(false)}
+                  onFocus={() => setHighlightDeltaRegion(true)}
+                  onBlur={() => setHighlightDeltaRegion(false)}
+                  className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-2 py-1 text-xs text-amber-100 hover:bg-amber-400/20"
+                  disabled={!visualMetrics.strongestRegion}
+                  title="Highlight the strongest visual-change region"
+                >
+                  Strongest region
+                </button>
+              </div>
+              <div className="grid grid-cols-3 gap-2 text-sm">
+                <div className="rounded border border-gray-700 bg-gray-950/50 p-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-500">Changed</div>
+                  <div className="mt-1 font-semibold text-gray-100">{visualMetrics.changedPercent.toFixed(1)}%</div>
+                </div>
+                <div className="rounded border border-gray-700 bg-gray-950/50 p-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-500">Avg Delta</div>
+                  <div className="mt-1 font-semibold text-gray-100">{visualMetrics.averageDelta.toFixed(1)}</div>
+                </div>
+                <div className="rounded border border-gray-700 bg-gray-950/50 p-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-500">Canvas</div>
+                  <div className="mt-1 font-semibold text-gray-100">{visualMetrics.width}x{visualMetrics.height}</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
+              <h3 className="mb-2 text-sm font-semibold uppercase tracking-wider text-cyan-100">Metadata Delta</h3>
+              {metadataDifferences.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {metadataDifferences.slice(0, 12).map((field) => (
+                    <span key={field} className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2 py-1 text-xs text-cyan-100">
+                      {getFieldLabel(field)}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-400">No normalized metadata differences detected.</p>
+              )}
+            </div>
+          </div>
+        )}
+
         <div className="flex flex-wrap justify-between items-center gap-3 mb-4 max-w-7xl mx-auto">
           <div>
             <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">Metadata</h3>

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -25,6 +25,23 @@ interface ComparisonOverlayViewProps {
 
 const ADVANCED_MODES = new Set<ComparisonViewMode>(['difference-map', 'flicker', 'loupe', 'edge-difference']);
 
+const getContainedRect = (
+  containerWidth: number,
+  containerHeight: number,
+  sourceWidth: number,
+  sourceHeight: number,
+) => {
+  const scale = Math.min(containerWidth / sourceWidth, containerHeight / sourceHeight);
+  const width = sourceWidth * scale;
+  const height = sourceHeight * scale;
+  return {
+    x: (containerWidth - width) / 2,
+    y: (containerHeight - height) / 2,
+    width,
+    height,
+  };
+};
+
 const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   leftImage,
   rightImage,
@@ -48,7 +65,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   const [heatmapUrl, setHeatmapUrl] = useState<string | null>(null);
   const [edgeMapUrl, setEdgeMapUrl] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<VisualComparisonMetrics | null>(null);
-  const [loupePoint, setLoupePoint] = useState<{ x: number; y: number } | null>(null);
+  const [loupePoint, setLoupePoint] = useState<{ x: number; y: number; localX: number; localY: number } | null>(null);
+  const [localTransform, setLocalTransform] = useState(sharedZoom);
   const transformRef = useRef<ReactZoomPanPinchRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDraggingHandle, setIsDraggingHandle] = useState(false);
@@ -60,6 +78,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     if (state.scale !== sharedZoom.zoom || state.positionX !== sharedZoom.x || state.positionY !== sharedZoom.y) {
       transformRef.current.setTransform(sharedZoom.x, sharedZoom.y, sharedZoom.zoom, 0);
     }
+    setLocalTransform(sharedZoom);
   }, [sharedZoom]);
 
   useEffect(() => {
@@ -110,6 +129,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   const handleTransform = (ref: ReactZoomPanPinchRef) => {
     if (!ref || !ref.state) return;
     const { positionX, positionY, scale } = ref.state;
+    setLocalTransform({ zoom: scale, x: positionX, y: positionY });
     onZoomChange(scale, positionX, positionY);
   };
 
@@ -174,9 +194,30 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   const updateLoupeFromMouse = (clientX: number, clientY: number) => {
     const rect = containerRef.current?.getBoundingClientRect();
     if (!rect) return;
+
+    const localX = clientX - rect.left;
+    const localY = clientY - rect.top;
+    const contentX = (localX - localTransform.x) / localTransform.zoom;
+    const contentY = (localY - localTransform.y) / localTransform.zoom;
+    const imageRect = metrics
+      ? getContainedRect(rect.width, rect.height, metrics.width, metrics.height)
+      : { x: 0, y: 0, width: rect.width, height: rect.height };
+    const isInsideImage =
+      contentX >= imageRect.x &&
+      contentX <= imageRect.x + imageRect.width &&
+      contentY >= imageRect.y &&
+      contentY <= imageRect.y + imageRect.height;
+
+    if (!isInsideImage) {
+      setLoupePoint(null);
+      return;
+    }
+
     setLoupePoint({
-      x: clamp(((clientX - rect.left) / rect.width) * 100, 0, 100),
-      y: clamp(((clientY - rect.top) / rect.height) * 100, 0, 100),
+      x: clamp(((contentX - imageRect.x) / imageRect.width) * 100, 0, 100),
+      y: clamp(((contentY - imageRect.y) / imageRect.height) * 100, 0, 100),
+      localX,
+      localY,
     });
   };
 
@@ -260,40 +301,6 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
       return (
         <>
           {leftUrl && <img src={leftUrl} alt={leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
-          {loupePoint && (
-            <div
-              className="pointer-events-none absolute overflow-hidden rounded-full border-2 border-white/80 bg-black shadow-2xl"
-              style={{
-                left: `${loupePoint.x}%`,
-                top: `${loupePoint.y}%`,
-                width: advancedSettings.loupeSize,
-                height: advancedSettings.loupeSize,
-                transform: 'translate(-50%, -50%)',
-              }}
-            >
-              {[leftUrl, heatmapUrl, rightUrl].map((url, index) => (
-                url ? (
-                  <img
-                    key={`${url}-${index}`}
-                    src={url}
-                    alt=""
-                    className="absolute h-full w-full object-contain"
-                    style={{
-                      left: `${(index - 1) * 33.33}%`,
-                      width: '166%',
-                      height: '166%',
-                      top: `${50 - loupePoint.y * (advancedSettings.loupeZoom / 1.8)}%`,
-                      transform: `translate(${50 - loupePoint.x * (advancedSettings.loupeZoom / 1.8)}%, -50%) scale(${advancedSettings.loupeZoom})`,
-                      opacity: index === 1 ? advancedSettings.opacity / 100 : 1,
-                      clipPath: index === 0 ? 'inset(0 66.66% 0 0)' : index === 1 ? 'inset(0 33.33% 0 33.33%)' : 'inset(0 0 0 66.66%)',
-                    }}
-                  />
-                ) : null
-              ))}
-              <div className="absolute inset-y-0 left-1/3 w-px bg-white/70" />
-              <div className="absolute inset-y-0 left-2/3 w-px bg-white/70" />
-            </div>
-          )}
           <div className="absolute left-1/2 top-4 -translate-x-1/2 rounded-full border border-white/10 bg-black/65 px-3 py-1 text-xs text-gray-100 shadow">
             Move over the image to inspect A / Diff / B
           </div>
@@ -302,6 +309,89 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     }
 
     return null;
+  };
+
+  const renderLoupeOverlay = () => {
+    if (mode !== 'loupe' || !loupePoint || !advancedReady) return null;
+
+    const loupeLayers = [
+      { url: leftUrl, label: 'A' },
+      { url: heatmapUrl, label: 'Diff', opacity: advancedSettings.opacity / 100 },
+      { url: rightUrl, label: 'B' },
+    ];
+    const container = containerRef.current?.getBoundingClientRect();
+    if (!container) return null;
+    const loupeSize = advancedSettings.loupeSize;
+    const paneWidth = loupeSize / 3;
+    const renderViewportClone = (url: string, opacity = 1) => (
+      <div
+        className="absolute top-0 overflow-hidden"
+        style={{
+          left: 0,
+          width: paneWidth,
+          height: loupeSize,
+        }}
+      >
+        <div
+          className="absolute overflow-hidden"
+          style={{
+            left: paneWidth / 2 - loupePoint.localX,
+            top: loupeSize / 2 - loupePoint.localY,
+            width: container.width,
+            height: container.height,
+            transform: `scale(${advancedSettings.loupeZoom})`,
+            transformOrigin: `${loupePoint.localX}px ${loupePoint.localY}px`,
+            opacity,
+          }}
+        >
+          <div
+            className="relative h-full w-full"
+            style={{
+              transform: `translate(${localTransform.x}px, ${localTransform.y}px) scale(${localTransform.zoom})`,
+              transformOrigin: '0 0',
+            }}
+          >
+            <img src={url} alt="" className="absolute inset-0 h-full w-full object-contain" />
+          </div>
+        </div>
+      </div>
+    );
+
+    return (
+      <div
+        className="pointer-events-none absolute z-20 overflow-hidden rounded-full border-2 border-white/80 bg-black shadow-2xl"
+        style={{
+          left: loupePoint.localX,
+          top: loupePoint.localY,
+          width: advancedSettings.loupeSize,
+          height: advancedSettings.loupeSize,
+          transform: 'translate(-50%, -50%)',
+        }}
+      >
+        {loupeLayers.map((layer, index) => (
+          layer.url ? (
+            <div
+              key={layer.label}
+              className="absolute top-0 overflow-hidden"
+              style={{
+                left: index * paneWidth,
+                width: paneWidth,
+                height: loupeSize,
+              }}
+            >
+              {renderViewportClone(layer.url, layer.opacity ?? 1)}
+            </div>
+          ) : null
+        ))}
+        <div className="absolute inset-y-0 left-1/3 w-px bg-white/70" />
+        <div className="absolute inset-y-0 left-2/3 w-px bg-white/70" />
+        <div className="absolute inset-x-0 top-2 grid grid-cols-3 px-4 text-center text-[10px] font-semibold uppercase tracking-wide text-white/85">
+          <span>A</span>
+          <span>Diff</span>
+          <span>B</span>
+        </div>
+      </div>
+    );
   };
 
   if (errorMessage) {
@@ -439,6 +529,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                 )}
               </div>
             </TransformComponent>
+
+            {renderLoupeOverlay()}
 
             <div className="absolute top-4 right-4 flex flex-col gap-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity z-10">
               <button

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -223,11 +223,14 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
 
   const regionStyle = useMemo<CSSProperties | null>(() => {
     if (!highlightedRegion || !metrics) return null;
+    const container = containerRef.current?.getBoundingClientRect();
+    if (!container) return null;
+    const imageRect = getContainedRect(container.width, container.height, metrics.width, metrics.height);
     return {
-      left: `${(highlightedRegion.x / metrics.width) * 100}%`,
-      top: `${(highlightedRegion.y / metrics.height) * 100}%`,
-      width: `${(highlightedRegion.width / metrics.width) * 100}%`,
-      height: `${(highlightedRegion.height / metrics.height) * 100}%`,
+      left: imageRect.x + (highlightedRegion.x / metrics.width) * imageRect.width,
+      top: imageRect.y + (highlightedRegion.y / metrics.height) * imageRect.height,
+      width: (highlightedRegion.width / metrics.width) * imageRect.width,
+      height: (highlightedRegion.height / metrics.height) * imageRect.height,
     };
   }, [highlightedRegion, metrics]);
 

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -187,7 +187,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
 
   const ready = Boolean(leftUrl && rightUrl);
   const isLoading = isLeftLoading || isRightLoading;
-  const advancedReady = !isAdvancedMode || Boolean(metrics);
+  const requiresVisualAnalysis = mode === 'difference-map' || mode === 'loupe' || mode === 'edge-difference';
+  const advancedReady = !requiresVisualAnalysis || Boolean(metrics);
   const overlayStyle =
     mode === 'slider'
       ? { clipPath: `inset(0 ${100 - sliderValue}% 0 0)`, transition: isDraggingHandle ? 'none' : 'clip-path 180ms ease' }

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -1,8 +1,13 @@
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { CSSProperties, FC, useEffect, useMemo, useRef, useState } from 'react';
 import { TransformComponent, TransformWrapper, ReactZoomPanPinchRef } from 'react-zoom-pan-pinch';
-import { ZoomIn, ZoomOut, RotateCcw, AlertCircle } from 'lucide-react';
-import { ComparisonViewMode, IndexedImage, ZoomState } from '../types';
+import { ZoomIn, ZoomOut, RotateCcw, AlertCircle, Pause, Play } from 'lucide-react';
+import { ComparisonAdvancedSettings, ComparisonViewMode, IndexedImage, ZoomState } from '../types';
 import useComparisonImageSource from '../hooks/useComparisonImageSource';
+import {
+  buildVisualComparisonFromUrls,
+  imageDataToDataUrl,
+  VisualComparisonMetrics,
+} from '../utils/visualComparison';
 
 interface ComparisonOverlayViewProps {
   leftImage: IndexedImage;
@@ -13,7 +18,12 @@ interface ComparisonOverlayViewProps {
   sharedZoom: ZoomState;
   onZoomChange: (zoom: number, x: number, y: number) => void;
   onActiveImageChange?: (index: number | null) => void;
+  advancedSettings: ComparisonAdvancedSettings;
+  onVisualAnalysisChange?: (metrics: VisualComparisonMetrics | null) => void;
+  highlightedRegion?: VisualComparisonMetrics['strongestRegion'] | null;
 }
+
+const ADVANCED_MODES = new Set<ComparisonViewMode>(['difference-map', 'flicker', 'loupe', 'edge-difference']);
 
 const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   leftImage,
@@ -24,14 +34,25 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   sharedZoom,
   onZoomChange,
   onActiveImageChange,
+  advancedSettings,
+  onVisualAnalysisChange,
+  highlightedRegion,
 }) => {
   const { imageUrl: leftUrl, loadError: leftError, isLoading: isLeftLoading } = useComparisonImageSource(leftImage, leftDirectory);
   const { imageUrl: rightUrl, loadError: rightError, isLoading: isRightLoading } = useComparisonImageSource(rightImage, rightDirectory);
   const [sliderValue, setSliderValue] = useState(50);
   const [isHovering, setIsHovering] = useState(false);
+  const [isFlickerShowingRight, setIsFlickerShowingRight] = useState(false);
+  const [isFlickerPaused, setIsFlickerPaused] = useState(false);
+  const [visualError, setVisualError] = useState<string | null>(null);
+  const [heatmapUrl, setHeatmapUrl] = useState<string | null>(null);
+  const [edgeMapUrl, setEdgeMapUrl] = useState<string | null>(null);
+  const [metrics, setMetrics] = useState<VisualComparisonMetrics | null>(null);
+  const [loupePoint, setLoupePoint] = useState<{ x: number; y: number } | null>(null);
   const transformRef = useRef<ReactZoomPanPinchRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDraggingHandle, setIsDraggingHandle] = useState(false);
+  const isAdvancedMode = ADVANCED_MODES.has(mode);
 
   useEffect(() => {
     if (!transformRef.current || !transformRef.current.state) return;
@@ -40,6 +61,51 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
       transformRef.current.setTransform(sharedZoom.x, sharedZoom.y, sharedZoom.zoom, 0);
     }
   }, [sharedZoom]);
+
+  useEffect(() => {
+    if (!isAdvancedMode || !leftUrl || !rightUrl) {
+      setHeatmapUrl(null);
+      setEdgeMapUrl(null);
+      setMetrics(null);
+      setVisualError(null);
+      onVisualAnalysisChange?.(null);
+      return;
+    }
+
+    let isMounted = true;
+    setVisualError(null);
+    buildVisualComparisonFromUrls(leftUrl, rightUrl, advancedSettings.threshold)
+      .then((result) => {
+        if (!isMounted) return;
+        const nextHeatmapUrl = imageDataToDataUrl(result.heatmap);
+        const nextEdgeMapUrl = imageDataToDataUrl(result.edgeMap);
+        setHeatmapUrl(nextHeatmapUrl);
+        setEdgeMapUrl(nextEdgeMapUrl);
+        setMetrics(result.metrics);
+        onVisualAnalysisChange?.(result.metrics);
+      })
+      .catch((error) => {
+        if (!isMounted) return;
+        const message = error instanceof Error ? error.message : String(error);
+        setVisualError(message);
+        setHeatmapUrl(null);
+        setEdgeMapUrl(null);
+        setMetrics(null);
+        onVisualAnalysisChange?.(null);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [advancedSettings.threshold, isAdvancedMode, leftUrl, onVisualAnalysisChange, rightUrl]);
+
+  useEffect(() => {
+    if (mode !== 'flicker' || isFlickerPaused) return;
+    const interval = window.setInterval(() => {
+      setIsFlickerShowingRight((current) => !current);
+    }, advancedSettings.flickerSpeedMs);
+    return () => window.clearInterval(interval);
+  }, [advancedSettings.flickerSpeedMs, isFlickerPaused, mode]);
 
   const handleTransform = (ref: ReactZoomPanPinchRef) => {
     if (!ref || !ref.state) return;
@@ -91,6 +157,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
 
   const ready = Boolean(leftUrl && rightUrl);
   const isLoading = isLeftLoading || isRightLoading;
+  const advancedReady = !isAdvancedMode || Boolean(metrics);
   const overlayStyle =
     mode === 'slider'
       ? { clipPath: `inset(0 ${100 - sliderValue}% 0 0)`, transition: isDraggingHandle ? 'none' : 'clip-path 180ms ease' }
@@ -101,6 +168,141 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
       : { opacity: 1 };
 
   const errorMessage = leftError || rightError;
+  const advancedBaseUrl = advancedSettings.baseMode === 'right' ? rightUrl : leftUrl;
+  const diffOnly = advancedSettings.baseMode === 'diff';
+
+  const updateLoupeFromMouse = (clientX: number, clientY: number) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setLoupePoint({
+      x: clamp(((clientX - rect.left) / rect.width) * 100, 0, 100),
+      y: clamp(((clientY - rect.top) / rect.height) * 100, 0, 100),
+    });
+  };
+
+  const regionStyle = useMemo<CSSProperties | null>(() => {
+    if (!highlightedRegion || !metrics) return null;
+    return {
+      left: `${(highlightedRegion.x / metrics.width) * 100}%`,
+      top: `${(highlightedRegion.y / metrics.height) * 100}%`,
+      width: `${(highlightedRegion.width / metrics.width) * 100}%`,
+      height: `${(highlightedRegion.height / metrics.height) * 100}%`,
+    };
+  }, [highlightedRegion, metrics]);
+
+  const renderAdvancedLayer = () => {
+    if (!ready) return null;
+    if (visualError) {
+      return (
+        <div className="absolute left-1/2 top-4 max-w-md -translate-x-1/2 rounded-lg border border-amber-500/30 bg-amber-950/80 px-3 py-2 text-sm text-amber-100 shadow-lg">
+          Visual analysis unavailable: {visualError}
+        </div>
+      );
+    }
+
+    if (!advancedReady) {
+      return (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="rounded-lg border border-white/10 bg-black/70 px-4 py-2 text-sm text-gray-200 shadow">
+            Building visual comparison...
+          </div>
+        </div>
+      );
+    }
+
+    if (mode === 'flicker') {
+      const currentUrl = isFlickerShowingRight ? rightUrl : leftUrl;
+      return (
+        <>
+          {currentUrl && <img src={currentUrl} alt={isFlickerShowingRight ? rightImage.name : leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
+          <div className="absolute left-1/2 top-4 flex -translate-x-1/2 items-center gap-2 rounded-full border border-white/10 bg-black/70 px-3 py-1.5 text-xs text-gray-100 shadow">
+            <button
+              type="button"
+              onClick={() => setIsFlickerPaused((current) => !current)}
+              className="rounded p-1 text-gray-200 hover:bg-white/10 hover:text-white"
+              title={isFlickerPaused ? 'Resume flicker' : 'Pause flicker'}
+            >
+              {isFlickerPaused ? <Play className="h-3.5 w-3.5" /> : <Pause className="h-3.5 w-3.5" />}
+            </button>
+            {advancedSettings.showLabels ? <span>{isFlickerShowingRight ? `Image B: ${rightImage.name}` : `Image A: ${leftImage.name}`}</span> : <span>{isFlickerShowingRight ? 'Image B' : 'Image A'}</span>}
+          </div>
+        </>
+      );
+    }
+
+    if (mode === 'difference-map') {
+      return (
+        <>
+          {!diffOnly && advancedBaseUrl && <img src={advancedBaseUrl} alt="Difference base" className="absolute inset-0 h-full w-full select-none object-contain" />}
+          {diffOnly && <div className="absolute inset-0 bg-black" />}
+          {heatmapUrl && <img src={heatmapUrl} alt="Difference heatmap" className="absolute inset-0 h-full w-full select-none object-contain" style={{ opacity: advancedSettings.opacity / 100 }} />}
+          {regionStyle && <div className="absolute border-2 border-white/80 bg-white/10 shadow-[0_0_18px_rgba(255,255,255,0.35)]" style={regionStyle} />}
+        </>
+      );
+    }
+
+    if (mode === 'edge-difference') {
+      return (
+        <>
+          {!diffOnly && advancedBaseUrl && <img src={advancedBaseUrl} alt="Edge base" className="absolute inset-0 h-full w-full select-none object-contain opacity-45" />}
+          {diffOnly && <div className="absolute inset-0 bg-black" />}
+          {edgeMapUrl && <img src={edgeMapUrl} alt="Edge difference map" className="absolute inset-0 h-full w-full select-none object-contain" style={{ opacity: advancedSettings.opacity / 100 }} />}
+          <div className="absolute left-4 top-4 rounded-lg border border-white/10 bg-black/65 px-3 py-1.5 text-xs text-gray-100">
+            <span className="text-cyan-200">Cyan: Image A</span>
+            <span className="mx-2 text-gray-500">/</span>
+            <span className="text-fuchsia-200">Magenta: Image B</span>
+          </div>
+        </>
+      );
+    }
+
+    if (mode === 'loupe') {
+      return (
+        <>
+          {leftUrl && <img src={leftUrl} alt={leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
+          {loupePoint && (
+            <div
+              className="pointer-events-none absolute overflow-hidden rounded-full border-2 border-white/80 bg-black shadow-2xl"
+              style={{
+                left: `${loupePoint.x}%`,
+                top: `${loupePoint.y}%`,
+                width: advancedSettings.loupeSize,
+                height: advancedSettings.loupeSize,
+                transform: 'translate(-50%, -50%)',
+              }}
+            >
+              {[leftUrl, heatmapUrl, rightUrl].map((url, index) => (
+                url ? (
+                  <img
+                    key={`${url}-${index}`}
+                    src={url}
+                    alt=""
+                    className="absolute h-full w-full object-contain"
+                    style={{
+                      left: `${(index - 1) * 33.33}%`,
+                      width: '166%',
+                      height: '166%',
+                      top: `${50 - loupePoint.y * (advancedSettings.loupeZoom / 1.8)}%`,
+                      transform: `translate(${50 - loupePoint.x * (advancedSettings.loupeZoom / 1.8)}%, -50%) scale(${advancedSettings.loupeZoom})`,
+                      opacity: index === 1 ? advancedSettings.opacity / 100 : 1,
+                      clipPath: index === 0 ? 'inset(0 66.66% 0 0)' : index === 1 ? 'inset(0 33.33% 0 33.33%)' : 'inset(0 0 0 66.66%)',
+                    }}
+                  />
+                ) : null
+              ))}
+              <div className="absolute inset-y-0 left-1/3 w-px bg-white/70" />
+              <div className="absolute inset-y-0 left-2/3 w-px bg-white/70" />
+            </div>
+          )}
+          <div className="absolute left-1/2 top-4 -translate-x-1/2 rounded-full border border-white/10 bg-black/65 px-3 py-1 text-xs text-gray-100 shadow">
+            Move over the image to inspect A / Diff / B
+          </div>
+        </>
+      );
+    }
+
+    return null;
+  };
 
   if (errorMessage) {
     return (
@@ -154,6 +356,16 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                       : undefined
                 }
                 onMouseMove={mode === 'slider' ? (event) => updateActiveImageFromClientX(event.clientX) : undefined}
+                onPointerMove={
+                  mode === 'loupe'
+                    ? (event) => updateLoupeFromMouse(event.clientX, event.clientY)
+                    : undefined
+                }
+                onPointerLeave={
+                  mode === 'loupe'
+                    ? () => setLoupePoint(null)
+                    : undefined
+                }
               >
                 {isLoading && !ready && (
                   <div className="absolute inset-0 flex items-center justify-center">
@@ -161,7 +373,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                   </div>
                 )}
 
-                {rightUrl && (
+                {!isAdvancedMode && rightUrl && (
                   <img
                     src={rightUrl}
                     alt={rightImage.name}
@@ -170,7 +382,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                   />
                 )}
 
-                {leftUrl && (
+                {!isAdvancedMode && leftUrl && (
                   <img
                     src={leftUrl}
                     alt={leftImage.name}
@@ -178,6 +390,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                     style={overlayStyle}
                   />
                 )}
+
+                {isAdvancedMode && renderAdvancedLayer()}
 
                 {ready && mode === 'slider' && (
                   <>

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -62,6 +62,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   const [isFlickerShowingRight, setIsFlickerShowingRight] = useState(false);
   const [isFlickerPaused, setIsFlickerPaused] = useState(false);
   const [visualError, setVisualError] = useState<string | null>(null);
+  const [leftAnalysisUrl, setLeftAnalysisUrl] = useState<string | null>(null);
+  const [rightAnalysisUrl, setRightAnalysisUrl] = useState<string | null>(null);
   const [heatmapUrl, setHeatmapUrl] = useState<string | null>(null);
   const [edgeMapUrl, setEdgeMapUrl] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<VisualComparisonMetrics | null>(null);
@@ -83,6 +85,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
 
   useEffect(() => {
     if (!isAdvancedMode || !leftUrl || !rightUrl) {
+      setLeftAnalysisUrl(null);
+      setRightAnalysisUrl(null);
       setHeatmapUrl(null);
       setEdgeMapUrl(null);
       setMetrics(null);
@@ -96,8 +100,12 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     buildVisualComparisonFromUrls(leftUrl, rightUrl, advancedSettings.threshold)
       .then((result) => {
         if (!isMounted) return;
+        const nextLeftAnalysisUrl = imageDataToDataUrl(result.left);
+        const nextRightAnalysisUrl = imageDataToDataUrl(result.right);
         const nextHeatmapUrl = imageDataToDataUrl(result.heatmap);
         const nextEdgeMapUrl = imageDataToDataUrl(result.edgeMap);
+        setLeftAnalysisUrl(nextLeftAnalysisUrl);
+        setRightAnalysisUrl(nextRightAnalysisUrl);
         setHeatmapUrl(nextHeatmapUrl);
         setEdgeMapUrl(nextEdgeMapUrl);
         setMetrics(result.metrics);
@@ -107,6 +115,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
         if (!isMounted) return;
         const message = error instanceof Error ? error.message : String(error);
         setVisualError(message);
+        setLeftAnalysisUrl(null);
+        setRightAnalysisUrl(null);
         setHeatmapUrl(null);
         setEdgeMapUrl(null);
         setMetrics(null);
@@ -188,7 +198,9 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
       : { opacity: 1 };
 
   const errorMessage = leftError || rightError;
-  const advancedBaseUrl = advancedSettings.baseMode === 'right' ? rightUrl : leftUrl;
+  const normalizedLeftUrl = leftAnalysisUrl || leftUrl;
+  const normalizedRightUrl = rightAnalysisUrl || rightUrl;
+  const advancedBaseUrl = advancedSettings.baseMode === 'right' ? normalizedRightUrl : normalizedLeftUrl;
   const diffOnly = advancedSettings.baseMode === 'diff';
 
   const updateLoupeFromMouse = (clientX: number, clientY: number) => {
@@ -303,7 +315,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     if (mode === 'loupe') {
       return (
         <>
-          {leftUrl && <img src={leftUrl} alt={leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
+          {normalizedLeftUrl && <img src={normalizedLeftUrl} alt={leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
           <div className="absolute left-1/2 top-4 -translate-x-1/2 rounded-full border border-white/10 bg-black/65 px-3 py-1 text-xs text-gray-100 shadow">
             Move over the image to inspect A / Diff / B
           </div>
@@ -318,9 +330,9 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     if (mode !== 'loupe' || !loupePoint || !advancedReady) return null;
 
     const loupeLayers = [
-      { url: leftUrl, label: 'A' },
+      { url: normalizedLeftUrl, label: 'A' },
       { url: heatmapUrl, label: 'Diff', opacity: advancedSettings.opacity / 100 },
-      { url: rightUrl, label: 'B' },
+      { url: normalizedRightUrl, label: 'B' },
     ];
     const container = containerRef.current?.getBoundingClientRect();
     if (!container) return null;

--- a/components/ComparisonPane.tsx
+++ b/components/ComparisonPane.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, FC } from 'react';
 import { TransformWrapper, TransformComponent, ReactZoomPanPinchRef } from 'react-zoom-pan-pinch';
-import { ZoomIn, ZoomOut, RotateCcw, AlertCircle, Sparkles } from 'lucide-react';
+import { ZoomIn, ZoomOut, RotateCcw, AlertCircle, Sparkles, X } from 'lucide-react';
 import { ComparisonPaneProps, BaseMetadata } from '../types';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } from './A1111GenerateModal';
@@ -13,6 +13,7 @@ const ComparisonPane: FC<ComparisonPaneProps> = ({
   externalZoom,
   onZoomChange,
   onHoverChange,
+  onRemove,
   className,
   imageLabel,
 }) => {
@@ -126,6 +127,21 @@ const ComparisonPane: FC<ComparisonPaneProps> = ({
               </button>
             </div>
 
+            {onRemove && (
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRemove();
+                }}
+                className="absolute left-4 top-4 z-10 rounded-lg border border-white/10 bg-black/65 p-2 text-white shadow-lg backdrop-blur-sm transition-colors hover:bg-red-600/90"
+                title={`Remove ${image.name} from comparison`}
+                aria-label={`Remove ${image.name} from comparison`}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+
             {/* Image Name Label */}
             <div className="absolute bottom-4 left-4 right-4 bg-black/60 backdrop-blur-sm rounded-lg p-2">
               <p className="text-white text-sm font-medium truncate" title={image.name}>
@@ -172,6 +188,7 @@ export default React.memo(ComparisonPane, (prev, next) => {
     prev.syncEnabled === next.syncEnabled &&
     prev.className === next.className &&
     prev.imageLabel === next.imageLabel &&
+    prev.onRemove === next.onRemove &&
     prev.externalZoom?.zoom === next.externalZoom?.zoom &&
     prev.externalZoom?.x === next.externalZoom?.x &&
     prev.externalZoom?.y === next.externalZoom?.y

--- a/types.ts
+++ b/types.ts
@@ -1028,6 +1028,7 @@ export interface ComparisonPaneProps {
   externalZoom?: ZoomState;
   onZoomChange?: (zoom: number, x: number, y: number) => void;
   onHoverChange?: (isHovered: boolean) => void;
+  onRemove?: () => void;
   className?: string;
   imageLabel?: string;
 }

--- a/types.ts
+++ b/types.ts
@@ -1000,8 +1000,26 @@ export interface ZoomState {
   y: number;
 }
 
-export type ComparisonViewMode = 'side-by-side' | 'slider' | 'hover';
+export type ComparisonViewMode =
+  | 'side-by-side'
+  | 'slider'
+  | 'hover'
+  | 'difference-map'
+  | 'flicker'
+  | 'loupe'
+  | 'edge-difference';
 export type ComparisonLayoutMode = 'strip' | 'grid';
+export type ComparisonAdvancedBaseMode = 'left' | 'right' | 'diff';
+
+export interface ComparisonAdvancedSettings {
+  threshold: number;
+  opacity: number;
+  baseMode: ComparisonAdvancedBaseMode;
+  flickerSpeedMs: number;
+  loupeSize: number;
+  loupeZoom: number;
+  showLabels: boolean;
+}
 
 export interface ComparisonPaneProps {
   image: IndexedImage;

--- a/utils/visualComparison.ts
+++ b/utils/visualComparison.ts
@@ -1,0 +1,247 @@
+export interface VisualDifferenceRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  score: number;
+}
+
+export interface VisualComparisonMetrics {
+  width: number;
+  height: number;
+  changedPixels: number;
+  totalPixels: number;
+  changedPercent: number;
+  averageDelta: number;
+  strongestRegion: VisualDifferenceRegion | null;
+}
+
+export interface VisualComparisonResult {
+  width: number;
+  height: number;
+  left: ImageData;
+  right: ImageData;
+  heatmap: ImageData;
+  edgeMap: ImageData;
+  metrics: VisualComparisonMetrics;
+}
+
+export const DEFAULT_VISUAL_COMPARE_MAX_EDGE = 1280;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const luminance = (data: Uint8ClampedArray, index: number): number =>
+  data[index] * 0.2126 + data[index + 1] * 0.7152 + data[index + 2] * 0.0722;
+
+export const calculatePixelDelta = (
+  left: Uint8ClampedArray,
+  right: Uint8ClampedArray,
+  index: number,
+): number => {
+  const red = Math.abs(left[index] - right[index]);
+  const green = Math.abs(left[index + 1] - right[index + 1]);
+  const blue = Math.abs(left[index + 2] - right[index + 2]);
+  const luma = Math.abs(luminance(left, index) - luminance(right, index));
+  return clamp((red + green + blue) / 3 * 0.65 + luma * 0.35, 0, 255);
+};
+
+export const createHeatmapImageData = (
+  left: ImageData,
+  right: ImageData,
+  threshold: number,
+): { imageData: ImageData; metrics: VisualComparisonMetrics } => {
+  const { width, height } = left;
+  const heatmap = new ImageData(width, height);
+  const heat = heatmap.data;
+  const leftData = left.data;
+  const rightData = right.data;
+  const safeThreshold = clamp(threshold, 0, 255);
+  const bucketCount = 8;
+  const bucketWidth = Math.max(1, Math.ceil(width / bucketCount));
+  const bucketHeight = Math.max(1, Math.ceil(height / bucketCount));
+  const buckets = Array.from({ length: bucketCount * bucketCount }, () => ({ score: 0, count: 0 }));
+  let changedPixels = 0;
+  let totalDelta = 0;
+
+  for (let pixel = 0; pixel < width * height; pixel += 1) {
+    const index = pixel * 4;
+    const delta = calculatePixelDelta(leftData, rightData, index);
+    totalDelta += delta;
+
+    if (delta >= safeThreshold) {
+      changedPixels += 1;
+      const intensity = clamp((delta - safeThreshold) / Math.max(1, 255 - safeThreshold), 0, 1);
+      heat[index] = 255;
+      heat[index + 1] = Math.round(210 * (1 - intensity) + 40 * intensity);
+      heat[index + 2] = Math.round(40 * (1 - intensity) + 120 * intensity);
+      heat[index + 3] = Math.round(105 + intensity * 150);
+
+      const x = pixel % width;
+      const y = Math.floor(pixel / width);
+      const bucketX = Math.min(bucketCount - 1, Math.floor(x / bucketWidth));
+      const bucketY = Math.min(bucketCount - 1, Math.floor(y / bucketHeight));
+      const bucket = buckets[bucketY * bucketCount + bucketX];
+      bucket.score += delta;
+      bucket.count += 1;
+    } else {
+      heat[index] = 0;
+      heat[index + 1] = 0;
+      heat[index + 2] = 0;
+      heat[index + 3] = 0;
+    }
+  }
+
+  let strongestRegion: VisualDifferenceRegion | null = null;
+  buckets.forEach((bucket, bucketIndex) => {
+    if (!bucket.count) return;
+    const score = bucket.score / bucket.count;
+    if (strongestRegion && score <= strongestRegion.score) return;
+    const bucketX = bucketIndex % bucketCount;
+    const bucketY = Math.floor(bucketIndex / bucketCount);
+    strongestRegion = {
+      x: bucketX * bucketWidth,
+      y: bucketY * bucketHeight,
+      width: Math.min(bucketWidth, width - bucketX * bucketWidth),
+      height: Math.min(bucketHeight, height - bucketY * bucketHeight),
+      score,
+    };
+  });
+
+  return {
+    imageData: heatmap,
+    metrics: {
+      width,
+      height,
+      changedPixels,
+      totalPixels: width * height,
+      changedPercent: width * height > 0 ? (changedPixels / (width * height)) * 100 : 0,
+      averageDelta: width * height > 0 ? totalDelta / (width * height) : 0,
+      strongestRegion,
+    },
+  };
+};
+
+const sobelAt = (data: Uint8ClampedArray, width: number, height: number, x: number, y: number): number => {
+  const sample = (offsetX: number, offsetY: number) => {
+    const sx = clamp(x + offsetX, 0, width - 1);
+    const sy = clamp(y + offsetY, 0, height - 1);
+    return luminance(data, (sy * width + sx) * 4);
+  };
+
+  const gx =
+    -sample(-1, -1) + sample(1, -1) -
+    2 * sample(-1, 0) + 2 * sample(1, 0) -
+    sample(-1, 1) + sample(1, 1);
+  const gy =
+    -sample(-1, -1) - 2 * sample(0, -1) - sample(1, -1) +
+    sample(-1, 1) + 2 * sample(0, 1) + sample(1, 1);
+
+  return clamp(Math.sqrt(gx * gx + gy * gy), 0, 255);
+};
+
+export const createEdgeDifferenceImageData = (left: ImageData, right: ImageData, threshold = 40): ImageData => {
+  const { width, height } = left;
+  const output = new ImageData(width, height);
+  const outputData = output.data;
+  const safeThreshold = clamp(threshold, 0, 255);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const index = (y * width + x) * 4;
+      const leftEdge = sobelAt(left.data, width, height, x, y);
+      const rightEdge = sobelAt(right.data, width, height, x, y);
+      const leftVisible = leftEdge >= safeThreshold;
+      const rightVisible = rightEdge >= safeThreshold;
+
+      outputData[index] = rightVisible ? 255 : 0;
+      outputData[index + 1] = leftVisible ? 220 : 0;
+      outputData[index + 2] = leftVisible ? 255 : rightVisible ? 220 : 0;
+      outputData[index + 3] = leftVisible || rightVisible ? 235 : 0;
+    }
+  }
+
+  return output;
+};
+
+export const buildVisualComparisonFromImageData = (
+  left: ImageData,
+  right: ImageData,
+  threshold = 18,
+  edgeThreshold = threshold,
+): VisualComparisonResult => {
+  if (left.width !== right.width || left.height !== right.height) {
+    throw new Error('ImageData dimensions must match for visual comparison');
+  }
+
+  const heatmap = createHeatmapImageData(left, right, threshold);
+  return {
+    width: left.width,
+    height: left.height,
+    left,
+    right,
+    heatmap: heatmap.imageData,
+    edgeMap: createEdgeDifferenceImageData(left, right, edgeThreshold),
+    metrics: heatmap.metrics,
+  };
+};
+
+const loadImageElement = (url: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.decoding = 'async';
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('Unable to decode image for visual comparison'));
+    image.src = url;
+  });
+
+const drawContainedImage = (
+  context: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  width: number,
+  height: number,
+) => {
+  const scale = Math.min(width / image.naturalWidth, height / image.naturalHeight);
+  const drawWidth = image.naturalWidth * scale;
+  const drawHeight = image.naturalHeight * scale;
+  const drawX = (width - drawWidth) / 2;
+  const drawY = (height - drawHeight) / 2;
+  context.clearRect(0, 0, width, height);
+  context.drawImage(image, drawX, drawY, drawWidth, drawHeight);
+};
+
+export const buildVisualComparisonFromUrls = async (
+  leftUrl: string,
+  rightUrl: string,
+  threshold = 18,
+  maxEdge = DEFAULT_VISUAL_COMPARE_MAX_EDGE,
+): Promise<VisualComparisonResult> => {
+  const [leftImage, rightImage] = await Promise.all([loadImageElement(leftUrl), loadImageElement(rightUrl)]);
+  const sourceWidth = Math.max(leftImage.naturalWidth, rightImage.naturalWidth);
+  const sourceHeight = Math.max(leftImage.naturalHeight, rightImage.naturalHeight);
+  const scale = Math.min(1, maxEdge / Math.max(sourceWidth, sourceHeight));
+  const width = Math.max(1, Math.round(sourceWidth * scale));
+  const height = Math.max(1, Math.round(sourceHeight * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) {
+    throw new Error('Canvas is not available for visual comparison');
+  }
+
+  drawContainedImage(context, leftImage, width, height);
+  const left = context.getImageData(0, 0, width, height);
+  drawContainedImage(context, rightImage, width, height);
+  const right = context.getImageData(0, 0, width, height);
+  return buildVisualComparisonFromImageData(left, right, threshold, threshold);
+};
+
+export const imageDataToDataUrl = (imageData: ImageData): string => {
+  const canvas = document.createElement('canvas');
+  canvas.width = imageData.width;
+  canvas.height = imageData.height;
+  const context = canvas.getContext('2d');
+  if (!context) return '';
+  context.putImageData(imageData, 0, 0);
+  return canvas.toDataURL('image/png');
+};

--- a/utils/visualComparison.ts
+++ b/utils/visualComparison.ts
@@ -41,8 +41,10 @@ export const calculatePixelDelta = (
   const red = Math.abs(left[index] - right[index]);
   const green = Math.abs(left[index + 1] - right[index + 1]);
   const blue = Math.abs(left[index + 2] - right[index + 2]);
+  const alpha = Math.abs(left[index + 3] - right[index + 3]);
   const luma = Math.abs(luminance(left, index) - luminance(right, index));
-  return clamp((red + green + blue) / 3 * 0.65 + luma * 0.35, 0, 255);
+  const colorDelta = (red + green + blue) / 3 * 0.65 + luma * 0.35;
+  return clamp(colorDelta * 0.8 + alpha * 0.2, 0, 255);
 };
 
 export const createHeatmapImageData = (

--- a/utils/visualComparison.ts
+++ b/utils/visualComparison.ts
@@ -68,7 +68,7 @@ export const createHeatmapImageData = (
     const delta = calculatePixelDelta(leftData, rightData, index);
     totalDelta += delta;
 
-    if (delta >= safeThreshold) {
+    if (delta > 0 && delta >= safeThreshold) {
       changedPixels += 1;
       const intensity = clamp((delta - safeThreshold) / Math.max(1, 255 - safeThreshold), 0, 1);
       heat[index] = 255;

--- a/utils/visualComparison.ts
+++ b/utils/visualComparison.ts
@@ -144,14 +144,15 @@ export const createEdgeDifferenceImageData = (left: ImageData, right: ImageData,
   const output = new ImageData(width, height);
   const outputData = output.data;
   const safeThreshold = clamp(threshold, 0, 255);
+  const minimumVisibleEdge = 0.5;
 
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
       const index = (y * width + x) * 4;
       const leftEdge = sobelAt(left.data, width, height, x, y);
       const rightEdge = sobelAt(right.data, width, height, x, y);
-      const leftVisible = leftEdge >= safeThreshold;
-      const rightVisible = rightEdge >= safeThreshold;
+      const leftVisible = leftEdge > minimumVisibleEdge && leftEdge >= safeThreshold;
+      const rightVisible = rightEdge > minimumVisibleEdge && rightEdge >= safeThreshold;
 
       outputData[index] = rightVisible ? 255 : 0;
       outputData[index + 1] = leftVisible ? 220 : 0;


### PR DESCRIPTION
## Summary

- Add advanced two-image compare modes: Diff Map, Flicker, Loupe, and Edges.
- Add canvas-based visual comparison metrics with Visual Delta and Metadata Delta summaries.
- Improve multi-image compare UX with per-pane remove buttons for 3-4 image comparisons.
- Fix the Loupe mode so it tracks the rendered image viewport and respects object-contain margins.

## Validation

- User ran tests and typecheck locally after the final Loupe fix.
- Earlier in this branch, focused compare tests, TypeScript, and production build passed before the final manual Loupe adjustment.

## Notes

- This PR targets `0.17.0-rc` as requested.
- Local `gh auth status` reports an invalid keyring token, so the PR was opened through the GitHub app connector.