### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,6 @@
 ## $(date +%Y-%m-%d) - Do not implement IIFE in JSX for performance
 **Learning:** Wrapping a loop in an IIFE directly inside JSX (e.g. `App.tsx`) to avoid mapping arrays reduces readability and is an anti-pattern. Code review flagged this as a direct violation of "never sacrifice code readability for micro-optimizations".
 **Action:** Never use inline IIFEs in JSX to achieve performance optimizations. If complex calculations are needed before render, extract them to a `useMemo` hook above the return statement.
+## $(date +%Y-%m-%d) - Eliminate chained Array methods when building Sets/Maps or resolving layouts
+**Learning:** Chaining array methods like `.map().filter()` inside heavily executed loops (e.g., collecting incoming/outgoing layout positions in `comfyUIVisualWorkflow.ts`) creates multiple intermediate array allocations that increase garbage collection overhead and execution time.
+**Action:** Replace `.map().filter()` chains with a single `for` or `for...of` loop and use conditional `.push()` to prevent unnecessary array allocation overhead per pass.

--- a/services/comfyUIVisualWorkflow.ts
+++ b/services/comfyUIVisualWorkflow.ts
@@ -299,12 +299,21 @@ function buildHybridLayout(
     placedInPass = false;
 
     for (const nodeId of Array.from(unresolved)) {
-      const incoming = (incomingEdgesByNode.get(nodeId) || [])
-        .map((edge) => hybridLayout.get(edge.from))
-        .filter((entry): entry is { x: number; y: number } => Boolean(entry));
-      const outgoing = (outgoingEdgesByNode.get(nodeId) || [])
-        .map((edge) => hybridLayout.get(edge.to))
-        .filter((entry): entry is { x: number; y: number } => Boolean(entry));
+      // Optimization: Replace .map().filter() with a for loop to avoid intermediate array allocations in a hot loop
+      // Impact: Reduces garbage collection overhead by eliminating O(N) array allocation overhead per pass
+      const incoming: { x: number; y: number }[] = [];
+      const incomingEdges = incomingEdgesByNode.get(nodeId) || [];
+      for (const edge of incomingEdges) {
+        const position = hybridLayout.get(edge.from);
+        if (position) incoming.push(position);
+      }
+
+      const outgoing: { x: number; y: number }[] = [];
+      const outgoingEdges = outgoingEdgesByNode.get(nodeId) || [];
+      for (const edge of outgoingEdges) {
+        const position = hybridLayout.get(edge.to);
+        if (position) outgoing.push(position);
+      }
 
       if (incoming.length === 0 && outgoing.length === 0) {
         continue;


### PR DESCRIPTION
**What:** Replaces `.map().filter()` inside the `buildHybridLayout` while-loop with explicit `for` loops.

**Why:** Because `.map().filter()` allocates intermediate arrays on every iteration of a potentially heavily executed `while` loop, creating garbage collection pressure and reducing execution efficiency. By replacing this with a `for` loop, we eliminate $O(N)$ temporary allocations.

**Impact:** Reduces garbage collection overhead when generating auto-layouts for complex ComfyUI workflows, lowering time complexity constant factors.

**Measurement:** Run `pnpm test` and verify that the ComfyUI parser layout building functions continue to work without error.

---
*PR created automatically by Jules for task [16299491562476620809](https://jules.google.com/task/16299491562476620809) started by @LuqP2*