### PR TITLE
Enforce MetaHub video metadata contract

### DIFF
--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -376,6 +376,32 @@ describe('ComfyUI Parser - MetaHub lineage metadata', () => {
     expect(result?.loras).toEqual([{ name: 'skin-detail', weight: 0.65 }]);
   });
 
+  it('keeps MetaHub payload as canonical when parameters disagree', async () => {
+    const result = await parseImageMetadata({
+      parameters: 'wrong prompt\nSteps: 1, Sampler: wrong, CFG scale: 1, Seed: 1, Size: 64x64, Model: wrong.safetensors',
+      imagemetahub_data: {
+        generator: 'ComfyUI',
+        prompt: 'canonical prompt',
+        negativePrompt: 'canonical negative',
+        seed: 456,
+        steps: 32,
+        cfg: 7,
+        sampler_name: 'dpmpp_2m',
+        scheduler: 'karras',
+        model: 'canonical.safetensors',
+        width: 768,
+        height: 1024,
+        metadata_status: 'complete',
+        metadata_sources: { prompt: 'detected', model_name: 'detected' },
+      },
+    } as any);
+
+    expect(result?.prompt).toBe('canonical prompt');
+    expect(result?.model).toBe('canonical.safetensors');
+    expect(result?._metadata_status).toBe('complete');
+    expect(result?._metadata_sources).toEqual({ prompt: 'detected', model_name: 'detected' });
+  });
+
   it('prefers parent_image for library lineage and keeps source_image as workflowSourceImage', async () => {
     const metadata: any = {
       imagemetahub_data: {

--- a/__tests__/video-metahub-parser.test.ts
+++ b/__tests__/video-metahub-parser.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { parseImageMetadata } from '../services/parsers/metadataParserFactory';
+import { parseVideoMetaHubMetadata } from '../services/parsers/videoMetaHubParser';
+
+describe('Video MetaHub parser', () => {
+  it('accepts structurally valid partial video payloads without prompt/model', () => {
+    const result = parseVideoMetaHubMetadata({
+      generator: 'ComfyUI',
+      media_type: 'video',
+      width: 640,
+      height: 480,
+      video: {
+        width: 640,
+        height: 480,
+        frame_rate: 24,
+        frame_count: 48,
+      },
+      metadata_status: 'partial',
+      metadata_sources: {
+        prompt: 'default',
+      },
+    });
+
+    expect(result).toMatchObject({
+      prompt: '',
+      model: '',
+      width: 640,
+      height: 480,
+      media_type: 'video',
+      _metadata_status: 'partial',
+    });
+  });
+
+  it('rejects arbitrary JSON comments instead of treating them as video metadata', () => {
+    const result = parseVideoMetaHubMetadata({
+      comment: JSON.stringify({
+        prompt: {
+          '1': {
+            class_type: 'KSampler',
+            inputs: {},
+          },
+        },
+      }),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('does not normalize invalid videometahub_data into blank video metadata', async () => {
+    const result = await parseImageMetadata({
+      videometahub_data: {
+        prompt: {
+          '1': {
+            class_type: 'KSampler',
+            inputs: {},
+          },
+        },
+      },
+    } as any);
+
+    expect(result).toBeNull();
+  });
+});

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -876,6 +876,8 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
           _detection_method: 'metahub_chunk',
           _metahub_pro: metahubData.imh_pro || null,
           _analytics: metahubData.analytics || null,
+          _metadata_status: metahubData.metadata_status || null,
+          _metadata_sources: metahubData.metadata_sources || null,
         };
       }
     }

--- a/services/parsers/metadataParserFactory.ts
+++ b/services/parsers/metadataParserFactory.ts
@@ -43,7 +43,7 @@ function isComfyPromptOnlyGraph(metadata: UnknownRecord): boolean {
 }
 
 interface ParserModule {
-    parse: (metadata: ImageMetadata, fileBuffer?: ArrayBuffer) => BaseMetadata | Promise<BaseMetadata>;
+    parse: (metadata: ImageMetadata, fileBuffer?: ArrayBuffer) => BaseMetadata | null | Promise<BaseMetadata | null>;
     generator: string;
 }
 
@@ -115,6 +115,8 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
                     lineage: result.lineage,
                     _analytics: result._analytics || null,
                     _metahub_pro: result._metahub_pro || null,
+                    _metadata_status: result._metadata_status || null,
+                    _metadata_sources: result._metadata_sources || null,
                     _detection_method: result._detection_method,
                 } as BaseMetadata;
             },
@@ -127,16 +129,7 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
     if ('videometahub_data' in metadata || rawMetadata.media_type === 'video') {
         return {
             parse: (data: VideoMetadata) => {
-                const result = parseVideoMetaHubMetadata(data);
-                return (result ?? {
-                    prompt: '',
-                    model: '',
-                    width: 0,
-                    height: 0,
-                    steps: 0,
-                    scheduler: '',
-                    media_type: 'video',
-                }) as BaseMetadata;
+                return parseVideoMetaHubMetadata(data);
             },
             generator: 'ComfyUI'
         };
@@ -292,6 +285,9 @@ export async function parseImageMetadata(metadata: ImageMetadata, fileBuffer?: A
     const parser = getMetadataParser(metadata);
     if (parser) {
         const result = await parser.parse(metadata, fileBuffer);
+        if (!result) {
+            return null;
+        }
         result.generator = parser.generator;
         return result;
     }

--- a/services/parsers/videoMetaHubParser.ts
+++ b/services/parsers/videoMetaHubParser.ts
@@ -14,6 +14,25 @@ const parseJsonSafe = (value: unknown): MetaHubVideoPayload | null => {
   }
 };
 
+const isMetaHubVideoPayload = (value: unknown): value is MetaHubVideoPayload => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const payload = value as MetaHubVideoPayload;
+  if (payload.generator !== 'ComfyUI' && payload.generator !== 'Image MetaHub') {
+    return false;
+  }
+  if (payload.media_type !== 'video') {
+    return false;
+  }
+  const video = payload.video && typeof payload.video === 'object'
+    ? payload.video as MetaHubVideoPayload
+    : null;
+  const width = normalizeNumber(video?.width ?? payload.width, 0);
+  const height = normalizeNumber(video?.height ?? payload.height, 0);
+  return width > 0 && height > 0 && Boolean(video);
+};
+
 const extractVideoMetaHubPayload = (rawData: unknown): MetaHubVideoPayload | null => {
   if (!rawData) {
     return null;
@@ -21,22 +40,23 @@ const extractVideoMetaHubPayload = (rawData: unknown): MetaHubVideoPayload | nul
 
   if (typeof rawData === 'object') {
     const data = rawData as MetaHubVideoPayload;
-    if (data.videometahub_data && typeof data.videometahub_data === 'object') {
+    if (isMetaHubVideoPayload(data.videometahub_data)) {
       return data.videometahub_data as MetaHubVideoPayload;
     }
     if (data.comment && typeof data.comment === 'string') {
       const parsed = parseJsonSafe(data.comment);
-      if (parsed) {
+      if (isMetaHubVideoPayload(parsed)) {
         return parsed;
       }
     }
-    if (data.media_type === 'video' || data.video) {
+    if (isMetaHubVideoPayload(data)) {
       return data;
     }
   }
 
   if (typeof rawData === 'string') {
-    return parseJsonSafe(rawData);
+    const parsed = parseJsonSafe(rawData);
+    return isMetaHubVideoPayload(parsed) ? parsed : null;
   }
 
   return null;
@@ -100,5 +120,7 @@ export const parseVideoMetaHubMetadata = (rawData: unknown): BaseMetadata | null
     model_hash: payload.model_hash,
     _analytics: payload.analytics || null,
     _metahub_pro: payload.imh_pro || null,
+    _metadata_status: payload.metadata_status || null,
+    _metadata_sources: payload.metadata_sources || null,
   };
 };


### PR DESCRIPTION
## Summary
- preserve MetaHub metadata status/source fields from image payloads
- reject invalid video metadata payloads instead of normalizing them as blank videos
- accept structurally valid partial video metadata without prompt/model
- add parser regression tests for canonical MetaHub payloads and video fallback rejection

## Tests
- npm test -- --run __tests__/comfyui-parser.test.ts __tests__/video-metahub-parser.test.ts