### PR TITLE
Fix ComfyUI MetaHub graph recovery

### DIFF
--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -112,6 +112,175 @@ describe('ComfyUI Parser - Detection from capitalized string keys', () => {
     expect(result?.prompt).toContain('Visualize a long, eel-like mutant lizard');
     expect(result?.prompt).toContain('fossilized ocean desert');
   });
+
+  it('should prefer ComfyUI graph chunks over non-empty parameters text', async () => {
+    const fixture = loadFixture('primitive-string-multiline.json');
+    const metadata: any = {
+      Prompt: JSON.stringify(fixture.prompt),
+      Workflow: JSON.stringify(fixture.workflow),
+      parameters: 'wrong prompt\nSteps: 1, Sampler: wrong, CFG scale: 1, Seed: 1, Size: 64x64, Model: wrong.safetensors'
+    };
+
+    const result = await parseImageMetadata(metadata);
+
+    expect(result?.generator).toBe('ComfyUI');
+    expect(result?.prompt).toContain('Visualize a long, eel-like mutant lizard');
+    expect(result?.model).not.toBe('wrong.safetensors');
+  });
+});
+
+describe('ComfyUI Parser - Output terminal traversal', () => {
+  it('should walk back from SaveImage through image links to prompt-bearing nodes', () => {
+    const prompt = {
+      '1': {
+        class_type: 'SaveImage',
+        inputs: {
+          images: ['2', 0],
+        },
+      },
+      '2': {
+        class_type: 'VAEDecode',
+        inputs: {
+          samples: ['3', 0],
+          vae: ['6', 2],
+        },
+      },
+      '3': {
+        class_type: 'WanImageToVideo',
+        inputs: {
+          positive: ['4', 0],
+          negative: ['5', 0],
+          vae: ['6', 2],
+          width: 832,
+          height: 480,
+          length: 49,
+          batch_size: 1,
+        },
+      },
+      '4': {
+        class_type: 'CLIPTextEncode',
+        inputs: {
+          text: 'cinematic motion portrait',
+        },
+      },
+      '5': {
+        class_type: 'CLIPTextEncode',
+        inputs: {
+          text: 'blur, artifacts',
+        },
+      },
+      '6': {
+        class_type: 'CheckpointLoaderSimple',
+        inputs: {
+          ckpt_name: 'wan-video-model.safetensors',
+        },
+      },
+    };
+
+    const result = resolvePromptFromGraph(undefined, prompt);
+
+    expect(result.prompt).toBe('cinematic motion portrait');
+    expect(result.negativePrompt).toBe('blur, artifacts');
+  });
+});
+
+describe('ComfyUI Parser - MetaHub chunk graph recovery', () => {
+  it('recovers prompt and seed from embedded prompt_api when old MetaHub chunks are empty', async () => {
+    const metadata: any = {
+      imagemetahub_data: {
+        generator: 'ComfyUI',
+        prompt: '',
+        negativePrompt: '',
+        seed: 0,
+        steps: 9,
+        cfg: 1,
+        sampler_name: 'euler',
+        scheduler: 'simple',
+        model: 'Z image Turbo\\z_image_turbo_bf16.safetensors',
+        vae: 'ae.safetensors',
+        denoise: 1,
+        width: 1056,
+        height: 1584,
+        loras: [],
+        workflow: { nodes: [] },
+        prompt_api: {
+          '1': {
+            class_type: 'UNETLoader',
+            inputs: { unet_name: 'Z image Turbo\\z_image_turbo_bf16.safetensors' },
+          },
+          '2': {
+            class_type: 'Lora Loader (LoraManager)',
+            inputs: {
+              text: 'luneva <lora:detail:0.80>',
+              model: ['1', 0],
+            },
+          },
+          '3': {
+            class_type: 'PathchSageAttentionKJ',
+            inputs: { model: ['2', 0] },
+          },
+          '4': {
+            class_type: 'easy positive',
+            inputs: { positive: 'gothic castle in teal fog' },
+          },
+          '5': {
+            class_type: 'JoinStrings',
+            inputs: { delimiter: ' ', string1: ['4', 0] },
+          },
+          '6': {
+            class_type: 'easy stylesSelector',
+            inputs: { positive: ['5', 0] },
+          },
+          '7': {
+            class_type: 'CLIPTextEncode',
+            inputs: { text: ['6', 0], clip: ['2', 1] },
+          },
+          '8': {
+            class_type: 'ConditioningZeroOut',
+            inputs: { conditioning: ['7', 0] },
+          },
+          '9': {
+            class_type: 'SeedGenerator',
+            inputs: { seed: 1100100895348371 },
+          },
+          '10': {
+            class_type: 'KSampler',
+            inputs: {
+              seed: ['9', 0],
+              steps: 9,
+              cfg: 1,
+              sampler_name: 'euler',
+              scheduler: 'simple',
+              denoise: 1,
+              model: ['3', 0],
+              positive: ['7', 0],
+              negative: ['8', 0],
+            },
+          },
+          '11': {
+            class_type: 'VAELoader',
+            inputs: { vae_name: 'ae.safetensors' },
+          },
+          '12': {
+            class_type: 'VAEDecode',
+            inputs: { samples: ['10', 0], vae: ['11', 0] },
+          },
+          '13': {
+            class_type: 'MetaHubSaveNode',
+            inputs: { images: ['12', 0] },
+          },
+        },
+      },
+    };
+
+    const result = await parseImageMetadata(metadata);
+
+    expect(result?.generator).toBe('ComfyUI');
+    expect(result?.prompt).toBe('gothic castle in teal fog');
+    expect(result?.negativePrompt).toBe('');
+    expect(result?.seed).toBe(1100100895348371);
+    expect(result?.model).toBe('Z image Turbo\\z_image_turbo_bf16.safetensors');
+  });
 });
 
 describe('ComfyUI Parser - Prompt-only graph payloads', () => {

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -173,6 +173,24 @@ function normalizePromptWhitespace(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
 }
 
+function firstNonBlankString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function firstNonNullish<T>(...values: Array<T | null | undefined>): T | undefined {
+  for (const value of values) {
+    if (value !== null && value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Advanced Seed Extraction with multiple formats:
  * - Numeric: "seed": 12345
@@ -833,6 +851,9 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
         const graph = workflowGraph || promptGraph
           ? createNodeMap(workflowGraph, promptGraph)
           : null;
+        const graphMetadata = graph
+          ? resolvePromptFromGraph(workflowGraph, promptGraph)
+          : {};
         const inferredLineage = graph
           ? detectComfyLineageFromGraph(graph, findTerminalNode(graph), metahubData.denoise)
           : {};
@@ -853,21 +874,26 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
 
         // Map MetaHub chunk fields to expected format
         return {
-          prompt: metahubData.prompt,
-          negativePrompt: metahubData.negativePrompt,
-          seed: metahubData.seed,
-          steps: metahubData.steps,
-          cfg: metahubData.cfg,
-          sampler_name: metahubData.sampler_name,
-          scheduler: metahubData.scheduler,
-          model: metahubData.model,
+          prompt: firstNonBlankString(metahubData.prompt, graphMetadata.prompt) || '',
+          negativePrompt: firstNonBlankString(metahubData.negativePrompt, graphMetadata.negativePrompt) || '',
+          seed: firstNonNullish(
+            metahubData.seed === 0 && graphMetadata.seed !== undefined ? graphMetadata.seed : metahubData.seed,
+            graphMetadata.seed
+          ),
+          steps: firstNonNullish(metahubData.steps, graphMetadata.steps),
+          cfg: firstNonNullish(metahubData.cfg, graphMetadata.cfg),
+          sampler_name: firstNonBlankString(metahubData.sampler_name, graphMetadata.sampler_name) || '',
+          scheduler: firstNonBlankString(metahubData.scheduler, graphMetadata.scheduler) || '',
+          model: firstNonBlankString(metahubData.model, graphMetadata.model) || '',
           model_hash: metahubData.model_hash,
-          vae: metahubData.vae,
-          denoise: metahubData.denoise,
+          vae: firstNonBlankString(metahubData.vae, graphMetadata.vae) || '',
+          denoise: firstNonNullish(metahubData.denoise, graphMetadata.denoise),
           width: metahubData.width,
           height: metahubData.height,
-          loras: metahubData.loras || [],
-          lora: metahubData.loras?.map((l: any) => l.name) || [], // Backward compatibility
+          loras: Array.isArray(metahubData.loras) && metahubData.loras.length > 0 ? metahubData.loras : (graphMetadata.loras || []),
+          lora: Array.isArray(metahubData.loras) && metahubData.loras.length > 0
+            ? metahubData.loras.map((l: any) => l.name)
+            : graphMetadata.lora || [], // Backward compatibility
           tags: userTags,
           notes: userNotes,
           generator: metahubData.generator === 'ComfyUI' ? 'ComfyUI' : 'Image MetaHub',

--- a/services/parsers/comfyui/nodeRegistry.ts
+++ b/services/parsers/comfyui/nodeRegistry.ts
@@ -204,6 +204,36 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     pass_through_rules: [{ from_input: 'model', to_output: 'MODEL' }],
     widget_order: ['lora_name', 'strength_model']
   },
+  'Lora Loader (LoraManager)': {
+    category: 'LOADING',
+    roles: ['TRANSFORM'],
+    inputs: { model: { type: 'MODEL' }, clip: { type: 'CLIP' }, text: { type: 'STRING' } },
+    outputs: { MODEL: { type: 'MODEL' }, CLIP: { type: 'CLIP' }, trigger_words: { type: 'STRING' }, loaded_loras: { type: 'STRING' } },
+    param_mapping: {
+      lora: {
+        source: 'custom_extractor',
+        extractor: (node: ParserNode) => {
+          const rawLoras = node.inputs?.loras?.__value__;
+          if (Array.isArray(rawLoras)) {
+            return rawLoras
+              .filter((lora: any) => lora && lora.active !== false && (lora.name || lora.lora_name))
+              .map((lora: any) => lora.name || lora.lora_name);
+          }
+
+          const text = typeof node.inputs?.text === 'string' ? node.inputs.text : '';
+          return text ? extractors.extractLorasFromText(text) : [];
+        },
+        accumulate: true,
+      },
+      model: { source: 'trace', input: 'model' },
+      prompt: { source: 'input', key: 'text' },
+    },
+    pass_through_rules: [
+      { from_input: 'model', to_output: 'MODEL' },
+      { from_input: 'clip', to_output: 'CLIP' },
+    ],
+    widget_order: ['__lm_autocomplete_meta_text', 'text', 'loras']
+  },
   'LoRA Stacker': {
     category: 'LOADING', roles: ['TRANSFORM'],
     inputs: {}, outputs: { '*': { type: 'ANY' } },
@@ -231,6 +261,22 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     inputs: { '*': { type: 'ANY' } }, outputs: { '*': { type: 'ANY' } },
     pass_through_rules: [{ from_input: '*', to_output: '*' }],
   },
+  'Any Switch (rgthree)': {
+    category: 'ROUTING', roles: ['PASS_THROUGH'],
+    inputs: { '*': { type: 'ANY' } }, outputs: { '*': { type: 'ANY' } },
+    pass_through_rules: [{ from_input: '*', to_output: '*' }],
+  },
+  'TriggerWord Toggle (LoraManager)': {
+    category: 'ROUTING',
+    roles: ['PASS_THROUGH'],
+    inputs: { trigger_words: { type: 'STRING' } },
+    outputs: { filtered_trigger_words: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'trace', input: 'trigger_words' },
+    },
+    pass_through_rules: [{ from_input: 'trigger_words', to_output: 'filtered_trigger_words' }],
+    widget_order: ['group_mode', 'default_active', 'allow_strength_adjustment', 'toggle_trigger_words', 'orinalMessage']
+  },
   ImpactSwitch: {
     category: 'ROUTING', roles: ['ROUTING'],
     inputs: { select: { type: 'INT' }, input1: { type: 'ANY' }, input2: { type: 'ANY' } },
@@ -257,7 +303,7 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
 
   // Common ComfyUI nodes that might appear in workflows
   SaveImage: {
-    category: 'IO', roles: ['SINK'],
+    category: 'IO', roles: ['SINK', 'PASS_THROUGH'],
     inputs: { images: { type: 'IMAGE' } }, 
     outputs: {},
     param_mapping: {},  // No direct params, but traverse inputs
@@ -265,7 +311,7 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
   },
 
   PreviewImage: {
-    category: 'IO', roles: ['SINK'],
+    category: 'IO', roles: ['SINK', 'PASS_THROUGH'],
     inputs: { images: { type: 'IMAGE' } }, outputs: {},
   },
 
@@ -296,6 +342,14 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     category: 'UTILS', roles: ['SOURCE'],
     inputs: { seed: { type: 'INT' } }, outputs: { INT: { type: 'INT' } },
     param_mapping: { seed: { source: 'input', key: 'seed' }, },
+  },
+  SeedGenerator: {
+    category: 'UTILS',
+    roles: ['SOURCE'],
+    inputs: { seed: { type: 'INT' } },
+    outputs: { seed: { type: 'INT' }, 'seed+1': { type: 'INT' } },
+    param_mapping: { seed: { source: 'input', key: 'seed' } },
+    widget_order: ['seed', 'control_after_generate']
   },
   'Seed (rgthree)': {
     category: 'UTILS',
@@ -556,6 +610,68 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     param_mapping: {},
     pass_through_rules: [{ from_input: 'clip', to_output: 'CLIP' }],
     widget_order: ['mean_pool', 'return_tokens']
+  },
+
+  'easy positive': {
+    category: 'UTILS',
+    roles: ['SOURCE'],
+    inputs: { positive: { type: 'STRING' } },
+    outputs: { positive: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'input', key: 'positive' },
+    },
+    widget_order: ['positive']
+  },
+
+  'easy stylesSelector': {
+    category: 'UTILS',
+    roles: ['PASS_THROUGH'],
+    inputs: { positive: { type: 'STRING' }, negative: { type: 'STRING' } },
+    outputs: { positive: { type: 'STRING' }, negative: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'trace', input: 'positive' },
+      negativePrompt: { source: 'trace', input: 'negative' },
+    },
+    pass_through_rules: [
+      { from_input: 'positive', to_output: 'positive' },
+      { from_input: 'negative', to_output: 'negative' },
+    ],
+    widget_order: ['styles', 'select_styles']
+  },
+
+  JoinStrings: {
+    category: 'UTILS',
+    roles: ['TRANSFORM'],
+    inputs: { string1: { type: 'STRING' }, string2: { type: 'STRING' }, string3: { type: 'STRING' }, string4: { type: 'STRING' } },
+    outputs: { STRING: { type: 'STRING' } },
+    param_mapping: {
+      prompt: {
+        source: 'custom_extractor',
+        extractor: (node, state, graph, traverseFromLink) =>
+          extractors.concatTextExtractor(node, state, graph, traverseFromLink, ['string1', 'string2', 'string3', 'string4'])
+      },
+      negativePrompt: {
+        source: 'custom_extractor',
+        extractor: (node, state, graph, traverseFromLink) =>
+          extractors.concatTextExtractor(node, state, graph, traverseFromLink, ['string1', 'string2', 'string3', 'string4'])
+      },
+    },
+    widget_order: ['delimiter']
+  },
+
+  ConditioningZeroOut: {
+    category: 'CONDITIONING',
+    roles: ['TRANSFORM'],
+    inputs: { conditioning: { type: 'CONDITIONING' } },
+    outputs: { CONDITIONING: { type: 'CONDITIONING' } },
+    param_mapping: {
+      prompt: { source: 'trace', input: 'conditioning' },
+      negativePrompt: {
+        source: 'custom_extractor',
+        extractor: () => '',
+      },
+    },
+    pass_through_rules: [{ from_input: 'conditioning', to_output: 'CONDITIONING' }]
   },
 
   ScaledFP8HybridUNetLoader: {
@@ -1193,6 +1309,16 @@ PerturbedAttention: {
   param_mapping: {},
   widget_order: ['hard_mode', 'boost'],
   pass_through_rules: [{ from_input: 'model', to_output: 'MODEL' }]
+},
+
+PathchSageAttentionKJ: {
+  category: 'TRANSFORM',
+  roles: ['PASS_THROUGH'],
+  inputs: { model: { type: 'MODEL' } },
+  outputs: { MODEL: { type: 'MODEL' } },
+  param_mapping: {},
+  pass_through_rules: [{ from_input: 'model', to_output: 'MODEL' }],
+  widget_order: ['sage_attention', 'allow_compile']
 },
 
 TiledDiffusion: {

--- a/services/parsers/comfyui/traversalEngine.ts
+++ b/services/parsers/comfyui/traversalEngine.ts
@@ -94,17 +94,35 @@ function traverse(
 
   // 4. Travessia Estática (PASS_THROUGH / TRANSFORM)
   if (nodeDef.roles.includes('PASS_THROUGH') || nodeDef.roles.includes('TRANSFORM')) {
+    let matchedTypedInput = false;
+
     // Procura por entradas que correspondam ao tipo de dado esperado para continuar a cadeia
     for (const inputName in nodeDef.inputs) {
       const inputDef = nodeDef.inputs[inputName];
       if (inputDef.type === state.expectedType || inputDef.type === 'ANY') {
         const inputLink = currentNode.inputs[inputName];
         if (inputLink && Array.isArray(inputLink)) {
+           matchedTypedInput = true;
            const result = traverseFromLink(inputLink as NodeLink, state, graph, accumulator);
            // Retorna o primeiro resultado encontrado, a menos que esteja acumulando LoRAs
            if (state.targetParam !== 'lora' && result !== null) {
                return result;
            }
+        }
+      }
+    }
+
+    // Some terminal/output chains expose IMAGE/LATENT links before the sampler
+    // that owns prompt/model/sampling facts. If no typed route exists, keep
+    // walking upstream through connected inputs until a known fact node is found.
+    if (!matchedTypedInput) {
+      for (const inputName in currentNode.inputs) {
+        const inputLink = currentNode.inputs[inputName];
+        if (inputLink && Array.isArray(inputLink)) {
+          const result = traverseFromLink(inputLink as NodeLink, state, graph, accumulator);
+          if (state.targetParam !== 'lora' && result !== null) {
+            return result;
+          }
         }
       }
     }

--- a/services/parsers/metadataParserFactory.ts
+++ b/services/parsers/metadataParserFactory.ts
@@ -140,11 +140,8 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
     const promptCI = getCaseInsensitive<unknown>(rawMetadata, 'prompt');
     const promptLooksLikeGraph = typeof promptCI === 'string' && /"class_type"|"inputs"/.test(promptCI);
     const promptOnlyGraph = isComfyPromptOnlyGraph(rawMetadata);
-    const hasParameters = 'parameters' in metadata &&
-        typeof metadata.parameters === 'string' &&
-        metadata.parameters.trim().length > 0;
 
-    if (!hasParameters && (workflowCI !== undefined || (promptCI && typeof promptCI === 'object') || promptLooksLikeGraph || promptOnlyGraph)) {
+    if (workflowCI !== undefined || (promptCI && typeof promptCI === 'object') || promptLooksLikeGraph || promptOnlyGraph) {
         return {
             parse: (data: ComfyUIMetadata) => {
                 // Parse workflow and prompt if they are strings


### PR DESCRIPTION
## Summary

- Prioritize ComfyUI `prompt`/`workflow` graph chunks even when a non-empty `parameters` chunk is present.
- Recover empty or zeroed MetaHub Save Node fields by re-parsing embedded `workflow` / `prompt_api` graph data.
- Add parser registry coverage for the custom nodes seen in the reported workflow, including LoraManager, easy-use prompt/string nodes, KJNodes Sage Attention, and related routing nodes.
- Allow output terminal nodes such as `SaveImage` / `PreviewImage` to walk upstream through image links when needed.

## Root Cause

The affected PNG had a valid `imagemetahub_data` chunk, but its canonical fields were already empty or defaulted (`prompt: ""`, `seed: 0`). The full ComfyUI prompt graph was still embedded, so the app can recover those fields by using the graph as a fallback.

## Validation

- `npm test -- comfyui-parser`
- `npx tsc --noEmit`
- `pytest tests/test_workflow_extractor.py` in `D:\ImageMetaHub-ComfyUI-Save` to confirm the current save-node extractor handles the pasted prompt graph.