### PR TITLE
🎨 Palette: Add dynamic tooltips and ARIA labels to ImageModal overlay controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-05-21 - Modal Close Icon Buttons Missing ARIA Labels
 **Learning:** Several modal components (TransferImagesModal, RenameImageModal, ProOnlyModal) lack `aria-label` attributes on their "Close" icon-only buttons, affecting screen reader accessibility. Although they have a `title` attribute, `aria-label` is standard for screen readers.
 **Action:** Always add descriptive `aria-label` attributes to icon-only buttons, especially "Close" buttons in modals, to ensure they meet the WCAG 2.5.3 Label in Name standard.
+
+## 2024-06-02 - ImageModal Zoom Controls & Overlay Icons Missing ARIA Labels & Disabled Reasons
+**Learning:** Icon-only buttons within the image viewer overlay (like zoom controls, full screen toggle, sidebar toggle) were missing `aria-label` attributes. Additionally, the zoom buttons became disabled at zoom limits but didn't provide a contextual reason in their tooltips.
+**Action:** When implementing or updating disabled states for interactive elements, dynamically update the `title` and `aria-label` to briefly explain why the element is disabled (e.g., "Zoom In (Maximum reached)"). Always include `aria-hidden="true"` on purely decorative SVGs within these buttons.

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2960,9 +2960,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 onClick={handleZoomIn}
                 disabled={zoom >= 5}
                 className="rounded p-2 text-white/90 transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30"
-                title="Zoom In"
+                title={zoom >= 5 ? 'Zoom In (Maximum reached)' : 'Zoom In'}
+                aria-label={zoom >= 5 ? 'Zoom In (Maximum reached)' : 'Zoom In'}
               >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
               </button>
@@ -2971,9 +2972,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 onClick={handleZoomOut}
                 disabled={zoom <= 1}
                 className="rounded p-2 text-white/90 transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30"
-                title="Zoom Out"
+                title={zoom <= 1 ? 'Zoom Out (Original size)' : 'Zoom Out'}
+                aria-label={zoom <= 1 ? 'Zoom Out (Original size)' : 'Zoom Out'}
               >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
                 </svg>
               </button>
@@ -2981,7 +2983,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 onClick={handleResetZoom}
                 disabled={zoom <= 1}
                 className="rounded p-2 text-white/90 transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30 text-xs"
-                title="Reset Zoom"
+                title={zoom <= 1 ? 'Reset Zoom (Already at original size)' : 'Reset Zoom'}
+                aria-label={zoom <= 1 ? 'Reset Zoom (Already at original size)' : 'Reset Zoom'}
               >
                 Reset
               </button>
@@ -3051,6 +3054,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                         : 'border-white/10 bg-black/35 hover:bg-black/55'
                     }`}
                     title={isAdjustmentPanelOpen ? 'Hide image adjustments' : 'Edit image adjustments'}
+                    aria-label={isAdjustmentPanelOpen ? 'Hide image adjustments' : 'Edit image adjustments'}
                   >
                     <SlidersHorizontal className="h-4 w-4" />
                   </button>
@@ -3059,6 +3063,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   onClick={() => setDetailsPlacement((current) => current === 'right' ? 'bottom' : 'right')}
                   className="rounded-full border border-white/10 bg-black/35 p-2 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/55"
                   title={showSidebarOnRight ? 'Show details on bottom' : 'Show details on right'}
+                  aria-label={showSidebarOnRight ? 'Show details on bottom' : 'Show details on right'}
                 >
                   {showSidebarOnRight ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
                 </button>
@@ -3066,6 +3071,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   onClick={() => setIsSidebarCollapsed((current) => !current)}
                   className="rounded-full border border-white/10 bg-black/35 p-2 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/55"
                   title={showSidebar ? 'Hide sidebar' : 'Show sidebar'}
+                  aria-label={showSidebar ? 'Hide sidebar' : 'Show sidebar'}
                 >
                   {showSidebar ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
@@ -3073,6 +3079,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   onClick={toggleFullscreen}
                   className="rounded-full border border-white/10 bg-black/35 p-2 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/55"
                   title={`Fullscreen (${toggleFullscreenKeybinding})`}
+                  aria-label={`Fullscreen (${toggleFullscreenKeybinding})`}
                 >
                   <Maximize2 className="h-4 w-4" />
                 </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label`s to the `ImageModal`'s zoom and overlay controls (fullscreen, sidebar toggle, etc.). When zoom controls reach their limits and become disabled, their tooltips dynamically explain why (e.g., "Maximum reached" or "Already at original size"). Added `aria-hidden="true"` to the decorative SVGs inside the zoom buttons.

🎯 **Why:** Icon-only buttons require `aria-label`s for screen reader support (WCAG 2.5.3). Moreover, disabling a button without explaining why can leave users confused. Providing clear, dynamic tooltips improves both accessibility and general usability.

♿ **Accessibility:**
- Added missing `aria-label`s to icon-only buttons.
- Hid decorative SVGs from screen readers via `aria-hidden`.
- Added contextual explanations to `title` and `aria-label` for disabled states.

---
*PR created automatically by Jules for task [9443331684927832557](https://jules.google.com/task/9443331684927832557) started by @LuqP2*