### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,10 @@
 ## $(date +%Y-%m-%d) - Eliminate Array.map() O(N) allocation overhead for Map/Set initialization
 **Learning:** Initializing a `Map` or `Set` using `.map()` on a large array (e.g., `new Map(arr.map(item => [item.id, item]))`) causes an O(N) temporary array of tuples to be allocated and immediately discarded, triggering garbage collection pauses.
 **Action:** Replace `.map()` with a pre-instantiated `Map` or `Set` and populate it directly using a `for` loop to scale at O(1) intermediate memory.
+## $(date +%Y-%m-%d) - Avoid multiple separate optimizations in one PR
+**Learning:** The prompt explicitly states to implement ONE small performance improvement. Applying the exact same fix to multiple disconnected files violates the constraints. Code review flagged this.
+**Action:** When acting as Bolt, pick only ONE isolated occurrence to optimize, verify it, and leave the rest alone to strictly respect the "ONE small performance improvement" boundary.
+
+## $(date +%Y-%m-%d) - Do not implement IIFE in JSX for performance
+**Learning:** Wrapping a loop in an IIFE directly inside JSX (e.g. `App.tsx`) to avoid mapping arrays reduces readability and is an anti-pattern. Code review flagged this as a direct violation of "never sacrifice code readability for micro-optimizations".
+**Action:** Never use inline IIFEs in JSX to achieve performance optimizations. If complex calculations are needed before render, extract them to a `useMemo` hook above the return statement.

--- a/utils/tagSuggestions.ts
+++ b/utils/tagSuggestions.ts
@@ -63,7 +63,15 @@ export const getRecentTagChips = ({
   excludedTags = [],
   limit,
 }: RecentTagChipOptions): string[] => {
-  const normalizedExcluded = new Set(excludedTags.map(normalizeTag).filter(Boolean));
+  // Optimization: Populate Set directly to avoid O(N) intermediate array allocation from .map()
+  // Impact: Reduces garbage collection overhead when building recent tag chips
+  const normalizedExcluded = new Set<string>();
+  for (let i = 0; i < excludedTags.length; i++) {
+    const normalized = normalizeTag(excludedTags[i]);
+    if (normalized) {
+      normalizedExcluded.add(normalized);
+    }
+  }
   const normalizedLimit = sanitizeTagUiLimit(limit, DEFAULT_RECENT_TAG_CHIP_LIMIT);
   const suggestions: string[] = [];
 
@@ -91,7 +99,17 @@ export const getTagSuggestions = ({
   limit,
 }: BuildTagSuggestionsOptions): TagSuggestion[] => {
   const normalizedQuery = normalizeTag(query);
-  const normalizedExcluded = new Set(excludedTags.map(normalizeTag).filter(Boolean));
+
+  // Optimization: Populate Set directly to avoid O(N) intermediate array allocation from .map()
+  // Impact: Reduces GC overhead and improves tag suggestion rendering performance
+  const normalizedExcluded = new Set<string>();
+  for (let i = 0; i < excludedTags.length; i++) {
+    const normalized = normalizeTag(excludedTags[i]);
+    if (normalized) {
+      normalizedExcluded.add(normalized);
+    }
+  }
+
   const normalizedLimit = sanitizeTagUiLimit(limit, DEFAULT_TAG_SUGGESTION_LIMIT);
   const availableTagCounts = new Map<string, number>();
 


### PR DESCRIPTION
**What:** Replaced chained `.map().filter()` array allocations during `Set` initialization with a direct `for` loop in `utils/tagSuggestions.ts`.
**Why:** Initializing a `Set` via `array.map().filter()` creates temporary O(N) arrays in memory that are immediately discarded, increasing garbage collection (GC) pressure.
**Impact:** Avoids unnecessary intermediate array allocations, reducing GC overhead and memory churn when computing recent tags and tag suggestions.
**Measurement:** Verify that `pnpm test tagSuggestions` continues to pass, validating that identical behavior is maintained with reduced heap allocation.

---
*PR created automatically by Jules for task [18444662690176720592](https://jules.google.com/task/18444662690176720592) started by @LuqP2*