### PR TITLE
Fix ComfyUI workspace navigation loop

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -121,6 +121,11 @@ const MAIN_CONTENT_MIN_WIDTH = 560;
 
 const getImageTimestamp = (image: IndexedImage): number => image.contentModifiedMs ?? image.lastModified ?? 0;
 
+const areStringArraysEqual = (left: string[] | null, right: string[]): boolean =>
+  Array.isArray(left) &&
+  left.length === right.length &&
+  left.every((value, index) => value === right[index]);
+
 const sortImagesNewestFirst = (images: IndexedImage[]): IndexedImage[] =>
   [...images].sort((a, b) => getImageTimestamp(b) - getImageTimestamp(a) || a.name.localeCompare(b.name));
 
@@ -2019,7 +2024,9 @@ export default function App() {
       : comfyUIWorkspaceSourceImages;
     const scopedImageIds = scopedImages.map((image) => image.id);
 
-    setComfyUIWorkspaceNavigationImageIds(scopedImageIds);
+    setComfyUIWorkspaceNavigationImageIds((current) =>
+      areStringArraysEqual(current, scopedImageIds) ? current : scopedImageIds
+    );
     setComfyUIWorkspaceImageId((current) => {
       if (current && scopedImageIds.includes(current)) {
         return current;
@@ -2141,7 +2148,10 @@ export default function App() {
       ? comfyUIWorkspaceSourceImages.filter((candidate) => candidate.directoryId === nextDirectoryId)
       : comfyUIWorkspaceSourceImages;
 
-    setComfyUIWorkspaceNavigationImageIds(nextImages.map((candidate) => candidate.id));
+    const nextImageIds = nextImages.map((candidate) => candidate.id);
+    setComfyUIWorkspaceNavigationImageIds((current) =>
+      areStringArraysEqual(current, nextImageIds) ? current : nextImageIds
+    );
     setComfyUIWorkspaceImageId(nextImages[0]?.id ?? null);
   }, [comfyUIWorkspaceSourceImages]);
   const handleComfyUIWorkspaceApplyLibraryFiltersChange = useCallback((applyFilters: boolean) => {


### PR DESCRIPTION
## Summary

- Prevent the ComfyUI Workspace from rewriting navigation image IDs when the list contents have not changed.
- Reuse the same guard when changing the workspace directory scope.
- Refers to #339 
- 
## Root Cause

The workspace navigation effect created a fresh image ID array and pushed it into React state even when the IDs were identical. Under the right library/workspace state, that can repeatedly schedule renders and surface as React error #185 / a black renderer screen.

## Validation

- `npm run build`