### PR TITLE
Restore navigation state across workspace switches

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -249,11 +249,25 @@ export default function App() {
   const availableSchedulers = useImageStore((state) => state.availableSchedulers);
   const availableDimensions = useImageStore((state) => state.availableDimensions);
   const selectedModels = useImageStore((state) => state.selectedModels);
+  const excludedModels = useImageStore((state) => state.excludedModels);
   const selectedLoras = useImageStore((state) => state.selectedLoras);
+  const excludedLoras = useImageStore((state) => state.excludedLoras);
   const selectedSamplers = useImageStore((state) => state.selectedSamplers);
+  const excludedSamplers = useImageStore((state) => state.excludedSamplers);
   const selectedSchedulers = useImageStore((state) => state.selectedSchedulers);
+  const excludedSchedulers = useImageStore((state) => state.excludedSchedulers);
+  const selectedGenerators = useImageStore((state) => state.selectedGenerators);
+  const excludedGenerators = useImageStore((state) => state.excludedGenerators);
+  const selectedGpuDevices = useImageStore((state) => state.selectedGpuDevices);
+  const excludedGpuDevices = useImageStore((state) => state.excludedGpuDevices);
   const advancedFilters = useImageStore((state) => state.advancedFilters);
   const selectedRatings = useImageStore((state) => state.selectedRatings);
+  const selectedTags = useImageStore((state) => state.selectedTags);
+  const excludedTags = useImageStore((state) => state.excludedTags);
+  const selectedTagsMatchMode = useImageStore((state) => state.selectedTagsMatchMode);
+  const selectedAutoTags = useImageStore((state) => state.selectedAutoTags);
+  const excludedAutoTags = useImageStore((state) => state.excludedAutoTags);
+  const favoriteFilterMode = useImageStore((state) => state.favoriteFilterMode);
   const setSelectedTags = useImageStore((state) => state.setSelectedTags);
   const setExcludedTags = useImageStore((state) => state.setExcludedTags);
   const setSelectedAutoTags = useImageStore((state) => state.setSelectedAutoTags);
@@ -299,6 +313,7 @@ export default function App() {
   const loadAutomationRules = useImageStore((state) => state.loadAutomationRules);
   const imageStoreSetSortOrder = useImageStore((state) => state.setSortOrder);
   const sortOrder = useImageStore((state) => state.sortOrder);
+  const randomSeed = useImageStore((state) => state.randomSeed);
   const reshuffle = useImageStore((state) => state.reshuffle);
   const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
   const getResolvedFilteredCollectionImages = useImageStore((state) => state.getResolvedFilteredCollectionImages);
@@ -2037,22 +2052,54 @@ export default function App() {
       lastImageId,
       searchQuery,
       selectedModels.join('\u001f'),
+      excludedModels.join('\u001f'),
       selectedLoras.join('\u001f'),
+      excludedLoras.join('\u001f'),
       selectedSamplers.join('\u001f'),
+      excludedSamplers.join('\u001f'),
       selectedSchedulers.join('\u001f'),
+      excludedSchedulers.join('\u001f'),
+      selectedGenerators.join('\u001f'),
+      excludedGenerators.join('\u001f'),
+      selectedGpuDevices.join('\u001f'),
+      excludedGpuDevices.join('\u001f'),
+      selectedTags.join('\u001f'),
+      excludedTags.join('\u001f'),
+      selectedTagsMatchMode,
+      selectedAutoTags.join('\u001f'),
+      excludedAutoTags.join('\u001f'),
+      favoriteFilterMode,
       selectedRatings.join('\u001f'),
+      JSON.stringify(advancedFilters),
       sortOrder,
+      randomSeed,
       groupBy,
     ].join('\u001e');
   }, [
+    advancedFilters,
+    excludedAutoTags,
+    excludedGenerators,
+    excludedGpuDevices,
+    excludedLoras,
+    excludedModels,
+    excludedSamplers,
+    excludedSchedulers,
+    excludedTags,
+    favoriteFilterMode,
     groupBy,
+    randomSeed,
     safeFilteredImages,
     searchQuery,
+    selectedAutoTags,
+    selectedGenerators,
+    selectedGpuDevices,
     selectedLoras,
     selectedModels,
     selectedRatings,
     selectedSamplers,
     selectedSchedulers,
+    selectedTags,
+    selectedTagsMatchMode,
     sortOrder,
   ]);
 
