### PR TITLE
perf: optimize metadata parser with for-in loops

### DIFF
--- a/services/parsers/metadataParserFactory.ts
+++ b/services/parsers/metadataParserFactory.ts
@@ -26,20 +26,35 @@ const isRecord = (value: unknown): value is UnknownRecord =>
 
 // Case-insensitive metadata key lookup (PNG/iTXt tags sometimes come capitalized)
 function getCaseInsensitive<T = unknown>(obj: UnknownRecord, key: string): T | undefined {
-    const foundKey = Object.keys(obj).find(k => k.toLowerCase() === key.toLowerCase());
-    return foundKey ? (obj[foundKey] as T) : undefined;
+    // Optimization: Avoids Object.keys() and .find() array allocations
+    // Impact: Reduces garbage collection pressure in metadata parsing hot paths
+    const lowerKey = key.toLowerCase();
+    for (const k in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, k)) {
+            if (k.toLowerCase() === lowerKey) {
+                return obj[k] as T;
+            }
+        }
+    }
+    return undefined;
 }
 
 function isComfyPromptOnlyGraph(metadata: UnknownRecord): boolean {
-    return Object.entries(metadata).some(([key, value]) => {
-        if (key === 'extra' || key === 'extraMetadata') {
-            return false;
-        }
+    // Optimization: Avoids Object.entries() and .some() array allocations
+    // Impact: Reduces garbage collection pressure in metadata parsing hot paths
+    for (const key in metadata) {
+        if (Object.prototype.hasOwnProperty.call(metadata, key)) {
+            if (key === 'extra' || key === 'extraMetadata') {
+                continue;
+            }
 
-        return isRecord(value) &&
-            'class_type' in value &&
-            'inputs' in value;
-    });
+            const value = metadata[key];
+            if (isRecord(value) && 'class_type' in value && 'inputs' in value) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 interface ParserModule {


### PR DESCRIPTION
**What**: Replaced `Object.keys().find()` and `Object.entries().some()` with `for...in` loops in `services/parsers/metadataParserFactory.ts`.

**Why**: `Object.keys()` and `Object.entries()` create intermediate arrays. In functions like `getCaseInsensitive` and `isComfyPromptOnlyGraph` that execute repeatedly when parsing a batch of images with ComfyUI metadata, this creates unnecessary memory overhead and garbage collection pressure. `for...in` loops allow for early returns without allocating arrays.

**Impact**: Reduces intermediate object allocations to $O(1)$ during ComfyUI metadata parsing, lowering garbage collection pressure.

**Measurement**: Verified functionality with `pnpm test`. Since it's an internal memory optimization, it's mostly observable via memory profilers in high-volume parsing, but functionality remains identical.

---
*PR created automatically by Jules for task [16762808308302670976](https://jules.google.com/task/16762808308302670976) started by @LuqP2*