@@ -2066,9 +2113,56 @@ export default function App() {
       firstImageId,
       lastImageId,
       searchQuery,
+      selectedModels.join('\u001f'),
+      excludedModels.join('\u001f'),
+      selectedLoras.join('\u001f'),
+      excludedLoras.join('\u001f'),
+      selectedSamplers.join('\u001f'),
+      excludedSamplers.join('\u001f'),
+      selectedSchedulers.join('\u001f'),
+      excludedSchedulers.join('\u001f'),
+      selectedGenerators.join('\u001f'),
+      excludedGenerators.join('\u001f'),
+      selectedGpuDevices.join('\u001f'),
+      excludedGpuDevices.join('\u001f'),
+      selectedTags.join('\u001f'),
+      excludedTags.join('\u001f'),
+      selectedTagsMatchMode,
+      selectedAutoTags.join('\u001f'),
+      excludedAutoTags.join('\u001f'),
+      favoriteFilterMode,
+      selectedRatings.join('\u001f'),
+      JSON.stringify(advancedFilters),
       sortOrder,
+      randomSeed,
     ].join('\u001e');
-  }, [activeCollectionId, collectionFilteredImages, searchQuery, sortOrder]);
+  }, [
+    activeCollectionId,
+    advancedFilters,
+    collectionFilteredImages,
+    excludedAutoTags,
+    excludedGenerators,
+    excludedGpuDevices,
+    excludedLoras,
+    excludedModels,
+    excludedSamplers,
+    excludedSchedulers,
+    excludedTags,
+    favoriteFilterMode,
+    randomSeed,
+    searchQuery,
+    selectedAutoTags,
+    selectedGenerators,
+    selectedGpuDevices,
+    selectedLoras,
+    selectedModels,
+    selectedRatings,
+    selectedSamplers,
+    selectedSchedulers,
+    selectedTags,
+    selectedTagsMatchMode,
+    sortOrder,
+  ]);
 
   useEffect(() => {
     if (previousLibraryGridSignatureRef.current === null) {

--- a/App.tsx
+++ b/App.tsx
@@ -354,9 +354,14 @@ export default function App() {
 
   // --- Local UI State ---
   const [currentPage, setCurrentPage] = useState(1);
+  const [modelViewPage, setModelViewPage] = useState(1);
   const [pendingJumpGroupRequest, setPendingJumpGroupRequest] = useState<{ groupId: string; requestId: number } | null>(null);
   const [searchInputValue, setSearchInputValue] = useState(searchQuery);
   const previousSearchQueryRef = useRef(searchQuery);
+  const previousLibraryGridSignatureRef = useRef<string | null>(null);
+  const previousCollectionsGridSignatureRef = useRef<string | null>(null);
+  const libraryGridScrollTopRef = useRef(0);
+  const collectionsGridScrollTopRef = useRef(0);
   const pendingSearchFlowIdRef = useRef<string | null>(null);
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>('library');
@@ -452,6 +457,22 @@ export default function App() {
   const queueCount = useGenerationQueueStore((state) =>
     state.items.filter((item) => item.status === 'waiting' || item.status === 'processing').length
   );
+
+  const resetLibraryGridScrollPosition = useCallback(() => {
+    libraryGridScrollTopRef.current = 0;
+  }, []);
+
+  const resetCollectionsGridScrollPosition = useCallback(() => {
+    collectionsGridScrollTopRef.current = 0;
+  }, []);
+
+  const handleLibraryGridScrollPositionChange = useCallback((scrollTop: number) => {
+    libraryGridScrollTopRef.current = scrollTop;
+  }, []);
+
+  const handleCollectionsGridScrollPositionChange = useCallback((scrollTop: number) => {
+    collectionsGridScrollTopRef.current = scrollTop;
+  }, []);
 
   const handleSearchChange = useCallback((query: string) => {
     if (pendingSearchFlowIdRef.current) {
@@ -864,6 +885,7 @@ export default function App() {
       }
 
       if (selectedFolders.size === 0) {
+        resetLibraryGridScrollPosition();
         setCurrentPage(1);
         return;
       }
@@ -877,12 +899,13 @@ export default function App() {
       );
 
       if (affectsVisibleScope) {
+        resetLibraryGridScrollPosition();
         setCurrentPage(1);
       }
     });
 
     return () => unsubscribe();
-  }, [directories, excludedFolders, includeSubfolders, processNewWatchedFiles, selectedFolders, sortOrder]);
+  }, [directories, excludedFolders, includeSubfolders, processNewWatchedFiles, resetLibraryGridScrollPosition, selectedFolders, sortOrder]);
 
   useEffect(() => {
     if (sortOrder === 'random' && groupBy !== 'none') {
@@ -1154,6 +1177,7 @@ export default function App() {
 
   useEffect(() => {
     if (previousSearchQueryRef.current !== searchQuery) {
+      resetLibraryGridScrollPosition();
       setCurrentPage(1);
       if (pendingSearchFlowIdRef.current) {
         markPerformanceFlow(pendingSearchFlowIdRef.current, 'store-commit', {
@@ -1172,15 +1196,16 @@ export default function App() {
       }
       previousSearchQueryRef.current = searchQuery;
     }
-  }, [safeFilteredImages.length, searchQuery]);
+  }, [resetLibraryGridScrollPosition, safeFilteredImages.length, searchQuery]);
 
   // Reset page if current page exceeds available pages after filtering
   useEffect(() => {
     const totalPages = Math.ceil(safeFilteredImages.length / itemsPerPage);
     if (currentPage > totalPages && totalPages > 0) {
+      resetLibraryGridScrollPosition();
       setCurrentPage(1);
     }
-  }, [safeFilteredImages.length, itemsPerPage, currentPage]);
+  }, [safeFilteredImages.length, itemsPerPage, currentPage, resetLibraryGridScrollPosition]);
 
   // Clean up selectedImage if its directory no longer exists
   useEffect(() => {
@@ -2002,6 +2027,73 @@ export default function App() {
       : safeFilteredImages;
   const comfyUIWorkspaceSourceImages = comfyUIWorkspaceApplyLibraryFilters ? displayImages : safeImages;
 
+  const libraryGridSignature = useMemo(() => {
+    const firstImageId = safeFilteredImages[0]?.id ?? '';
+    const lastImageId = safeFilteredImages[safeFilteredImages.length - 1]?.id ?? '';
+
+    return [
+      safeFilteredImages.length,
+      firstImageId,
+      lastImageId,
+      searchQuery,
+      selectedModels.join('\u001f'),
+      selectedLoras.join('\u001f'),
+      selectedSamplers.join('\u001f'),
+      selectedSchedulers.join('\u001f'),
+      selectedRatings.join('\u001f'),
+      sortOrder,
+      groupBy,
+    ].join('\u001e');
+  }, [
+    groupBy,
+    safeFilteredImages,
+    searchQuery,
+    selectedLoras,
+    selectedModels,
+    selectedRatings,
+    selectedSamplers,
+    selectedSchedulers,
+    sortOrder,
+  ]);
+
+  const collectionsGridSignature = useMemo(() => {
+    const firstImageId = collectionFilteredImages[0]?.id ?? '';
+    const lastImageId = collectionFilteredImages[collectionFilteredImages.length - 1]?.id ?? '';
+
+    return [
+      activeCollectionId ?? '',
+      collectionFilteredImages.length,
+      firstImageId,
+      lastImageId,
+      searchQuery,
+      sortOrder,
+    ].join('\u001e');
+  }, [activeCollectionId, collectionFilteredImages, searchQuery, sortOrder]);
+
+  useEffect(() => {
+    if (previousLibraryGridSignatureRef.current === null) {
+      previousLibraryGridSignatureRef.current = libraryGridSignature;
+      return;
+    }
+
+    if (previousLibraryGridSignatureRef.current !== libraryGridSignature) {
+      resetLibraryGridScrollPosition();
+      previousLibraryGridSignatureRef.current = libraryGridSignature;
+    }
+  }, [libraryGridSignature, resetLibraryGridScrollPosition]);
+
+  useEffect(() => {
+    if (previousCollectionsGridSignatureRef.current === null) {
+      previousCollectionsGridSignatureRef.current = collectionsGridSignature;
+      return;
+    }
+
+    if (previousCollectionsGridSignatureRef.current !== collectionsGridSignature) {
+      resetCollectionsGridScrollPosition();
+      previousCollectionsGridSignatureRef.current = collectionsGridSignature;
+    }
+  }, [collectionsGridSignature, resetCollectionsGridScrollPosition]);
+
   useEffect(() => {
     if (libraryView !== 'comfyui') {
       return;
@@ -2259,9 +2351,11 @@ export default function App() {
   useEffect(() => {
     const scopedTotalPages = Math.ceil(displayImages.length / itemsPerPage);
     if (currentPage > scopedTotalPages && scopedTotalPages > 0) {
+      resetLibraryGridScrollPosition();
+      resetCollectionsGridScrollPosition();
       setCurrentPage(1);
     }
-  }, [currentPage, displayImages.length, itemsPerPage]);
+  }, [currentPage, displayImages.length, itemsPerPage, resetCollectionsGridScrollPosition, resetLibraryGridScrollPosition]);
 
   useEffect(() => {
     if (libraryView !== 'collections') {
@@ -2790,6 +2884,9 @@ export default function App() {
                           groupBy={effectiveLibraryGroupBy}
                           groupSortOrder={imageGroupingSortOrder}
                           jumpToGroupRequest={pendingJumpGroupRequest}
+                          initialScrollTop={libraryGridScrollTopRef.current}
+                          onScrollPositionChange={handleLibraryGridScrollPositionChange}
+                          scrollResetKey={libraryGridSignature}
                         />
                       ) : (
                         <ImageTable
@@ -2810,7 +2907,12 @@ export default function App() {
                   <ModelView
                     isQueueOpen={isQueueOpen}
                     onToggleQueue={() => setIsQueueOpen((prev) => !prev)}
+                    page={modelViewPage}
+                    onPageChange={setModelViewPage}
+                    activeModelName={selectedModels.length === 1 ? selectedModels[0] : null}
                     onModelSelect={(modelName) => {
+                      resetLibraryGridScrollPosition();
+                      setModelViewPage(1);
                       setSelectedFilters({ models: [modelName] });
                       setLibraryView('library');
                     }}
@@ -2836,6 +2938,9 @@ export default function App() {
                         onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
                         onOpenImageEditor={(image) => handleOpenImageEditor(image, displayImages)}
                         onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
+                        initialScrollTop={collectionsGridScrollTopRef.current}
+                        onScrollPositionChange={handleCollectionsGridScrollPositionChange}
+                        scrollResetKey={collectionsGridSignature}
                       />
                     ) : (
                       <ImageTable

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1210,6 +1210,10 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     }
   }, [getGridScrollElement]);
 
+  const getScrollRestoreKey = useCallback((scrollTop: number) => (
+    `${scrollResetKey ?? 'grid'}:${isInfinite ? 'virtual' : 'static'}:${Math.round(Math.max(0, scrollTop))}`
+  ), [isInfinite, scrollResetKey]);
+
   useEffect(() => {
     if (lastScrollResetKeyRef.current === scrollResetKey) {
       return;
@@ -1220,12 +1224,13 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       return;
     }
 
+    lastRestoredScrollKeyRef.current = getScrollRestoreKey(initialScrollTop);
     restoreGridScrollPosition(0);
     onScrollPositionChange?.(0);
-  }, [onScrollPositionChange, restoreGridScrollPosition, scrollResetKey]);
+  }, [getScrollRestoreKey, initialScrollTop, onScrollPositionChange, restoreGridScrollPosition, scrollResetKey]);
 
   useEffect(() => {
-    const restoreKey = `${scrollResetKey ?? 'grid'}:${isInfinite ? 'virtual' : 'static'}:${Math.round(Math.max(0, initialScrollTop))}`;
+    const restoreKey = getScrollRestoreKey(initialScrollTop);
     if (lastRestoredScrollKeyRef.current === restoreKey) {
       return;
     }
@@ -1247,7 +1252,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       window.cancelAnimationFrame(firstFrame);
       window.cancelAnimationFrame(secondFrame);
     };
-  }, [initialScrollTop, isInfinite, restoreGridScrollPosition, scrollResetKey]);
+  }, [getScrollRestoreKey, initialScrollTop, restoreGridScrollPosition]);
 
   const getActiveColumnCount = useCallback(() => {
     if (isInfinite) {

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1043,6 +1043,9 @@ interface ImageGridProps {
   groupBy?: ImageGroupByMode;
   groupSortOrder?: ImageGroupingSortOrder;
   jumpToGroupRequest?: { groupId: string; requestId: number } | null;
+  initialScrollTop?: number;
+  onScrollPositionChange?: (scrollTop: number) => void;
+  scrollResetKey?: string;
 }
 
 const InnerGridElement = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => (
@@ -1068,6 +1071,9 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   groupBy = 'none',
   groupSortOrder = 'date-desc',
   jumpToGroupRequest = null,
+  initialScrollTop = 0,
+  onScrollPositionChange,
+  scrollResetKey,
 }) => {
   const imageSize = useSettingsStore((state) => state.imageSize);
   const itemsPerPage = useSettingsStore((state) => state.itemsPerPage);
@@ -1103,6 +1109,8 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const cardRefCallbacksRef = useRef<Map<string, (el: HTMLDivElement | null) => void>>(new Map());
   const columnCountRef = useRef<number>(1);
   const lastWarmupWindowRef = useRef<string>('');
+  const lastScrollResetKeyRef = useRef<string | undefined>(scrollResetKey);
+  const lastRestoredScrollKeyRef = useRef<string>('');
   const releasePaginatedBackgroundPauseRef = useRef<(() => void) | null>(null);
   const lastScrollSampleRef = useRef<{ top: number; at: number }>({ top: 0, at: 0 });
   const focusedImageIndexRef = useRef<number | null>(null);
@@ -1189,6 +1197,57 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const submenuHorizontalClass = contextMenu.horizontalDirection === 'left' ? 'right-full' : 'left-full';
 
   const getGridScrollElement = useCallback(() => gridScrollRef.current ?? gridScopeRef.current, []);
+
+  const restoreGridScrollPosition = useCallback((scrollTop: number) => {
+    const nextScrollTop = Math.max(0, scrollTop);
+
+    virtualGridRef.current?.scrollTo({ scrollTop: nextScrollTop, scrollLeft: 0 });
+
+    const scrollElement = getGridScrollElement();
+    if (scrollElement) {
+      scrollElement.scrollTop = nextScrollTop;
+      scrollElement.scrollLeft = 0;
+    }
+  }, [getGridScrollElement]);
+
+  useEffect(() => {
+    if (lastScrollResetKeyRef.current === scrollResetKey) {
+      return;
+    }
+
+    lastScrollResetKeyRef.current = scrollResetKey;
+    if (!scrollResetKey) {
+      return;
+    }
+
+    restoreGridScrollPosition(0);
+    onScrollPositionChange?.(0);
+  }, [onScrollPositionChange, restoreGridScrollPosition, scrollResetKey]);
+
+  useEffect(() => {
+    const restoreKey = `${scrollResetKey ?? 'grid'}:${isInfinite ? 'virtual' : 'static'}:${Math.round(Math.max(0, initialScrollTop))}`;
+    if (lastRestoredScrollKeyRef.current === restoreKey) {
+      return;
+    }
+
+    lastRestoredScrollKeyRef.current = restoreKey;
+    if (initialScrollTop <= 0) {
+      return;
+    }
+
+    let firstFrame = 0;
+    let secondFrame = 0;
+    firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => {
+        restoreGridScrollPosition(initialScrollTop);
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      window.cancelAnimationFrame(secondFrame);
+    };
+  }, [initialScrollTop, isInfinite, restoreGridScrollPosition, scrollResetKey]);
 
   const getActiveColumnCount = useCallback(() => {
     if (isInfinite) {
@@ -2668,6 +2727,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                     width={width}
                     outerRef={gridScrollRef}
                     className="no-scrollbar-if-needed"
+                    initialScrollTop={Math.max(0, initialScrollTop)}
                     itemData={cellData}
                     itemKey={({ columnIndex, rowIndex, data }) => {
                       const itemIndex = rowIndex * safeColumnCount + columnIndex;
@@ -2686,6 +2746,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                     style={{ overflowX: 'hidden' }}
                     innerElementType={InnerGridElement}
                     onScroll={({ scrollTop, scrollUpdateWasRequested }) => {
+                      onScrollPositionChange?.(scrollTop);
                       const currentAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
                       const previousSample = lastScrollSampleRef.current;
                       const deltaMs = Math.max(1, currentAt - previousSample.at);
@@ -2830,6 +2891,9 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
+        onScroll={(event) => {
+          onScrollPositionChange?.(event.currentTarget.scrollTop);
+        }}
       >
         <div
           className="flex flex-wrap gap-4"

--- a/components/ModelCard.tsx
+++ b/components/ModelCard.tsx
@@ -10,9 +10,10 @@ interface ModelCardProps {
   imageCount: number;
   onClick: () => void;
   onFindMatchingPrompts?: () => void;
+  isActive?: boolean;
 }
 
-const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, onClick, onFindMatchingPrompts }) => {
+const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, onClick, onFindMatchingPrompts, isActive = false }) => {
   const cardRef = useRef<HTMLButtonElement | null>(null);
   const [previewIndex, setPreviewIndex] = useState(0);
   const rafRef = useRef<number | null>(null);
@@ -63,7 +64,9 @@ const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, on
       onClick={onClick}
       onPointerMove={handlePointerMove}
       onPointerLeave={handlePointerLeave}
-      className="group text-left bg-gray-900/60 border border-gray-800 rounded-2xl overflow-hidden shadow-lg transition-all hover:shadow-xl hover:shadow-blue-500/20 hover:border-blue-500/30 cursor-pointer"
+      className={`group text-left bg-gray-900/60 border rounded-2xl overflow-hidden shadow-lg transition-all hover:shadow-xl hover:shadow-blue-500/20 hover:border-blue-500/30 cursor-pointer ${
+        isActive ? 'border-blue-400/70 shadow-blue-500/20' : 'border-gray-800'
+      }`}
       type="button"
     >
       <div className="relative aspect-[4/5] overflow-hidden">
@@ -129,8 +132,9 @@ const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, on
         <p className="text-sm font-semibold text-gray-100 truncate" title={modelName}>
           {modelName}
         </p>
-        <p className="text-xs text-gray-400 mt-1">
-          {imageCount} image{imageCount !== 1 ? 's' : ''}
+        <p className="mt-1 flex items-center justify-between gap-2 text-xs text-gray-400">
+          <span>{imageCount} image{imageCount !== 1 ? 's' : ''}</span>
+          {isActive && <span className="shrink-0 text-blue-300">Selected</span>}
         </p>
       </div>
     </button>

--- a/components/ModelView.tsx
+++ b/components/ModelView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -48,6 +48,7 @@ export const ModelView: React.FC<ModelViewProps> = ({
 
   const [internalPage, setInternalPage] = useState(1);
   const [sortBy] = useState<'count' | 'name'>('count');
+  const previousActiveModelNameRef = useRef(activeModelName);
   const page = controlledPage ?? internalPage;
 
   const modelEntries = useMemo(() => {
@@ -86,6 +87,22 @@ export const ModelView: React.FC<ModelViewProps> = ({
   }, [activeModelName, images, sortBy]);
 
   const totalPages = itemsPerPage === -1 ? 1 : Math.ceil(modelEntries.length / itemsPerPage);
+
+  useEffect(() => {
+    if (previousActiveModelNameRef.current === activeModelName) {
+      return;
+    }
+
+    previousActiveModelNameRef.current = activeModelName;
+    if (!activeModelName) {
+      return;
+    }
+
+    onPageChange?.(1);
+    if (controlledPage == null) {
+      setInternalPage(1);
+    }
+  }, [activeModelName, controlledPage, onPageChange]);
 
   useEffect(() => {
     if (page > totalPages && totalPages > 0) {

--- a/components/ModelView.tsx
+++ b/components/ModelView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -19,10 +19,21 @@ interface ModelViewProps {
   onToggleQueue?: () => void;
   onModelSelect: (modelName: string) => void;
   onFindMatchingPrompts?: (modelName: string) => void;
+  page?: number;
+  onPageChange?: (page: number) => void;
+  activeModelName?: string | null;
 }
 
 
-export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onToggleQueue, onModelSelect, onFindMatchingPrompts }) => {
+export const ModelView: React.FC<ModelViewProps> = ({
+  isQueueOpen = false,
+  onToggleQueue,
+  onModelSelect,
+  onFindMatchingPrompts,
+  page: controlledPage,
+  onPageChange,
+  activeModelName = null,
+}) => {
   const images = useImageStore((state) => state.images);
   const filteredImages = useImageStore((state) => state.filteredImages);
   const selectionTotalImages = useImageStore((state) => state.selectionTotalImages);
@@ -35,8 +46,9 @@ export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onTog
     state.items.filter((item) => item.status === 'waiting' || item.status === 'processing').length
   );
 
-  const [page, setPage] = useState(1);
+  const [internalPage, setInternalPage] = useState(1);
   const [sortBy] = useState<'count' | 'name'>('count');
+  const page = controlledPage ?? internalPage;
 
   const modelEntries = useMemo(() => {
     const models = new Map<string, IndexedImage[]>();
@@ -60,15 +72,29 @@ export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onTog
     }));
 
     return entries.sort((a, b) => {
+      if (activeModelName) {
+        if (a.name === activeModelName) return -1;
+        if (b.name === activeModelName) return 1;
+      }
+
       if (sortBy === 'count') {
         const countDiff = b.count - a.count;
         if (countDiff !== 0) return countDiff;
       }
       return a.name.localeCompare(b.name);
     });
-  }, [images, sortBy]);
+  }, [activeModelName, images, sortBy]);
 
   const totalPages = itemsPerPage === -1 ? 1 : Math.ceil(modelEntries.length / itemsPerPage);
+
+  useEffect(() => {
+    if (page > totalPages && totalPages > 0) {
+      onPageChange?.(1);
+      if (controlledPage == null) {
+        setInternalPage(1);
+      }
+    }
+  }, [controlledPage, onPageChange, page, totalPages]);
   
   const paginatedEntries = useMemo(() => {
     if (itemsPerPage === -1) return modelEntries;
@@ -77,7 +103,10 @@ export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onTog
   }, [modelEntries, page, itemsPerPage]);
 
   const handlePageChange = (newPage: number) => {
-    setPage(newPage);
+    onPageChange?.(newPage);
+    if (controlledPage == null) {
+      setInternalPage(newPage);
+    }
   };
 
   return (
@@ -101,6 +130,7 @@ export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onTog
                 modelName={entry.name}
                 images={entry.images}
                 imageCount={entry.count}
+                isActive={entry.name === activeModelName}
                 onClick={() => onModelSelect(entry.name)}
                 onFindMatchingPrompts={onFindMatchingPrompts ? () => onFindMatchingPrompts(entry.name) : undefined}
               />


### PR DESCRIPTION
## Summary

- Preserve Library and Collections grid scroll positions when switching away and back.
- Restore grid scroll after mount for both virtualized and non-virtualized grid modes.
- Keep the selected Model View context visible by surfacing the active model at the top and marking it as selected.

## Why

Switching from Library or Model View into ComfyUI Workspace and back was resetting the user’s place, which made navigation feel unnecessarily lossy. This keeps the browsing context intact while still resetting scroll when filters or result sets actually change.

## Validation

- `npx tsc --noEmit`