### PR TITLE
Merge 0.17.0 RC into main

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ### Current Stack
 
-* **Version:** 0.16.1
+* **Version:** 0.17.0-rc
 * **Renderer:** React 18 + TypeScript
 * **Desktop shell:** Electron 38
 * **State management:** Zustand

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ### Current Stack
 
-* **Version:** 0.17.0-rc
+* **Version:** 0.17.0
 * **Renderer:** React 18 + TypeScript
 * **Desktop shell:** Electron 38
 * **State management:** Zustand

--- a/App.tsx
+++ b/App.tsx
@@ -36,6 +36,7 @@ import FindSimilarModal from './components/FindSimilarModal';
 import ModelPromptPickerModal from './components/ModelPromptPickerModal';
 import CollectionsWorkspace from './components/CollectionsWorkspace';
 import ComfyUIWorkspace from './components/ComfyUIWorkspace';
+import ImageEditorWorkspace from './components/ImageEditorWorkspace';
 import GridToolbar from './components/GridToolbar';
 import AnalyticsSummaryStrip from './components/AnalyticsSummaryStrip';
 import BatchExportModal from './components/BatchExportModal';
@@ -403,7 +404,7 @@ export default function App() {
   const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false);
   const [currentVersion, setCurrentVersion] = useState<string>('0.10.0');
   const [isQueueOpen, setIsQueueOpen] = useState(false);
-  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node' | 'collections' | 'comfyui'>('library');
+  const [libraryView, setLibraryView] = useState<'library' | 'smart' | 'model' | 'node' | 'collections' | 'comfyui' | 'editor'>('library');
   const [nodeViewVisibleImages, setNodeViewVisibleImages] = useState<IndexedImage[]>([]);
   const [nodeViewResultImages, setNodeViewResultImages] = useState<IndexedImage[]>([]);
   const [isA1111GenerateModalOpen, setIsA1111GenerateModalOpen] = useState(false);
@@ -420,6 +421,8 @@ export default function App() {
     return window.localStorage.getItem(COMFYUI_WORKSPACE_APPLY_FILTERS_STORAGE_KEY) === 'true';
   });
   const [isComfyUIWorkspaceGenerating, setIsComfyUIWorkspaceGenerating] = useState(false);
+  const [editorImageId, setEditorImageId] = useState<string | null>(null);
+  const [editorNavigationImageIds, setEditorNavigationImageIds] = useState<string[] | null>(null);
   const [newImagesToast, setNewImagesToast] = useState<{ message: string } | null>(null);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
   const [batchExportRequest, setBatchExportRequest] = useState<BatchExportRequestState | null>(null);
@@ -485,8 +488,8 @@ export default function App() {
       setNodeViewResultImages([]);
     }
   }, [libraryView, nodeViewResultImages.length]);
-  const hasLeftSidebar = hasDirectories && libraryView !== 'comfyui';
-  const hasRightSidebar = Boolean(isQueueOpen || (previewImage && libraryView !== 'comfyui'));
+  const hasLeftSidebar = hasDirectories && libraryView !== 'comfyui' && libraryView !== 'editor';
+  const hasRightSidebar = Boolean(isQueueOpen || (previewImage && libraryView !== 'comfyui' && libraryView !== 'editor'));
   const { leftWidth: sidebarWidth, rightWidth: rightSidebarWidth } = useMemo(
     () =>
       resolveSidebarWidths({
@@ -1791,6 +1794,27 @@ export default function App() {
     setLibraryView('comfyui');
   }, []);
 
+  const handleOpenImageEditor = useCallback((image: IndexedImage, navigationImages?: IndexedImage[]) => {
+    const navigationImageIds = navigationImages && navigationImages.length > 0
+      ? navigationImages.map((item) => item.id)
+      : [image.id];
+    setEditorImageId(image.id);
+    setEditorNavigationImageIds(navigationImageIds);
+    setSelectedImage(image);
+    setLibraryView('editor');
+  }, [setSelectedImage]);
+
+  const handleOpenImageEditorFromImageModal = useCallback((
+    modalId: string,
+    image: IndexedImage,
+    navigationImages?: IndexedImage[],
+  ) => {
+    handleOpenImageEditor(image, navigationImages);
+    suppressSelectedImageModalOpenRef.current = image.id;
+    setOpenImageModals((current) => current.filter((modal) => modal.modalId !== modalId));
+    setActiveImageModalId((current) => (current === modalId ? null : current));
+  }, [handleOpenImageEditor]);
+
   const openComfyUIWorkflowInWorkspace = useCallback((
     image: IndexedImage,
     navigationImages?: IndexedImage[],
@@ -1841,6 +1865,24 @@ export default function App() {
         return { ...modal, isMinimized: true };
       });
 
+      return changed ? next : current;
+    });
+  }, [libraryView]);
+
+  useEffect(() => {
+    if (libraryView !== 'editor') {
+      return;
+    }
+
+    setOpenImageModals((current) => {
+      let changed = false;
+      const next = current.map((modal) => {
+        if (modal.isMinimized) {
+          return modal;
+        }
+        changed = true;
+        return { ...modal, isMinimized: true };
+      });
       return changed ? next : current;
     });
   }, [libraryView]);
@@ -1940,6 +1982,19 @@ export default function App() {
       return preferredImage?.id ?? null;
     });
   }, [comfyUIWorkspaceDirectoryId, comfyUIWorkspaceImageId, comfyUIWorkspaceSourceImages, imageLookup, libraryView, previewImage, selectedImage]);
+
+  const editorImage = editorImageId ? imageLookup.get(editorImageId) ?? null : null;
+  const editorNavigationImages = useMemo(() => {
+    if (editorNavigationImageIds && editorNavigationImageIds.length > 0) {
+      return editorNavigationImageIds
+        .map((imageId) => imageLookup.get(imageId))
+        .filter((image): image is IndexedImage => Boolean(image));
+    }
+    return editorImage ? [editorImage] : [];
+  }, [editorImage, editorNavigationImageIds, imageLookup]);
+  const editorDirectoryPath = editorImage
+    ? directoryPathById.get(editorImage.directoryId || '') ?? undefined
+    : undefined;
 
   const openFindSimilar = useCallback((
     sourceImage: IndexedImage,
@@ -2519,7 +2574,7 @@ export default function App() {
           onSubmit={handleSaveCurrentFilteredAsCollection}
         />
 
-        <main className={`flex-1 flex flex-col min-h-0 w-full ${libraryView === 'comfyui' ? 'p-0' : 'mx-auto p-4'}`}>
+        <main className={`flex-1 flex flex-col min-h-0 w-full ${libraryView === 'comfyui' || libraryView === 'editor' ? 'p-0' : 'mx-auto p-4'}`}>
           {showGeneratorSetupNotice && (
             <div className="my-4 flex items-center justify-between gap-3 rounded-lg border border-blue-700/40 bg-blue-900/30 p-3 text-blue-100">
               <div className="flex-1 text-sm">
@@ -2631,6 +2686,7 @@ export default function App() {
                       setSelectedImageForGeneration(image);
                       setIsComfyUIGenerateModalOpen(true);
                     }}
+                    onOpenImageEditor={(image) => handleOpenImageEditor(image, displayImages)}
                     onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
                     onCompare={(images) => {
                       setComparisonImages(images);
@@ -2663,6 +2719,7 @@ export default function App() {
                           onBatchExport={handleOpenBatchExport}
                           onImageRenamed={handleImageRenamed}
                           onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
+                          onOpenImageEditor={(image) => handleOpenImageEditor(image, displayImages)}
                           onOpenComfyUIWorkspace={(image) => openComfyUIWorkflowInWorkspace(image, displayImages)}
                           groupBy={effectiveLibraryGroupBy}
                           groupSortOrder={imageGroupingSortOrder}
@@ -2676,6 +2733,7 @@ export default function App() {
                           onBatchExport={handleOpenBatchExport}
                           onImageRenamed={handleImageRenamed}
                           onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
+                          onOpenImageEditor={(image) => handleOpenImageEditor(image, displayImages)}
                           onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
                           groupBy={effectiveLibraryGroupBy}
                           groupSortOrder={imageGroupingSortOrder}
@@ -2710,6 +2768,7 @@ export default function App() {
                         isCollectionsView
                         onImageRenamed={handleImageRenamed}
                         onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
+                        onOpenImageEditor={(image) => handleOpenImageEditor(image, displayImages)}
                         onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
                       />
                     ) : (
@@ -2722,6 +2781,7 @@ export default function App() {
                         isCollectionsView
                         onImageRenamed={handleImageRenamed}
                         onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
+                        onOpenImageEditor={(image) => handleOpenImageEditor(image, displayImages)}
                         onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
                       />
                     )}
@@ -2761,6 +2821,20 @@ export default function App() {
                     onOpenCompare={handleOpenFindSimilarCompare}
                     workflowLoadRequest={comfyUIWorkspaceWorkflowLoadRequest}
                   />
+                ) : libraryView === 'editor' ? (
+                  editorImage ? (
+                    <ImageEditorWorkspace
+                      image={editorImage}
+                      navigationImages={editorNavigationImages}
+                      directoryPath={editorDirectoryPath}
+                      onBack={() => setLibraryView('library')}
+                      onOpenComfyUIWorkflow={(image) => openComfyUIWorkflowInWorkspace(image, editorNavigationImages)}
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-sm text-gray-500">
+                      Select an image to edit.
+                    </div>
+                  )
                 ) : (
                   <SmartLibrary
                     isQueueOpen={isQueueOpen}
@@ -2773,7 +2847,7 @@ export default function App() {
                 )}
               </div>
 
-              {(libraryView === 'library' || libraryView === 'comfyui' || (libraryView === 'collections' && Boolean(activeCollection))) && (
+              {(libraryView === 'library' || libraryView === 'comfyui' || libraryView === 'editor' || (libraryView === 'collections' && Boolean(activeCollection))) && (
                 <Footer
                   currentPage={currentPage}
                   totalPages={totalPages}
@@ -2795,10 +2869,10 @@ export default function App() {
                   queueCount={queueCount}
                   isQueueOpen={isQueueOpen}
                   onToggleQueue={() => setIsQueueOpen((prev) => !prev)}
-                  customText={libraryView === 'comfyui' ? 'ComfyUI Workspace' : undefined}
+                  customText={libraryView === 'comfyui' ? 'ComfyUI Workspace' : libraryView === 'editor' ? 'Image Editor' : undefined}
                   windowItems={footerWindowItems}
                   onWindowSelect={(modalId) => {
-                    if (libraryView === 'comfyui') {
+                    if (libraryView === 'comfyui' || libraryView === 'editor') {
                       setLibraryView('library');
                     }
                     handleActivateImageModal(modalId);
@@ -2838,6 +2912,7 @@ export default function App() {
             onSlideshowStartAcknowledged={() => handleSlideshowStartAcknowledged(modal.modalId)}
             onFindSimilar={(image) => openFindSimilar(image, modal.navigationImages)}
             onOpenComfyUIWorkflow={(image) => handleOpenComfyUIWorkflowFromImageModal(modal.modalId, image, modal.navigationImages)}
+            onOpenImageEditor={(image) => handleOpenImageEditorFromImageModal(modal.modalId, image, modal.navigationImages)}
           />
         ))}
 

--- a/App.tsx
+++ b/App.tsx
@@ -249,11 +249,25 @@ export default function App() {
   const availableSchedulers = useImageStore((state) => state.availableSchedulers);
   const availableDimensions = useImageStore((state) => state.availableDimensions);
   const selectedModels = useImageStore((state) => state.selectedModels);
+  const excludedModels = useImageStore((state) => state.excludedModels);
   const selectedLoras = useImageStore((state) => state.selectedLoras);
+  const excludedLoras = useImageStore((state) => state.excludedLoras);
   const selectedSamplers = useImageStore((state) => state.selectedSamplers);
+  const excludedSamplers = useImageStore((state) => state.excludedSamplers);
   const selectedSchedulers = useImageStore((state) => state.selectedSchedulers);
+  const excludedSchedulers = useImageStore((state) => state.excludedSchedulers);
+  const selectedGenerators = useImageStore((state) => state.selectedGenerators);
+  const excludedGenerators = useImageStore((state) => state.excludedGenerators);
+  const selectedGpuDevices = useImageStore((state) => state.selectedGpuDevices);
+  const excludedGpuDevices = useImageStore((state) => state.excludedGpuDevices);
   const advancedFilters = useImageStore((state) => state.advancedFilters);
   const selectedRatings = useImageStore((state) => state.selectedRatings);
+  const selectedTags = useImageStore((state) => state.selectedTags);
+  const excludedTags = useImageStore((state) => state.excludedTags);
+  const selectedTagsMatchMode = useImageStore((state) => state.selectedTagsMatchMode);
+  const selectedAutoTags = useImageStore((state) => state.selectedAutoTags);
+  const excludedAutoTags = useImageStore((state) => state.excludedAutoTags);
+  const favoriteFilterMode = useImageStore((state) => state.favoriteFilterMode);
   const setSelectedTags = useImageStore((state) => state.setSelectedTags);
   const setExcludedTags = useImageStore((state) => state.setExcludedTags);
   const setSelectedAutoTags = useImageStore((state) => state.setSelectedAutoTags);
@@ -299,6 +313,7 @@ export default function App() {
   const loadAutomationRules = useImageStore((state) => state.loadAutomationRules);
   const imageStoreSetSortOrder = useImageStore((state) => state.setSortOrder);
   const sortOrder = useImageStore((state) => state.sortOrder);
+  const randomSeed = useImageStore((state) => state.randomSeed);
   const reshuffle = useImageStore((state) => state.reshuffle);
   const getResolvedCollectionImages = useImageStore((state) => state.getResolvedCollectionImages);
   const getResolvedFilteredCollectionImages = useImageStore((state) => state.getResolvedFilteredCollectionImages);
@@ -2037,22 +2052,54 @@ export default function App() {
       lastImageId,
       searchQuery,
       selectedModels.join('\u001f'),
+      excludedModels.join('\u001f'),
       selectedLoras.join('\u001f'),
+      excludedLoras.join('\u001f'),
       selectedSamplers.join('\u001f'),
+      excludedSamplers.join('\u001f'),
       selectedSchedulers.join('\u001f'),
+      excludedSchedulers.join('\u001f'),
+      selectedGenerators.join('\u001f'),
+      excludedGenerators.join('\u001f'),
+      selectedGpuDevices.join('\u001f'),
+      excludedGpuDevices.join('\u001f'),
+      selectedTags.join('\u001f'),
+      excludedTags.join('\u001f'),
+      selectedTagsMatchMode,
+      selectedAutoTags.join('\u001f'),
+      excludedAutoTags.join('\u001f'),
+      favoriteFilterMode,
       selectedRatings.join('\u001f'),
+      JSON.stringify(advancedFilters),
       sortOrder,
+      randomSeed,
       groupBy,
     ].join('\u001e');
   }, [
+    advancedFilters,
+    excludedAutoTags,
+    excludedGenerators,
+    excludedGpuDevices,
+    excludedLoras,
+    excludedModels,
+    excludedSamplers,
+    excludedSchedulers,
+    excludedTags,
+    favoriteFilterMode,
     groupBy,
+    randomSeed,
     safeFilteredImages,
     searchQuery,
+    selectedAutoTags,
+    selectedGenerators,
+    selectedGpuDevices,
     selectedLoras,
     selectedModels,
     selectedRatings,
     selectedSamplers,
     selectedSchedulers,
+    selectedTags,
+    selectedTagsMatchMode,
     sortOrder,
   ]);
 
@@ -2066,9 +2113,56 @@ export default function App() {
       firstImageId,
       lastImageId,
       searchQuery,
+      selectedModels.join('\u001f'),
+      excludedModels.join('\u001f'),
+      selectedLoras.join('\u001f'),
+      excludedLoras.join('\u001f'),
+      selectedSamplers.join('\u001f'),
+      excludedSamplers.join('\u001f'),
+      selectedSchedulers.join('\u001f'),
+      excludedSchedulers.join('\u001f'),
+      selectedGenerators.join('\u001f'),
+      excludedGenerators.join('\u001f'),
+      selectedGpuDevices.join('\u001f'),
+      excludedGpuDevices.join('\u001f'),
+      selectedTags.join('\u001f'),
+      excludedTags.join('\u001f'),
+      selectedTagsMatchMode,
+      selectedAutoTags.join('\u001f'),
+      excludedAutoTags.join('\u001f'),
+      favoriteFilterMode,
+      selectedRatings.join('\u001f'),
+      JSON.stringify(advancedFilters),
       sortOrder,
+      randomSeed,
     ].join('\u001e');
-  }, [activeCollectionId, collectionFilteredImages, searchQuery, sortOrder]);
+  }, [
+    activeCollectionId,
+    advancedFilters,
+    collectionFilteredImages,
+    excludedAutoTags,
+    excludedGenerators,
+    excludedGpuDevices,
+    excludedLoras,
+    excludedModels,
+    excludedSamplers,
+    excludedSchedulers,
+    excludedTags,
+    favoriteFilterMode,
+    randomSeed,
+    searchQuery,
+    selectedAutoTags,
+    selectedGenerators,
+    selectedGpuDevices,
+    selectedLoras,
+    selectedModels,
+    selectedRatings,
+    selectedSamplers,
+    selectedSchedulers,
+    selectedTags,
+    selectedTagsMatchMode,
+    sortOrder,
+  ]);
 
   useEffect(() => {
     if (previousLibraryGridSignatureRef.current === null) {

--- a/App.tsx
+++ b/App.tsx
@@ -121,6 +121,11 @@ const MAIN_CONTENT_MIN_WIDTH = 560;
 
 const getImageTimestamp = (image: IndexedImage): number => image.contentModifiedMs ?? image.lastModified ?? 0;
 
+const areStringArraysEqual = (left: string[] | null, right: string[]): boolean =>
+  Array.isArray(left) &&
+  left.length === right.length &&
+  left.every((value, index) => value === right[index]);
+
 const sortImagesNewestFirst = (images: IndexedImage[]): IndexedImage[] =>
   [...images].sort((a, b) => getImageTimestamp(b) - getImageTimestamp(a) || a.name.localeCompare(b.name));
 
@@ -2019,7 +2024,9 @@ export default function App() {
       : comfyUIWorkspaceSourceImages;
     const scopedImageIds = scopedImages.map((image) => image.id);
 
-    setComfyUIWorkspaceNavigationImageIds(scopedImageIds);
+    setComfyUIWorkspaceNavigationImageIds((current) =>
+      areStringArraysEqual(current, scopedImageIds) ? current : scopedImageIds
+    );
     setComfyUIWorkspaceImageId((current) => {
       if (current && scopedImageIds.includes(current)) {
         return current;
@@ -2141,7 +2148,10 @@ export default function App() {
       ? comfyUIWorkspaceSourceImages.filter((candidate) => candidate.directoryId === nextDirectoryId)
       : comfyUIWorkspaceSourceImages;
 
-    setComfyUIWorkspaceNavigationImageIds(nextImages.map((candidate) => candidate.id));
+    const nextImageIds = nextImages.map((candidate) => candidate.id);
+    setComfyUIWorkspaceNavigationImageIds((current) =>
+      areStringArraysEqual(current, nextImageIds) ? current : nextImageIds
+    );
     setComfyUIWorkspaceImageId(nextImages[0]?.id ?? null);
   }, [comfyUIWorkspaceSourceImages]);
   const handleComfyUIWorkspaceApplyLibraryFiltersChange = useCallback((applyFilters: boolean) => {

--- a/App.tsx
+++ b/App.tsx
@@ -354,9 +354,14 @@ export default function App() {
 
   // --- Local UI State ---
   const [currentPage, setCurrentPage] = useState(1);
+  const [modelViewPage, setModelViewPage] = useState(1);
   const [pendingJumpGroupRequest, setPendingJumpGroupRequest] = useState<{ groupId: string; requestId: number } | null>(null);
   const [searchInputValue, setSearchInputValue] = useState(searchQuery);
   const previousSearchQueryRef = useRef(searchQuery);
+  const previousLibraryGridSignatureRef = useRef<string | null>(null);
+  const previousCollectionsGridSignatureRef = useRef<string | null>(null);
+  const libraryGridScrollTopRef = useRef(0);
+  const collectionsGridScrollTopRef = useRef(0);
   const pendingSearchFlowIdRef = useRef<string | null>(null);
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>('library');
@@ -452,6 +457,22 @@ export default function App() {
   const queueCount = useGenerationQueueStore((state) =>
     state.items.filter((item) => item.status === 'waiting' || item.status === 'processing').length
   );
+
+  const resetLibraryGridScrollPosition = useCallback(() => {
+    libraryGridScrollTopRef.current = 0;
+  }, []);
+
+  const resetCollectionsGridScrollPosition = useCallback(() => {
+    collectionsGridScrollTopRef.current = 0;
+  }, []);
+
+  const handleLibraryGridScrollPositionChange = useCallback((scrollTop: number) => {
+    libraryGridScrollTopRef.current = scrollTop;
+  }, []);
+
+  const handleCollectionsGridScrollPositionChange = useCallback((scrollTop: number) => {
+    collectionsGridScrollTopRef.current = scrollTop;
+  }, []);
 
   const handleSearchChange = useCallback((query: string) => {
     if (pendingSearchFlowIdRef.current) {
@@ -864,6 +885,7 @@ export default function App() {
       }
 
       if (selectedFolders.size === 0) {
+        resetLibraryGridScrollPosition();
         setCurrentPage(1);
         return;
       }
@@ -877,12 +899,13 @@ export default function App() {
       );
 
       if (affectsVisibleScope) {
+        resetLibraryGridScrollPosition();
         setCurrentPage(1);
       }
     });
 
     return () => unsubscribe();
-  }, [directories, excludedFolders, includeSubfolders, processNewWatchedFiles, selectedFolders, sortOrder]);
+  }, [directories, excludedFolders, includeSubfolders, processNewWatchedFiles, resetLibraryGridScrollPosition, selectedFolders, sortOrder]);
 
   useEffect(() => {
     if (sortOrder === 'random' && groupBy !== 'none') {
@@ -1154,6 +1177,7 @@ export default function App() {
 
   useEffect(() => {
     if (previousSearchQueryRef.current !== searchQuery) {
+      resetLibraryGridScrollPosition();
       setCurrentPage(1);
       if (pendingSearchFlowIdRef.current) {
         markPerformanceFlow(pendingSearchFlowIdRef.current, 'store-commit', {
@@ -1172,15 +1196,16 @@ export default function App() {
       }
       previousSearchQueryRef.current = searchQuery;
     }
-  }, [safeFilteredImages.length, searchQuery]);
+  }, [resetLibraryGridScrollPosition, safeFilteredImages.length, searchQuery]);
 
   // Reset page if current page exceeds available pages after filtering
   useEffect(() => {
     const totalPages = Math.ceil(safeFilteredImages.length / itemsPerPage);
     if (currentPage > totalPages && totalPages > 0) {
+      resetLibraryGridScrollPosition();
       setCurrentPage(1);
     }
-  }, [safeFilteredImages.length, itemsPerPage, currentPage]);
+  }, [safeFilteredImages.length, itemsPerPage, currentPage, resetLibraryGridScrollPosition]);
 
   // Clean up selectedImage if its directory no longer exists
   useEffect(() => {
@@ -2002,6 +2027,73 @@ export default function App() {
       : safeFilteredImages;
   const comfyUIWorkspaceSourceImages = comfyUIWorkspaceApplyLibraryFilters ? displayImages : safeImages;
 
+  const libraryGridSignature = useMemo(() => {
+    const firstImageId = safeFilteredImages[0]?.id ?? '';
+    const lastImageId = safeFilteredImages[safeFilteredImages.length - 1]?.id ?? '';
+
+    return [
+      safeFilteredImages.length,
+      firstImageId,
+      lastImageId,
+      searchQuery,
+      selectedModels.join('\u001f'),
+      selectedLoras.join('\u001f'),
+      selectedSamplers.join('\u001f'),
+      selectedSchedulers.join('\u001f'),
+      selectedRatings.join('\u001f'),
+      sortOrder,
+      groupBy,
+    ].join('\u001e');
+  }, [
+    groupBy,
+    safeFilteredImages,
+    searchQuery,
+    selectedLoras,
+    selectedModels,
+    selectedRatings,
+    selectedSamplers,
+    selectedSchedulers,
+    sortOrder,
+  ]);
+
+  const collectionsGridSignature = useMemo(() => {
+    const firstImageId = collectionFilteredImages[0]?.id ?? '';
+    const lastImageId = collectionFilteredImages[collectionFilteredImages.length - 1]?.id ?? '';
+
+    return [
+      activeCollectionId ?? '',
+      collectionFilteredImages.length,
+      firstImageId,
+      lastImageId,
+      searchQuery,
+      sortOrder,
+    ].join('\u001e');
+  }, [activeCollectionId, collectionFilteredImages, searchQuery, sortOrder]);
+
+  useEffect(() => {
+    if (previousLibraryGridSignatureRef.current === null) {
+      previousLibraryGridSignatureRef.current = libraryGridSignature;
+      return;
+    }
+
+    if (previousLibraryGridSignatureRef.current !== libraryGridSignature) {
+      resetLibraryGridScrollPosition();
+      previousLibraryGridSignatureRef.current = libraryGridSignature;
+    }
+  }, [libraryGridSignature, resetLibraryGridScrollPosition]);
+
+  useEffect(() => {
+    if (previousCollectionsGridSignatureRef.current === null) {
+      previousCollectionsGridSignatureRef.current = collectionsGridSignature;
+      return;
+    }
+
+    if (previousCollectionsGridSignatureRef.current !== collectionsGridSignature) {
+      resetCollectionsGridScrollPosition();
+      previousCollectionsGridSignatureRef.current = collectionsGridSignature;
+    }
+  }, [collectionsGridSignature, resetCollectionsGridScrollPosition]);
+
   useEffect(() => {
     if (libraryView !== 'comfyui') {
       return;
@@ -2259,9 +2351,11 @@ export default function App() {
   useEffect(() => {
     const scopedTotalPages = Math.ceil(displayImages.length / itemsPerPage);
     if (currentPage > scopedTotalPages && scopedTotalPages > 0) {
+      resetLibraryGridScrollPosition();
+      resetCollectionsGridScrollPosition();
       setCurrentPage(1);
     }
-  }, [currentPage, displayImages.length, itemsPerPage]);
+  }, [currentPage, displayImages.length, itemsPerPage, resetCollectionsGridScrollPosition, resetLibraryGridScrollPosition]);
 
   useEffect(() => {
     if (libraryView !== 'collections') {
@@ -2790,6 +2884,9 @@ export default function App() {
                           groupBy={effectiveLibraryGroupBy}
                           groupSortOrder={imageGroupingSortOrder}
                           jumpToGroupRequest={pendingJumpGroupRequest}
+                          initialScrollTop={libraryGridScrollTopRef.current}
+                          onScrollPositionChange={handleLibraryGridScrollPositionChange}
+                          scrollResetKey={libraryGridSignature}
                         />
                       ) : (
                         <ImageTable
@@ -2810,7 +2907,12 @@ export default function App() {
                   <ModelView
                     isQueueOpen={isQueueOpen}
                     onToggleQueue={() => setIsQueueOpen((prev) => !prev)}
+                    page={modelViewPage}
+                    onPageChange={setModelViewPage}
+                    activeModelName={selectedModels.length === 1 ? selectedModels[0] : null}
                     onModelSelect={(modelName) => {
+                      resetLibraryGridScrollPosition();
+                      setModelViewPage(1);
                       setSelectedFilters({ models: [modelName] });
                       setLibraryView('library');
                     }}
@@ -2836,6 +2938,9 @@ export default function App() {
                         onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
                         onOpenImageEditor={(image) => handleOpenImageEditor(image, displayImages)}
                         onOpenComfyUIWorkspace={(image) => handleOpenComfyUIWorkspace(image, displayImages)}
+                        initialScrollTop={collectionsGridScrollTopRef.current}
+                        onScrollPositionChange={handleCollectionsGridScrollPositionChange}
+                        scrollResetKey={collectionsGridSignature}
                       />
                     ) : (
                       <ImageTable

--- a/App.tsx
+++ b/App.tsx
@@ -1896,6 +1896,7 @@ export default function App() {
       : [image.id];
     setEditorImageId(image.id);
     setEditorNavigationImageIds(navigationImageIds);
+    suppressSelectedImageModalOpenRef.current = image.id;
     setSelectedImage(image);
     setLibraryView('editor');
   }, [setSelectedImage]);
@@ -1906,7 +1907,6 @@ export default function App() {
     navigationImages?: IndexedImage[],
   ) => {
     handleOpenImageEditor(image, navigationImages);
-    suppressSelectedImageModalOpenRef.current = image.id;
     setOpenImageModals((current) => current.filter((modal) => modal.modalId !== modalId));
     setActiveImageModalId((current) => (current === modalId ? null : current));
   }, [handleOpenImageEditor]);

--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,7 @@ import { useImageSelection } from './hooks/useImageSelection';
 import { useHotkeys } from './hooks/useHotkeys';
 import { useFeatureAccess } from './hooks/useFeatureAccess';
 import { Directory } from './types';
-import { X } from 'lucide-react';
+import { Image as ImageIcon, X } from 'lucide-react';
 
 import FolderSelector from './components/FolderSelector';
 import ImageGrid from './components/ImageGrid';
@@ -1995,6 +1995,16 @@ export default function App() {
   const editorDirectoryPath = editorImage
     ? directoryPathById.get(editorImage.directoryId || '') ?? undefined
     : undefined;
+  const editorOpenCandidate = useMemo(() => {
+    if (previewImage) {
+      return previewImage;
+    }
+    if (selectedImage) {
+      return selectedImage;
+    }
+    const firstSelectedId = Array.from(safeSelectedImages)[0];
+    return firstSelectedId ? imageLookup.get(firstSelectedId) ?? null : null;
+  }, [imageLookup, previewImage, safeSelectedImages, selectedImage]);
 
   const openFindSimilar = useCallback((
     sourceImage: IndexedImage,
@@ -2557,7 +2567,6 @@ export default function App() {
           onGeneratorSetupNeeded={handleGeneratorSetupNeeded}
           libraryView={libraryView}
           onLibraryViewChange={setLibraryView}
-          editorAvailable={Boolean(editorImageId)}
         />
 
         <CollectionFormModal
@@ -2832,8 +2841,33 @@ export default function App() {
                       onOpenComfyUIWorkflow={(image) => openComfyUIWorkflowInWorkspace(image, editorNavigationImages)}
                     />
                   ) : (
-                    <div className="flex h-full items-center justify-center text-sm text-gray-500">
-                      Select an image to edit.
+                    <div className="flex h-full items-center justify-center bg-gray-950 p-8 text-gray-300">
+                      <div className="max-w-md rounded-lg border border-gray-800 bg-gray-900/70 p-6 text-center shadow-xl shadow-black/20">
+                        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-cyan-400/30 bg-cyan-500/10 text-cyan-200">
+                          <ImageIcon className="h-6 w-6" />
+                        </div>
+                        <h2 className="text-lg font-semibold text-gray-100">Image Editor</h2>
+                        <p className="mt-2 text-sm text-gray-400">
+                          Open an image from the library context menu, or start with the current selected image.
+                        </p>
+                        <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-center">
+                          <button
+                            type="button"
+                            onClick={() => editorOpenCandidate && handleOpenImageEditor(editorOpenCandidate, displayImages)}
+                            disabled={!editorOpenCandidate}
+                            className="inline-flex items-center justify-center rounded-md bg-cyan-600 px-4 py-2 text-sm font-semibold text-white hover:bg-cyan-500 disabled:bg-gray-800 disabled:text-gray-500"
+                          >
+                            Open Selected Image
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setLibraryView('library')}
+                            className="inline-flex items-center justify-center rounded-md border border-gray-700 px-4 py-2 text-sm font-semibold text-gray-200 hover:bg-gray-800"
+                          >
+                            Go to Library
+                          </button>
+                        </div>
+                      </div>
                     </div>
                   )
                 ) : (

--- a/App.tsx
+++ b/App.tsx
@@ -2557,6 +2557,7 @@ export default function App() {
           onGeneratorSetupNeeded={handleGeneratorSetupNeeded}
           libraryView={libraryView}
           onLibraryViewChange={setLibraryView}
+          editorAvailable={Boolean(editorImageId)}
         />
 
         <CollectionFormModal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.0] - [Unreleased]
+## [0.17.0] - 2026-06-05
+
+### Added
+
+- **Expanded Compare View**: Added new two-image comparison modes, including slider, hover, flicker, difference map, loupe, and edge comparison.
+- **Built-in Image Editor**: Added a new local image editor for still images, with adjustments, crop, rotate, flip, resize, sharpen, blur, annotations, text, highlights, blur/pixelate regions, undo/redo, zoom, Save As, and Overwrite.
+
 
 ### Improved
 
-- **Image Modal Navigation Performance**: Improved rapid left/right arrow navigation in the image viewer by coalescing repeated key events, using cheaper navigation indexes, and temporarily keeping heavy sidebar rendering out of the hot path while keys are held.
+- **Image Editing Tools**: Expanded the previous adjustment panel into a fuller editing workflow with separate controls for adjustments, crop, transform, resize, and enhance tools.
+- **Performance and Responsiveness**: Improved responsiveness in large libraries, faster image viewer navigation, and reduced UI slowdowns during cache updates, file watching, and rapid browsing.
+- **Image Viewer Navigation**: Improved rapid left/right navigation in the image viewer, especially when holding arrow keys through large folders.
+- **Image Viewer Zoom**: Improved fit/actual-size zoom behavior and zoom limits in the image viewer.
+- **ComfyUI Metadata Parsing**: Improved metadata extraction from ComfyUI workflows, including better support for additional node patterns and workflow graph structures.
+- **Edited Image Saving**: Improved Save As and Overwrite behavior for edited images so saved files are refreshed in the library more reliably.
+- **Media Playback Diagnostics**: Improved audio/video playback diagnostics to help identify desktop media playback issues.
+- **Accessibility**: Added more accessible labels and control descriptions across icon-only buttons and editor/viewer controls.
 
 ### Fixed
 
-- **Watched File Deletion Stability**: Fixed watched file deletions so cache pruning no longer blocks the renderer, updates both flat and recursive cache variants, and safely rewrites multi-chunk caches without overwriting chunks that are still being read.
+- **Watched File Deletions**: Fixed watched file deletions so removed files are cleared from library cache more reliably without blocking the app.
+- **Image Viewer Performance**: Fixed slowdowns caused by heavy sidebar updates during fast image navigation.
+- **Edited Image Metadata**: Fixed edited image saves so generated PNGs carry updated output size and edit information more consistently.
+- **Video Metadata Parsing**: Improved validation for MetaHub video metadata so invalid fallback metadata is no longer treated as a prompt.
+- **ComfyUI Seed Parsing**: Fixed explicit ComfyUI seed `0` values being treated as missing in some metadata parsing paths.
 
 ## [0.16.1] - [2026-05-23]
 

--- a/__tests__/ComparisonModal.interaction.test.tsx
+++ b/__tests__/ComparisonModal.interaction.test.tsx
@@ -1,18 +1,31 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ComparisonModal from '../components/ComparisonModal';
 import { useImageStore } from '../store/useImageStore';
 import type { IndexedImage } from '../types';
 
 vi.mock('../components/ComparisonPane', () => ({
-  default: ({ image, onHoverChange }: { image: IndexedImage; onHoverChange?: (isHovered: boolean) => void }) => (
+  default: ({
+    image,
+    onHoverChange,
+    onRemove,
+  }: {
+    image: IndexedImage;
+    onHoverChange?: (isHovered: boolean) => void;
+    onRemove?: () => void;
+  }) => (
     <div
       data-testid={`pane-${image.id}`}
       onMouseEnter={() => onHoverChange?.(true)}
       onMouseLeave={() => onHoverChange?.(false)}
     >
       {image.name}
+      {onRemove ? (
+        <button type="button" onClick={onRemove} aria-label={`Remove ${image.name} from comparison pane`}>
+          Remove pane
+        </button>
+      ) : null}
     </div>
   ),
 }));
@@ -118,5 +131,45 @@ describe('ComparisonModal interactions', () => {
     expect(screen.getByText('Metadata Delta')).toBeTruthy();
     expect(screen.getByText('Sensitivity')).toBeTruthy();
     expect(screen.getByText('Opacity')).toBeTruthy();
+  });
+
+  it('clears the visual delta panel when returning to side-by-side mode', async () => {
+    const first = createImage('img-1', 'first prompt');
+    const second = createImage('img-2', 'second prompt');
+
+    useImageStore.setState({
+      comparisonImages: [first, second],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+    } as any);
+
+    render(<ComparisonModal isOpen onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff Map' }));
+    expect(screen.getByText('Visual Delta')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Side-by-Side' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Visual Delta')).toBeNull();
+    });
+  });
+
+  it('removes one pane from a 3-image comparison without closing the modal', () => {
+    const first = createImage('img-1', 'first prompt');
+    const second = createImage('img-2', 'second prompt');
+    const third = createImage('img-3', 'third prompt');
+    const onClose = vi.fn();
+
+    useImageStore.setState({
+      comparisonImages: [first, second, third],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+    } as any);
+
+    render(<ComparisonModal isOpen onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove img-2.png from comparison pane' }));
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(useImageStore.getState().comparisonImages.map((image) => image.id)).toEqual(['img-1', 'img-3']);
   });
 });

--- a/__tests__/ComparisonModal.interaction.test.tsx
+++ b/__tests__/ComparisonModal.interaction.test.tsx
@@ -18,7 +18,21 @@ vi.mock('../components/ComparisonPane', () => ({
 }));
 
 vi.mock('../components/ComparisonOverlayView', () => ({
-  default: () => <div data-testid="overlay-view">overlay</div>,
+  default: ({ onVisualAnalysisChange }: { onVisualAnalysisChange?: (metrics: any) => void }) => {
+    React.useEffect(() => {
+      onVisualAnalysisChange?.({
+        width: 100,
+        height: 80,
+        changedPixels: 25,
+        totalPixels: 8000,
+        changedPercent: 0.3125,
+        averageDelta: 12,
+        strongestRegion: { x: 10, y: 10, width: 20, height: 20, score: 90 },
+      });
+    }, [onVisualAnalysisChange]);
+
+    return <div data-testid="overlay-view">overlay</div>;
+  },
 }));
 
 vi.mock('../components/ComparisonMetadataPanel', () => ({
@@ -84,5 +98,25 @@ describe('ComparisonModal interactions', () => {
 
     fireEvent.mouseLeave(screen.getByTestId('pane-img-2'));
     expect(screen.getByTestId('metadata-img-2').getAttribute('data-highlighted')).toBe('false');
+  });
+
+  it('enables advanced two-image modes and shows visual delta controls', () => {
+    const first = createImage('img-1', 'first prompt');
+    const second = createImage('img-2', 'second prompt');
+
+    useImageStore.setState({
+      comparisonImages: [first, second],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+    } as any);
+
+    render(<ComparisonModal isOpen onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff Map' }));
+
+    expect(screen.getByTestId('overlay-view')).toBeTruthy();
+    expect(screen.getByText('Visual Delta')).toBeTruthy();
+    expect(screen.getByText('Metadata Delta')).toBeTruthy();
+    expect(screen.getByText('Sensitivity')).toBeTruthy();
+    expect(screen.getByText('Opacity')).toBeTruthy();
   });
 });

--- a/__tests__/ImageAdjustmentPanel.test.tsx
+++ b/__tests__/ImageAdjustmentPanel.test.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import ImageAdjustmentPanel from '../components/ImageAdjustmentPanel';
-import { DEFAULT_IMAGE_ADJUSTMENTS } from '../services/imageEditingService';
+import { DEFAULT_IMAGE_EDIT_RECIPE } from '../services/imageEditingService';
 
 describe('ImageAdjustmentPanel', () => {
   it('emits slider changes', () => {
     const onChange = vi.fn();
     render(
       <ImageAdjustmentPanel
-        adjustments={DEFAULT_IMAGE_ADJUSTMENTS}
+        recipe={DEFAULT_IMAGE_EDIT_RECIPE}
         onChange={onChange}
         onReset={vi.fn()}
         onSaveAs={vi.fn()}
@@ -19,8 +19,11 @@ describe('ImageAdjustmentPanel', () => {
 
     fireEvent.change(screen.getByRole('slider', { name: /brightness/i }), { target: { value: '140' } });
     expect(onChange).toHaveBeenCalledWith({
-      ...DEFAULT_IMAGE_ADJUSTMENTS,
-      brightness: 140,
+      ...DEFAULT_IMAGE_EDIT_RECIPE,
+      adjustments: {
+        ...DEFAULT_IMAGE_EDIT_RECIPE.adjustments,
+        brightness: 140,
+      },
     });
   });
 
@@ -28,7 +31,10 @@ describe('ImageAdjustmentPanel', () => {
     const onReset = vi.fn();
     render(
       <ImageAdjustmentPanel
-        adjustments={{ ...DEFAULT_IMAGE_ADJUSTMENTS, contrast: 80 }}
+        recipe={{
+          ...DEFAULT_IMAGE_EDIT_RECIPE,
+          adjustments: { ...DEFAULT_IMAGE_EDIT_RECIPE.adjustments, contrast: 80 },
+        }}
         onChange={vi.fn()}
         onReset={onReset}
         onSaveAs={vi.fn()}
@@ -45,7 +51,7 @@ describe('ImageAdjustmentPanel', () => {
     const onOverwrite = vi.fn();
     const { rerender } = render(
       <ImageAdjustmentPanel
-        adjustments={DEFAULT_IMAGE_ADJUSTMENTS}
+        recipe={DEFAULT_IMAGE_EDIT_RECIPE}
         onChange={vi.fn()}
         onReset={vi.fn()}
         onSaveAs={onSaveAs}
@@ -58,7 +64,10 @@ describe('ImageAdjustmentPanel', () => {
 
     rerender(
       <ImageAdjustmentPanel
-        adjustments={{ ...DEFAULT_IMAGE_ADJUSTMENTS, saturation: 120 }}
+        recipe={{
+          ...DEFAULT_IMAGE_EDIT_RECIPE,
+          adjustments: { ...DEFAULT_IMAGE_EDIT_RECIPE.adjustments, saturation: 120 },
+        }}
         onChange={vi.fn()}
         onReset={vi.fn()}
         onSaveAs={onSaveAs}
@@ -76,7 +85,10 @@ describe('ImageAdjustmentPanel', () => {
   it('disables controls while saving', () => {
     render(
       <ImageAdjustmentPanel
-        adjustments={{ ...DEFAULT_IMAGE_ADJUSTMENTS, hue: 20 }}
+        recipe={{
+          ...DEFAULT_IMAGE_EDIT_RECIPE,
+          adjustments: { ...DEFAULT_IMAGE_EDIT_RECIPE.adjustments, hue: 20 },
+        }}
         onChange={vi.fn()}
         onReset={vi.fn()}
         onSaveAs={vi.fn()}
@@ -94,7 +106,10 @@ describe('ImageAdjustmentPanel', () => {
     const onOverwrite = vi.fn();
     render(
       <ImageAdjustmentPanel
-        adjustments={{ ...DEFAULT_IMAGE_ADJUSTMENTS, brightness: 120 }}
+        recipe={{
+          ...DEFAULT_IMAGE_EDIT_RECIPE,
+          adjustments: { ...DEFAULT_IMAGE_EDIT_RECIPE.adjustments, brightness: 120 },
+        }}
         onChange={vi.fn()}
         onReset={vi.fn()}
         onSaveAs={onSaveAs}
@@ -111,5 +126,67 @@ describe('ImageAdjustmentPanel', () => {
     expect(screen.getByRole('button', { name: /overwrite/i })).toHaveProperty('disabled', true);
     expect(onSaveAs).toHaveBeenCalled();
     expect(onOverwrite).not.toHaveBeenCalled();
+  });
+
+  it('emits transform and resize changes', () => {
+    const onChange = vi.fn();
+    render(
+      <ImageAdjustmentPanel
+        recipe={DEFAULT_IMAGE_EDIT_RECIPE}
+        onChange={onChange}
+        onReset={vi.fn()}
+        onSaveAs={vi.fn()}
+        onOverwrite={vi.fn()}
+        sourceDimensions={{ width: 100, height: 50 }}
+        activeTab="transform"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /rotate right/i }));
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      transform: expect.objectContaining({ rotation: 90 }),
+    }));
+
+    fireEvent.change(screen.getByRole('spinbutton', { name: /resize width/i }), { target: { value: '200' } });
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      resize: expect.objectContaining({ enabled: true, width: 200, height: 100 }),
+    }));
+  });
+
+  it('emits crop and AI upscale actions', () => {
+    const onChange = vi.fn();
+    const onAIUpscale = vi.fn();
+    const { rerender } = render(
+      <ImageAdjustmentPanel
+        recipe={DEFAULT_IMAGE_EDIT_RECIPE}
+        onChange={onChange}
+        onReset={vi.fn()}
+        onSaveAs={vi.fn()}
+        onOverwrite={vi.fn()}
+        onAIUpscale={onAIUpscale}
+        sourceDimensions={{ width: 100, height: 50 }}
+        activeTab="crop"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /enable crop/i }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      crop: expect.objectContaining({ enabled: true }),
+    }));
+
+    rerender(
+      <ImageAdjustmentPanel
+        recipe={DEFAULT_IMAGE_EDIT_RECIPE}
+        onChange={onChange}
+        onReset={vi.fn()}
+        onSaveAs={vi.fn()}
+        onOverwrite={vi.fn()}
+        onAIUpscale={onAIUpscale}
+        sourceDimensions={{ width: 100, height: 50 }}
+        activeTab="enhance"
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /ai upscale/i }));
+    expect(onAIUpscale).toHaveBeenCalled();
   });
 });

--- a/__tests__/ImageAdjustmentPanel.test.tsx
+++ b/__tests__/ImageAdjustmentPanel.test.tsx
@@ -153,6 +153,26 @@ describe('ImageAdjustmentPanel', () => {
     }));
   });
 
+  it('seeds resize controls from base dimensions when resize is enabled', () => {
+    const onChange = vi.fn();
+    render(
+      <ImageAdjustmentPanel
+        recipe={DEFAULT_IMAGE_EDIT_RECIPE}
+        onChange={onChange}
+        onReset={vi.fn()}
+        onSaveAs={vi.fn()}
+        onOverwrite={vi.fn()}
+        sourceDimensions={{ width: 100, height: 50 }}
+        activeTab="transform"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /^resize$/i }));
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      resize: expect.objectContaining({ width: 100, height: 50 }),
+    }));
+  });
+
   it('emits crop and AI upscale actions', () => {
     const onChange = vi.fn();
     const onAIUpscale = vi.fn();

--- a/__tests__/ImageModal.slideshow.test.tsx
+++ b/__tests__/ImageModal.slideshow.test.tsx
@@ -219,6 +219,6 @@ describe('ImageModal slideshow behavior', () => {
       );
     });
 
-    await waitFor(() => expect(screen.getByText('100%')).toBeTruthy());
+    await waitFor(() => expect(screen.getByTitle('Fit to Screen (Current)')).toBeTruthy());
   });
 });

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -457,6 +457,18 @@ describe('ComfyUI Parser - LoRA Workflows', () => {
           widgets_values: [', '],
           mode: 0,
         },
+        {
+          id: 4,
+          type: 'CLIPTextEncode',
+          widgets_values: [''],
+          mode: 0,
+        },
+        {
+          id: 5,
+          type: 'KSampler',
+          widgets_values: [123, 'fixed', 20, 7, 'euler', 'normal', 1],
+          mode: 0,
+        },
       ],
     }, {
       '1': {
@@ -473,6 +485,25 @@ describe('ComfyUI Parser - LoRA Workflows', () => {
           delimiter: ', ',
           string1: ['1', 0],
           string2: ['2', 0],
+        },
+      },
+      '4': {
+        class_type: 'CLIPTextEncode',
+        inputs: {
+          text: ['3', 0],
+        },
+      },
+      '5': {
+        class_type: 'KSampler',
+        inputs: {
+          seed: 123,
+          steps: 20,
+          cfg: 7,
+          sampler_name: 'euler',
+          scheduler: 'normal',
+          denoise: 1,
+          positive: ['4', 0],
+          negative: ['4', 0],
         },
       },
     });

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -435,6 +435,50 @@ describe('ComfyUI Parser - LoRA Workflows', () => {
     expect(result.lora).toContain('ui_lora.safetensors');
     expect(result.lora).not.toContain('disabled_lora.safetensors');
   });
+
+  it('should preserve JoinStrings delimiter from widget values', () => {
+    const result = resolvePromptFromGraph({
+      nodes: [
+        {
+          id: 1,
+          type: 'String Literal',
+          widgets_values: ['alpha'],
+          mode: 0,
+        },
+        {
+          id: 2,
+          type: 'String Literal',
+          widgets_values: ['beta'],
+          mode: 0,
+        },
+        {
+          id: 3,
+          type: 'JoinStrings',
+          widgets_values: [', '],
+          mode: 0,
+        },
+      ],
+    }, {
+      '1': {
+        class_type: 'String Literal',
+        inputs: { string: 'alpha' },
+      },
+      '2': {
+        class_type: 'String Literal',
+        inputs: { string: 'beta' },
+      },
+      '3': {
+        class_type: 'JoinStrings',
+        inputs: {
+          delimiter: ', ',
+          string1: ['1', 0],
+          string2: ['2', 0],
+        },
+      },
+    });
+
+    expect(result.prompt).toBe('alpha, beta');
+  });
 });
 
 describe('ComfyUI Parser - ControlNet Workflows', () => {

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -376,6 +376,32 @@ describe('ComfyUI Parser - MetaHub lineage metadata', () => {
     expect(result?.loras).toEqual([{ name: 'skin-detail', weight: 0.65 }]);
   });
 
+  it('keeps MetaHub payload as canonical when parameters disagree', async () => {
+    const result = await parseImageMetadata({
+      parameters: 'wrong prompt\nSteps: 1, Sampler: wrong, CFG scale: 1, Seed: 1, Size: 64x64, Model: wrong.safetensors',
+      imagemetahub_data: {
+        generator: 'ComfyUI',
+        prompt: 'canonical prompt',
+        negativePrompt: 'canonical negative',
+        seed: 456,
+        steps: 32,
+        cfg: 7,
+        sampler_name: 'dpmpp_2m',
+        scheduler: 'karras',
+        model: 'canonical.safetensors',
+        width: 768,
+        height: 1024,
+        metadata_status: 'complete',
+        metadata_sources: { prompt: 'detected', model_name: 'detected' },
+      },
+    } as any);
+
+    expect(result?.prompt).toBe('canonical prompt');
+    expect(result?.model).toBe('canonical.safetensors');
+    expect(result?._metadata_status).toBe('complete');
+    expect(result?._metadata_sources).toEqual({ prompt: 'detected', model_name: 'detected' });
+  });
+
   it('prefers parent_image for library lineage and keeps source_image as workflowSourceImage', async () => {
     const metadata: any = {
       imagemetahub_data: {

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -571,6 +571,41 @@ describe('ComfyUI Parser - MetaHub lineage metadata', () => {
     expect(result?._metadata_sources).toEqual({ prompt: 'detected', model_name: 'detected' });
   });
 
+  it('preserves explicit MetaHub seed zero even when prompt graph has another seed', async () => {
+    const result = await parseImageMetadata({
+      imagemetahub_data: {
+        generator: 'ComfyUI',
+        prompt: 'zero seed prompt',
+        negativePrompt: '',
+        seed: 0,
+        steps: 20,
+        cfg: 7,
+        sampler_name: 'euler',
+        scheduler: 'normal',
+        model: 'zero-seed.safetensors',
+        width: 512,
+        height: 512,
+        metadata_status: 'partial',
+        metadata_sources: { seed: 'manual_override' },
+        prompt_api: {
+          '1': {
+            class_type: 'KSampler',
+            inputs: {
+              seed: 999,
+              steps: 20,
+              cfg: 7,
+              sampler_name: 'euler',
+              scheduler: 'normal',
+              denoise: 1,
+            },
+          },
+        },
+      },
+    } as any);
+
+    expect(result?.seed).toBe(0);
+  });
+
   it('prefers parent_image for library lineage and keeps source_image as workflowSourceImage', async () => {
     const metadata: any = {
       imagemetahub_data: {

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -112,6 +112,175 @@ describe('ComfyUI Parser - Detection from capitalized string keys', () => {
     expect(result?.prompt).toContain('Visualize a long, eel-like mutant lizard');
     expect(result?.prompt).toContain('fossilized ocean desert');
   });
+
+  it('should prefer ComfyUI graph chunks over non-empty parameters text', async () => {
+    const fixture = loadFixture('primitive-string-multiline.json');
+    const metadata: any = {
+      Prompt: JSON.stringify(fixture.prompt),
+      Workflow: JSON.stringify(fixture.workflow),
+      parameters: 'wrong prompt\nSteps: 1, Sampler: wrong, CFG scale: 1, Seed: 1, Size: 64x64, Model: wrong.safetensors'
+    };
+
+    const result = await parseImageMetadata(metadata);
+
+    expect(result?.generator).toBe('ComfyUI');
+    expect(result?.prompt).toContain('Visualize a long, eel-like mutant lizard');
+    expect(result?.model).not.toBe('wrong.safetensors');
+  });
+});
+
+describe('ComfyUI Parser - Output terminal traversal', () => {
+  it('should walk back from SaveImage through image links to prompt-bearing nodes', () => {
+    const prompt = {
+      '1': {
+        class_type: 'SaveImage',
+        inputs: {
+          images: ['2', 0],
+        },
+      },
+      '2': {
+        class_type: 'VAEDecode',
+        inputs: {
+          samples: ['3', 0],
+          vae: ['6', 2],
+        },
+      },
+      '3': {
+        class_type: 'WanImageToVideo',
+        inputs: {
+          positive: ['4', 0],
+          negative: ['5', 0],
+          vae: ['6', 2],
+          width: 832,
+          height: 480,
+          length: 49,
+          batch_size: 1,
+        },
+      },
+      '4': {
+        class_type: 'CLIPTextEncode',
+        inputs: {
+          text: 'cinematic motion portrait',
+        },
+      },
+      '5': {
+        class_type: 'CLIPTextEncode',
+        inputs: {
+          text: 'blur, artifacts',
+        },
+      },
+      '6': {
+        class_type: 'CheckpointLoaderSimple',
+        inputs: {
+          ckpt_name: 'wan-video-model.safetensors',
+        },
+      },
+    };
+
+    const result = resolvePromptFromGraph(undefined, prompt);
+
+    expect(result.prompt).toBe('cinematic motion portrait');
+    expect(result.negativePrompt).toBe('blur, artifacts');
+  });
+});
+
+describe('ComfyUI Parser - MetaHub chunk graph recovery', () => {
+  it('recovers prompt and seed from embedded prompt_api when old MetaHub chunks are empty', async () => {
+    const metadata: any = {
+      imagemetahub_data: {
+        generator: 'ComfyUI',
+        prompt: '',
+        negativePrompt: '',
+        seed: 0,
+        steps: 9,
+        cfg: 1,
+        sampler_name: 'euler',
+        scheduler: 'simple',
+        model: 'Z image Turbo\\z_image_turbo_bf16.safetensors',
+        vae: 'ae.safetensors',
+        denoise: 1,
+        width: 1056,
+        height: 1584,
+        loras: [],
+        workflow: { nodes: [] },
+        prompt_api: {
+          '1': {
+            class_type: 'UNETLoader',
+            inputs: { unet_name: 'Z image Turbo\\z_image_turbo_bf16.safetensors' },
+          },
+          '2': {
+            class_type: 'Lora Loader (LoraManager)',
+            inputs: {
+              text: 'luneva <lora:detail:0.80>',
+              model: ['1', 0],
+            },
+          },
+          '3': {
+            class_type: 'PathchSageAttentionKJ',
+            inputs: { model: ['2', 0] },
+          },
+          '4': {
+            class_type: 'easy positive',
+            inputs: { positive: 'gothic castle in teal fog' },
+          },
+          '5': {
+            class_type: 'JoinStrings',
+            inputs: { delimiter: ' ', string1: ['4', 0] },
+          },
+          '6': {
+            class_type: 'easy stylesSelector',
+            inputs: { positive: ['5', 0] },
+          },
+          '7': {
+            class_type: 'CLIPTextEncode',
+            inputs: { text: ['6', 0], clip: ['2', 1] },
+          },
+          '8': {
+            class_type: 'ConditioningZeroOut',
+            inputs: { conditioning: ['7', 0] },
+          },
+          '9': {
+            class_type: 'SeedGenerator',
+            inputs: { seed: 1100100895348371 },
+          },
+          '10': {
+            class_type: 'KSampler',
+            inputs: {
+              seed: ['9', 0],
+              steps: 9,
+              cfg: 1,
+              sampler_name: 'euler',
+              scheduler: 'simple',
+              denoise: 1,
+              model: ['3', 0],
+              positive: ['7', 0],
+              negative: ['8', 0],
+            },
+          },
+          '11': {
+            class_type: 'VAELoader',
+            inputs: { vae_name: 'ae.safetensors' },
+          },
+          '12': {
+            class_type: 'VAEDecode',
+            inputs: { samples: ['10', 0], vae: ['11', 0] },
+          },
+          '13': {
+            class_type: 'MetaHubSaveNode',
+            inputs: { images: ['12', 0] },
+          },
+        },
+      },
+    };
+
+    const result = await parseImageMetadata(metadata);
+
+    expect(result?.generator).toBe('ComfyUI');
+    expect(result?.prompt).toBe('gothic castle in teal fog');
+    expect(result?.negativePrompt).toBe('');
+    expect(result?.seed).toBe(1100100895348371);
+    expect(result?.model).toBe('Z image Turbo\\z_image_turbo_bf16.safetensors');
+  });
 });
 
 describe('ComfyUI Parser - Prompt-only graph payloads', () => {

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -385,6 +385,56 @@ describe('ComfyUI Parser - LoRA Workflows', () => {
     expect(result.sampler_name).toBe('dpmpp_2m');
     expect(result.scheduler).toBe('karras');
   });
+
+  it('should read LoraManager LoRAs from workflow widget values', () => {
+    const result = resolvePromptFromGraph({
+      nodes: [
+        {
+          id: 2,
+          type: 'Lora Loader (LoraManager)',
+          widgets_values: [
+            '',
+            'cinematic portrait',
+            [
+              { name: 'ui_lora.safetensors', active: true },
+              { name: 'disabled_lora.safetensors', active: false },
+            ],
+          ],
+          mode: 0,
+        },
+        {
+          id: 3,
+          type: 'KSampler',
+          widgets_values: [123, 'fixed', 20, 7, 'euler', 'normal', 1],
+          mode: 0,
+        },
+      ],
+    }, {
+      '2': {
+        class_type: 'Lora Loader (LoraManager)',
+        inputs: {
+          text: 'cinematic portrait',
+          model: ['1', 0],
+          clip: ['1', 1],
+        },
+      },
+      '3': {
+        class_type: 'KSampler',
+        inputs: {
+          seed: 123,
+          steps: 20,
+          cfg: 7,
+          sampler_name: 'euler',
+          scheduler: 'normal',
+          denoise: 1,
+          model: ['2', 0],
+        },
+      },
+    });
+
+    expect(result.lora).toContain('ui_lora.safetensors');
+    expect(result.lora).not.toContain('disabled_lora.safetensors');
+  });
 });
 
 describe('ComfyUI Parser - ControlNet Workflows', () => {

--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -318,6 +318,44 @@ describe('imageEditingService', () => {
     expect(payload.edit.output_dimensions).toEqual({ width: 512, height: 384 });
   });
 
+  it('preserves resize edits in embedded MetaHub recipe metadata', () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x00,
+      0x49, 0x45, 0x4e, 0x44,
+      0xae, 0x42, 0x60, 0x82,
+    ]);
+
+    const output = embedMetaHubMetadataInPngBytes(
+      pngBytes,
+      {
+        prompt: 'resized edit',
+        width: 1024,
+        height: 768,
+      },
+      {
+        ...DEFAULT_IMAGE_EDIT_RECIPE,
+        resize: {
+          enabled: true,
+          width: 512,
+          height: 384,
+          lockAspectRatio: true,
+        },
+      },
+      undefined,
+      { width: 512, height: 384 },
+    );
+    const chunks = collectPngTextChunks(output);
+    const payload = JSON.parse(chunks.imagemetahub_data);
+
+    expect(payload.edit.recipe.resize).toEqual({
+      enabled: true,
+      width: 512,
+      height: 384,
+      lockAspectRatio: true,
+    });
+  });
+
   it('preserves embedded ComfyUI workflow chunks when saving edited PNG bytes', () => {
     const pngBytes = new Uint8Array([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,

--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_IMAGE_ADJUSTMENTS,
   DEFAULT_IMAGE_EDIT_RECIPE,
+  createImageEditorDocument,
   buildImageAdjustmentFilter,
   clampImageAdjustment,
   clampImageEditCropRect,
   embedMetaHubMetadataInPngBytes,
   getImageEditOutputDimensions,
   hasImageEditRecipeChanges,
+  hasImageEditorDocumentChanges,
   hasImageAdjustments,
   normalizeImageAdjustments,
+  normalizeImageEditorDocument,
   normalizeImageEditRecipe,
   normalizeImageEditRotation,
   renderAdjustedImageToPngBytes,
@@ -78,6 +81,59 @@ describe('imageEditingService', () => {
     expect(getImageEditOutputDimensions({
       resize: { enabled: true, width: 12, height: 10, lockAspectRatio: false },
     }, { width: 100, height: 80 })).toEqual({ width: 12, height: 10 });
+  });
+
+  it('normalizes image editor documents and clamps object bounds', () => {
+    const document = normalizeImageEditorDocument({
+      sourceImageId: 'dir::image.png',
+      sourceName: 'image.png',
+      sourceDimensions: { width: 400, height: 300 },
+      canvasDimensions: { width: 400, height: 300 },
+      objects: [
+        {
+          id: 'rect-1',
+          type: 'rectangle',
+          bounds: { x: -10, y: 20, width: 999, height: 60 },
+          zIndex: 3,
+          opacity: 2,
+          style: { stroke: '#ffffff', fill: 'transparent', strokeWidth: 200, fontSize: 0 },
+        },
+      ],
+    });
+
+    expect(document.objects).toHaveLength(1);
+    expect(document.objects[0].bounds).toEqual({ x: 0, y: 20, width: 400, height: 60 });
+    expect(document.objects[0].style.opacity).toBe(1);
+    expect(document.objects[0].style.strokeWidth).toBe(80);
+    expect(document.objects[0].style.fontSize).toBe(8);
+  });
+
+  it('detects neutral and dirty image editor documents', () => {
+    const document = createImageEditorDocument({
+      imageId: 'dir::image.png',
+      name: 'image.png',
+      width: 400,
+      height: 300,
+    });
+
+    expect(hasImageEditorDocumentChanges(document)).toBe(false);
+    expect(hasImageEditorDocumentChanges({
+      ...document,
+      objects: [
+        {
+          id: 'arrow-1',
+          type: 'arrow',
+          bounds: { x: 10, y: 10, width: 120, height: 40 },
+          zIndex: 1,
+          opacity: 1,
+          style: { stroke: '#ffffff', fill: 'transparent', strokeWidth: 4, fontSize: 24 },
+        },
+      ],
+    })).toBe(true);
+    expect(hasImageEditorDocumentChanges({
+      ...document,
+      background: { ...document.background, kind: 'color', color: '#101820' },
+    })).toBe(true);
   });
 
   it('renders adjusted image bytes as PNG', async () => {
@@ -180,6 +236,10 @@ describe('imageEditingService', () => {
     }, DEFAULT_IMAGE_ADJUSTMENTS, {
       workflow,
       prompt,
+    }, undefined, {
+      tool: 'image-editor-workspace-v1',
+      annotationCount: 2,
+      sourceImageId: 'dir::image.png',
     });
     const text = new TextDecoder().decode(output);
 
@@ -187,5 +247,7 @@ describe('imageEditingService', () => {
     expect(text).toContain('prompt_api');
     expect(text).toContain('KSampler');
     expect(text).toContain('"seed":123');
+    expect(text).toContain('image-editor-workspace-v1');
+    expect(text).toContain('"annotation_count":2');
   });
 });

--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -111,6 +111,10 @@ describe('imageEditingService', () => {
     expect(recipe.resize).toMatchObject({ enabled: true, width: 64, height: 32 });
     expect(recipe.effects).toEqual({ sharpen: 100, blur: 0 });
     expect(hasImageEditRecipeChanges(recipe)).toBe(true);
+    expect(hasImageEditRecipeChanges({
+      ...DEFAULT_IMAGE_EDIT_RECIPE,
+      resize: { enabled: true, width: 64, height: 32, lockAspectRatio: false },
+    })).toBe(true);
   });
 
   it('computes output dimensions for crop, rotate, and resize', () => {

--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -108,6 +108,33 @@ describe('imageEditingService', () => {
     expect(document.objects[0].style.fontSize).toBe(8);
   });
 
+  it('preserves directional points for line and arrow objects', () => {
+    const document = normalizeImageEditorDocument({
+      sourceImageId: 'dir::image.png',
+      sourceName: 'image.png',
+      sourceDimensions: { width: 400, height: 300 },
+      canvasDimensions: { width: 400, height: 300 },
+      objects: [
+        {
+          id: 'arrow-1',
+          type: 'arrow',
+          bounds: { x: 20, y: 20, width: 180, height: 120 },
+          points: [
+            { x: 200, y: 40 },
+            { x: 20, y: 140 },
+          ],
+          zIndex: 1,
+          style: { strokeColor: '#ffffff', fillColor: 'transparent', textColor: '#ffffff', strokeWidth: 4, fontSize: 24, opacity: 1 },
+        },
+      ],
+    });
+
+    expect(document.objects[0].points).toEqual([
+      { x: 200, y: 40 },
+      { x: 20, y: 140 },
+    ]);
+  });
+
   it('detects neutral and dirty image editor documents', () => {
     const document = createImageEditorDocument({
       imageId: 'dir::image.png',

--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -18,6 +18,22 @@ import {
   renderAdjustedImageToPngBytes,
 } from '../services/imageEditingService';
 
+const collectPngChunkTypes = (bytes: Uint8Array): string[] => {
+  const types: string[] = [];
+  let offset = 8;
+  while (offset + 12 <= bytes.byteLength) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset + offset, 8);
+    const length = view.getUint32(0, false);
+    const type = String.fromCharCode(bytes[offset + 4], bytes[offset + 5], bytes[offset + 6], bytes[offset + 7]);
+    types.push(type);
+    offset += length + 12;
+    if (type === 'IEND') {
+      break;
+    }
+  }
+  return types;
+};
+
 describe('imageEditingService', () => {
   it('treats default adjustments as neutral', () => {
     expect(hasImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS)).toBe(false);
@@ -276,5 +292,37 @@ describe('imageEditingService', () => {
     expect(text).toContain('"seed":123');
     expect(text).toContain('image-editor-workspace-v1');
     expect(text).toContain('"annotation_count":2');
+
+    const types = collectPngChunkTypes(output);
+    expect(types.filter((type) => type === 'tEXt')).toHaveLength(3);
+  });
+
+  it('preserves raw ComfyUI workflow chunks even without normalized metadata', () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x00,
+      0x49, 0x45, 0x4e, 0x44,
+      0xae, 0x42, 0x60, 0x82,
+    ]);
+    const workflow = { nodes: [{ id: 2, type: 'CLIPTextEncode' }] };
+    const promptApi = { '2': { class_type: 'CLIPTextEncode', inputs: { text: 'original prompt' } } };
+
+    const output = embedMetaHubMetadataInPngBytes(
+      pngBytes,
+      undefined,
+      DEFAULT_IMAGE_ADJUSTMENTS,
+      {
+        workflow,
+        prompt_api: promptApi,
+      },
+    );
+    const text = new TextDecoder().decode(output);
+
+    expect(text).toContain('workflow');
+    expect(text).toContain('prompt');
+    expect(text).toContain('CLIPTextEncode');
+    expect(text).toContain('original prompt');
+    expect(text).not.toContain('imagemetahub_data');
+    expect(collectPngChunkTypes(output).filter((type) => type === 'tEXt')).toHaveLength(2);
   });
 });

--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -34,6 +34,35 @@ const collectPngChunkTypes = (bytes: Uint8Array): string[] => {
   return types;
 };
 
+const collectPngTextChunks = (bytes: Uint8Array): Record<string, string> => {
+  const chunks: Record<string, string> = {};
+  const decoder = new TextDecoder();
+  let offset = 8;
+  while (offset + 12 <= bytes.byteLength) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset + offset, 8);
+    const length = view.getUint32(0, false);
+    const type = String.fromCharCode(bytes[offset + 4], bytes[offset + 5], bytes[offset + 6], bytes[offset + 7]);
+    if (type === 'tEXt' || type === 'iTXt') {
+      const data = bytes.slice(offset + 8, offset + 8 + length);
+      const separatorIndex = data.indexOf(0);
+      if (separatorIndex !== -1) {
+        const keyword = decoder.decode(data.slice(0, separatorIndex));
+        if (type === 'tEXt') {
+          chunks[keyword] = decoder.decode(data.slice(separatorIndex + 1));
+        } else {
+          const textStart = separatorIndex + 5;
+          chunks[keyword] = decoder.decode(data.slice(textStart));
+        }
+      }
+    }
+    offset += length + 12;
+    if (type === 'IEND') {
+      break;
+    }
+  }
+  return chunks;
+};
+
 describe('imageEditingService', () => {
   it('treats default adjustments as neutral', () => {
     expect(hasImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS)).toBe(false);
@@ -260,6 +289,33 @@ describe('imageEditingService', () => {
     expect(text).toContain('imagemetahub_data');
     expect(text).toContain('Image MetaHub');
     expect(text).toContain('model.safetensors');
+  });
+
+  it('stores edited output dimensions in the top-level MetaHub payload', () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x00,
+      0x49, 0x45, 0x4e, 0x44,
+      0xae, 0x42, 0x60, 0x82,
+    ]);
+
+    const output = embedMetaHubMetadataInPngBytes(
+      pngBytes,
+      {
+        prompt: 'cropped edit',
+        width: 1024,
+        height: 768,
+      },
+      DEFAULT_IMAGE_ADJUSTMENTS,
+      undefined,
+      { width: 512, height: 384 },
+    );
+    const chunks = collectPngTextChunks(output);
+    const payload = JSON.parse(chunks.imagemetahub_data);
+
+    expect(payload.width).toBe(512);
+    expect(payload.height).toBe(384);
+    expect(payload.edit.output_dimensions).toEqual({ width: 512, height: 384 });
   });
 
   it('preserves embedded ComfyUI workflow chunks when saving edited PNG bytes', () => {

--- a/__tests__/imageEditingService.test.ts
+++ b/__tests__/imageEditingService.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_IMAGE_ADJUSTMENTS,
+  DEFAULT_IMAGE_EDIT_RECIPE,
   buildImageAdjustmentFilter,
   clampImageAdjustment,
+  clampImageEditCropRect,
   embedMetaHubMetadataInPngBytes,
+  getImageEditOutputDimensions,
+  hasImageEditRecipeChanges,
   hasImageAdjustments,
   normalizeImageAdjustments,
+  normalizeImageEditRecipe,
+  normalizeImageEditRotation,
   renderAdjustedImageToPngBytes,
 } from '../services/imageEditingService';
 
@@ -34,6 +40,46 @@ describe('imageEditingService', () => {
       .toBe('brightness(120%) contrast(80%) saturate(150%) hue-rotate(-30deg)');
   });
 
+  it('normalizes edit recipes and detects neutral edits', () => {
+    expect(hasImageEditRecipeChanges(DEFAULT_IMAGE_EDIT_RECIPE)).toBe(false);
+    expect(normalizeImageEditRotation(275)).toBe(270);
+    expect(normalizeImageEditRotation(-90)).toBe(270);
+    expect(clampImageEditCropRect({ x: -5, y: 20, width: 999, height: 40 }, { width: 100, height: 80 })).toEqual({
+      x: 0,
+      y: 20,
+      width: 100,
+      height: 40,
+    });
+
+    const recipe = normalizeImageEditRecipe({
+      transform: { rotation: 91, flipHorizontal: true },
+      crop: { enabled: true, aspect: '1:1', rect: { x: 10, y: 15, width: 40, height: 40 } },
+      resize: { enabled: true, width: 64, height: 32, lockAspectRatio: false },
+      effects: { sharpen: 150, blur: -5 },
+    }, { width: 100, height: 80 });
+
+    expect(recipe.transform.rotation).toBe(90);
+    expect(recipe.transform.flipHorizontal).toBe(true);
+    expect(recipe.resize).toMatchObject({ enabled: true, width: 64, height: 32 });
+    expect(recipe.effects).toEqual({ sharpen: 100, blur: 0 });
+    expect(hasImageEditRecipeChanges(recipe)).toBe(true);
+  });
+
+  it('computes output dimensions for crop, rotate, and resize', () => {
+    expect(getImageEditOutputDimensions({
+      crop: { enabled: true, aspect: 'free', rect: { x: 0, y: 0, width: 40, height: 20 } },
+    }, { width: 100, height: 80 })).toEqual({ width: 40, height: 20 });
+
+    expect(getImageEditOutputDimensions({
+      crop: { enabled: true, aspect: 'free', rect: { x: 0, y: 0, width: 40, height: 20 } },
+      transform: { rotation: 90, flipHorizontal: false, flipVertical: false },
+    }, { width: 100, height: 80 })).toEqual({ width: 20, height: 40 });
+
+    expect(getImageEditOutputDimensions({
+      resize: { enabled: true, width: 12, height: 10, lockAspectRatio: false },
+    }, { width: 100, height: 80 })).toEqual({ width: 12, height: 10 });
+  });
+
   it('renders adjusted image bytes as PNG', async () => {
     const drawImage = vi.fn();
     const toBlob = vi.fn((callback: BlobCallback) => {
@@ -45,7 +91,14 @@ describe('imageEditingService', () => {
         return {
           width: 0,
           height: 0,
-          getContext: () => ({ filter: '', drawImage }),
+          getContext: () => ({
+            filter: '',
+            drawImage,
+            translate: vi.fn(),
+            rotate: vi.fn(),
+            scale: vi.fn(),
+            setTransform: vi.fn(),
+          }),
           toBlob,
         } as unknown as HTMLCanvasElement;
       }

--- a/__tests__/video-metahub-parser.test.ts
+++ b/__tests__/video-metahub-parser.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { parseImageMetadata } from '../services/parsers/metadataParserFactory';
+import { parseVideoMetaHubMetadata } from '../services/parsers/videoMetaHubParser';
+
+describe('Video MetaHub parser', () => {
+  it('accepts structurally valid partial video payloads without prompt/model', () => {
+    const result = parseVideoMetaHubMetadata({
+      generator: 'ComfyUI',
+      media_type: 'video',
+      width: 640,
+      height: 480,
+      video: {
+        width: 640,
+        height: 480,
+        frame_rate: 24,
+        frame_count: 48,
+      },
+      metadata_status: 'partial',
+      metadata_sources: {
+        prompt: 'default',
+      },
+    });
+
+    expect(result).toMatchObject({
+      prompt: '',
+      model: '',
+      width: 640,
+      height: 480,
+      media_type: 'video',
+      _metadata_status: 'partial',
+    });
+  });
+
+  it('rejects arbitrary JSON comments instead of treating them as video metadata', () => {
+    const result = parseVideoMetaHubMetadata({
+      comment: JSON.stringify({
+        prompt: {
+          '1': {
+            class_type: 'KSampler',
+            inputs: {},
+          },
+        },
+      }),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('does not normalize invalid videometahub_data into blank video metadata', async () => {
+    const result = await parseImageMetadata({
+      videometahub_data: {
+        prompt: {
+          '1': {
+            class_type: 'KSampler',
+            inputs: {},
+          },
+        },
+      },
+    } as any);
+
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/visualComparison.test.ts
+++ b/__tests__/visualComparison.test.ts
@@ -52,6 +52,17 @@ describe('visualComparison utilities', () => {
     expect(createHeatmapImageData(left, right, 5).metrics.changedPixels).toBe(1);
   });
 
+  it('does not count identical pixels as changed at zero threshold', () => {
+    const left = imageData(1, 1, [[80, 90, 100, 255]]);
+    const right = imageData(1, 1, [[80, 90, 100, 255]]);
+
+    const result = createHeatmapImageData(left, right, 0);
+
+    expect(result.metrics.changedPixels).toBe(0);
+    expect(result.metrics.changedPercent).toBe(0);
+    expect(result.imageData.data[3]).toBe(0);
+  });
+
   it('detects the strongest changed region', () => {
     const left = imageData(2, 2, [
       [0, 0, 0, 255], [0, 0, 0, 255],

--- a/__tests__/visualComparison.test.ts
+++ b/__tests__/visualComparison.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
   buildVisualComparisonFromImageData,
+  calculatePixelDelta,
   createEdgeDifferenceImageData,
   createHeatmapImageData,
 } from '../utils/visualComparison';
@@ -61,6 +62,14 @@ describe('visualComparison utilities', () => {
     expect(result.metrics.changedPixels).toBe(0);
     expect(result.metrics.changedPercent).toBe(0);
     expect(result.imageData.data[3]).toBe(0);
+  });
+
+  it('detects alpha-only pixel changes', () => {
+    const opaqueBlack = imageData(1, 1, [[0, 0, 0, 255]]);
+    const transparentBlack = imageData(1, 1, [[0, 0, 0, 0]]);
+
+    expect(calculatePixelDelta(opaqueBlack.data, transparentBlack.data, 0)).toBeGreaterThan(0);
+    expect(createHeatmapImageData(opaqueBlack, transparentBlack, 18).metrics.changedPixels).toBe(1);
   });
 
   it('detects the strongest changed region', () => {

--- a/__tests__/visualComparison.test.ts
+++ b/__tests__/visualComparison.test.ts
@@ -95,4 +95,20 @@ describe('visualComparison utilities', () => {
 
     expect(visibleAlphaValues.length).toBeGreaterThan(0);
   });
+
+  it('does not render flat zero-strength edges at zero threshold', () => {
+    const left = imageData(2, 2, [
+      [40, 40, 40, 255], [40, 40, 40, 255],
+      [40, 40, 40, 255], [40, 40, 40, 255],
+    ]);
+    const right = imageData(2, 2, [
+      [40, 40, 40, 255], [40, 40, 40, 255],
+      [40, 40, 40, 255], [40, 40, 40, 255],
+    ]);
+
+    const edgeMap = createEdgeDifferenceImageData(left, right, 0);
+    const visibleAlphaValues = Array.from(edgeMap.data).filter((_, index) => index % 4 === 3 && edgeMap.data[index] > 0);
+
+    expect(visibleAlphaValues).toHaveLength(0);
+  });
 });

--- a/__tests__/visualComparison.test.ts
+++ b/__tests__/visualComparison.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  buildVisualComparisonFromImageData,
+  createEdgeDifferenceImageData,
+  createHeatmapImageData,
+} from '../utils/visualComparison';
+
+class TestImageData {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+
+  constructor(dataOrWidth: Uint8ClampedArray | number, widthOrHeight: number, height?: number) {
+    if (typeof dataOrWidth === 'number') {
+      this.width = dataOrWidth;
+      this.height = widthOrHeight;
+      this.data = new Uint8ClampedArray(this.width * this.height * 4);
+      return;
+    }
+
+    this.data = dataOrWidth;
+    this.width = widthOrHeight;
+    this.height = height ?? 0;
+  }
+}
+
+const imageData = (width: number, height: number, pixels: Array<[number, number, number, number]>): ImageData =>
+  new ImageData(new Uint8ClampedArray(pixels.flat()), width, height);
+
+describe('visualComparison utilities', () => {
+  beforeAll(() => {
+    if (typeof ImageData === 'undefined') {
+      (globalThis as unknown as { ImageData: typeof ImageData }).ImageData = TestImageData as unknown as typeof ImageData;
+    }
+  });
+
+  it('returns zero visual delta for identical images', () => {
+    const left = imageData(1, 1, [[20, 40, 60, 255]]);
+    const result = buildVisualComparisonFromImageData(left, imageData(1, 1, [[20, 40, 60, 255]]), 18);
+
+    expect(result.metrics.changedPixels).toBe(0);
+    expect(result.metrics.changedPercent).toBe(0);
+    expect(result.metrics.averageDelta).toBe(0);
+    expect(result.metrics.strongestRegion).toBeNull();
+  });
+
+  it('respects the heatmap threshold', () => {
+    const left = imageData(1, 1, [[100, 100, 100, 255]]);
+    const right = imageData(1, 1, [[110, 110, 110, 255]]);
+
+    expect(createHeatmapImageData(left, right, 20).metrics.changedPixels).toBe(0);
+    expect(createHeatmapImageData(left, right, 5).metrics.changedPixels).toBe(1);
+  });
+
+  it('detects the strongest changed region', () => {
+    const left = imageData(2, 2, [
+      [0, 0, 0, 255], [0, 0, 0, 255],
+      [0, 0, 0, 255], [0, 0, 0, 255],
+    ]);
+    const right = imageData(2, 2, [
+      [0, 0, 0, 255], [0, 0, 0, 255],
+      [0, 0, 0, 255], [255, 255, 255, 255],
+    ]);
+    const result = buildVisualComparisonFromImageData(left, right, 18);
+
+    expect(result.metrics.changedPixels).toBe(1);
+    expect(result.metrics.strongestRegion).toMatchObject({ x: 1, y: 1 });
+  });
+
+  it('creates visible Sobel edge differences for simple shapes', () => {
+    const left = imageData(3, 3, [
+      [0, 0, 0, 255], [255, 255, 255, 255], [0, 0, 0, 255],
+      [0, 0, 0, 255], [255, 255, 255, 255], [0, 0, 0, 255],
+      [0, 0, 0, 255], [255, 255, 255, 255], [0, 0, 0, 255],
+    ]);
+    const right = imageData(3, 3, [
+      [0, 0, 0, 255], [0, 0, 0, 255], [0, 0, 0, 255],
+      [255, 255, 255, 255], [255, 255, 255, 255], [255, 255, 255, 255],
+      [0, 0, 0, 255], [0, 0, 0, 255], [0, 0, 0, 255],
+    ]);
+
+    const edgeMap = createEdgeDifferenceImageData(left, right, 20);
+    const visibleAlphaValues = Array.from(edgeMap.data).filter((_, index) => index % 4 === 3 && edgeMap.data[index] > 0);
+
+    expect(visibleAlphaValues.length).toBeGreaterThan(0);
+  });
+});

--- a/cli.ts
+++ b/cli.ts
@@ -13,7 +13,7 @@ const program = new Command();
 program
   .name('imagemetahub-cli')
   .description('Image MetaHub CLI - Parse AI-generated image metadata')
-  .version('0.17.0-rc');
+  .version('0.17.0');
 
 type ParseOptions = { json: boolean; pretty: boolean; raw?: boolean; quiet?: boolean };
 type IndexOptions = { out: string; recursive: boolean; raw?: boolean; quiet?: boolean; concurrency?: string };

--- a/cli.ts
+++ b/cli.ts
@@ -13,7 +13,7 @@ const program = new Command();
 program
   .name('imagemetahub-cli')
   .description('Image MetaHub CLI - Parse AI-generated image metadata')
-  .version('0.16.1');
+  .version('0.17.0-rc');
 
 type ParseOptions = { json: boolean; pretty: boolean; raw?: boolean; quiet?: boolean };
 type IndexOptions = { out: string; recursive: boolean; raw?: boolean; quiet?: boolean; concurrency?: string };

--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Music } from 'lucide-react';
+import { AlertTriangle, ExternalLink, Music } from 'lucide-react';
 import { type MediaDiagnosticsContext, useMediaDiagnostics } from '../hooks/useMediaDiagnostics';
 
 interface AudioPlayerProps {
@@ -11,6 +11,7 @@ interface AudioPlayerProps {
   onLoadedMetadata?: React.ReactEventHandler<HTMLAudioElement>;
   onCanPlay?: React.ReactEventHandler<HTMLAudioElement>;
   onPlaying?: React.ReactEventHandler<HTMLAudioElement>;
+  externalPath?: string | null;
   diagnostics?: Omit<MediaDiagnosticsContext, 'mediaKind' | 'src'>;
 }
 
@@ -23,14 +24,66 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
   onLoadedMetadata,
   onCanPlay,
   onPlaying,
+  externalPath,
   diagnostics,
 }) => {
+  const [audioRendererFailed, setAudioRendererFailed] = React.useState(false);
+  const [openError, setOpenError] = React.useState<string | null>(null);
+  const handleAudioRendererError = React.useCallback(() => {
+    setAudioRendererFailed(true);
+  }, []);
   const mediaDiagnostics = useMediaDiagnostics({
     mediaKind: 'audio',
     fileName: diagnostics?.fileName ?? title,
     surface: diagnostics?.surface ?? 'audio-player',
     src,
+    onAudioRendererError: handleAudioRendererError,
   });
+
+  React.useEffect(() => {
+    setAudioRendererFailed(false);
+    setOpenError(null);
+  }, [src]);
+
+  const openExternally = React.useCallback(async () => {
+    if (!externalPath) return;
+    const result = await window.electronAPI?.openPath?.(externalPath);
+    if (!result?.success) {
+      setOpenError(result?.error || 'Failed to open media externally.');
+    }
+  }, [externalPath]);
+
+  if (audioRendererFailed) {
+    return (
+      <div
+        data-media-element="true"
+        className={`flex w-full flex-col items-center justify-center bg-black text-gray-100 ${compact ? 'gap-3 p-4' : 'h-full gap-5 p-8'}`}
+        onContextMenu={onContextMenu}
+      >
+        <div className={`rounded-full border border-amber-400/30 bg-amber-400/10 text-amber-200 ${compact ? 'p-3' : 'p-6'}`}>
+          <AlertTriangle className={compact ? 'h-8 w-8' : 'h-16 w-16'} />
+        </div>
+        <div className="max-w-full text-center">
+          <p className={`truncate font-medium text-gray-100 ${compact ? 'text-sm' : 'text-lg'}`} title={title}>
+            Audio playback failed in Electron
+          </p>
+          <p className="mt-1 max-w-md text-xs text-gray-400">
+            The macOS audio service reported an audio renderer error.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={openExternally}
+          disabled={!externalPath}
+          className="inline-flex items-center gap-2 rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm font-medium text-gray-100 transition-colors hover:border-gray-500 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <ExternalLink className="h-4 w-4" />
+          Open Externally
+        </button>
+        {openError && <p className="max-w-md text-center text-xs text-red-300">{openError}</p>}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -60,7 +60,13 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   );
 
   const updateSharedZoom = (zoom: number, x: number, y: number) => {
-    setSharedZoom({ zoom, x, y });
+    setSharedZoom((current) => {
+      const unchanged =
+        Math.abs(current.zoom - zoom) < 0.001 &&
+        Math.abs(current.x - x) < 0.5 &&
+        Math.abs(current.y - y) < 0.5;
+      return unchanged ? current : { zoom, x, y };
+    });
   };
 
   const handleZoomChange = (zoom: number, x: number, y: number) => {

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -113,6 +113,12 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   }, [supportsOverlayModes, viewMode]);
 
   useEffect(() => {
+    if (isAdvancedMode) return;
+    setVisualMetrics(null);
+    setHighlightDeltaRegion(false);
+  }, [isAdvancedMode]);
+
+  useEffect(() => {
     if (!isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -143,17 +149,6 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [imageCount, isOpen, viewMode]);
 
-  if (!isOpen || imageCount < 2) return null;
-
-  const viewModes: { id: ComparisonViewMode; label: string; hint: string; disabled?: boolean }[] = [
-    { id: 'side-by-side', label: imageCount > 2 ? 'Compare' : 'Side-by-Side', hint: imageCount > 2 ? 'Compare all selected images together' : 'Two panes with optional synced zoom' },
-    { id: 'slider', label: 'Slider', hint: 'Drag the divider to reveal each image', disabled: !supportsOverlayModes },
-    { id: 'hover', label: 'Hover', hint: 'Hover to toggle between the images', disabled: !supportsOverlayModes },
-    { id: 'difference-map', label: 'Diff Map', hint: 'Highlight changed pixels as a heatmap', disabled: !supportsOverlayModes },
-    { id: 'flicker', label: 'Flicker', hint: 'Alternate images in the same viewport', disabled: !supportsOverlayModes },
-    { id: 'loupe', label: 'Loupe', hint: 'Inspect Image A, diff, and Image B under the cursor', disabled: !supportsOverlayModes },
-    { id: 'edge-difference', label: 'Edges', hint: 'Compare structural outlines and silhouettes', disabled: !supportsOverlayModes },
-  ];
   const isSideBySide = viewMode === 'side-by-side';
   const metadataReference = comparisonImages[0]?.metadata?.normalizedMetadata ?? null;
   const leftMetadata = comparisonImages[0]?.metadata?.normalizedMetadata ?? null;
@@ -173,6 +168,18 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   const updateAdvancedSettings = (patch: Partial<ComparisonAdvancedSettings>) => {
     setAdvancedSettings((current) => ({ ...current, ...patch }));
   };
+
+  if (!isOpen || imageCount < 2) return null;
+
+  const viewModes: { id: ComparisonViewMode; label: string; hint: string; disabled?: boolean }[] = [
+    { id: 'side-by-side', label: imageCount > 2 ? 'Compare' : 'Side-by-Side', hint: imageCount > 2 ? 'Compare all selected images together' : 'Two panes with optional synced zoom' },
+    { id: 'slider', label: 'Slider', hint: 'Drag the divider to reveal each image', disabled: !supportsOverlayModes },
+    { id: 'hover', label: 'Hover', hint: 'Hover to toggle between the images', disabled: !supportsOverlayModes },
+    { id: 'difference-map', label: 'Diff Map', hint: 'Highlight changed pixels as a heatmap', disabled: !supportsOverlayModes },
+    { id: 'flicker', label: 'Flicker', hint: 'Alternate images in the same viewport', disabled: !supportsOverlayModes },
+    { id: 'loupe', label: 'Loupe', hint: 'Inspect Image A, diff, and Image B under the cursor', disabled: !supportsOverlayModes },
+    { id: 'edge-difference', label: 'Edges', hint: 'Compare structural outlines and silhouettes', disabled: !supportsOverlayModes },
+  ];
 
   return (
     <div className="fixed inset-0 z-[140] bg-black/85 backdrop-blur-sm flex flex-col">
@@ -434,6 +441,7 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
                   onHoverChange={(isHovered) =>
                     setActiveMetadataIndex((current) => (isHovered ? index : current === index ? null : current))
                   }
+                  onRemove={imageCount > 2 ? () => handleRemoveImage(index) : undefined}
                   className={`h-full rounded-xl border border-gray-800 overflow-hidden ${isOddLastGridItem ? 'md:col-span-2' : ''}`}
                   imageLabel={`Image ${index + 1}`}
                 />

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, FC, useMemo } from 'react';
 import { X, Repeat, ArrowLeft } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
-import { BaseMetadata, ComparisonLayoutMode, ComparisonModalProps, IndexedImage, ZoomState, ComparisonViewMode } from '../types';
+import { BaseMetadata, ComparisonAdvancedSettings, ComparisonLayoutMode, ComparisonModalProps, IndexedImage, ZoomState, ComparisonViewMode } from '../types';
 import ComparisonPane from './ComparisonPane';
 import ComparisonMetadataPanel from './ComparisonMetadataPanel';
 import ComparisonOverlayView from './ComparisonOverlayView';
+import { getFieldLabel, getMetadataDifferences } from '../utils/metadataComparison';
+import { VisualComparisonMetrics } from '../utils/visualComparison';
 
 export const getComparisonMetadataReference = (
   comparisonImages: IndexedImage[],
@@ -33,9 +35,25 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   const [layoutMode, setLayoutMode] = useState<ComparisonLayoutMode>('strip');
   const [metadataViewMode, setMetadataViewMode] = useState<'standard' | 'diff'>('standard');
   const [activeMetadataIndex, setActiveMetadataIndex] = useState<number | null>(null);
+  const [visualMetrics, setVisualMetrics] = useState<VisualComparisonMetrics | null>(null);
+  const [highlightDeltaRegion, setHighlightDeltaRegion] = useState(false);
+  const [advancedSettings, setAdvancedSettings] = useState<ComparisonAdvancedSettings>({
+    threshold: 18,
+    opacity: 65,
+    baseMode: 'left',
+    flickerSpeedMs: 700,
+    loupeSize: 220,
+    loupeZoom: 2,
+    showLabels: true,
+  });
 
   const imageCount = comparisonImages.length;
   const supportsOverlayModes = imageCount === 2;
+  const advancedModes = useMemo(
+    () => new Set<ComparisonViewMode>(['difference-map', 'flicker', 'loupe', 'edge-difference']),
+    []
+  );
+  const isAdvancedMode = advancedModes.has(viewMode);
   const directoryPathById = useMemo(
     () => new Map(directories.map((directory) => [directory.id, directory.path])),
     [directories]
@@ -84,6 +102,8 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
   useEffect(() => {
     setExpandedMetadataIndexes(new Set());
     setActiveMetadataIndex(null);
+    setVisualMetrics(null);
+    setHighlightDeltaRegion(false);
   }, [comparisonImages]);
 
   useEffect(() => {
@@ -129,9 +149,30 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
     { id: 'side-by-side', label: imageCount > 2 ? 'Compare' : 'Side-by-Side', hint: imageCount > 2 ? 'Compare all selected images together' : 'Two panes with optional synced zoom' },
     { id: 'slider', label: 'Slider', hint: 'Drag the divider to reveal each image', disabled: !supportsOverlayModes },
     { id: 'hover', label: 'Hover', hint: 'Hover to toggle between the images', disabled: !supportsOverlayModes },
+    { id: 'difference-map', label: 'Diff Map', hint: 'Highlight changed pixels as a heatmap', disabled: !supportsOverlayModes },
+    { id: 'flicker', label: 'Flicker', hint: 'Alternate images in the same viewport', disabled: !supportsOverlayModes },
+    { id: 'loupe', label: 'Loupe', hint: 'Inspect Image A, diff, and Image B under the cursor', disabled: !supportsOverlayModes },
+    { id: 'edge-difference', label: 'Edges', hint: 'Compare structural outlines and silhouettes', disabled: !supportsOverlayModes },
   ];
   const isSideBySide = viewMode === 'side-by-side';
   const metadataReference = comparisonImages[0]?.metadata?.normalizedMetadata ?? null;
+  const leftMetadata = comparisonImages[0]?.metadata?.normalizedMetadata ?? null;
+  const rightMetadata = comparisonImages[1]?.metadata?.normalizedMetadata ?? null;
+  const metadataDifferences = useMemo(() => {
+    if (!leftMetadata || !rightMetadata) return [];
+    const priority = ['prompt', 'negativePrompt', 'seed', 'model', 'models', 'loras', 'cfg_scale', 'steps', 'sampler', 'scheduler', 'width', 'height'];
+    const differences = Array.from(getMetadataDifferences(leftMetadata, rightMetadata));
+    return differences.sort((left, right) => {
+      const leftIndex = priority.indexOf(left);
+      const rightIndex = priority.indexOf(right);
+      const normalizedLeft = leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex;
+      const normalizedRight = rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex;
+      return normalizedLeft - normalizedRight || left.localeCompare(right);
+    });
+  }, [leftMetadata, rightMetadata]);
+  const updateAdvancedSettings = (patch: Partial<ComparisonAdvancedSettings>) => {
+    setAdvancedSettings((current) => ({ ...current, ...patch }));
+  };
 
   return (
     <div className="fixed inset-0 z-[140] bg-black/85 backdrop-blur-sm flex flex-col">
@@ -247,6 +288,108 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
             <span>Back to Grid</span>
           </button>
         </div>
+
+        {isAdvancedMode && supportsOverlayModes && (
+          <div className="flex flex-wrap items-center gap-3 rounded-lg border border-gray-700/60 bg-gray-950/45 px-3 py-2">
+            {(viewMode === 'difference-map' || viewMode === 'edge-difference' || viewMode === 'loupe') && (
+              <>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Sensitivity
+                  <input
+                    type="range"
+                    min={0}
+                    max={80}
+                    value={advancedSettings.threshold}
+                    onChange={(event) => updateAdvancedSettings({ threshold: Number(event.target.value) })}
+                    className="w-28 accent-blue-500"
+                  />
+                  <span className="w-6 text-right text-gray-500">{advancedSettings.threshold}</span>
+                </label>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Opacity
+                  <input
+                    type="range"
+                    min={20}
+                    max={100}
+                    value={advancedSettings.opacity}
+                    onChange={(event) => updateAdvancedSettings({ opacity: Number(event.target.value) })}
+                    className="w-24 accent-blue-500"
+                  />
+                  <span className="w-8 text-right text-gray-500">{advancedSettings.opacity}%</span>
+                </label>
+                {viewMode !== 'loupe' && (
+                  <select
+                    value={advancedSettings.baseMode}
+                    onChange={(event) => updateAdvancedSettings({ baseMode: event.target.value as ComparisonAdvancedSettings['baseMode'] })}
+                    className="rounded-lg border border-gray-700 bg-gray-900 px-2 py-1 text-xs text-gray-200"
+                    title="Choose the base image below the visual difference layer"
+                  >
+                    <option value="left">Image A base</option>
+                    <option value="right">Image B base</option>
+                    <option value="diff">Diff only</option>
+                  </select>
+                )}
+              </>
+            )}
+
+            {viewMode === 'flicker' && (
+              <>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Speed
+                  <input
+                    type="range"
+                    min={150}
+                    max={1500}
+                    step={50}
+                    value={advancedSettings.flickerSpeedMs}
+                    onChange={(event) => updateAdvancedSettings({ flickerSpeedMs: Number(event.target.value) })}
+                    className="w-32 accent-blue-500"
+                  />
+                  <span className="w-12 text-right text-gray-500">{advancedSettings.flickerSpeedMs}ms</span>
+                </label>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  <input
+                    type="checkbox"
+                    checked={advancedSettings.showLabels}
+                    onChange={(event) => updateAdvancedSettings({ showLabels: event.target.checked })}
+                    className="accent-blue-500"
+                  />
+                  Labels
+                </label>
+              </>
+            )}
+
+            {viewMode === 'loupe' && (
+              <>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Size
+                  <input
+                    type="range"
+                    min={160}
+                    max={340}
+                    step={10}
+                    value={advancedSettings.loupeSize}
+                    onChange={(event) => updateAdvancedSettings({ loupeSize: Number(event.target.value) })}
+                    className="w-24 accent-blue-500"
+                  />
+                </label>
+                <label className="flex items-center gap-2 text-xs text-gray-300">
+                  Zoom
+                  <input
+                    type="range"
+                    min={1.4}
+                    max={3.5}
+                    step={0.1}
+                    value={advancedSettings.loupeZoom}
+                    onChange={(event) => updateAdvancedSettings({ loupeZoom: Number(event.target.value) })}
+                    className="w-24 accent-blue-500"
+                  />
+                  <span className="w-8 text-right text-gray-500">{advancedSettings.loupeZoom.toFixed(1)}x</span>
+                </label>
+              </>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="flex-1 min-h-0 overflow-hidden">
@@ -260,6 +403,9 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
             sharedZoom={sharedZoom}
             onZoomChange={updateSharedZoom}
             onActiveImageChange={setActiveMetadataIndex}
+            advancedSettings={advancedSettings}
+            onVisualAnalysisChange={setVisualMetrics}
+            highlightedRegion={highlightDeltaRegion ? visualMetrics?.strongestRegion : null}
           />
         ) : (
           <div className="h-full overflow-auto bg-gray-950 p-2">
@@ -299,6 +445,57 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
       </div>
 
       <div className="bg-gray-900/50 border-t border-gray-700 p-4 overflow-y-auto max-h-[40vh]">
+        {supportsOverlayModes && visualMetrics && (
+          <div className="mx-auto mb-4 grid max-w-7xl grid-cols-1 gap-3 md:grid-cols-[1.1fr_1fr]">
+            <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wider text-amber-100">Visual Delta</h3>
+                <button
+                  type="button"
+                  onMouseEnter={() => setHighlightDeltaRegion(true)}
+                  onMouseLeave={() => setHighlightDeltaRegion(false)}
+                  onFocus={() => setHighlightDeltaRegion(true)}
+                  onBlur={() => setHighlightDeltaRegion(false)}
+                  className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-2 py-1 text-xs text-amber-100 hover:bg-amber-400/20"
+                  disabled={!visualMetrics.strongestRegion}
+                  title="Highlight the strongest visual-change region"
+                >
+                  Strongest region
+                </button>
+              </div>
+              <div className="grid grid-cols-3 gap-2 text-sm">
+                <div className="rounded border border-gray-700 bg-gray-950/50 p-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-500">Changed</div>
+                  <div className="mt-1 font-semibold text-gray-100">{visualMetrics.changedPercent.toFixed(1)}%</div>
+                </div>
+                <div className="rounded border border-gray-700 bg-gray-950/50 p-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-500">Avg Delta</div>
+                  <div className="mt-1 font-semibold text-gray-100">{visualMetrics.averageDelta.toFixed(1)}</div>
+                </div>
+                <div className="rounded border border-gray-700 bg-gray-950/50 p-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-500">Canvas</div>
+                  <div className="mt-1 font-semibold text-gray-100">{visualMetrics.width}x{visualMetrics.height}</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
+              <h3 className="mb-2 text-sm font-semibold uppercase tracking-wider text-cyan-100">Metadata Delta</h3>
+              {metadataDifferences.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {metadataDifferences.slice(0, 12).map((field) => (
+                    <span key={field} className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2 py-1 text-xs text-cyan-100">
+                      {getFieldLabel(field)}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-400">No normalized metadata differences detected.</p>
+              )}
+            </div>
+          </div>
+        )}
+
         <div className="flex flex-wrap justify-between items-center gap-3 mb-4 max-w-7xl mx-auto">
           <div>
             <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">Metadata</h3>

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -25,6 +25,23 @@ interface ComparisonOverlayViewProps {
 
 const ADVANCED_MODES = new Set<ComparisonViewMode>(['difference-map', 'flicker', 'loupe', 'edge-difference']);
 
+const getContainedRect = (
+  containerWidth: number,
+  containerHeight: number,
+  sourceWidth: number,
+  sourceHeight: number,
+) => {
+  const scale = Math.min(containerWidth / sourceWidth, containerHeight / sourceHeight);
+  const width = sourceWidth * scale;
+  const height = sourceHeight * scale;
+  return {
+    x: (containerWidth - width) / 2,
+    y: (containerHeight - height) / 2,
+    width,
+    height,
+  };
+};
+
 const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   leftImage,
   rightImage,
@@ -48,7 +65,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   const [heatmapUrl, setHeatmapUrl] = useState<string | null>(null);
   const [edgeMapUrl, setEdgeMapUrl] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<VisualComparisonMetrics | null>(null);
-  const [loupePoint, setLoupePoint] = useState<{ x: number; y: number } | null>(null);
+  const [loupePoint, setLoupePoint] = useState<{ x: number; y: number; localX: number; localY: number } | null>(null);
+  const [localTransform, setLocalTransform] = useState(sharedZoom);
   const transformRef = useRef<ReactZoomPanPinchRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDraggingHandle, setIsDraggingHandle] = useState(false);
@@ -60,6 +78,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     if (state.scale !== sharedZoom.zoom || state.positionX !== sharedZoom.x || state.positionY !== sharedZoom.y) {
       transformRef.current.setTransform(sharedZoom.x, sharedZoom.y, sharedZoom.zoom, 0);
     }
+    setLocalTransform(sharedZoom);
   }, [sharedZoom]);
 
   useEffect(() => {
@@ -110,6 +129,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   const handleTransform = (ref: ReactZoomPanPinchRef) => {
     if (!ref || !ref.state) return;
     const { positionX, positionY, scale } = ref.state;
+    setLocalTransform({ zoom: scale, x: positionX, y: positionY });
     onZoomChange(scale, positionX, positionY);
   };
 
@@ -174,9 +194,30 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   const updateLoupeFromMouse = (clientX: number, clientY: number) => {
     const rect = containerRef.current?.getBoundingClientRect();
     if (!rect) return;
+
+    const localX = clientX - rect.left;
+    const localY = clientY - rect.top;
+    const contentX = (localX - localTransform.x) / localTransform.zoom;
+    const contentY = (localY - localTransform.y) / localTransform.zoom;
+    const imageRect = metrics
+      ? getContainedRect(rect.width, rect.height, metrics.width, metrics.height)
+      : { x: 0, y: 0, width: rect.width, height: rect.height };
+    const isInsideImage =
+      contentX >= imageRect.x &&
+      contentX <= imageRect.x + imageRect.width &&
+      contentY >= imageRect.y &&
+      contentY <= imageRect.y + imageRect.height;
+
+    if (!isInsideImage) {
+      setLoupePoint(null);
+      return;
+    }
+
     setLoupePoint({
-      x: clamp(((clientX - rect.left) / rect.width) * 100, 0, 100),
-      y: clamp(((clientY - rect.top) / rect.height) * 100, 0, 100),
+      x: clamp(((contentX - imageRect.x) / imageRect.width) * 100, 0, 100),
+      y: clamp(((contentY - imageRect.y) / imageRect.height) * 100, 0, 100),
+      localX,
+      localY,
     });
   };
 
@@ -260,40 +301,6 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
       return (
         <>
           {leftUrl && <img src={leftUrl} alt={leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
-          {loupePoint && (
-            <div
-              className="pointer-events-none absolute overflow-hidden rounded-full border-2 border-white/80 bg-black shadow-2xl"
-              style={{
-                left: `${loupePoint.x}%`,
-                top: `${loupePoint.y}%`,
-                width: advancedSettings.loupeSize,
-                height: advancedSettings.loupeSize,
-                transform: 'translate(-50%, -50%)',
-              }}
-            >
-              {[leftUrl, heatmapUrl, rightUrl].map((url, index) => (
-                url ? (
-                  <img
-                    key={`${url}-${index}`}
-                    src={url}
-                    alt=""
-                    className="absolute h-full w-full object-contain"
-                    style={{
-                      left: `${(index - 1) * 33.33}%`,
-                      width: '166%',
-                      height: '166%',
-                      top: `${50 - loupePoint.y * (advancedSettings.loupeZoom / 1.8)}%`,
-                      transform: `translate(${50 - loupePoint.x * (advancedSettings.loupeZoom / 1.8)}%, -50%) scale(${advancedSettings.loupeZoom})`,
-                      opacity: index === 1 ? advancedSettings.opacity / 100 : 1,
-                      clipPath: index === 0 ? 'inset(0 66.66% 0 0)' : index === 1 ? 'inset(0 33.33% 0 33.33%)' : 'inset(0 0 0 66.66%)',
-                    }}
-                  />
-                ) : null
-              ))}
-              <div className="absolute inset-y-0 left-1/3 w-px bg-white/70" />
-              <div className="absolute inset-y-0 left-2/3 w-px bg-white/70" />
-            </div>
-          )}
           <div className="absolute left-1/2 top-4 -translate-x-1/2 rounded-full border border-white/10 bg-black/65 px-3 py-1 text-xs text-gray-100 shadow">
             Move over the image to inspect A / Diff / B
           </div>
@@ -302,6 +309,89 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     }
 
     return null;
+  };
+
+  const renderLoupeOverlay = () => {
+    if (mode !== 'loupe' || !loupePoint || !advancedReady) return null;
+
+    const loupeLayers = [
+      { url: leftUrl, label: 'A' },
+      { url: heatmapUrl, label: 'Diff', opacity: advancedSettings.opacity / 100 },
+      { url: rightUrl, label: 'B' },
+    ];
+    const container = containerRef.current?.getBoundingClientRect();
+    if (!container) return null;
+    const loupeSize = advancedSettings.loupeSize;
+    const paneWidth = loupeSize / 3;
+    const renderViewportClone = (url: string, opacity = 1) => (
+      <div
+        className="absolute top-0 overflow-hidden"
+        style={{
+          left: 0,
+          width: paneWidth,
+          height: loupeSize,
+        }}
+      >
+        <div
+          className="absolute overflow-hidden"
+          style={{
+            left: paneWidth / 2 - loupePoint.localX,
+            top: loupeSize / 2 - loupePoint.localY,
+            width: container.width,
+            height: container.height,
+            transform: `scale(${advancedSettings.loupeZoom})`,
+            transformOrigin: `${loupePoint.localX}px ${loupePoint.localY}px`,
+            opacity,
+          }}
+        >
+          <div
+            className="relative h-full w-full"
+            style={{
+              transform: `translate(${localTransform.x}px, ${localTransform.y}px) scale(${localTransform.zoom})`,
+              transformOrigin: '0 0',
+            }}
+          >
+            <img src={url} alt="" className="absolute inset-0 h-full w-full object-contain" />
+          </div>
+        </div>
+      </div>
+    );
+
+    return (
+      <div
+        className="pointer-events-none absolute z-20 overflow-hidden rounded-full border-2 border-white/80 bg-black shadow-2xl"
+        style={{
+          left: loupePoint.localX,
+          top: loupePoint.localY,
+          width: advancedSettings.loupeSize,
+          height: advancedSettings.loupeSize,
+          transform: 'translate(-50%, -50%)',
+        }}
+      >
+        {loupeLayers.map((layer, index) => (
+          layer.url ? (
+            <div
+              key={layer.label}
+              className="absolute top-0 overflow-hidden"
+              style={{
+                left: index * paneWidth,
+                width: paneWidth,
+                height: loupeSize,
+              }}
+            >
+              {renderViewportClone(layer.url, layer.opacity ?? 1)}
+            </div>
+          ) : null
+        ))}
+        <div className="absolute inset-y-0 left-1/3 w-px bg-white/70" />
+        <div className="absolute inset-y-0 left-2/3 w-px bg-white/70" />
+        <div className="absolute inset-x-0 top-2 grid grid-cols-3 px-4 text-center text-[10px] font-semibold uppercase tracking-wide text-white/85">
+          <span>A</span>
+          <span>Diff</span>
+          <span>B</span>
+        </div>
+      </div>
+    );
   };
 
   if (errorMessage) {
@@ -439,6 +529,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                 )}
               </div>
             </TransformComponent>
+
+            {renderLoupeOverlay()}
 
             <div className="absolute top-4 right-4 flex flex-col gap-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity z-10">
               <button

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -223,11 +223,14 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
 
   const regionStyle = useMemo<CSSProperties | null>(() => {
     if (!highlightedRegion || !metrics) return null;
+    const container = containerRef.current?.getBoundingClientRect();
+    if (!container) return null;
+    const imageRect = getContainedRect(container.width, container.height, metrics.width, metrics.height);
     return {
-      left: `${(highlightedRegion.x / metrics.width) * 100}%`,
-      top: `${(highlightedRegion.y / metrics.height) * 100}%`,
-      width: `${(highlightedRegion.width / metrics.width) * 100}%`,
-      height: `${(highlightedRegion.height / metrics.height) * 100}%`,
+      left: imageRect.x + (highlightedRegion.x / metrics.width) * imageRect.width,
+      top: imageRect.y + (highlightedRegion.y / metrics.height) * imageRect.height,
+      width: (highlightedRegion.width / metrics.width) * imageRect.width,
+      height: (highlightedRegion.height / metrics.height) * imageRect.height,
     };
   }, [highlightedRegion, metrics]);
 

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -187,7 +187,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
 
   const ready = Boolean(leftUrl && rightUrl);
   const isLoading = isLeftLoading || isRightLoading;
-  const advancedReady = !isAdvancedMode || Boolean(metrics);
+  const requiresVisualAnalysis = mode === 'difference-map' || mode === 'loupe' || mode === 'edge-difference';
+  const advancedReady = !requiresVisualAnalysis || Boolean(metrics);
   const overlayStyle =
     mode === 'slider'
       ? { clipPath: `inset(0 ${100 - sliderValue}% 0 0)`, transition: isDraggingHandle ? 'none' : 'clip-path 180ms ease' }

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -23,7 +23,7 @@ interface ComparisonOverlayViewProps {
   highlightedRegion?: VisualComparisonMetrics['strongestRegion'] | null;
 }
 
-const ADVANCED_MODES = new Set<ComparisonViewMode>(['difference-map', 'flicker', 'loupe', 'edge-difference']);
+const ADVANCED_MODES = new Set<ComparisonViewMode>(['difference-map', 'loupe', 'edge-difference']);
 
 const getContainedRect = (
   containerWidth: number,

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -1,8 +1,13 @@
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { CSSProperties, FC, useEffect, useMemo, useRef, useState } from 'react';
 import { TransformComponent, TransformWrapper, ReactZoomPanPinchRef } from 'react-zoom-pan-pinch';
-import { ZoomIn, ZoomOut, RotateCcw, AlertCircle } from 'lucide-react';
-import { ComparisonViewMode, IndexedImage, ZoomState } from '../types';
+import { ZoomIn, ZoomOut, RotateCcw, AlertCircle, Pause, Play } from 'lucide-react';
+import { ComparisonAdvancedSettings, ComparisonViewMode, IndexedImage, ZoomState } from '../types';
 import useComparisonImageSource from '../hooks/useComparisonImageSource';
+import {
+  buildVisualComparisonFromUrls,
+  imageDataToDataUrl,
+  VisualComparisonMetrics,
+} from '../utils/visualComparison';
 
 interface ComparisonOverlayViewProps {
   leftImage: IndexedImage;
@@ -13,7 +18,12 @@ interface ComparisonOverlayViewProps {
   sharedZoom: ZoomState;
   onZoomChange: (zoom: number, x: number, y: number) => void;
   onActiveImageChange?: (index: number | null) => void;
+  advancedSettings: ComparisonAdvancedSettings;
+  onVisualAnalysisChange?: (metrics: VisualComparisonMetrics | null) => void;
+  highlightedRegion?: VisualComparisonMetrics['strongestRegion'] | null;
 }
+
+const ADVANCED_MODES = new Set<ComparisonViewMode>(['difference-map', 'flicker', 'loupe', 'edge-difference']);
 
 const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   leftImage,
@@ -24,14 +34,25 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   sharedZoom,
   onZoomChange,
   onActiveImageChange,
+  advancedSettings,
+  onVisualAnalysisChange,
+  highlightedRegion,
 }) => {
   const { imageUrl: leftUrl, loadError: leftError, isLoading: isLeftLoading } = useComparisonImageSource(leftImage, leftDirectory);
   const { imageUrl: rightUrl, loadError: rightError, isLoading: isRightLoading } = useComparisonImageSource(rightImage, rightDirectory);
   const [sliderValue, setSliderValue] = useState(50);
   const [isHovering, setIsHovering] = useState(false);
+  const [isFlickerShowingRight, setIsFlickerShowingRight] = useState(false);
+  const [isFlickerPaused, setIsFlickerPaused] = useState(false);
+  const [visualError, setVisualError] = useState<string | null>(null);
+  const [heatmapUrl, setHeatmapUrl] = useState<string | null>(null);
+  const [edgeMapUrl, setEdgeMapUrl] = useState<string | null>(null);
+  const [metrics, setMetrics] = useState<VisualComparisonMetrics | null>(null);
+  const [loupePoint, setLoupePoint] = useState<{ x: number; y: number } | null>(null);
   const transformRef = useRef<ReactZoomPanPinchRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDraggingHandle, setIsDraggingHandle] = useState(false);
+  const isAdvancedMode = ADVANCED_MODES.has(mode);
 
   useEffect(() => {
     if (!transformRef.current || !transformRef.current.state) return;
@@ -40,6 +61,51 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
       transformRef.current.setTransform(sharedZoom.x, sharedZoom.y, sharedZoom.zoom, 0);
     }
   }, [sharedZoom]);
+
+  useEffect(() => {
+    if (!isAdvancedMode || !leftUrl || !rightUrl) {
+      setHeatmapUrl(null);
+      setEdgeMapUrl(null);
+      setMetrics(null);
+      setVisualError(null);
+      onVisualAnalysisChange?.(null);
+      return;
+    }
+
+    let isMounted = true;
+    setVisualError(null);
+    buildVisualComparisonFromUrls(leftUrl, rightUrl, advancedSettings.threshold)
+      .then((result) => {
+        if (!isMounted) return;
+        const nextHeatmapUrl = imageDataToDataUrl(result.heatmap);
+        const nextEdgeMapUrl = imageDataToDataUrl(result.edgeMap);
+        setHeatmapUrl(nextHeatmapUrl);
+        setEdgeMapUrl(nextEdgeMapUrl);
+        setMetrics(result.metrics);
+        onVisualAnalysisChange?.(result.metrics);
+      })
+      .catch((error) => {
+        if (!isMounted) return;
+        const message = error instanceof Error ? error.message : String(error);
+        setVisualError(message);
+        setHeatmapUrl(null);
+        setEdgeMapUrl(null);
+        setMetrics(null);
+        onVisualAnalysisChange?.(null);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [advancedSettings.threshold, isAdvancedMode, leftUrl, onVisualAnalysisChange, rightUrl]);
+
+  useEffect(() => {
+    if (mode !== 'flicker' || isFlickerPaused) return;
+    const interval = window.setInterval(() => {
+      setIsFlickerShowingRight((current) => !current);
+    }, advancedSettings.flickerSpeedMs);
+    return () => window.clearInterval(interval);
+  }, [advancedSettings.flickerSpeedMs, isFlickerPaused, mode]);
 
   const handleTransform = (ref: ReactZoomPanPinchRef) => {
     if (!ref || !ref.state) return;
@@ -91,6 +157,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
 
   const ready = Boolean(leftUrl && rightUrl);
   const isLoading = isLeftLoading || isRightLoading;
+  const advancedReady = !isAdvancedMode || Boolean(metrics);
   const overlayStyle =
     mode === 'slider'
       ? { clipPath: `inset(0 ${100 - sliderValue}% 0 0)`, transition: isDraggingHandle ? 'none' : 'clip-path 180ms ease' }
@@ -101,6 +168,141 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
       : { opacity: 1 };
 
   const errorMessage = leftError || rightError;
+  const advancedBaseUrl = advancedSettings.baseMode === 'right' ? rightUrl : leftUrl;
+  const diffOnly = advancedSettings.baseMode === 'diff';
+
+  const updateLoupeFromMouse = (clientX: number, clientY: number) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setLoupePoint({
+      x: clamp(((clientX - rect.left) / rect.width) * 100, 0, 100),
+      y: clamp(((clientY - rect.top) / rect.height) * 100, 0, 100),
+    });
+  };
+
+  const regionStyle = useMemo<CSSProperties | null>(() => {
+    if (!highlightedRegion || !metrics) return null;
+    return {
+      left: `${(highlightedRegion.x / metrics.width) * 100}%`,
+      top: `${(highlightedRegion.y / metrics.height) * 100}%`,
+      width: `${(highlightedRegion.width / metrics.width) * 100}%`,
+      height: `${(highlightedRegion.height / metrics.height) * 100}%`,
+    };
+  }, [highlightedRegion, metrics]);
+
+  const renderAdvancedLayer = () => {
+    if (!ready) return null;
+    if (visualError) {
+      return (
+        <div className="absolute left-1/2 top-4 max-w-md -translate-x-1/2 rounded-lg border border-amber-500/30 bg-amber-950/80 px-3 py-2 text-sm text-amber-100 shadow-lg">
+          Visual analysis unavailable: {visualError}
+        </div>
+      );
+    }
+
+    if (!advancedReady) {
+      return (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="rounded-lg border border-white/10 bg-black/70 px-4 py-2 text-sm text-gray-200 shadow">
+            Building visual comparison...
+          </div>
+        </div>
+      );
+    }
+
+    if (mode === 'flicker') {
+      const currentUrl = isFlickerShowingRight ? rightUrl : leftUrl;
+      return (
+        <>
+          {currentUrl && <img src={currentUrl} alt={isFlickerShowingRight ? rightImage.name : leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
+          <div className="absolute left-1/2 top-4 flex -translate-x-1/2 items-center gap-2 rounded-full border border-white/10 bg-black/70 px-3 py-1.5 text-xs text-gray-100 shadow">
+            <button
+              type="button"
+              onClick={() => setIsFlickerPaused((current) => !current)}
+              className="rounded p-1 text-gray-200 hover:bg-white/10 hover:text-white"
+              title={isFlickerPaused ? 'Resume flicker' : 'Pause flicker'}
+            >
+              {isFlickerPaused ? <Play className="h-3.5 w-3.5" /> : <Pause className="h-3.5 w-3.5" />}
+            </button>
+            {advancedSettings.showLabels ? <span>{isFlickerShowingRight ? `Image B: ${rightImage.name}` : `Image A: ${leftImage.name}`}</span> : <span>{isFlickerShowingRight ? 'Image B' : 'Image A'}</span>}
+          </div>
+        </>
+      );
+    }
+
+    if (mode === 'difference-map') {
+      return (
+        <>
+          {!diffOnly && advancedBaseUrl && <img src={advancedBaseUrl} alt="Difference base" className="absolute inset-0 h-full w-full select-none object-contain" />}
+          {diffOnly && <div className="absolute inset-0 bg-black" />}
+          {heatmapUrl && <img src={heatmapUrl} alt="Difference heatmap" className="absolute inset-0 h-full w-full select-none object-contain" style={{ opacity: advancedSettings.opacity / 100 }} />}
+          {regionStyle && <div className="absolute border-2 border-white/80 bg-white/10 shadow-[0_0_18px_rgba(255,255,255,0.35)]" style={regionStyle} />}
+        </>
+      );
+    }
+
+    if (mode === 'edge-difference') {
+      return (
+        <>
+          {!diffOnly && advancedBaseUrl && <img src={advancedBaseUrl} alt="Edge base" className="absolute inset-0 h-full w-full select-none object-contain opacity-45" />}
+          {diffOnly && <div className="absolute inset-0 bg-black" />}
+          {edgeMapUrl && <img src={edgeMapUrl} alt="Edge difference map" className="absolute inset-0 h-full w-full select-none object-contain" style={{ opacity: advancedSettings.opacity / 100 }} />}
+          <div className="absolute left-4 top-4 rounded-lg border border-white/10 bg-black/65 px-3 py-1.5 text-xs text-gray-100">
+            <span className="text-cyan-200">Cyan: Image A</span>
+            <span className="mx-2 text-gray-500">/</span>
+            <span className="text-fuchsia-200">Magenta: Image B</span>
+          </div>
+        </>
+      );
+    }
+
+    if (mode === 'loupe') {
+      return (
+        <>
+          {leftUrl && <img src={leftUrl} alt={leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
+          {loupePoint && (
+            <div
+              className="pointer-events-none absolute overflow-hidden rounded-full border-2 border-white/80 bg-black shadow-2xl"
+              style={{
+                left: `${loupePoint.x}%`,
+                top: `${loupePoint.y}%`,
+                width: advancedSettings.loupeSize,
+                height: advancedSettings.loupeSize,
+                transform: 'translate(-50%, -50%)',
+              }}
+            >
+              {[leftUrl, heatmapUrl, rightUrl].map((url, index) => (
+                url ? (
+                  <img
+                    key={`${url}-${index}`}
+                    src={url}
+                    alt=""
+                    className="absolute h-full w-full object-contain"
+                    style={{
+                      left: `${(index - 1) * 33.33}%`,
+                      width: '166%',
+                      height: '166%',
+                      top: `${50 - loupePoint.y * (advancedSettings.loupeZoom / 1.8)}%`,
+                      transform: `translate(${50 - loupePoint.x * (advancedSettings.loupeZoom / 1.8)}%, -50%) scale(${advancedSettings.loupeZoom})`,
+                      opacity: index === 1 ? advancedSettings.opacity / 100 : 1,
+                      clipPath: index === 0 ? 'inset(0 66.66% 0 0)' : index === 1 ? 'inset(0 33.33% 0 33.33%)' : 'inset(0 0 0 66.66%)',
+                    }}
+                  />
+                ) : null
+              ))}
+              <div className="absolute inset-y-0 left-1/3 w-px bg-white/70" />
+              <div className="absolute inset-y-0 left-2/3 w-px bg-white/70" />
+            </div>
+          )}
+          <div className="absolute left-1/2 top-4 -translate-x-1/2 rounded-full border border-white/10 bg-black/65 px-3 py-1 text-xs text-gray-100 shadow">
+            Move over the image to inspect A / Diff / B
+          </div>
+        </>
+      );
+    }
+
+    return null;
+  };
 
   if (errorMessage) {
     return (
@@ -154,6 +356,16 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                       : undefined
                 }
                 onMouseMove={mode === 'slider' ? (event) => updateActiveImageFromClientX(event.clientX) : undefined}
+                onPointerMove={
+                  mode === 'loupe'
+                    ? (event) => updateLoupeFromMouse(event.clientX, event.clientY)
+                    : undefined
+                }
+                onPointerLeave={
+                  mode === 'loupe'
+                    ? () => setLoupePoint(null)
+                    : undefined
+                }
               >
                 {isLoading && !ready && (
                   <div className="absolute inset-0 flex items-center justify-center">
@@ -161,7 +373,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                   </div>
                 )}
 
-                {rightUrl && (
+                {!isAdvancedMode && rightUrl && (
                   <img
                     src={rightUrl}
                     alt={rightImage.name}
@@ -170,7 +382,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                   />
                 )}
 
-                {leftUrl && (
+                {!isAdvancedMode && leftUrl && (
                   <img
                     src={leftUrl}
                     alt={leftImage.name}
@@ -178,6 +390,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                     style={overlayStyle}
                   />
                 )}
+
+                {isAdvancedMode && renderAdvancedLayer()}
 
                 {ready && mode === 'slider' && (
                   <>

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -62,6 +62,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   const [isFlickerShowingRight, setIsFlickerShowingRight] = useState(false);
   const [isFlickerPaused, setIsFlickerPaused] = useState(false);
   const [visualError, setVisualError] = useState<string | null>(null);
+  const [leftAnalysisUrl, setLeftAnalysisUrl] = useState<string | null>(null);
+  const [rightAnalysisUrl, setRightAnalysisUrl] = useState<string | null>(null);
   const [heatmapUrl, setHeatmapUrl] = useState<string | null>(null);
   const [edgeMapUrl, setEdgeMapUrl] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<VisualComparisonMetrics | null>(null);
@@ -83,6 +85,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
 
   useEffect(() => {
     if (!isAdvancedMode || !leftUrl || !rightUrl) {
+      setLeftAnalysisUrl(null);
+      setRightAnalysisUrl(null);
       setHeatmapUrl(null);
       setEdgeMapUrl(null);
       setMetrics(null);
@@ -96,8 +100,12 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     buildVisualComparisonFromUrls(leftUrl, rightUrl, advancedSettings.threshold)
       .then((result) => {
         if (!isMounted) return;
+        const nextLeftAnalysisUrl = imageDataToDataUrl(result.left);
+        const nextRightAnalysisUrl = imageDataToDataUrl(result.right);
         const nextHeatmapUrl = imageDataToDataUrl(result.heatmap);
         const nextEdgeMapUrl = imageDataToDataUrl(result.edgeMap);
+        setLeftAnalysisUrl(nextLeftAnalysisUrl);
+        setRightAnalysisUrl(nextRightAnalysisUrl);
         setHeatmapUrl(nextHeatmapUrl);
         setEdgeMapUrl(nextEdgeMapUrl);
         setMetrics(result.metrics);
@@ -107,6 +115,8 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
         if (!isMounted) return;
         const message = error instanceof Error ? error.message : String(error);
         setVisualError(message);
+        setLeftAnalysisUrl(null);
+        setRightAnalysisUrl(null);
         setHeatmapUrl(null);
         setEdgeMapUrl(null);
         setMetrics(null);
@@ -188,7 +198,9 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
       : { opacity: 1 };
 
   const errorMessage = leftError || rightError;
-  const advancedBaseUrl = advancedSettings.baseMode === 'right' ? rightUrl : leftUrl;
+  const normalizedLeftUrl = leftAnalysisUrl || leftUrl;
+  const normalizedRightUrl = rightAnalysisUrl || rightUrl;
+  const advancedBaseUrl = advancedSettings.baseMode === 'right' ? normalizedRightUrl : normalizedLeftUrl;
   const diffOnly = advancedSettings.baseMode === 'diff';
 
   const updateLoupeFromMouse = (clientX: number, clientY: number) => {
@@ -303,7 +315,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     if (mode === 'loupe') {
       return (
         <>
-          {leftUrl && <img src={leftUrl} alt={leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
+          {normalizedLeftUrl && <img src={normalizedLeftUrl} alt={leftImage.name} className="absolute inset-0 h-full w-full select-none object-contain" />}
           <div className="absolute left-1/2 top-4 -translate-x-1/2 rounded-full border border-white/10 bg-black/65 px-3 py-1 text-xs text-gray-100 shadow">
             Move over the image to inspect A / Diff / B
           </div>
@@ -318,9 +330,9 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
     if (mode !== 'loupe' || !loupePoint || !advancedReady) return null;
 
     const loupeLayers = [
-      { url: leftUrl, label: 'A' },
+      { url: normalizedLeftUrl, label: 'A' },
       { url: heatmapUrl, label: 'Diff', opacity: advancedSettings.opacity / 100 },
-      { url: rightUrl, label: 'B' },
+      { url: normalizedRightUrl, label: 'B' },
     ];
     const container = containerRef.current?.getBoundingClientRect();
     if (!container) return null;

--- a/components/ComparisonPane.tsx
+++ b/components/ComparisonPane.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, FC } from 'react';
 import { TransformWrapper, TransformComponent, ReactZoomPanPinchRef } from 'react-zoom-pan-pinch';
-import { ZoomIn, ZoomOut, RotateCcw, AlertCircle, Sparkles } from 'lucide-react';
+import { ZoomIn, ZoomOut, RotateCcw, AlertCircle, Sparkles, X } from 'lucide-react';
 import { ComparisonPaneProps, BaseMetadata } from '../types';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } from './A1111GenerateModal';
@@ -13,6 +13,7 @@ const ComparisonPane: FC<ComparisonPaneProps> = ({
   externalZoom,
   onZoomChange,
   onHoverChange,
+  onRemove,
   className,
   imageLabel,
 }) => {
@@ -126,6 +127,21 @@ const ComparisonPane: FC<ComparisonPaneProps> = ({
               </button>
             </div>
 
+            {onRemove && (
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRemove();
+                }}
+                className="absolute left-4 top-4 z-10 rounded-lg border border-white/10 bg-black/65 p-2 text-white shadow-lg backdrop-blur-sm transition-colors hover:bg-red-600/90"
+                title={`Remove ${image.name} from comparison`}
+                aria-label={`Remove ${image.name} from comparison`}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+
             {/* Image Name Label */}
             <div className="absolute bottom-4 left-4 right-4 bg-black/60 backdrop-blur-sm rounded-lg p-2">
               <p className="text-white text-sm font-medium truncate" title={image.name}>
@@ -172,6 +188,7 @@ export default React.memo(ComparisonPane, (prev, next) => {
     prev.syncEnabled === next.syncEnabled &&
     prev.className === next.className &&
     prev.imageLabel === next.imageLabel &&
+    prev.onRemove === next.onRemove &&
     prev.externalZoom?.zoom === next.externalZoom?.zoom &&
     prev.externalZoom?.x === next.externalZoom?.x &&
     prev.externalZoom?.y === next.externalZoom?.y

--- a/components/FolderSelector.tsx
+++ b/components/FolderSelector.tsx
@@ -18,7 +18,7 @@ const FolderSelector: React.FC<FolderSelectorProps> = ({ onSelectFolder }) => {
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center p-8 border-2 border-dashed border-gray-700 rounded-xl bg-gray-800/50">
       <img src="logo1.png" alt="Image MetaHub Logo" className="h-64 w-64 mb-4 rounded-lg shadow-lg" />
   <h2 className="text-2xl font-semibold mb-2 text-gray-100">Welcome to Image MetaHub v0.15</h2>
-  <p className="text-xs text-gray-500 mb-4">v0.16.1</p>
+  <p className="text-xs text-gray-500 mb-4">v0.17.0-rc</p>
       <p className="text-gray-400 max-w-md mb-6">
         Select a folder to get started. The app will automatically scan <strong className="text-gray-200">all subfolders</strong> and display images from the entire directory tree.
       </p>

--- a/components/FolderSelector.tsx
+++ b/components/FolderSelector.tsx
@@ -18,7 +18,7 @@ const FolderSelector: React.FC<FolderSelectorProps> = ({ onSelectFolder }) => {
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center p-8 border-2 border-dashed border-gray-700 rounded-xl bg-gray-800/50">
       <img src="logo1.png" alt="Image MetaHub Logo" className="h-64 w-64 mb-4 rounded-lg shadow-lg" />
   <h2 className="text-2xl font-semibold mb-2 text-gray-100">Welcome to Image MetaHub v0.15</h2>
-  <p className="text-xs text-gray-500 mb-4">v0.17.0-rc</p>
+  <p className="text-xs text-gray-500 mb-4">v0.17.0</p>
       <p className="text-gray-400 max-w-md mb-6">
         Select a folder to get started. The app will automatically scan <strong className="text-gray-200">all subfolders</strong> and display images from the entire directory tree.
       </p>

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -22,6 +22,7 @@ import {
 import { useImageStore } from '../store/useImageStore';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
+import { getFileExtension, isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 import { SmartCollection, type IndexedImage } from '../types';
 
 import ActiveFilters from './ActiveFilters';
@@ -32,6 +33,13 @@ import Tooltip from './Tooltip';
 import type { ImageGroup, ImageGroupByMode } from '../utils/imageGrouping';
 
 const OPEN_BATCH_EXPORT_EVENT = 'imagemetahub:open-batch-export';
+
+const canOpenImageEditorForImage = (image?: IndexedImage): boolean => (
+  Boolean(image)
+  && !isVideoFileName(image!.name, image!.fileType)
+  && !isAudioFileName(image!.name, image!.fileType)
+  && getFileExtension(image!.name) !== '.gif'
+);
 
 interface GridToolbarProps {
 
@@ -242,6 +250,14 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       .filter((image): image is IndexedImage => Boolean(image));
   }, [images, selectedImages]);
   const firstSelectedImage = selectedImagesList[0];
+  const canOpenSelectedImageEditor = Boolean(
+    selectedCount === 1 &&
+    onOpenImageEditor &&
+    canOpenImageEditorForImage(firstSelectedImage),
+  );
+  const editImageTooltip = selectedCount === 1
+    ? (canOpenSelectedImageEditor ? 'Edit image' : 'Image editor is available for static images')
+    : 'Select one image to edit';
   // Check if all selected images are favorites
   const allFavorites = selectedImagesList.length > 0 && selectedImagesList.every(img => img.isFavorite);
 
@@ -360,7 +376,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   };
 
   const handleOpenImageEditor = () => {
-    if (firstSelectedImage && onOpenImageEditor) {
+    if (firstSelectedImage && canOpenSelectedImageEditor && onOpenImageEditor) {
       onOpenImageEditor(firstSelectedImage);
     }
   };
@@ -664,17 +680,17 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                 <div className="w-px h-4 bg-gray-700 mx-1" />
 
                 {/* Compare */}
-                <Tooltip label={selectedCount === 1 ? 'Edit image' : 'Select one image to edit'}>
+                <Tooltip label={editImageTooltip}>
                   <button
                     onClick={handleOpenImageEditor}
                     className={`p-1.5 rounded transition-colors ${
-                      selectedCount === 1 && onOpenImageEditor
+                      canOpenSelectedImageEditor
                         ? 'text-gray-400 hover:text-cyan-300 hover:bg-gray-700'
                         : 'text-gray-600 cursor-not-allowed'
                     }`}
-                    title={selectedCount === 1 ? 'Edit image' : 'Select one image to edit'}
+                    title={editImageTooltip}
                     aria-label="Edit image"
-                    disabled={selectedCount !== 1 || !onOpenImageEditor}
+                    disabled={!canOpenSelectedImageEditor}
                   >
                     <ImageIcon className="w-4 h-4" />
                   </button>

--- a/components/GridToolbar.tsx
+++ b/components/GridToolbar.tsx
@@ -15,6 +15,7 @@ import {
   Plus,
   Play,
   Workflow,
+  Image as ImageIcon,
   X,
   Search
 } from 'lucide-react';
@@ -44,6 +45,7 @@ interface GridToolbarProps {
   onGenerateA1111: (image: IndexedImage) => void;
   onGenerateComfyUI: (image: IndexedImage) => void;
   onOpenComfyUIWorkspace?: (image: IndexedImage) => void;
+  onOpenImageEditor?: (image: IndexedImage) => void;
   onCompare: (images: IndexedImage[]) => void;
   onBatchExport: () => void;
   onStartSlideshow: () => void;
@@ -193,6 +195,7 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
   onGenerateA1111,
   onGenerateComfyUI,
   onOpenComfyUIWorkspace,
+  onOpenImageEditor,
   onCompare,
   onBatchExport,
   onStartSlideshow,
@@ -354,6 +357,12 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
       onOpenComfyUIWorkspace(firstSelectedImage);
     }
     setGenerateDropdownOpen(false);
+  };
+
+  const handleOpenImageEditor = () => {
+    if (firstSelectedImage && onOpenImageEditor) {
+      onOpenImageEditor(firstSelectedImage);
+    }
   };
 
   const handleTagClick = () => {
@@ -655,6 +664,22 @@ const GridToolbar: React.FC<GridToolbarProps> = ({
                 <div className="w-px h-4 bg-gray-700 mx-1" />
 
                 {/* Compare */}
+                <Tooltip label={selectedCount === 1 ? 'Edit image' : 'Select one image to edit'}>
+                  <button
+                    onClick={handleOpenImageEditor}
+                    className={`p-1.5 rounded transition-colors ${
+                      selectedCount === 1 && onOpenImageEditor
+                        ? 'text-gray-400 hover:text-cyan-300 hover:bg-gray-700'
+                        : 'text-gray-600 cursor-not-allowed'
+                    }`}
+                    title={selectedCount === 1 ? 'Edit image' : 'Select one image to edit'}
+                    aria-label="Edit image"
+                    disabled={selectedCount !== 1 || !onOpenImageEditor}
+                  >
+                    <ImageIcon className="w-4 h-4" />
+                  </button>
+                </Tooltip>
+
                 <Tooltip label={selectedCount >= 2 && selectedCount <= 4 ? `Compare ${selectedCount} Images` : 'Select between 2 and 4 images to compare'}>
                   <button
                     onClick={handleCompare}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,7 +7,7 @@ import { A1111ApiClient } from '../services/a1111ApiClient';
 import { ComfyUIApiClient } from '../services/comfyUIApiClient';
 import { detectGeneratorFromLaunchCommand } from '../utils/detectGeneratorLaunch';
 
-type LibraryView = 'library' | 'smart' | 'model' | 'node' | 'collections' | 'comfyui';
+type LibraryView = 'library' | 'smart' | 'model' | 'node' | 'collections' | 'comfyui' | 'editor';
 
 interface HeaderProps {
     onOpenSettings: () => void;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,7 +16,6 @@ interface HeaderProps {
     onGeneratorSetupNeeded?: () => void;
     libraryView?: LibraryView;
     onLibraryViewChange?: (view: LibraryView) => void;
-    editorAvailable?: boolean;
 }
 
 const Header: React.FC<HeaderProps> = ({ 
@@ -25,8 +24,7 @@ const Header: React.FC<HeaderProps> = ({
     onOpenLicense, 
     onGeneratorSetupNeeded,
     libraryView,
-    onLibraryViewChange,
-    editorAvailable = false
+    onLibraryViewChange
 }) => {
   const {
     canUseAnalytics,
@@ -329,10 +327,10 @@ const Header: React.FC<HeaderProps> = ({
       { id: 'model' as const, label: 'Model View' },
       { id: 'node' as const, label: 'Node View' },
       { id: 'collections' as const, label: 'Collections' },
-      ...(editorAvailable ? [{ id: 'editor' as const, label: 'Image Editor', icon: ImageIcon }] : []),
+      { id: 'editor' as const, label: 'Image Editor', icon: ImageIcon },
       { id: 'comfyui' as const, label: 'ComfyUI', icon: Workflow },
     ],
-    [clustersCount, editorAvailable]
+    [clustersCount]
   );
   const utilityButtonClassName = 'app-top-icon-button';
   const handleViewTabClick = useCallback((view: LibraryView) => {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Settings, Bug, BarChart3, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft, Workflow } from 'lucide-react';
+import { Settings, Bug, BarChart3, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft, Workflow, Image as ImageIcon } from 'lucide-react';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
@@ -16,6 +16,7 @@ interface HeaderProps {
     onGeneratorSetupNeeded?: () => void;
     libraryView?: LibraryView;
     onLibraryViewChange?: (view: LibraryView) => void;
+    editorAvailable?: boolean;
 }
 
 const Header: React.FC<HeaderProps> = ({ 
@@ -24,7 +25,8 @@ const Header: React.FC<HeaderProps> = ({
     onOpenLicense, 
     onGeneratorSetupNeeded,
     libraryView,
-    onLibraryViewChange
+    onLibraryViewChange,
+    editorAvailable = false
 }) => {
   const {
     canUseAnalytics,
@@ -327,9 +329,10 @@ const Header: React.FC<HeaderProps> = ({
       { id: 'model' as const, label: 'Model View' },
       { id: 'node' as const, label: 'Node View' },
       { id: 'collections' as const, label: 'Collections' },
+      ...(editorAvailable ? [{ id: 'editor' as const, label: 'Image Editor', icon: ImageIcon }] : []),
       { id: 'comfyui' as const, label: 'ComfyUI', icon: Workflow },
     ],
-    [clustersCount]
+    [clustersCount, editorAvailable]
   );
   const utilityButtonClassName = 'app-top-icon-button';
   const handleViewTabClick = useCallback((view: LibraryView) => {

--- a/components/ImageAdjustmentPanel.tsx
+++ b/components/ImageAdjustmentPanel.tsx
@@ -190,6 +190,20 @@ const ImageAdjustmentPanel: React.FC<ImageAdjustmentPanelProps> = ({
     });
   };
 
+  const setResizeEnabled = (enabled: boolean) => {
+    const base = baseOutputDimensions || sourceDimensions || { width: 1, height: 1 };
+    const shouldSeedFromBase = enabled && !normalizedRecipe.resize.enabled;
+    emit({
+      ...normalizedRecipe,
+      resize: {
+        ...normalizedRecipe.resize,
+        enabled,
+        width: shouldSeedFromBase ? base.width : normalizedRecipe.resize.width,
+        height: shouldSeedFromBase ? base.height : normalizedRecipe.resize.height,
+      },
+    });
+  };
+
   const applyResizePreset = (scale: number) => {
     const base = baseOutputDimensions || sourceDimensions;
     if (!base) {
@@ -398,7 +412,7 @@ const ImageAdjustmentPanel: React.FC<ImageAdjustmentPanelProps> = ({
                   type="checkbox"
                   checked={normalizedRecipe.resize.enabled}
                   disabled={controlsDisabled || !sourceDimensions}
-                  onChange={(event) => emit({ ...normalizedRecipe, resize: { ...normalizedRecipe.resize, enabled: event.target.checked } })}
+                  onChange={(event) => setResizeEnabled(event.target.checked)}
                   className="h-4 w-4 accent-cyan-500"
                 />
                 Resize

--- a/components/ImageAdjustmentPanel.tsx
+++ b/components/ImageAdjustmentPanel.tsx
@@ -1,25 +1,56 @@
 import React from 'react';
-import { RotateCcw, Save, SaveAll } from 'lucide-react';
-import type { ImageAdjustments } from '../types';
 import {
-  DEFAULT_IMAGE_ADJUSTMENTS,
+  Crop,
+  FlipHorizontal,
+  FlipVertical,
+  Maximize2,
+  RotateCcw,
+  RotateCw,
+  Save,
+  SaveAll,
+  Sparkles,
+} from 'lucide-react';
+import type {
+  ImageAdjustments,
+  ImageEditCropAspect,
+  ImageEditRecipe,
+} from '../types';
+import {
+  CROP_ASPECTS,
+  DEFAULT_IMAGE_EDIT_RECIPE,
   clampImageAdjustment,
-  hasImageAdjustments,
+  clampImageEditCropRect,
+  clampImageEditEffect,
+  createDefaultCropRect,
+  getRecipeBaseOutputDimensions,
+  getImageEditOutputDimensions,
+  hasImageEditRecipeChanges,
+  normalizeImageEditRecipe,
+  normalizeImageEditRotation,
 } from '../services/imageEditingService';
 
+type EditorTab = 'adjust' | 'crop' | 'transform' | 'enhance';
+
 interface ImageAdjustmentPanelProps {
-  adjustments: ImageAdjustments;
-  onChange: (adjustments: ImageAdjustments) => void;
+  recipe: ImageEditRecipe;
+  onChange: (recipe: ImageEditRecipe) => void;
   onReset: () => void;
   onSaveAs: () => void;
   onOverwrite: () => void;
+  sourceDimensions?: { width: number; height: number };
+  activeTab?: EditorTab;
+  onActiveTabChange?: (tab: EditorTab) => void;
   canOverwrite?: boolean;
   overwriteUnavailableReason?: string;
   isSaving?: boolean;
   disabled?: boolean;
+  onAIUpscale?: () => void;
+  canAIUpscale?: boolean;
+  aiUpscaleDisabledReason?: string;
+  isAIUpscaling?: boolean;
 }
 
-const CONTROLS: Array<{
+const ADJUSTMENT_CONTROLS: Array<{
   key: keyof ImageAdjustments;
   label: string;
   min: number;
@@ -32,25 +63,146 @@ const CONTROLS: Array<{
   { key: 'hue', label: 'Hue', min: -180, max: 180, unit: 'deg' },
 ];
 
+const TABS: Array<{ key: EditorTab; label: string }> = [
+  { key: 'adjust', label: 'Adjust' },
+  { key: 'crop', label: 'Crop' },
+  { key: 'transform', label: 'Transform' },
+  { key: 'enhance', label: 'Enhance' },
+];
+
+const ASPECT_LABELS: Record<ImageEditCropAspect, string> = {
+  free: 'Free',
+  original: 'Original',
+  '1:1': '1:1',
+  '4:3': '4:3',
+  '3:2': '3:2',
+  '16:9': '16:9',
+  '9:16': '9:16',
+};
+
 const ImageAdjustmentPanel: React.FC<ImageAdjustmentPanelProps> = ({
-  adjustments,
+  recipe,
   onChange,
   onReset,
   onSaveAs,
   onOverwrite,
+  sourceDimensions,
+  activeTab = 'adjust',
+  onActiveTabChange,
   canOverwrite = true,
   overwriteUnavailableReason = 'Overwrite original file',
   isSaving = false,
   disabled = false,
+  onAIUpscale,
+  canAIUpscale = true,
+  aiUpscaleDisabledReason = 'Connect ComfyUI to use AI Upscale.',
+  isAIUpscaling = false,
 }) => {
-  const hasChanges = hasImageAdjustments(adjustments);
+  const normalizedRecipe = normalizeImageEditRecipe(recipe, sourceDimensions);
+  const hasChanges = hasImageEditRecipeChanges(normalizedRecipe);
   const controlsDisabled = disabled || isSaving;
   const overwriteDisabled = controlsDisabled || !hasChanges || !canOverwrite;
+  const cropRect = normalizedRecipe.crop.rect;
+  const outputDimensions = sourceDimensions
+    ? getImageEditOutputDimensions(normalizedRecipe, sourceDimensions)
+    : null;
+  const baseOutputDimensions = sourceDimensions
+    ? getRecipeBaseOutputDimensions(normalizedRecipe, sourceDimensions)
+    : null;
+
+  const emit = (nextRecipe: ImageEditRecipe) => {
+    onChange(normalizeImageEditRecipe(nextRecipe, sourceDimensions));
+  };
 
   const updateAdjustment = (key: keyof ImageAdjustments, rawValue: number) => {
-    onChange({
-      ...adjustments,
-      [key]: clampImageAdjustment(key, rawValue),
+    emit({
+      ...normalizedRecipe,
+      adjustments: {
+        ...normalizedRecipe.adjustments,
+        [key]: clampImageAdjustment(key, rawValue),
+      },
+    });
+  };
+
+  const setCropAspect = (aspect: ImageEditCropAspect) => {
+    const rect = normalizedRecipe.crop.enabled
+      ? createDefaultCropRect(sourceDimensions, aspect)
+      : normalizedRecipe.crop.rect;
+    emit({
+      ...normalizedRecipe,
+      crop: {
+        enabled: normalizedRecipe.crop.enabled,
+        aspect,
+        rect,
+      },
+    });
+  };
+
+  const setCropEnabled = (enabled: boolean) => {
+    emit({
+      ...normalizedRecipe,
+      crop: {
+        ...normalizedRecipe.crop,
+        enabled,
+        rect: enabled
+          ? normalizedRecipe.crop.rect || createDefaultCropRect(sourceDimensions, normalizedRecipe.crop.aspect)
+          : normalizedRecipe.crop.rect,
+      },
+    });
+  };
+
+  const updateCropValue = (key: 'x' | 'y' | 'width' | 'height', value: number) => {
+    emit({
+      ...normalizedRecipe,
+      crop: {
+        ...normalizedRecipe.crop,
+        enabled: true,
+        rect: clampImageEditCropRect({
+          ...(cropRect || createDefaultCropRect(sourceDimensions, normalizedRecipe.crop.aspect) || { x: 0, y: 0, width: 1, height: 1 }),
+          [key]: value,
+        }, sourceDimensions),
+      },
+    });
+  };
+
+  const updateResizeDimension = (key: 'width' | 'height', value: number) => {
+    const nextValue = Math.max(1, Math.round(value) || 1);
+    const base = baseOutputDimensions || sourceDimensions || { width: 1, height: 1 };
+    let width = key === 'width' ? nextValue : normalizedRecipe.resize.width || base.width;
+    let height = key === 'height' ? nextValue : normalizedRecipe.resize.height || base.height;
+    if (normalizedRecipe.resize.lockAspectRatio && base.width > 0 && base.height > 0) {
+      const ratio = base.width / base.height;
+      if (key === 'width') {
+        height = Math.max(1, Math.round(width / ratio));
+      } else {
+        width = Math.max(1, Math.round(height * ratio));
+      }
+    }
+
+    emit({
+      ...normalizedRecipe,
+      resize: {
+        ...normalizedRecipe.resize,
+        enabled: true,
+        width,
+        height,
+      },
+    });
+  };
+
+  const applyResizePreset = (scale: number) => {
+    const base = baseOutputDimensions || sourceDimensions;
+    if (!base) {
+      return;
+    }
+    emit({
+      ...normalizedRecipe,
+      resize: {
+        ...normalizedRecipe.resize,
+        enabled: scale !== 1,
+        width: Math.max(1, Math.round(base.width * scale)),
+        height: Math.max(1, Math.round(base.height * scale)),
+      },
     });
   };
 
@@ -58,53 +210,310 @@ const ImageAdjustmentPanel: React.FC<ImageAdjustmentPanelProps> = ({
     <div className="space-y-4 rounded-lg border border-cyan-500/20 bg-gray-950/50 p-3">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h3 className="text-sm font-semibold text-gray-100">Adjust</h3>
-          <p className="text-xs text-gray-500">PNG output</p>
+          <h3 className="text-sm font-semibold text-gray-100">Edit</h3>
+          <p className="text-xs text-gray-500">
+            PNG output{outputDimensions ? ` · ${outputDimensions.width}x${outputDimensions.height}` : ''}
+          </p>
         </div>
         <button
           type="button"
           onClick={onReset}
           disabled={controlsDisabled || !hasChanges}
           className="inline-flex items-center gap-1.5 rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-xs font-medium text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
-          title="Reset adjustments"
+          title="Reset edits"
         >
           <RotateCcw className="h-3.5 w-3.5" />
           Reset
         </button>
       </div>
 
-      <div className="space-y-3">
-        {CONTROLS.map((control) => (
-          <label key={control.key} className="block space-y-1.5">
-            <div className="flex items-center justify-between gap-2">
-              <span className="text-xs font-medium text-gray-300">{control.label}</span>
-              <div className="flex items-center gap-1">
-                <input
-                  type="number"
-                  min={control.min}
-                  max={control.max}
-                  value={adjustments[control.key]}
-                  disabled={controlsDisabled}
-                  onChange={(event) => updateAdjustment(control.key, Number(event.target.value))}
-                  className="h-7 w-16 rounded-md border border-gray-700 bg-gray-900 px-2 text-right text-xs text-gray-100 outline-none transition-colors focus:border-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label={control.label}
-                />
-                <span className="w-7 text-xs text-gray-500">{control.unit}</span>
-              </div>
-            </div>
-            <input
-              type="range"
-              aria-label={`${control.label} slider`}
-              min={control.min}
-              max={control.max}
-              value={adjustments[control.key]}
-              disabled={controlsDisabled}
-              onChange={(event) => updateAdjustment(control.key, Number(event.target.value))}
-              className="w-full accent-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
-            />
-          </label>
+      <div className="grid grid-cols-4 gap-1 rounded-lg border border-gray-800 bg-gray-900/70 p-1">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => onActiveTabChange?.(tab.key)}
+            className={`rounded-md px-2 py-1.5 text-xs font-medium transition-colors ${
+              activeTab === tab.key
+                ? 'bg-cyan-500/20 text-cyan-100'
+                : 'text-gray-400 hover:bg-gray-800 hover:text-gray-200'
+            }`}
+          >
+            {tab.label}
+          </button>
         ))}
       </div>
+
+      {activeTab === 'adjust' && (
+        <div className="space-y-3">
+          {ADJUSTMENT_CONTROLS.map((control) => (
+            <label key={control.key} className="block space-y-1.5">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs font-medium text-gray-300">{control.label}</span>
+                <div className="flex items-center gap-1">
+                  <input
+                    type="number"
+                    min={control.min}
+                    max={control.max}
+                    value={normalizedRecipe.adjustments[control.key]}
+                    disabled={controlsDisabled}
+                    onChange={(event) => updateAdjustment(control.key, Number(event.target.value))}
+                    className="h-7 w-16 rounded-md border border-gray-700 bg-gray-900 px-2 text-right text-xs text-gray-100 outline-none transition-colors focus:border-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label={control.label}
+                  />
+                  <span className="w-7 text-xs text-gray-500">{control.unit}</span>
+                </div>
+              </div>
+              <input
+                type="range"
+                aria-label={`${control.label} slider`}
+                min={control.min}
+                max={control.max}
+                value={normalizedRecipe.adjustments[control.key]}
+                disabled={controlsDisabled}
+                onChange={(event) => updateAdjustment(control.key, Number(event.target.value))}
+                className="w-full accent-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+              />
+            </label>
+          ))}
+        </div>
+      )}
+
+      {activeTab === 'crop' && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <label className="inline-flex items-center gap-2 text-xs font-medium text-gray-300">
+              <input
+                type="checkbox"
+                checked={normalizedRecipe.crop.enabled}
+                disabled={controlsDisabled || !sourceDimensions}
+                onChange={(event) => setCropEnabled(event.target.checked)}
+                className="h-4 w-4 accent-cyan-500"
+              />
+              Enable crop
+            </label>
+            <select
+              value={normalizedRecipe.crop.aspect}
+              disabled={controlsDisabled || !sourceDimensions}
+              onChange={(event) => setCropAspect(event.target.value as ImageEditCropAspect)}
+              className="h-8 rounded-md border border-gray-700 bg-gray-900 px-2 text-xs text-gray-100 outline-none focus:border-cyan-500"
+              aria-label="Crop aspect ratio"
+            >
+              {CROP_ASPECTS.map((aspect) => (
+                <option key={aspect} value={aspect}>{ASPECT_LABELS[aspect]}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            {(['x', 'y', 'width', 'height'] as const).map((key) => (
+              <label key={key} className="space-y-1 text-xs text-gray-400">
+                <span className="capitalize">{key}</span>
+                <input
+                  type="number"
+                  min={key === 'x' || key === 'y' ? 0 : 1}
+                  value={cropRect?.[key] ?? 0}
+                  disabled={controlsDisabled || !normalizedRecipe.crop.enabled}
+                  onChange={(event) => updateCropValue(key, Number(event.target.value))}
+                  className="h-8 w-full rounded-md border border-gray-700 bg-gray-900 px-2 text-right text-xs text-gray-100 outline-none focus:border-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label={`Crop ${key}`}
+                />
+              </label>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => setCropEnabled(true)}
+              disabled={controlsDisabled || !sourceDimensions}
+              className="inline-flex items-center justify-center gap-1.5 rounded-md border border-gray-700 bg-gray-900 px-2 py-1.5 text-xs font-medium text-gray-300 hover:border-gray-600 hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Crop className="h-3.5 w-3.5" />
+              Center Crop
+            </button>
+            <button
+              type="button"
+              onClick={() => emit({ ...normalizedRecipe, crop: { ...normalizedRecipe.crop, enabled: false, rect: null } })}
+              disabled={controlsDisabled || !normalizedRecipe.crop.enabled}
+              className="inline-flex items-center justify-center gap-1.5 rounded-md border border-gray-700 bg-gray-900 px-2 py-1.5 text-xs font-medium text-gray-300 hover:border-gray-600 hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Maximize2 className="h-3.5 w-3.5" />
+              Full Image
+            </button>
+          </div>
+          <p className="text-xs text-gray-500">Drag the crop box on the image to reposition it.</p>
+        </div>
+      )}
+
+      {activeTab === 'transform' && (
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => emit({ ...normalizedRecipe, transform: { ...normalizedRecipe.transform, rotation: normalizeImageEditRotation(normalizedRecipe.transform.rotation - 90) } })}
+              disabled={controlsDisabled}
+              className="inline-flex items-center justify-center gap-1.5 rounded-md border border-gray-700 bg-gray-900 px-2 py-2 text-xs font-medium text-gray-300 hover:border-gray-600 hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <RotateCcw className="h-3.5 w-3.5" />
+              Rotate Left
+            </button>
+            <button
+              type="button"
+              onClick={() => emit({ ...normalizedRecipe, transform: { ...normalizedRecipe.transform, rotation: normalizeImageEditRotation(normalizedRecipe.transform.rotation + 90) } })}
+              disabled={controlsDisabled}
+              className="inline-flex items-center justify-center gap-1.5 rounded-md border border-gray-700 bg-gray-900 px-2 py-2 text-xs font-medium text-gray-300 hover:border-gray-600 hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <RotateCw className="h-3.5 w-3.5" />
+              Rotate Right
+            </button>
+            <button
+              type="button"
+              onClick={() => emit({ ...normalizedRecipe, transform: { ...normalizedRecipe.transform, flipHorizontal: !normalizedRecipe.transform.flipHorizontal } })}
+              disabled={controlsDisabled}
+              className={`inline-flex items-center justify-center gap-1.5 rounded-md border px-2 py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                normalizedRecipe.transform.flipHorizontal ? 'border-cyan-400/40 bg-cyan-500/20 text-cyan-100' : 'border-gray-700 bg-gray-900 text-gray-300 hover:border-gray-600 hover:bg-gray-800'
+              }`}
+            >
+              <FlipHorizontal className="h-3.5 w-3.5" />
+              Flip H
+            </button>
+            <button
+              type="button"
+              onClick={() => emit({ ...normalizedRecipe, transform: { ...normalizedRecipe.transform, flipVertical: !normalizedRecipe.transform.flipVertical } })}
+              disabled={controlsDisabled}
+              className={`inline-flex items-center justify-center gap-1.5 rounded-md border px-2 py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                normalizedRecipe.transform.flipVertical ? 'border-cyan-400/40 bg-cyan-500/20 text-cyan-100' : 'border-gray-700 bg-gray-900 text-gray-300 hover:border-gray-600 hover:bg-gray-800'
+              }`}
+            >
+              <FlipVertical className="h-3.5 w-3.5" />
+              Flip V
+            </button>
+          </div>
+
+          <div className="rounded-lg border border-gray-800 bg-gray-900/40 p-2">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <label className="inline-flex items-center gap-2 text-xs font-medium text-gray-300">
+                <input
+                  type="checkbox"
+                  checked={normalizedRecipe.resize.enabled}
+                  disabled={controlsDisabled || !sourceDimensions}
+                  onChange={(event) => emit({ ...normalizedRecipe, resize: { ...normalizedRecipe.resize, enabled: event.target.checked } })}
+                  className="h-4 w-4 accent-cyan-500"
+                />
+                Resize
+              </label>
+              <label className="inline-flex items-center gap-1.5 text-xs text-gray-400">
+                <input
+                  type="checkbox"
+                  checked={normalizedRecipe.resize.lockAspectRatio}
+                  disabled={controlsDisabled || !sourceDimensions}
+                  onChange={(event) => emit({ ...normalizedRecipe, resize: { ...normalizedRecipe.resize, lockAspectRatio: event.target.checked } })}
+                  className="h-4 w-4 accent-cyan-500"
+                />
+                Lock
+              </label>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <label className="space-y-1 text-xs text-gray-400">
+                <span>Width</span>
+                <input
+                  type="number"
+                  min={1}
+                  value={normalizedRecipe.resize.width}
+                  disabled={controlsDisabled || !sourceDimensions}
+                  onChange={(event) => updateResizeDimension('width', Number(event.target.value))}
+                  className="h-8 w-full rounded-md border border-gray-700 bg-gray-900 px-2 text-right text-xs text-gray-100 outline-none focus:border-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Resize width"
+                />
+              </label>
+              <label className="space-y-1 text-xs text-gray-400">
+                <span>Height</span>
+                <input
+                  type="number"
+                  min={1}
+                  value={normalizedRecipe.resize.height}
+                  disabled={controlsDisabled || !sourceDimensions}
+                  onChange={(event) => updateResizeDimension('height', Number(event.target.value))}
+                  className="h-8 w-full rounded-md border border-gray-700 bg-gray-900 px-2 text-right text-xs text-gray-100 outline-none focus:border-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Resize height"
+                />
+              </label>
+            </div>
+            <div className="mt-2 grid grid-cols-3 gap-1">
+              {[0.5, 1, 2].map((scale) => (
+                <button
+                  key={scale}
+                  type="button"
+                  onClick={() => applyResizePreset(scale)}
+                  disabled={controlsDisabled || !sourceDimensions}
+                  className="rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-xs font-medium text-gray-300 hover:border-gray-600 hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {Math.round(scale * 100)}%
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'enhance' && (
+        <div className="space-y-4">
+          {(['sharpen', 'blur'] as const).map((key) => (
+            <label key={key} className="block space-y-1.5">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs font-medium capitalize text-gray-300">{key}</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={key === 'blur' ? 20 : 100}
+                  value={normalizedRecipe.effects[key]}
+                  disabled={controlsDisabled}
+                  onChange={(event) => emit({
+                    ...normalizedRecipe,
+                    effects: {
+                      ...normalizedRecipe.effects,
+                      [key]: clampImageEditEffect(key, Number(event.target.value)),
+                    },
+                  })}
+                  className="h-7 w-16 rounded-md border border-gray-700 bg-gray-900 px-2 text-right text-xs text-gray-100 outline-none transition-colors focus:border-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label={key}
+                />
+              </div>
+              <input
+                type="range"
+                aria-label={`${key} slider`}
+                min={0}
+                max={key === 'blur' ? 20 : 100}
+                value={normalizedRecipe.effects[key]}
+                disabled={controlsDisabled}
+                onChange={(event) => emit({
+                  ...normalizedRecipe,
+                  effects: {
+                    ...normalizedRecipe.effects,
+                    [key]: clampImageEditEffect(key, Number(event.target.value)),
+                  },
+                })}
+                className="w-full accent-cyan-500 disabled:cursor-not-allowed disabled:opacity-50"
+              />
+            </label>
+          ))}
+
+          <div className="rounded-lg border border-purple-500/20 bg-purple-500/10 p-2">
+            <button
+              type="button"
+              onClick={onAIUpscale}
+              disabled={controlsDisabled || isAIUpscaling || !canAIUpscale}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-purple-400/30 bg-purple-500/15 px-3 py-2 text-xs font-semibold text-purple-100 transition-colors hover:border-purple-300/50 hover:bg-purple-500/25 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
+              title={canAIUpscale ? 'Queue a ComfyUI upscale workflow' : aiUpscaleDisabledReason}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              {isAIUpscaling ? 'Queueing...' : 'AI Upscale'}
+            </button>
+            <p className="mt-1.5 text-xs text-purple-200/70">ComfyUI transform</p>
+          </div>
+        </div>
+      )}
 
       <div className="grid grid-cols-2 gap-2">
         <button
@@ -129,12 +538,10 @@ const ImageAdjustmentPanel: React.FC<ImageAdjustmentPanelProps> = ({
         </button>
       </div>
 
-      {isSaving && (
-        <div className="text-xs text-gray-400">Saving edited image...</div>
-      )}
+      {isSaving && <div className="text-xs text-gray-400">Saving edited image...</div>}
       {!hasChanges && (
         <div className="text-xs text-gray-500">
-          Neutral: {DEFAULT_IMAGE_ADJUSTMENTS.brightness}/{DEFAULT_IMAGE_ADJUSTMENTS.contrast}/{DEFAULT_IMAGE_ADJUSTMENTS.saturation}/{DEFAULT_IMAGE_ADJUSTMENTS.hue}
+          Neutral: {DEFAULT_IMAGE_EDIT_RECIPE.adjustments.brightness}/{DEFAULT_IMAGE_EDIT_RECIPE.adjustments.contrast}/{DEFAULT_IMAGE_EDIT_RECIPE.adjustments.saturation}/{DEFAULT_IMAGE_EDIT_RECIPE.adjustments.hue}
         </div>
       )}
     </div>

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -13,12 +13,12 @@ import {
   Layers,
   Minus,
   MousePointer2,
+  Pipette,
   Pencil,
   Redo2,
   RotateCcw,
   RotateCw,
   Save,
-  Scissors,
   Search,
   Shield,
   Sparkles,
@@ -26,7 +26,6 @@ import {
   Type,
   Undo2,
   Workflow,
-  ZoomIn,
 } from 'lucide-react';
 import type {
   BaseMetadata,
@@ -37,8 +36,6 @@ import type {
   IndexedImage,
 } from '../types';
 import {
-  DEFAULT_IMAGE_EDIT_RECIPE,
-  DEFAULT_IMAGE_EDITOR_BACKGROUND,
   DEFAULT_IMAGE_EDITOR_OBJECT_STYLE,
   clampImageAdjustment,
   clampImageEditEffect,
@@ -75,15 +72,39 @@ type HistoryState = {
   future: ImageEditorDocument[];
 };
 
+type EditorSessionState = {
+  document: ImageEditorDocument;
+  activeTool: ImageEditorTool;
+  activeStyle: ImageEditorObjectStyle;
+  history: HistoryState;
+  zoom: number;
+};
+
 type DragState = {
   tool: ImageEditorTool;
   start: { x: number; y: number };
   current: { x: number; y: number };
   points?: { x: number; y: number }[];
+  movingObjectId?: string;
+  resizeHandle?: ResizeHandle;
+  keepAspectRatio?: boolean;
 };
+
+type ResizeHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
+
+type PanState = {
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  scrollLeft: number;
+  scrollTop: number;
+};
+
+const editorSessionCache = new Map<string, EditorSessionState>();
 
 const TOOL_DEFS: Array<{ id: ImageEditorTool; label: string; icon: React.ReactNode }> = [
   { id: 'select', label: 'Select', icon: <MousePointer2 className="h-4 w-4" /> },
+  { id: 'color-picker', label: 'Pick Color', icon: <Pipette className="h-4 w-4" /> },
   { id: 'crop', label: 'Crop', icon: <Crop className="h-4 w-4" /> },
   { id: 'rectangle', label: 'Rectangle', icon: <Square className="h-4 w-4" /> },
   { id: 'ellipse', label: 'Ellipse', icon: <Circle className="h-4 w-4" /> },
@@ -91,16 +112,17 @@ const TOOL_DEFS: Array<{ id: ImageEditorTool; label: string; icon: React.ReactNo
   { id: 'arrow', label: 'Arrow', icon: <ArrowLeft className="h-4 w-4 rotate-180" /> },
   { id: 'freehand', label: 'Freehand', icon: <Pencil className="h-4 w-4" /> },
   { id: 'text', label: 'Text', icon: <Type className="h-4 w-4" /> },
-  { id: 'step', label: 'Step', icon: <span className="text-xs font-bold">1</span> },
   { id: 'highlight', label: 'Highlight', icon: <Highlighter className="h-4 w-4" /> },
   { id: 'blur', label: 'Blur', icon: <Eye className="h-4 w-4" /> },
   { id: 'pixelate', label: 'Pixelate', icon: <Shield className="h-4 w-4" /> },
   { id: 'spotlight', label: 'Spotlight', icon: <Search className="h-4 w-4" /> },
-  { id: 'magnify', label: 'Magnify', icon: <ZoomIn className="h-4 w-4" /> },
 ];
+
+const isEnabledEditorTool = (tool: ImageEditorTool) => TOOL_DEFS.some((definition) => definition.id === tool);
 
 const TOOL_HINTS: Record<ImageEditorTool, string> = {
   select: 'Click an object to select it.',
+  'color-picker': 'Click the image to pick a color for the active style.',
   crop: 'Drag a crop area. The crop is editable in the inspector.',
   rectangle: 'Drag to create a rectangle annotation.',
   ellipse: 'Drag to create an ellipse annotation.',
@@ -120,8 +142,6 @@ const clamp = (value: number, min: number, max: number) => Math.min(max, Math.ma
 
 const clampZoom = (value: number) => clamp(Math.round(value * 100) / 100, 0.1, 6);
 
-const cloneDocument = (document: ImageEditorDocument): ImageEditorDocument => JSON.parse(JSON.stringify(document));
-
 const createObjectId = () => `editor_obj_${Date.now()}_${Math.random().toString(16).slice(2, 8)}`;
 
 const isEditableShortcutTarget = (target: EventTarget | null): boolean => {
@@ -133,11 +153,14 @@ const isEditableShortcutTarget = (target: EventTarget | null): boolean => {
 };
 
 const isAnnotationTool = (tool: ImageEditorTool): tool is ImageEditorObject['type'] => (
-  tool !== 'select' && tool !== 'crop'
+  tool !== 'select' && tool !== 'color-picker' && tool !== 'crop'
 );
+
+const isResizableObjectType = (type: ImageEditorObject['type']) => type === 'rectangle' || type === 'ellipse';
 
 const TOOL_SHORTCUTS: Partial<Record<string, ImageEditorTool>> = {
   v: 'select',
+  i: 'color-picker',
   c: 'crop',
   r: 'rectangle',
   e: 'ellipse',
@@ -145,12 +168,10 @@ const TOOL_SHORTCUTS: Partial<Record<string, ImageEditorTool>> = {
   a: 'arrow',
   f: 'freehand',
   t: 'text',
-  n: 'step',
   h: 'highlight',
   b: 'blur',
   p: 'pixelate',
   s: 'spotlight',
-  m: 'magnify',
 };
 
 const getUsableNormalizedMetadata = (image: IndexedImage): BaseMetadata | undefined => (
@@ -210,6 +231,125 @@ const getCanvasPoint = (
   };
 };
 
+const colorComponentToHex = (value: number) => Math.round(value).toString(16).padStart(2, '0');
+const rgbToHex = (red: number, green: number, blue: number) => `#${colorComponentToHex(red)}${colorComponentToHex(green)}${colorComponentToHex(blue)}`;
+const toColorInputValue = (value: string | undefined) => /^#[0-9a-f]{6}$/i.test(value || '') ? value as string : '#000000';
+
+const RESIZE_HANDLES: ResizeHandle[] = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
+
+const getHandlePoint = (bounds: ImageEditorObject['bounds'], handle: ResizeHandle) => {
+  const centerX = bounds.x + bounds.width / 2;
+  const centerY = bounds.y + bounds.height / 2;
+  const right = bounds.x + bounds.width;
+  const bottom = bounds.y + bounds.height;
+
+  switch (handle) {
+    case 'nw': return { x: bounds.x, y: bounds.y };
+    case 'n': return { x: centerX, y: bounds.y };
+    case 'ne': return { x: right, y: bounds.y };
+    case 'e': return { x: right, y: centerY };
+    case 'se': return { x: right, y: bottom };
+    case 's': return { x: centerX, y: bottom };
+    case 'sw': return { x: bounds.x, y: bottom };
+    case 'w': return { x: bounds.x, y: centerY };
+  }
+};
+
+const getResizeHandleAtPoint = (
+  point: { x: number; y: number },
+  bounds: ImageEditorObject['bounds'],
+  tolerance: number,
+): ResizeHandle | null => {
+  for (const handle of RESIZE_HANDLES) {
+    const handlePoint = getHandlePoint(bounds, handle);
+    if (Math.abs(point.x - handlePoint.x) <= tolerance && Math.abs(point.y - handlePoint.y) <= tolerance) {
+      return handle;
+    }
+  }
+  return null;
+};
+
+const resizeBoundsFromHandle = (
+  bounds: ImageEditorObject['bounds'],
+  handle: ResizeHandle,
+  deltaX: number,
+  deltaY: number,
+  canvasDimensions: { width: number; height: number },
+  keepAspectRatio = false,
+) => {
+  const minSize = 8;
+  const originalAspectRatio = bounds.width / Math.max(1, bounds.height);
+  let x = bounds.x;
+  let y = bounds.y;
+  let width = bounds.width;
+  let height = bounds.height;
+
+  if (handle.includes('w')) {
+    x += deltaX;
+    width -= deltaX;
+  }
+  if (handle.includes('e')) {
+    width += deltaX;
+  }
+  if (handle.includes('n')) {
+    y += deltaY;
+    height -= deltaY;
+  }
+  if (handle.includes('s')) {
+    height += deltaY;
+  }
+
+  if (keepAspectRatio) {
+    const widthFromHeight = Math.max(minSize, Math.abs(height)) * originalAspectRatio;
+    const heightFromWidth = Math.max(minSize, Math.abs(width)) / originalAspectRatio;
+    if (handle.length === 2) {
+      if (Math.abs(deltaX) >= Math.abs(deltaY)) {
+        height = heightFromWidth;
+      } else {
+        width = widthFromHeight;
+      }
+      if (handle.includes('w')) {
+        x = bounds.x + bounds.width - width;
+      }
+      if (handle.includes('n')) {
+        y = bounds.y + bounds.height - height;
+      }
+    } else if (handle === 'e' || handle === 'w') {
+      height = heightFromWidth;
+      y = bounds.y + (bounds.height - height) / 2;
+      if (handle === 'w') {
+        x = bounds.x + bounds.width - width;
+      }
+    } else {
+      width = widthFromHeight;
+      x = bounds.x + (bounds.width - width) / 2;
+      if (handle === 'n') {
+        y = bounds.y + bounds.height - height;
+      }
+    }
+  }
+
+  if (width < minSize) {
+    if (handle.includes('w')) {
+      x = bounds.x + bounds.width - minSize;
+    }
+    width = minSize;
+  }
+  if (height < minSize) {
+    if (handle.includes('n')) {
+      y = bounds.y + bounds.height - minSize;
+    }
+    height = minSize;
+  }
+
+  x = clamp(x, 0, Math.max(0, canvasDimensions.width - minSize));
+  y = clamp(y, 0, Math.max(0, canvasDimensions.height - minSize));
+  width = clamp(width, minSize, canvasDimensions.width - x);
+  height = clamp(height, minSize, canvasDimensions.height - y);
+
+  return { x, y, width, height };
+};
+
 const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   image,
   navigationImages = [],
@@ -230,6 +370,10 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const [zoom, setZoom] = useState(1);
   const [hydratedImage, setHydratedImage] = useState<IndexedImage | null>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const previewImageRef = useRef<HTMLImageElement>(null);
+  const sessionRef = useRef<EditorSessionState | null>(null);
+  const panStateRef = useRef<PanState | null>(null);
 
   const directories = useImageStore((state) => state.directories);
   const addImages = useImageStore((state) => state.addImages);
@@ -248,18 +392,62 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     () => documentState ? normalizeImageEditorDocument(documentState) : null,
     [documentState],
   );
+  const basePreviewDocument = useMemo(
+    () => normalizedDocument
+      ? {
+        ...normalizedDocument,
+        objects: [],
+        selectedObjectIds: [],
+      }
+      : null,
+    [
+      normalizedDocument?.background,
+      normalizedDocument?.canvasDimensions.height,
+      normalizedDocument?.canvasDimensions.width,
+      normalizedDocument?.recipe,
+      normalizedDocument?.sourceDimensions.height,
+      normalizedDocument?.sourceDimensions.width,
+      normalizedDocument?.sourceImageId,
+      normalizedDocument?.sourceName,
+    ],
+  );
+  const basePreviewKey = useMemo(
+    () => basePreviewDocument
+      ? JSON.stringify({
+        background: basePreviewDocument.background,
+        canvasDimensions: basePreviewDocument.canvasDimensions,
+        recipe: basePreviewDocument.recipe,
+        sourceDimensions: basePreviewDocument.sourceDimensions,
+        sourceImageId: basePreviewDocument.sourceImageId,
+      })
+      : '',
+    [basePreviewDocument],
+  );
   const hasChanges = normalizedDocument ? hasImageEditorDocumentChanges(normalizedDocument) : false;
   const selectedObject = normalizedDocument?.objects.find((object) => normalizedDocument.selectedObjectIds.includes(object.id)) || null;
   const canOverwrite = getFileExtension(image.name) === '.png';
   const displayWidth = Math.max(160, Math.round(1080 * zoom));
+
+  useEffect(() => {
+    if (!documentState) {
+      sessionRef.current = null;
+      return;
+    }
+    sessionRef.current = {
+      document: documentState,
+      activeTool,
+      activeStyle,
+      history,
+      zoom,
+    };
+  }, [activeStyle, activeTool, documentState, history, zoom]);
 
   const commitDocument = useCallback((updater: (current: ImageEditorDocument) => ImageEditorDocument, label: string) => {
     setDocumentState((current) => {
       if (!current) {
         return current;
       }
-      const before = cloneDocument(current);
-      const after = normalizeImageEditorDocument(updater(before));
+      const after = normalizeImageEditorDocument(updater(current));
       setHistory((historyState) => ({
         past: [...historyState.past, current].slice(-80),
         future: [],
@@ -292,12 +480,21 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
           element.src = source;
         });
         if (!mounted) return;
-        setDocumentState(createImageEditorDocument({
-          imageId: image.id,
-          name: image.name,
-          width: dimensions.width,
-          height: dimensions.height,
-        }));
+        const cachedSession = editorSessionCache.get(image.id);
+        if (cachedSession) {
+          setDocumentState(cachedSession.document);
+          setActiveTool(isEnabledEditorTool(cachedSession.activeTool) ? cachedSession.activeTool : 'select');
+          setActiveStyle(cachedSession.activeStyle);
+          setHistory(cachedSession.history);
+          setZoom(cachedSession.zoom);
+        } else {
+          setDocumentState(createImageEditorDocument({
+            imageId: image.id,
+            name: image.name,
+            width: dimensions.width,
+            height: dimensions.height,
+          }));
+        }
         setSourceReady(true);
       } catch (error) {
         if (mounted) {
@@ -309,6 +506,9 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     void load();
     return () => {
       mounted = false;
+      if (sessionRef.current) {
+        editorSessionCache.set(image.id, sessionRef.current);
+      }
     };
   }, [directoryPath, image, setError]);
 
@@ -319,14 +519,14 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   }, [previewUrl]);
 
   useEffect(() => {
-    if (!sourceUrl || !normalizedDocument || !sourceReady) {
+    if (!sourceUrl || !basePreviewDocument || !sourceReady) {
       return;
     }
     let canceled = false;
     setIsRendering(true);
     const timeoutId = window.setTimeout(async () => {
       try {
-        const blob = await renderImageEditorDocumentToPngBlob(sourceUrl, normalizedDocument);
+        const blob = await renderImageEditorDocumentToPngBlob(sourceUrl, basePreviewDocument);
         if (canceled) return;
         const nextUrl = URL.createObjectURL(blob);
         setPreviewUrl((current) => {
@@ -348,7 +548,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       canceled = true;
       window.clearTimeout(timeoutId);
     };
-  }, [normalizedDocument, sourceReady, sourceUrl]);
+  }, [basePreviewKey, sourceReady, sourceUrl]);
 
   const ensureHydratedImage = useCallback(async () => {
     if (hydratedImage?.id === image.id) {
@@ -579,16 +779,6 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     });
   }, [documentState]);
 
-  const resetDocument = useCallback(() => {
-    if (!normalizedDocument) return;
-    commitDocument(() => createImageEditorDocument({
-      imageId: image.id,
-      name: image.name,
-      width: normalizedDocument.sourceDimensions.width,
-      height: normalizedDocument.sourceDimensions.height,
-    }), 'Reset');
-  }, [commitDocument, image, normalizedDocument]);
-
   const updateRecipe = useCallback((recipe: ImageEditorDocument['recipe']) => {
     commitDocument((current) => ({ ...current, recipe: normalizeImageEditRecipe(recipe, current.sourceDimensions) }), 'Edit recipe');
   }, [commitDocument]);
@@ -621,16 +811,106 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     setSuccess('Flatten will be applied in the saved PNG output.');
   }, [commitDocument, normalizedDocument, setSuccess]);
 
+  const restoreOriginal = useCallback(() => {
+    if (!normalizedDocument) return;
+    if (!window.confirm('Restore the original image and discard all editor changes?')) {
+      return;
+    }
+    setDocumentState(createImageEditorDocument({
+      imageId: image.id,
+      name: image.name,
+      width: normalizedDocument.sourceDimensions.width,
+      height: normalizedDocument.sourceDimensions.height,
+    }));
+    setHistory({ past: [], future: [] });
+    setDragState(null);
+  }, [image.id, image.name, normalizedDocument]);
+
+  const pickColorAtPoint = useCallback((point: { x: number; y: number }) => {
+    const imageElement = previewImageRef.current;
+    if (!imageElement || !normalizedDocument) {
+      return;
+    }
+    const sampleCanvas = document.createElement('canvas');
+    const sampleContext = sampleCanvas.getContext('2d', { willReadFrequently: true });
+    if (!sampleContext) {
+      return;
+    }
+    const width = imageElement.naturalWidth || imageElement.width;
+    const height = imageElement.naturalHeight || imageElement.height;
+    sampleCanvas.width = 1;
+    sampleCanvas.height = 1;
+    const sampleX = clamp(Math.round((point.x / normalizedDocument.canvasDimensions.width) * width), 0, Math.max(0, width - 1));
+    const sampleY = clamp(Math.round((point.y / normalizedDocument.canvasDimensions.height) * height), 0, Math.max(0, height - 1));
+    sampleContext.drawImage(imageElement, sampleX, sampleY, 1, 1, 0, 0, 1, 1);
+    const [red, green, blue] = sampleContext.getImageData(0, 0, 1, 1).data;
+    const color = rgbToHex(red, green, blue);
+    setActiveStyle((current) => ({ ...current, strokeColor: color, textColor: color }));
+    if (selectedObject) {
+      updateSelectedObjectStyle(selectedObject.type === 'text' || selectedObject.type === 'step'
+        ? { textColor: color }
+        : { strokeColor: color });
+    }
+  }, [normalizedDocument, selectedObject, updateSelectedObjectStyle]);
+
   const pointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    if (!normalizedDocument || event.button !== 0) return;
+    if (!normalizedDocument) return;
+    if (event.button === 1) {
+      event.preventDefault();
+      const scrollContainer = scrollContainerRef.current;
+      if (!scrollContainer) return;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      panStateRef.current = {
+        pointerId: event.pointerId,
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        scrollLeft: scrollContainer.scrollLeft,
+        scrollTop: scrollContainer.scrollTop,
+      };
+      return;
+    }
+    if (event.button !== 0) return;
     const point = getCanvasPoint(event, canvasRef.current, normalizedDocument);
     event.currentTarget.setPointerCapture(event.pointerId);
 
-    if (activeTool === 'select') {
-      const selected = [...normalizedDocument.objects]
-        .reverse()
-        .find((object) => point.x >= object.bounds.x && point.x <= object.bounds.x + object.bounds.width && point.y >= object.bounds.y && point.y <= object.bounds.y + object.bounds.height);
+    if (selectedObject && isResizableObjectType(selectedObject.type)) {
+      const tolerance = Math.max(8, normalizedDocument.canvasDimensions.width / Math.max(1, displayWidth) * 10);
+      const resizeHandle = getResizeHandleAtPoint(point, selectedObject.bounds, tolerance);
+      if (resizeHandle) {
+        setDragState({
+          tool: 'select',
+          start: point,
+          current: point,
+          movingObjectId: selectedObject.id,
+          resizeHandle,
+          keepAspectRatio: event.shiftKey,
+        });
+        return;
+      }
+    }
+
+    if (activeTool === 'color-picker') {
+      pickColorAtPoint(point);
+      return;
+    }
+
+    const selected = [...normalizedDocument.objects]
+      .reverse()
+      .find((object) => point.x >= object.bounds.x && point.x <= object.bounds.x + object.bounds.width && point.y >= object.bounds.y && point.y <= object.bounds.y + object.bounds.height);
+
+    if (selected && (activeTool === 'select' || activeTool === selected.type || normalizedDocument.selectedObjectIds.includes(selected.id))) {
+      setDragState({
+        tool: 'select',
+        start: point,
+        current: point,
+        movingObjectId: selected.id,
+      });
       commitDocument((current) => ({ ...current, selectedObjectIds: selected ? [selected.id] : [] }), 'Select');
+      return;
+    }
+
+    if (activeTool === 'select') {
+      commitDocument((current) => ({ ...current, selectedObjectIds: [] }), 'Select');
       return;
     }
 
@@ -640,22 +920,79 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       current: point,
       points: activeTool === 'freehand' ? [point] : undefined,
     });
-  }, [activeTool, commitDocument, normalizedDocument]);
+  }, [activeTool, commitDocument, displayWidth, normalizedDocument, pickColorAtPoint, selectedObject]);
 
   const pointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const panState = panStateRef.current;
+    if (panState) {
+      const scrollContainer = scrollContainerRef.current;
+      if (scrollContainer) {
+        scrollContainer.scrollLeft = panState.scrollLeft - (event.clientX - panState.startClientX);
+        scrollContainer.scrollTop = panState.scrollTop - (event.clientY - panState.startClientY);
+      }
+      return;
+    }
     if (!dragState || !normalizedDocument) return;
     const point = getCanvasPoint(event, canvasRef.current, normalizedDocument);
     setDragState((current) => current ? {
       ...current,
       current: point,
+      keepAspectRatio: current.resizeHandle ? event.shiftKey : current.keepAspectRatio,
       points: current.points ? [...current.points, point] : undefined,
     } : current);
   }, [dragState, normalizedDocument]);
 
-  const pointerUp = useCallback(() => {
+  const pointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+      return;
+    }
     if (!dragState || !normalizedDocument) return;
     const completedDrag = dragState;
     setDragState(null);
+
+    if (completedDrag.tool === 'select' && completedDrag.movingObjectId) {
+      const deltaX = completedDrag.current.x - completedDrag.start.x;
+      const deltaY = completedDrag.current.y - completedDrag.start.y;
+      if (Math.abs(deltaX) > 0.5 || Math.abs(deltaY) > 0.5) {
+        commitDocument((current) => ({
+          ...current,
+          objects: current.objects.map((object) => {
+            if (object.id !== completedDrag.movingObjectId) {
+              return object;
+            }
+            if (completedDrag.resizeHandle) {
+              const resizedBounds = resizeBoundsFromHandle(
+                object.bounds,
+                completedDrag.resizeHandle,
+                deltaX,
+                deltaY,
+                current.canvasDimensions,
+                completedDrag.keepAspectRatio,
+              );
+              return {
+                ...object,
+                bounds: resizedBounds,
+              };
+            }
+            const x = clamp(object.bounds.x + deltaX, 0, Math.max(0, current.canvasDimensions.width - object.bounds.width));
+            const y = clamp(object.bounds.y + deltaY, 0, Math.max(0, current.canvasDimensions.height - object.bounds.height));
+            const appliedDeltaX = x - object.bounds.x;
+            const appliedDeltaY = y - object.bounds.y;
+            return {
+              ...object,
+              bounds: { ...object.bounds, x, y },
+              points: object.points?.map((point) => ({
+                x: clamp(point.x + appliedDeltaX, 0, current.canvasDimensions.width),
+                y: clamp(point.y + appliedDeltaY, 0, current.canvasDimensions.height),
+              })),
+            };
+          }),
+          selectedObjectIds: [completedDrag.movingObjectId],
+        }), 'Move object');
+      }
+      return;
+    }
 
     if (completedDrag.tool === 'crop') {
       const x = Math.min(completedDrag.start.x, completedDrag.current.x);
@@ -940,13 +1277,70 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const handleWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
     event.preventDefault();
     const factor = event.deltaY < 0 ? 1.1 : 1 / 1.1;
-    setZoom((current) => clampZoom(current * factor));
+    const canvasRect = canvasRef.current?.getBoundingClientRect();
+    const scrollContainer = scrollContainerRef.current;
+    const anchorX = canvasRect ? event.clientX - canvasRect.left : 0;
+    const anchorY = canvasRect ? event.clientY - canvasRect.top : 0;
+    setZoom((current) => {
+      const next = clampZoom(current * factor);
+      const scale = next / current;
+      if (scrollContainer && canvasRect && scale !== 1) {
+        requestAnimationFrame(() => {
+          scrollContainer.scrollLeft += anchorX * (scale - 1);
+          scrollContainer.scrollTop += anchorY * (scale - 1);
+        });
+      }
+      return next;
+    });
   }, []);
 
   const activeOutputDimensions = normalizedDocument
     ? getImageEditOutputDimensions(normalizedDocument.recipe, normalizedDocument.sourceDimensions)
     : null;
   const selectedCount = normalizedDocument?.selectedObjectIds.length || 0;
+  const canvasDimensionsForOverlay = normalizedDocument?.canvasDimensions ?? { width: 1, height: 1 };
+  const selectedDragOffset = dragState?.tool === 'select' && !dragState.resizeHandle && selectedObject && dragState.movingObjectId === selectedObject.id
+    ? {
+      x: dragState.current.x - dragState.start.x,
+      y: dragState.current.y - dragState.start.y,
+    }
+    : { x: 0, y: 0 };
+  const selectedDisplayBounds = selectedObject && dragState?.tool === 'select' && dragState.resizeHandle && dragState.movingObjectId === selectedObject.id
+    ? resizeBoundsFromHandle(
+      selectedObject.bounds,
+      dragState.resizeHandle,
+      dragState.current.x - dragState.start.x,
+      dragState.current.y - dragState.start.y,
+      canvasDimensionsForOverlay,
+      dragState.keepAspectRatio,
+    )
+    : selectedObject
+      ? {
+      ...selectedObject.bounds,
+      x: selectedObject.bounds.x + selectedDragOffset.x,
+      y: selectedObject.bounds.y + selectedDragOffset.y,
+      }
+      : null;
+  const selectedDisplayPoints = selectedObject?.points?.map((point) => ({
+    x: point.x + selectedDragOffset.x,
+    y: point.y + selectedDragOffset.y,
+  }));
+  const styleTargetType = selectedObject?.type ?? (isAnnotationTool(activeTool) ? activeTool : null);
+  const displayedStyle = selectedObject?.style ?? activeStyle;
+  const canUseStrokeColor = Boolean(styleTargetType && ['rectangle', 'ellipse', 'line', 'arrow', 'freehand', 'highlight', 'magnify'].includes(styleTargetType));
+  const canUseFillColor = Boolean(styleTargetType && ['rectangle', 'ellipse', 'highlight', 'step'].includes(styleTargetType));
+  const canUseTextColor = Boolean(styleTargetType && ['text', 'step'].includes(styleTargetType));
+  const canUseStrokeWidth = Boolean(styleTargetType && styleTargetType !== 'text' && styleTargetType !== 'step');
+  const canUseFontSize = Boolean(styleTargetType && ['text', 'step'].includes(styleTargetType));
+  const displayedObjects = [...(normalizedDocument?.objects ?? [])]
+    .sort((first, second) => first.zIndex - second.zIndex)
+    .map((object) => object.id === selectedObject?.id
+      ? {
+        ...object,
+        bounds: selectedDisplayBounds ?? object.bounds,
+        points: selectedDisplayPoints ?? object.points,
+      }
+      : object);
 
   if (!normalizedDocument || !sourceUrl) {
     return (
@@ -981,6 +1375,10 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
           <button type="button" onClick={flattenSelection} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Flatten">
             <Layers className="h-4 w-4" />
           </button>
+          <button type="button" onClick={restoreOriginal} disabled={!hasChanges} className="inline-flex items-center gap-1 rounded-md px-2 py-2 text-xs font-semibold text-gray-300 hover:bg-gray-800 disabled:opacity-40" title="Restore Original">
+            <RotateCcw className="h-4 w-4" />
+            Restore
+          </button>
           <button type="button" onClick={handleCopy} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Copy image">
             <Copy className="h-4 w-4" />
           </button>
@@ -1014,33 +1412,165 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
         </div>
 
         <div className="relative flex min-w-0 flex-1 flex-col bg-gray-950">
-          <div className="flex flex-1 items-center justify-center overflow-auto p-8">
+          <div ref={scrollContainerRef} className="flex flex-1 items-start justify-start overflow-auto p-8">
             <div
               ref={canvasRef}
               data-testid="image-editor-canvas"
-              className="relative max-h-full max-w-full touch-none select-none overflow-hidden rounded-sm border border-gray-800 bg-[linear-gradient(45deg,#1f2937_25%,transparent_25%),linear-gradient(-45deg,#1f2937_25%,transparent_25%),linear-gradient(45deg,transparent_75%,#1f2937_75%),linear-gradient(-45deg,transparent_75%,#1f2937_75%)] bg-[length:20px_20px] bg-[position:0_0,0_10px,10px_-10px,-10px_0px]"
+              className="relative mx-auto my-auto flex-none touch-none select-none overflow-hidden rounded-sm border border-gray-800 bg-[linear-gradient(45deg,#1f2937_25%,transparent_25%),linear-gradient(-45deg,#1f2937_25%,transparent_25%),linear-gradient(45deg,transparent_75%,#1f2937_75%),linear-gradient(-45deg,transparent_75%,#1f2937_75%)] bg-[length:20px_20px] bg-[position:0_0,0_10px,10px_-10px,-10px_0px]"
               style={{
                 aspectRatio: `${Math.max(1, normalizedDocument.canvasDimensions.width)} / ${Math.max(1, normalizedDocument.canvasDimensions.height)}`,
                 width: `${displayWidth}px`,
+                maxWidth: 'none',
               }}
               onPointerDown={pointerDown}
               onPointerMove={pointerMove}
               onPointerUp={pointerUp}
-              onPointerCancel={() => setDragState(null)}
+              onPointerCancel={() => {
+                setDragState(null);
+                panStateRef.current = null;
+              }}
+              onAuxClick={(event) => event.preventDefault()}
               onWheel={handleWheel}
             >
               {previewUrl ? (
-                <img src={previewUrl} alt={image.name} className="block h-full w-full object-contain" draggable={false} />
+                <img ref={previewImageRef} src={previewUrl} alt={image.name} className="block h-full w-full object-contain" draggable={false} />
               ) : (
-                <img src={sourceUrl} alt={image.name} className="block h-full w-full object-contain opacity-80" draggable={false} />
+                <img ref={previewImageRef} src={sourceUrl} alt={image.name} className="block h-full w-full object-contain opacity-80" draggable={false} />
               )}
+              <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
+                {displayedObjects.map((object) => {
+                  const { bounds, style } = object;
+                  if (object.type === 'rectangle' || object.type === 'highlight') {
+                    return (
+                      <rect
+                        key={object.id}
+                        x={bounds.x}
+                        y={bounds.y}
+                        width={bounds.width}
+                        height={bounds.height}
+                        fill={object.type === 'highlight' ? 'rgba(250, 204, 21, 0.28)' : style.fillColor}
+                        stroke={object.type === 'rectangle' ? style.strokeColor : 'transparent'}
+                        strokeWidth={object.type === 'rectangle' ? style.strokeWidth : 0}
+                        opacity={style.opacity}
+                      />
+                    );
+                  }
+                  if (object.type === 'ellipse' || object.type === 'spotlight' || object.type === 'magnify') {
+                    return (
+                      <ellipse
+                        key={object.id}
+                        cx={bounds.x + bounds.width / 2}
+                        cy={bounds.y + bounds.height / 2}
+                        rx={bounds.width / 2}
+                        ry={bounds.height / 2}
+                        fill={object.type === 'ellipse' ? style.fillColor : 'rgba(0, 0, 0, 0.18)'}
+                        stroke={style.strokeColor}
+                        strokeWidth={style.strokeWidth}
+                        opacity={style.opacity}
+                        strokeDasharray={object.type === 'spotlight' || object.type === 'magnify' ? '10 8' : undefined}
+                      />
+                    );
+                  }
+                  if (object.type === 'line' || object.type === 'arrow') {
+                    const start = object.points?.[0] ?? { x: bounds.x, y: bounds.y };
+                    const end = object.points?.[1] ?? { x: bounds.x + bounds.width, y: bounds.y + bounds.height };
+                    return (
+                      <g key={object.id} opacity={style.opacity}>
+                        <line
+                          x1={start.x}
+                          y1={start.y}
+                          x2={end.x}
+                          y2={end.y}
+                          stroke={style.strokeColor}
+                          strokeWidth={style.strokeWidth}
+                          strokeLinecap="round"
+                          markerEnd={object.type === 'arrow' ? `url(#image-editor-arrow-${object.id})` : undefined}
+                        />
+                        {object.type === 'arrow' && (
+                          <defs>
+                            <marker id={`image-editor-arrow-${object.id}`} markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth">
+                              <path d="M 0 0 L 10 5 L 0 10 z" fill={style.strokeColor} />
+                            </marker>
+                          </defs>
+                        )}
+                      </g>
+                    );
+                  }
+                  if (object.type === 'freehand' && object.points && object.points.length > 1) {
+                    return (
+                      <polyline
+                        key={object.id}
+                        points={object.points.map((point) => `${point.x},${point.y}`).join(' ')}
+                        fill="none"
+                        stroke={style.strokeColor}
+                        strokeWidth={style.strokeWidth}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        opacity={style.opacity}
+                      />
+                    );
+                  }
+                  if (object.type === 'text') {
+                    return (
+                      <text
+                        key={object.id}
+                        x={bounds.x}
+                        y={bounds.y + style.fontSize}
+                        fill={style.textColor}
+                        fontSize={style.fontSize}
+                        fontFamily="system-ui, sans-serif"
+                        opacity={style.opacity}
+                      >
+                        {object.text || 'Text'}
+                      </text>
+                    );
+                  }
+                  if (object.type === 'step') {
+                    const radius = Math.max(16, Math.min(bounds.width, bounds.height) / 2);
+                    return (
+                      <g key={object.id} opacity={style.opacity}>
+                        <circle cx={bounds.x + radius} cy={bounds.y + radius} r={radius} fill={style.strokeColor} />
+                        <text
+                          x={bounds.x + radius}
+                          y={bounds.y + radius + 1}
+                          fill={style.textColor}
+                          fontSize={Math.round(radius)}
+                          fontWeight={700}
+                          textAnchor="middle"
+                          dominantBaseline="middle"
+                          fontFamily="system-ui, sans-serif"
+                        >
+                          {object.stepNumber || 1}
+                        </text>
+                      </g>
+                    );
+                  }
+                  if (object.type === 'blur' || object.type === 'pixelate') {
+                    return (
+                      <rect
+                        key={object.id}
+                        x={bounds.x}
+                        y={bounds.y}
+                        width={bounds.width}
+                        height={bounds.height}
+                        fill="rgba(103, 232, 249, 0.08)"
+                        stroke={style.strokeColor}
+                        strokeWidth={Math.max(2, style.strokeWidth / 2)}
+                        strokeDasharray="10 8"
+                        opacity={style.opacity}
+                      />
+                    );
+                  }
+                  return null;
+                })}
+              </svg>
               {dragState && (dragState.tool === 'line' || dragState.tool === 'arrow') ? (
-                <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible">
+                <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
                   <line
-                    x1={`${(dragState.start.x / normalizedDocument.canvasDimensions.width) * 100}%`}
-                    y1={`${(dragState.start.y / normalizedDocument.canvasDimensions.height) * 100}%`}
-                    x2={`${(dragState.current.x / normalizedDocument.canvasDimensions.width) * 100}%`}
-                    y2={`${(dragState.current.y / normalizedDocument.canvasDimensions.height) * 100}%`}
+                    x1={dragState.start.x}
+                    y1={dragState.start.y}
+                    x2={dragState.current.x}
+                    y2={dragState.current.y}
                     stroke="rgb(103 232 249)"
                     strokeWidth="2"
                     strokeLinecap="round"
@@ -1051,6 +1581,17 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                       <path d="M 0 0 L 10 5 L 0 10 z" fill="rgb(103 232 249)" />
                     </marker>
                   </defs>
+                </svg>
+              ) : dragState?.tool === 'freehand' && dragState.points?.length ? (
+                <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
+                  <polyline
+                    points={dragState.points.map((point) => `${point.x},${point.y}`).join(' ')}
+                    fill="none"
+                    stroke="rgb(103 232 249)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
                 </svg>
               ) : dragState && (
                 <div
@@ -1063,29 +1604,46 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                   }}
                 />
               )}
-              {selectedObject && (selectedObject.type === 'line' || selectedObject.type === 'arrow') && selectedObject.points?.[0] && selectedObject.points?.[1] ? (
-                <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible">
+              {selectedObject && (selectedObject.type === 'line' || selectedObject.type === 'arrow') && selectedDisplayPoints?.[0] && selectedDisplayPoints?.[1] ? (
+                <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
                   <line
-                    x1={`${(selectedObject.points[0].x / normalizedDocument.canvasDimensions.width) * 100}%`}
-                    y1={`${(selectedObject.points[0].y / normalizedDocument.canvasDimensions.height) * 100}%`}
-                    x2={`${(selectedObject.points[1].x / normalizedDocument.canvasDimensions.width) * 100}%`}
-                    y2={`${(selectedObject.points[1].y / normalizedDocument.canvasDimensions.height) * 100}%`}
+                    x1={selectedDisplayPoints[0].x}
+                    y1={selectedDisplayPoints[0].y}
+                    x2={selectedDisplayPoints[1].x}
+                    y2={selectedDisplayPoints[1].y}
                     stroke="rgb(103 232 249)"
                     strokeWidth="2"
                     strokeDasharray="6 5"
                     strokeLinecap="round"
                   />
                 </svg>
-              ) : selectedObject && (
+              ) : selectedDisplayBounds && (
                 <div
                   className="pointer-events-none absolute border-2 border-cyan-300"
                   style={{
-                    left: `${(selectedObject.bounds.x / normalizedDocument.canvasDimensions.width) * 100}%`,
-                    top: `${(selectedObject.bounds.y / normalizedDocument.canvasDimensions.height) * 100}%`,
-                    width: `${(selectedObject.bounds.width / normalizedDocument.canvasDimensions.width) * 100}%`,
-                    height: `${(selectedObject.bounds.height / normalizedDocument.canvasDimensions.height) * 100}%`,
+                    left: `${(selectedDisplayBounds.x / normalizedDocument.canvasDimensions.width) * 100}%`,
+                    top: `${(selectedDisplayBounds.y / normalizedDocument.canvasDimensions.height) * 100}%`,
+                    width: `${(selectedDisplayBounds.width / normalizedDocument.canvasDimensions.width) * 100}%`,
+                    height: `${(selectedDisplayBounds.height / normalizedDocument.canvasDimensions.height) * 100}%`,
                   }}
                 />
+              )}
+              {selectedDisplayBounds && selectedObject && isResizableObjectType(selectedObject.type) && (
+                <>
+                  {RESIZE_HANDLES.map((handle) => {
+                    const point = getHandlePoint(selectedDisplayBounds, handle);
+                    return (
+                      <div
+                        key={handle}
+                        className="pointer-events-none absolute h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border border-cyan-950 bg-cyan-300 shadow-sm shadow-black/50"
+                        style={{
+                          left: `${(point.x / normalizedDocument.canvasDimensions.width) * 100}%`,
+                          top: `${(point.y / normalizedDocument.canvasDimensions.height) * 100}%`,
+                        }}
+                      />
+                    );
+                  })}
+                </>
               )}
             </div>
           </div>
@@ -1164,34 +1722,106 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
             </section>
 
             <section className="space-y-3">
-              <h3 className="text-sm font-semibold text-gray-100">Object Style</h3>
-              <div className="grid grid-cols-2 gap-2">
-                <label className="space-y-1 text-xs text-gray-400">
-                  <span>Stroke</span>
-                  <input type="color" value={activeStyle.strokeColor} onChange={(event) => { setActiveStyle({ ...activeStyle, strokeColor: event.target.value }); updateSelectedObjectStyle({ strokeColor: event.target.value }); }} className="h-8 w-full rounded border border-gray-700 bg-gray-950" />
-                </label>
-                <label className="space-y-1 text-xs text-gray-400">
-                  <span>Text</span>
-                  <input type="color" value={activeStyle.textColor} onChange={(event) => { setActiveStyle({ ...activeStyle, textColor: event.target.value }); updateSelectedObjectStyle({ textColor: event.target.value }); }} className="h-8 w-full rounded border border-gray-700 bg-gray-950" />
-                </label>
-                <label className="space-y-1 text-xs text-gray-400">
-                  <span>Width</span>
-                  <input type="number" value={activeStyle.strokeWidth} min={1} max={80} onChange={(event) => { const value = clamp(Math.round(Number(event.target.value) || 1), 1, 80); setActiveStyle({ ...activeStyle, strokeWidth: value }); updateSelectedObjectStyle({ strokeWidth: value }); }} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
-                </label>
-                <label className="space-y-1 text-xs text-gray-400">
-                  <span>Font</span>
-                  <input type="number" value={activeStyle.fontSize} min={8} max={240} onChange={(event) => { const value = clamp(Math.round(Number(event.target.value) || 32), 8, 240); setActiveStyle({ ...activeStyle, fontSize: value }); updateSelectedObjectStyle({ fontSize: value }); }} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
-                </label>
-              </div>
-              <div className="grid grid-cols-4 gap-1">
-                <button type="button" onClick={() => moveSelected('front')} disabled={!selectedObject} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800 disabled:opacity-40">Front</button>
-                <button type="button" onClick={() => moveSelected('forward')} disabled={!selectedObject} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800 disabled:opacity-40">Up</button>
-                <button type="button" onClick={() => moveSelected('backward')} disabled={!selectedObject} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800 disabled:opacity-40">Down</button>
-                <button type="button" onClick={() => moveSelected('back')} disabled={!selectedObject} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800 disabled:opacity-40">Back</button>
-              </div>
-              <button type="button" onClick={deleteSelected} disabled={!selectedObject} className="w-full rounded-md border border-red-500/30 bg-red-500/10 px-2 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/20 disabled:opacity-40">
-                Delete Selected
-              </button>
+              <h3 className="text-sm font-semibold text-gray-100">{selectedObject ? 'Selected Object' : 'Tool Style'}</h3>
+              {styleTargetType ? (
+                <>
+                  <div className="grid grid-cols-2 gap-2">
+                    {canUseStrokeColor && (
+                      <label className="space-y-1 text-xs text-gray-400">
+                        <span>Stroke</span>
+                        <input
+                          type="color"
+                          value={displayedStyle.strokeColor}
+                          onChange={(event) => {
+                            setActiveStyle({ ...activeStyle, strokeColor: event.target.value });
+                            updateSelectedObjectStyle({ strokeColor: event.target.value });
+                          }}
+                          className="h-8 w-full rounded border border-gray-700 bg-gray-950"
+                        />
+                      </label>
+                    )}
+                    {canUseFillColor && (
+                      <label className="space-y-1 text-xs text-gray-400">
+                        <span>Fill</span>
+                        <input
+                          type="color"
+                          value={toColorInputValue(displayedStyle.fillColor)}
+                          onChange={(event) => {
+                            setActiveStyle({ ...activeStyle, fillColor: event.target.value });
+                            updateSelectedObjectStyle({ fillColor: event.target.value });
+                          }}
+                          className="h-8 w-full rounded border border-gray-700 bg-gray-950"
+                        />
+                      </label>
+                    )}
+                    {canUseTextColor && (
+                      <label className="space-y-1 text-xs text-gray-400">
+                        <span>Text</span>
+                        <input
+                          type="color"
+                          value={displayedStyle.textColor}
+                          onChange={(event) => {
+                            setActiveStyle({ ...activeStyle, textColor: event.target.value });
+                            updateSelectedObjectStyle({ textColor: event.target.value });
+                          }}
+                          className="h-8 w-full rounded border border-gray-700 bg-gray-950"
+                        />
+                      </label>
+                    )}
+                    {canUseStrokeWidth && (
+                      <label className="space-y-1 text-xs text-gray-400">
+                        <span>{styleTargetType === 'blur' || styleTargetType === 'pixelate' ? 'Strength' : 'Width'}</span>
+                        <input
+                          type="number"
+                          value={displayedStyle.strokeWidth}
+                          min={1}
+                          max={80}
+                          onChange={(event) => {
+                            const value = clamp(Math.round(Number(event.target.value) || 1), 1, 80);
+                            setActiveStyle({ ...activeStyle, strokeWidth: value });
+                            updateSelectedObjectStyle({ strokeWidth: value });
+                          }}
+                          className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100"
+                        />
+                      </label>
+                    )}
+                    {canUseFontSize && (
+                      <label className="space-y-1 text-xs text-gray-400">
+                        <span>Font</span>
+                        <input
+                          type="number"
+                          value={displayedStyle.fontSize}
+                          min={8}
+                          max={240}
+                          onChange={(event) => {
+                            const value = clamp(Math.round(Number(event.target.value) || 32), 8, 240);
+                            setActiveStyle({ ...activeStyle, fontSize: value });
+                            updateSelectedObjectStyle({ fontSize: value });
+                          }}
+                          className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100"
+                        />
+                      </label>
+                    )}
+                  </div>
+                  {selectedObject && (
+                    <>
+                      <div className="grid grid-cols-4 gap-1">
+                        <button type="button" onClick={() => moveSelected('front')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Front</button>
+                        <button type="button" onClick={() => moveSelected('forward')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Up</button>
+                        <button type="button" onClick={() => moveSelected('backward')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Down</button>
+                        <button type="button" onClick={() => moveSelected('back')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Back</button>
+                      </div>
+                      <button type="button" onClick={deleteSelected} className="w-full rounded-md border border-red-500/30 bg-red-500/10 px-2 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/20">
+                        Delete Selected
+                      </button>
+                    </>
+                  )}
+                </>
+              ) : (
+                <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-500">
+                  Pick an annotation tool or select an object to edit its style.
+                </div>
+              )}
             </section>
 
             <section className="space-y-3">
@@ -1258,9 +1888,9 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
               </div>
             </section>
 
-            <button type="button" onClick={resetDocument} disabled={!hasChanges} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-40">
-              <Scissors className="h-4 w-4" />
-              Reset Editor
+            <button type="button" onClick={restoreOriginal} disabled={!hasChanges} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-40">
+              <RotateCcw className="h-4 w-4" />
+              Restore Original
             </button>
           </div>
         </aside>

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -270,6 +270,28 @@ const toCanvasPercentBounds = (bounds: ImageEditorObject['bounds'], dimensions: 
   height: `${(bounds.height / dimensions.height) * 100}%`,
 });
 
+const getEditorCursor = (tool: ImageEditorTool, isPanning: boolean) => {
+  if (isPanning) return 'grabbing';
+  switch (tool) {
+    case 'select': return 'default';
+    case 'color-picker': return 'crosshair';
+    case 'crop': return 'crosshair';
+    case 'text': return 'text';
+    case 'freehand': return 'crosshair';
+    case 'line':
+    case 'arrow':
+    case 'rectangle':
+    case 'ellipse':
+    case 'highlight':
+    case 'blur':
+    case 'pixelate':
+    case 'spotlight':
+      return 'crosshair';
+    default:
+      return 'crosshair';
+  }
+};
+
 const RESIZE_HANDLES: ResizeHandle[] = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
 
 const getHandlePoint = (bounds: ImageEditorObject['bounds'], handle: ResizeHandle) => {
@@ -385,6 +407,62 @@ const resizeBoundsFromHandle = (
   return { x, y, width, height };
 };
 
+const PixelatePreview: React.FC<{
+  sourceUrl: string;
+  bounds: ImageEditorObject['bounds'];
+  canvasDimensions: { width: number; height: number };
+  strength: number;
+}> = ({ sourceUrl, bounds, canvasDimensions, strength }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || bounds.width <= 0 || bounds.height <= 0) {
+      return;
+    }
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return;
+    }
+    const width = Math.max(1, Math.round(bounds.width));
+    const height = Math.max(1, Math.round(bounds.height));
+    canvas.width = width;
+    canvas.height = height;
+
+    const image = new Image();
+    image.onload = () => {
+      const pixelSize = Math.max(6, strength * 3);
+      const smallWidth = Math.max(1, Math.round(width / pixelSize));
+      const smallHeight = Math.max(1, Math.round(height / pixelSize));
+      const scratch = document.createElement('canvas');
+      const scratchContext = scratch.getContext('2d');
+      if (!scratchContext) {
+        return;
+      }
+      scratch.width = smallWidth;
+      scratch.height = smallHeight;
+      scratchContext.imageSmoothingEnabled = false;
+      scratchContext.drawImage(
+        image,
+        (bounds.x / canvasDimensions.width) * image.width,
+        (bounds.y / canvasDimensions.height) * image.height,
+        (bounds.width / canvasDimensions.width) * image.width,
+        (bounds.height / canvasDimensions.height) * image.height,
+        0,
+        0,
+        smallWidth,
+        smallHeight,
+      );
+      context.clearRect(0, 0, width, height);
+      context.imageSmoothingEnabled = false;
+      context.drawImage(scratch, 0, 0, smallWidth, smallHeight, 0, 0, width, height);
+    };
+    image.src = sourceUrl;
+  }, [bounds.height, bounds.width, bounds.x, bounds.y, canvasDimensions.height, canvasDimensions.width, sourceUrl, strength]);
+
+  return <canvas ref={canvasRef} className="h-full w-full" />;
+};
+
 const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   image,
   navigationImages = [],
@@ -402,6 +480,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const [isRendering, setIsRendering] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [dragState, setDragState] = useState<DragState | null>(null);
+  const [isPanning, setIsPanning] = useState(false);
   const [zoom, setZoom] = useState(1);
   const [hydratedImage, setHydratedImage] = useState<IndexedImage | null>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
@@ -888,11 +967,11 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     sampleContext.drawImage(imageElement, sampleX, sampleY, 1, 1, 0, 0, 1, 1);
     const [red, green, blue] = sampleContext.getImageData(0, 0, 1, 1).data;
     const color = rgbToHex(red, green, blue);
-    setActiveStyle((current) => ({ ...current, strokeColor: color, textColor: color }));
+    setActiveStyle((current) => ({ ...current, strokeColor: color, fillColor: color, textColor: color }));
     if (selectedObject) {
       updateSelectedObjectStyle(selectedObject.type === 'text' || selectedObject.type === 'step'
         ? { textColor: color }
-        : { strokeColor: color });
+        : { strokeColor: color, fillColor: color });
     }
   }, [normalizedDocument, selectedObject, updateSelectedObjectStyle]);
 
@@ -910,6 +989,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
         scrollLeft: scrollContainer.scrollLeft,
         scrollTop: scrollContainer.scrollTop,
       };
+      setIsPanning(true);
       return;
     }
     if (event.button !== 0) return;
@@ -996,6 +1076,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const pointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (panStateRef.current?.pointerId === event.pointerId) {
       panStateRef.current = null;
+      setIsPanning(false);
       return;
     }
     if (!dragState || !normalizedDocument) return;
@@ -1435,6 +1516,8 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const selectedDisplayedObjects = displayedObjects.filter((object) => normalizedDocument?.selectedObjectIds.includes(object.id));
   const effectOverlayObjects = displayedObjects.filter((object) => object.type === 'blur' || object.type === 'pixelate');
   const dragPreviewBounds = dragState ? boundsFromDrag(dragState) : null;
+  const basePreviewSource = previewUrl || sourceUrl;
+  const editorCursor = getEditorCursor(activeTool, isPanning);
 
   if (!normalizedDocument || !sourceUrl) {
     return (
@@ -1515,6 +1598,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                 aspectRatio: `${Math.max(1, normalizedDocument.canvasDimensions.width)} / ${Math.max(1, normalizedDocument.canvasDimensions.height)}`,
                 width: `${displayWidth}px`,
                 maxWidth: 'none',
+                cursor: editorCursor,
               }}
               onPointerDown={pointerDown}
               onPointerMove={pointerMove}
@@ -1522,6 +1606,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
               onPointerCancel={() => {
                 setDragState(null);
                 panStateRef.current = null;
+                setIsPanning(false);
               }}
               onAuxClick={(event) => event.preventDefault()}
             >
@@ -1530,19 +1615,28 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
               ) : (
                 <img ref={previewImageRef} src={sourceUrl} alt={image.name} className="block h-full w-full object-contain opacity-80" draggable={false} />
               )}
-              {effectOverlayObjects.map((object) => (
-                <div
-                  key={`effect-${object.id}`}
-                  className="pointer-events-none absolute border border-cyan-300/70 bg-cyan-300/10"
-                  style={{
-                    ...toCanvasPercentBounds(object.bounds, normalizedDocument.canvasDimensions),
-                    backdropFilter: object.type === 'blur'
-                      ? `blur(${Math.max(4, object.style.strokeWidth * 2)}px)`
-                      : 'blur(1px) contrast(1.35)',
-                    imageRendering: object.type === 'pixelate' ? 'pixelated' : undefined,
-                  }}
-                />
-              ))}
+              {effectOverlayObjects.map((object) => {
+                const boundsStyle = toCanvasPercentBounds(object.bounds, normalizedDocument.canvasDimensions);
+                return (
+                  <div
+                    key={`effect-${object.id}`}
+                    className="pointer-events-none absolute overflow-hidden"
+                    style={{
+                      ...boundsStyle,
+                      backdropFilter: object.type === 'blur' ? `blur(${Math.max(4, object.style.strokeWidth * 2)}px)` : undefined,
+                    }}
+                  >
+                    {object.type === 'pixelate' && basePreviewSource && (
+                      <PixelatePreview
+                        sourceUrl={basePreviewSource}
+                        bounds={object.bounds}
+                        canvasDimensions={normalizedDocument.canvasDimensions}
+                        strength={object.style.strokeWidth}
+                      />
+                    )}
+                  </div>
+                );
+              })}
               <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
                 {displayedObjects.map((object) => {
                   const { bounds, style } = object;
@@ -1697,15 +1791,21 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                 <>
                   {(dragState.tool === 'blur' || dragState.tool === 'pixelate') && (
                     <div
-                      className="pointer-events-none absolute border-2 border-cyan-300 bg-cyan-300/10"
+                      className="pointer-events-none absolute overflow-hidden"
                       style={{
                         ...toCanvasPercentBounds(dragPreviewBounds, normalizedDocument.canvasDimensions),
-                        backdropFilter: dragState.tool === 'blur'
-                          ? `blur(${Math.max(4, activeStyle.strokeWidth * 2)}px)`
-                          : 'blur(1px) contrast(1.35)',
-                        imageRendering: dragState.tool === 'pixelate' ? 'pixelated' : undefined,
+                        backdropFilter: dragState.tool === 'blur' ? `blur(${Math.max(4, activeStyle.strokeWidth * 2)}px)` : undefined,
                       }}
-                    />
+                    >
+                      {dragState.tool === 'pixelate' && basePreviewSource && (
+                        <PixelatePreview
+                          sourceUrl={basePreviewSource}
+                          bounds={dragPreviewBounds}
+                          canvasDimensions={normalizedDocument.canvasDimensions}
+                          strength={activeStyle.strokeWidth}
+                        />
+                      )}
+                    </div>
                   )}
                   <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
                     {dragState.tool === 'ellipse' || dragState.tool === 'spotlight' ? (
@@ -1746,9 +1846,9 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                         y={dragPreviewBounds.y}
                         width={dragPreviewBounds.width}
                         height={dragPreviewBounds.height}
-                        fill={dragState.tool === 'highlight' ? 'rgba(250, 204, 21, 0.28)' : dragState.tool === 'rectangle' ? activeStyle.fillColor : 'rgba(103, 232, 249, 0.08)'}
+                        fill={dragState.tool === 'highlight' ? 'rgba(250, 204, 21, 0.28)' : dragState.tool === 'rectangle' ? activeStyle.fillColor : 'none'}
                         stroke={activeStyle.strokeColor}
-                        strokeWidth={dragState.tool === 'rectangle' ? activeStyle.strokeWidth : Math.max(2, activeStyle.strokeWidth / 2)}
+                        strokeWidth={dragState.tool === 'blur' || dragState.tool === 'pixelate' ? 0 : dragState.tool === 'rectangle' ? activeStyle.strokeWidth : Math.max(2, activeStyle.strokeWidth / 2)}
                         strokeDasharray={dragState.tool === 'blur' || dragState.tool === 'pixelate' ? '10 8' : undefined}
                       />
                     )}

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -202,9 +202,80 @@ const TOOL_SHORTCUTS: Partial<Record<string, ImageEditorTool>> = {
   s: 'spotlight',
 };
 
-const getUsableNormalizedMetadata = (image: IndexedImage): BaseMetadata | undefined => (
-  image.metadata?.normalizedMetadata as BaseMetadata | undefined
-);
+const parseDimensions = (value?: string): { width: number; height: number } => {
+  const match = String(value || '').match(/(\d+)\s*x\s*(\d+)/i);
+  return {
+    width: match ? Number(match[1]) : 0,
+    height: match ? Number(match[2]) : 0,
+  };
+};
+
+const getUsableNormalizedMetadata = (image: IndexedImage): BaseMetadata | undefined => {
+  const normalized = image.metadata?.normalizedMetadata as BaseMetadata | undefined;
+  if (normalized) {
+    return normalized;
+  }
+
+  const hasFlattenedMetadata = Boolean(
+    image.prompt ||
+    image.negativePrompt ||
+    image.models?.length ||
+    image.loras?.length ||
+    image.sampler ||
+    image.scheduler ||
+    image.seed !== undefined ||
+    image.steps !== undefined ||
+    image.cfgScale !== undefined ||
+    image.dimensions
+  );
+
+  if (!hasFlattenedMetadata) {
+    return undefined;
+  }
+
+  const dimensions = parseDimensions(image.dimensions);
+  const model = image.models?.[0] || '';
+  return {
+    prompt: image.prompt || '',
+    negativePrompt: image.negativePrompt || '',
+    model,
+    models: image.models || [],
+    loras: image.loras || [],
+    sampler: image.sampler || '',
+    scheduler: image.scheduler || '',
+    seed: image.seed,
+    steps: image.steps || 0,
+    cfgScale: image.cfgScale,
+    cfg_scale: image.cfgScale,
+    width: dimensions.width,
+    height: dimensions.height,
+    dimensions: image.dimensions || `${dimensions.width}x${dimensions.height}`,
+  };
+};
+
+const scheduleEditedImageCacheUpsert = (
+  directory: { path: string; name: string },
+  image: IndexedImage,
+  scanSubfolders: boolean,
+) => {
+  window.setTimeout(() => {
+    const cacheModes = Array.from(new Set([scanSubfolders, !scanSubfolders]));
+    Promise.all(
+      cacheModes.map((scanSubfoldersMode) =>
+        cacheManager.applyChunkedCacheDelta(
+          directory.path,
+          directory.name,
+          [image],
+          [],
+          [],
+          scanSubfoldersMode,
+        )
+      )
+    ).catch((error) => {
+      console.error('Failed to update cache after editor image save:', error);
+    });
+  }, 0);
+};
 
 const boundsFromPoints = (points: Array<{ x: number; y: number }>): ImageEditorObject['bounds'] => {
   const minX = Math.min(...points.map((point) => point.x));
@@ -797,14 +868,12 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     if (mode === 'overwrite') {
       mergeImages([indexedImage]);
       setImageThumbnail(image.id, { thumbnailUrl: null, thumbnailHandle: null, status: 'pending', error: null });
-      await cacheManager.updateCachedImages(sourceDirectory.path, sourceDirectory.name, [indexedImage], scanSubfolders);
     } else if (allImages.some((candidate) => candidate.id === indexedImage.id)) {
       mergeImages([indexedImage]);
-      await cacheManager.updateCachedImages(sourceDirectory.path, sourceDirectory.name, [indexedImage], scanSubfolders);
     } else {
       addImages([indexedImage]);
-      await cacheManager.appendToCache(sourceDirectory.path, sourceDirectory.name, [indexedImage], scanSubfolders);
     }
+    scheduleEditedImageCacheUpsert(sourceDirectory, indexedImage, scanSubfolders);
     return indexedImage;
   }, [
     addImages,

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -373,6 +373,37 @@ const toCanvasPercentBounds = (bounds: ImageEditorObject['bounds'], dimensions: 
   height: `${(bounds.height / dimensions.height) * 100}%`,
 });
 
+const areDimensionsEqual = (
+  first: { width: number; height: number },
+  second: { width: number; height: number },
+) => first.width === second.width && first.height === second.height;
+
+const remapObjectToCanvasDimensions = (
+  object: ImageEditorObject,
+  from: { width: number; height: number },
+  to: { width: number; height: number },
+): ImageEditorObject => {
+  const scaleX = to.width / Math.max(1, from.width);
+  const scaleY = to.height / Math.max(1, from.height);
+  const bounds = {
+    x: clamp(object.bounds.x * scaleX, 0, Math.max(0, to.width - 1)),
+    y: clamp(object.bounds.y * scaleY, 0, Math.max(0, to.height - 1)),
+    width: clamp(object.bounds.width * scaleX, 1, to.width),
+    height: clamp(object.bounds.height * scaleY, 1, to.height),
+  };
+  bounds.width = clamp(bounds.width, 1, Math.max(1, to.width - bounds.x));
+  bounds.height = clamp(bounds.height, 1, Math.max(1, to.height - bounds.y));
+
+  return {
+    ...object,
+    bounds,
+    points: object.points?.map((point) => ({
+      x: clamp(point.x * scaleX, 0, to.width),
+      y: clamp(point.y * scaleY, 0, to.height),
+    })),
+  };
+};
+
 const getEditorCursor = (tool: ImageEditorTool, isPanning: boolean) => {
   if (isPanning) return 'grabbing';
   switch (tool) {
@@ -1008,7 +1039,30 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   }, [documentState]);
 
   const updateRecipe = useCallback((recipe: ImageEditorDocument['recipe']) => {
-    commitDocument((current) => ({ ...current, recipe: normalizeImageEditRecipe(recipe, current.sourceDimensions) }), 'Edit recipe');
+    commitDocument((current) => {
+      const normalizedRecipe = normalizeImageEditRecipe(recipe, current.sourceDimensions);
+      const nextCanvasDimensions = getImageEditOutputDimensions(normalizedRecipe, current.sourceDimensions);
+      const currentCanvasDimensions = current.canvasDimensions;
+
+      if (areDimensionsEqual(currentCanvasDimensions, nextCanvasDimensions)) {
+        return {
+          ...current,
+          recipe: normalizedRecipe,
+          canvasDimensions: nextCanvasDimensions,
+        };
+      }
+
+      return {
+        ...current,
+        recipe: normalizedRecipe,
+        canvasDimensions: nextCanvasDimensions,
+        objects: current.objects.map((object) => remapObjectToCanvasDimensions(
+          object,
+          currentCanvasDimensions,
+          nextCanvasDimensions,
+        )),
+      };
+    }, 'Edit recipe');
   }, [commitDocument]);
 
   const updateSelectedObjectStyle = useCallback((style: Partial<ImageEditorObjectStyle>) => {

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -644,6 +644,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const previewImageRef = useRef<HTMLImageElement>(null);
   const textEditorRef = useRef<HTMLTextAreaElement>(null);
   const sessionRef = useRef<EditorSessionState | null>(null);
+  const shouldSkipSessionCacheRef = useRef(false);
   const panStateRef = useRef<PanState | null>(null);
 
   const directories = useImageStore((state) => state.directories);
@@ -769,6 +770,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     setHydratedImage(null);
 
     const load = async () => {
+      shouldSkipSessionCacheRef.current = false;
       try {
         const source = await mediaSourceCache.getOrLoad(image, directoryPath, { prioritize: true });
         if (!mounted) return;
@@ -806,7 +808,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     void load();
     return () => {
       mounted = false;
-      if (sessionRef.current) {
+      if (!shouldSkipSessionCacheRef.current && sessionRef.current) {
         editorSessionCache.set(image.id, sessionRef.current);
       }
     };
@@ -1031,8 +1033,11 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     if (hasChanges && !window.confirm('Leave the image editor and discard the current editor state?')) {
       return;
     }
+    shouldSkipSessionCacheRef.current = true;
+    editorSessionCache.delete(image.id);
+    sessionRef.current = null;
     onBack();
-  }, [hasChanges, onBack]);
+  }, [hasChanges, image.id, onBack]);
 
   const undo = useCallback(() => {
     setHistory((current) => {
@@ -1122,6 +1127,9 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     if (!window.confirm('Restore the original image and discard all editor changes?')) {
       return;
     }
+    shouldSkipSessionCacheRef.current = true;
+    editorSessionCache.delete(image.id);
+    sessionRef.current = null;
     setDocumentState(createImageEditorDocument({
       imageId: image.id,
       name: image.name,

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -228,9 +228,7 @@ const objectFromDrag = (
     ? { x: drag.start.x, y: drag.start.y, width: tool === 'step' ? 44 : Math.max(160, width), height: tool === 'step' ? 44 : Math.max(48, height) }
     : { x, y, width, height };
 
-  const text = tool === 'text'
-    ? window.prompt('Text annotation', 'Text') || 'Text'
-    : undefined;
+  const text = tool === 'text' ? 'Text' : undefined;
   const directionalPoints = tool === 'line' || tool === 'arrow'
     ? [drag.start, drag.current]
     : undefined;
@@ -265,6 +263,12 @@ const getCanvasPoint = (
 const colorComponentToHex = (value: number) => Math.round(value).toString(16).padStart(2, '0');
 const rgbToHex = (red: number, green: number, blue: number) => `#${colorComponentToHex(red)}${colorComponentToHex(green)}${colorComponentToHex(blue)}`;
 const toColorInputValue = (value: string | undefined) => /^#[0-9a-f]{6}$/i.test(value || '') ? value as string : '#000000';
+const toCanvasPercentBounds = (bounds: ImageEditorObject['bounds'], dimensions: { width: number; height: number }) => ({
+  left: `${(bounds.x / dimensions.width) * 100}%`,
+  top: `${(bounds.y / dimensions.height) * 100}%`,
+  width: `${(bounds.width / dimensions.width) * 100}%`,
+  height: `${(bounds.height / dimensions.height) * 100}%`,
+});
 
 const RESIZE_HANDLES: ResizeHandle[] = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
 
@@ -826,6 +830,14 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     }), 'Object style');
   }, [commitDocument, selectedObject]);
 
+  const updateSelectedObjectText = useCallback((text: string) => {
+    if (!selectedObject || selectedObject.type !== 'text') return;
+    commitDocument((current) => ({
+      ...current,
+      objects: current.objects.map((object) => object.id === selectedObject.id ? { ...object, text } : object),
+    }), 'Text');
+  }, [commitDocument, selectedObject]);
+
   const deleteSelected = useCallback(() => {
     if (!normalizedDocument?.selectedObjectIds.length) return;
     const ids = new Set(normalizedDocument.selectedObjectIds);
@@ -1326,24 +1338,33 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     undo,
   ]);
 
-  const handleWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    const factor = event.deltaY < 0 ? 1.1 : 1 / 1.1;
-    const canvasRect = canvasRef.current?.getBoundingClientRect();
-    const scrollContainer = scrollContainerRef.current;
-    const anchorX = canvasRect ? event.clientX - canvasRect.left : 0;
-    const anchorY = canvasRect ? event.clientY - canvasRect.top : 0;
-    setZoom((current) => {
-      const next = clampZoom(current * factor);
-      const scale = next / current;
-      if (scrollContainer && canvasRect && scale !== 1) {
-        requestAnimationFrame(() => {
-          scrollContainer.scrollLeft += anchorX * (scale - 1);
-          scrollContainer.scrollTop += anchorY * (scale - 1);
-        });
-      }
-      return next;
-    });
+  useEffect(() => {
+    const canvasElement = canvasRef.current;
+    if (!canvasElement) {
+      return;
+    }
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const factor = event.deltaY < 0 ? 1.1 : 1 / 1.1;
+      const canvasRect = canvasRef.current?.getBoundingClientRect();
+      const scrollContainer = scrollContainerRef.current;
+      const anchorX = canvasRect ? event.clientX - canvasRect.left : 0;
+      const anchorY = canvasRect ? event.clientY - canvasRect.top : 0;
+      setZoom((current) => {
+        const next = clampZoom(current * factor);
+        const scale = next / current;
+        if (scrollContainer && canvasRect && scale !== 1) {
+          requestAnimationFrame(() => {
+            scrollContainer.scrollLeft += anchorX * (scale - 1);
+            scrollContainer.scrollTop += anchorY * (scale - 1);
+          });
+        }
+        return next;
+      });
+    };
+
+    canvasElement.addEventListener('wheel', handleWheel, { passive: false });
+    return () => canvasElement.removeEventListener('wheel', handleWheel);
   }, []);
 
   const activeOutputDimensions = normalizedDocument
@@ -1412,6 +1433,8 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       return object;
     });
   const selectedDisplayedObjects = displayedObjects.filter((object) => normalizedDocument?.selectedObjectIds.includes(object.id));
+  const effectOverlayObjects = displayedObjects.filter((object) => object.type === 'blur' || object.type === 'pixelate');
+  const dragPreviewBounds = dragState ? boundsFromDrag(dragState) : null;
 
   if (!normalizedDocument || !sourceUrl) {
     return (
@@ -1501,13 +1524,25 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                 panStateRef.current = null;
               }}
               onAuxClick={(event) => event.preventDefault()}
-              onWheel={handleWheel}
             >
               {previewUrl ? (
                 <img ref={previewImageRef} src={previewUrl} alt={image.name} className="block h-full w-full object-contain" draggable={false} />
               ) : (
                 <img ref={previewImageRef} src={sourceUrl} alt={image.name} className="block h-full w-full object-contain opacity-80" draggable={false} />
               )}
+              {effectOverlayObjects.map((object) => (
+                <div
+                  key={`effect-${object.id}`}
+                  className="pointer-events-none absolute border border-cyan-300/70 bg-cyan-300/10"
+                  style={{
+                    ...toCanvasPercentBounds(object.bounds, normalizedDocument.canvasDimensions),
+                    backdropFilter: object.type === 'blur'
+                      ? `blur(${Math.max(4, object.style.strokeWidth * 2)}px)`
+                      : 'blur(1px) contrast(1.35)',
+                    imageRendering: object.type === 'pixelate' ? 'pixelated' : undefined,
+                  }}
+                />
+              ))}
               <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
                 {displayedObjects.map((object) => {
                   const { bounds, style } = object;
@@ -1526,7 +1561,45 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                       />
                     );
                   }
-                  if (object.type === 'ellipse' || object.type === 'spotlight' || object.type === 'magnify') {
+                  if (object.type === 'spotlight') {
+                    const maskId = `image-editor-spotlight-${object.id}`;
+                    return (
+                      <g key={object.id}>
+                        <defs>
+                          <mask id={maskId}>
+                            <rect x={0} y={0} width={normalizedDocument.canvasDimensions.width} height={normalizedDocument.canvasDimensions.height} fill="white" />
+                            <ellipse
+                              cx={bounds.x + bounds.width / 2}
+                              cy={bounds.y + bounds.height / 2}
+                              rx={bounds.width / 2}
+                              ry={bounds.height / 2}
+                              fill="black"
+                            />
+                          </mask>
+                        </defs>
+                        <rect
+                          x={0}
+                          y={0}
+                          width={normalizedDocument.canvasDimensions.width}
+                          height={normalizedDocument.canvasDimensions.height}
+                          fill="rgba(0, 0, 0, 0.48)"
+                          mask={`url(#${maskId})`}
+                        />
+                        <ellipse
+                          cx={bounds.x + bounds.width / 2}
+                          cy={bounds.y + bounds.height / 2}
+                          rx={bounds.width / 2}
+                          ry={bounds.height / 2}
+                          fill="none"
+                          stroke={style.strokeColor}
+                          strokeWidth={style.strokeWidth}
+                          opacity={style.opacity}
+                          strokeDasharray="10 8"
+                        />
+                      </g>
+                    );
+                  }
+                  if (object.type === 'ellipse' || object.type === 'magnify') {
                     return (
                       <ellipse
                         key={object.id}
@@ -1616,26 +1689,72 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                       </g>
                     );
                   }
-                  if (object.type === 'blur' || object.type === 'pixelate') {
-                    return (
-                      <rect
-                        key={object.id}
-                        x={bounds.x}
-                        y={bounds.y}
-                        width={bounds.width}
-                        height={bounds.height}
-                        fill="rgba(103, 232, 249, 0.08)"
-                        stroke={style.strokeColor}
-                        strokeWidth={Math.max(2, style.strokeWidth / 2)}
-                        strokeDasharray="10 8"
-                        opacity={style.opacity}
-                      />
-                    );
-                  }
+                  if (object.type === 'blur' || object.type === 'pixelate') return null;
                   return null;
                 })}
               </svg>
-              {dragState && (dragState.tool === 'line' || dragState.tool === 'arrow') ? (
+              {dragPreviewBounds && dragState && (dragState.tool === 'rectangle' || dragState.tool === 'highlight' || dragState.tool === 'ellipse' || dragState.tool === 'blur' || dragState.tool === 'pixelate' || dragState.tool === 'spotlight') ? (
+                <>
+                  {(dragState.tool === 'blur' || dragState.tool === 'pixelate') && (
+                    <div
+                      className="pointer-events-none absolute border-2 border-cyan-300 bg-cyan-300/10"
+                      style={{
+                        ...toCanvasPercentBounds(dragPreviewBounds, normalizedDocument.canvasDimensions),
+                        backdropFilter: dragState.tool === 'blur'
+                          ? `blur(${Math.max(4, activeStyle.strokeWidth * 2)}px)`
+                          : 'blur(1px) contrast(1.35)',
+                        imageRendering: dragState.tool === 'pixelate' ? 'pixelated' : undefined,
+                      }}
+                    />
+                  )}
+                  <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
+                    {dragState.tool === 'ellipse' || dragState.tool === 'spotlight' ? (
+                      dragState.tool === 'spotlight' ? (
+                        <g>
+                          <defs>
+                            <mask id="image-editor-spotlight-preview">
+                              <rect x={0} y={0} width={normalizedDocument.canvasDimensions.width} height={normalizedDocument.canvasDimensions.height} fill="white" />
+                              <ellipse cx={dragPreviewBounds.x + dragPreviewBounds.width / 2} cy={dragPreviewBounds.y + dragPreviewBounds.height / 2} rx={dragPreviewBounds.width / 2} ry={dragPreviewBounds.height / 2} fill="black" />
+                            </mask>
+                          </defs>
+                          <rect x={0} y={0} width={normalizedDocument.canvasDimensions.width} height={normalizedDocument.canvasDimensions.height} fill="rgba(0, 0, 0, 0.48)" mask="url(#image-editor-spotlight-preview)" />
+                          <ellipse
+                            cx={dragPreviewBounds.x + dragPreviewBounds.width / 2}
+                            cy={dragPreviewBounds.y + dragPreviewBounds.height / 2}
+                            rx={dragPreviewBounds.width / 2}
+                            ry={dragPreviewBounds.height / 2}
+                            fill="none"
+                            stroke={activeStyle.strokeColor}
+                            strokeWidth={activeStyle.strokeWidth}
+                            strokeDasharray="10 8"
+                          />
+                        </g>
+                      ) : (
+                        <ellipse
+                          cx={dragPreviewBounds.x + dragPreviewBounds.width / 2}
+                          cy={dragPreviewBounds.y + dragPreviewBounds.height / 2}
+                          rx={dragPreviewBounds.width / 2}
+                          ry={dragPreviewBounds.height / 2}
+                          fill={activeStyle.fillColor}
+                          stroke={activeStyle.strokeColor}
+                          strokeWidth={activeStyle.strokeWidth}
+                        />
+                      )
+                    ) : (
+                      <rect
+                        x={dragPreviewBounds.x}
+                        y={dragPreviewBounds.y}
+                        width={dragPreviewBounds.width}
+                        height={dragPreviewBounds.height}
+                        fill={dragState.tool === 'highlight' ? 'rgba(250, 204, 21, 0.28)' : dragState.tool === 'rectangle' ? activeStyle.fillColor : 'rgba(103, 232, 249, 0.08)'}
+                        stroke={activeStyle.strokeColor}
+                        strokeWidth={dragState.tool === 'rectangle' ? activeStyle.strokeWidth : Math.max(2, activeStyle.strokeWidth / 2)}
+                        strokeDasharray={dragState.tool === 'blur' || dragState.tool === 'pixelate' ? '10 8' : undefined}
+                      />
+                    )}
+                  </svg>
+                </>
+              ) : dragState && (dragState.tool === 'line' || dragState.tool === 'arrow') ? (
                 <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
                   <line
                     x1={dragState.start.x}
@@ -1804,6 +1923,17 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
               {styleTargetType ? (
                 <>
                   <div className="grid grid-cols-2 gap-2">
+                    {selectedObject?.type === 'text' && (
+                      <label className="col-span-2 space-y-1 text-xs text-gray-400">
+                        <span>Text</span>
+                        <input
+                          type="text"
+                          value={selectedObject.text || ''}
+                          onChange={(event) => updateSelectedObjectText(event.target.value)}
+                          className="h-9 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-sm text-gray-100"
+                        />
+                      </label>
+                    )}
                     {canUseStrokeColor && (
                       <label className="space-y-1 text-xs text-gray-400">
                         <span>Stroke</span>

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -1974,7 +1974,19 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
               <input
                 type="checkbox"
                 checked={normalizedDocument.recipe.resize.enabled}
-                onChange={(event) => updateRecipe({ ...normalizedDocument.recipe, resize: { ...normalizedDocument.recipe.resize, enabled: event.target.checked } })}
+                onChange={(event) => {
+                  const enabled = event.target.checked;
+                  const base = baseOutputDimensions || normalizedDocument.sourceDimensions;
+                  updateRecipe({
+                    ...normalizedDocument.recipe,
+                    resize: {
+                      ...normalizedDocument.recipe.resize,
+                      enabled,
+                      width: enabled ? Math.max(1, Math.round(base.width)) : normalizedDocument.recipe.resize.width,
+                      height: enabled ? Math.max(1, Math.round(base.height)) : normalizedDocument.recipe.resize.height,
+                    },
+                  });
+                }}
                 className="h-4 w-4 accent-cyan-500"
               />
               Enable

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -26,9 +26,11 @@ import {
   Type,
   Undo2,
   Workflow,
+  X,
 } from 'lucide-react';
 import type {
   BaseMetadata,
+  ImageEditCropAspect,
   ImageEditorDocument,
   ImageEditorObject,
   ImageEditorObjectStyle,
@@ -36,13 +38,18 @@ import type {
   IndexedImage,
 } from '../types';
 import {
+  CROP_ASPECTS,
   DEFAULT_IMAGE_EDITOR_OBJECT_STYLE,
   clampImageAdjustment,
+  clampImageEditCropRect,
   clampImageEditEffect,
+  createDefaultCropRect,
   createImageEditorDocument,
   embedMetaHubMetadataInPngBytes,
   getImageEditOutputDimensions,
+  getRecipeBaseOutputDimensions,
   hasImageEditorDocumentChanges,
+  normalizeImageEditRotation,
   normalizeImageEditRecipe,
   normalizeImageEditorDocument,
   renderImageEditorDocumentToPngBlob,
@@ -93,6 +100,8 @@ type DragState = {
 
 type ResizeHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
 
+type InspectorTab = 'edit' | 'style' | 'canvas' | 'ai' | 'info';
+
 type PanState = {
   pointerId: number;
   startClientX: number;
@@ -118,6 +127,24 @@ const TOOL_DEFS: Array<{ id: ImageEditorTool; label: string; icon: React.ReactNo
   { id: 'pixelate', label: 'Pixelate', icon: <Shield className="h-4 w-4" /> },
   { id: 'spotlight', label: 'Spotlight', icon: <Search className="h-4 w-4" /> },
 ];
+
+const INSPECTOR_TABS: Array<{ id: InspectorTab; label: string }> = [
+  { id: 'edit', label: 'Edit' },
+  { id: 'style', label: 'Style' },
+  { id: 'canvas', label: 'Canvas' },
+  { id: 'ai', label: 'AI' },
+  { id: 'info', label: 'Info' },
+];
+
+const ASPECT_LABELS: Record<ImageEditCropAspect, string> = {
+  free: 'Free',
+  original: 'Original',
+  '1:1': '1:1',
+  '4:3': '4:3',
+  '3:2': '3:2',
+  '16:9': '16:9',
+  '9:16': '9:16',
+};
 
 const isEnabledEditorTool = (tool: ImageEditorTool) => TOOL_DEFS.some((definition) => definition.id === tool);
 
@@ -483,6 +510,8 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const [isPanning, setIsPanning] = useState(false);
   const [zoom, setZoom] = useState(1);
   const [hydratedImage, setHydratedImage] = useState<IndexedImage | null>(null);
+  const [inspectorTab, setInspectorTab] = useState<InspectorTab>('info');
+  const [isInspectorOpen, setIsInspectorOpen] = useState(false);
   const canvasRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const previewImageRef = useRef<HTMLImageElement>(null);
@@ -541,6 +570,24 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const selectedObject = normalizedDocument?.objects.find((object) => normalizedDocument.selectedObjectIds.includes(object.id)) || null;
   const canOverwrite = getFileExtension(image.name) === '.png';
   const displayWidth = Math.max(160, Math.round(1080 * zoom));
+
+  useEffect(() => {
+    if (!normalizedDocument) {
+      setInspectorTab('info');
+      return;
+    }
+    if (activeTool === 'crop') {
+      setInspectorTab('edit');
+      return;
+    }
+    if (normalizedDocument.selectedObjectIds.length > 0 || isAnnotationTool(activeTool)) {
+      setInspectorTab('style');
+      return;
+    }
+    if (activeTool === 'select' || activeTool === 'color-picker') {
+      setInspectorTab('info');
+    }
+  }, [activeTool, normalizedDocument?.selectedObjectIds.length]);
 
   useEffect(() => {
     if (!documentState) {
@@ -1518,6 +1565,446 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const dragPreviewBounds = dragState ? boundsFromDrag(dragState) : null;
   const basePreviewSource = previewUrl || sourceUrl;
   const editorCursor = getEditorCursor(activeTool, isPanning);
+  const cropRect = normalizedDocument?.recipe.crop.rect ?? null;
+  const baseOutputDimensions = normalizedDocument
+    ? getRecipeBaseOutputDimensions(normalizedDocument.recipe, normalizedDocument.sourceDimensions)
+    : null;
+
+  const setActiveOrSelectedStyle = (style: Partial<ImageEditorObjectStyle>) => {
+    setActiveStyle((current) => ({ ...current, ...style }));
+    updateSelectedObjectStyle(style);
+  };
+
+  const renderSliderRow = (
+    label: string,
+    value: number,
+    min: number,
+    max: number,
+    onChange: (value: number) => void,
+    suffix?: string,
+  ) => (
+    <label className="block space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-medium text-gray-300">{label}</span>
+        <div className="flex items-center gap-1">
+          <input
+            type="number"
+            min={min}
+            max={max}
+            value={value}
+            onChange={(event) => onChange(Number(event.target.value))}
+            className="h-7 w-16 rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100 outline-none focus:border-cyan-500"
+            aria-label={label}
+          />
+          {suffix && <span className="w-7 text-xs text-gray-500">{suffix}</span>}
+        </div>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="w-full accent-cyan-500"
+        aria-label={`${label} slider`}
+      />
+    </label>
+  );
+
+  const renderColorSwatch = (
+    label: string,
+    value: string,
+    onChange: (value: string) => void,
+  ) => (
+    <label className="flex items-center justify-between gap-3 rounded-md border border-gray-800 bg-gray-950 px-2 py-2 text-xs text-gray-300">
+      <span>{label}</span>
+      <input
+        type="color"
+        value={toColorInputValue(value)}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-6 w-8 cursor-pointer rounded border border-gray-700 bg-gray-950 p-0.5"
+        aria-label={label}
+      />
+    </label>
+  );
+
+  const renderInspectorContent = () => {
+    if (!normalizedDocument) return null;
+
+    if (inspectorTab === 'edit') {
+      return (
+        <div className="space-y-4">
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold text-gray-100">Local Edits</h3>
+              <button type="button" onClick={restoreOriginal} disabled={!hasChanges} className="rounded-md border border-gray-700 px-2 py-1 text-xs font-medium text-gray-300 hover:bg-gray-800 disabled:opacity-40">
+                Reset
+              </button>
+            </div>
+            {(['brightness', 'contrast', 'saturation'] as const).map((key) => (
+              <React.Fragment key={key}>
+                {renderSliderRow(
+                  key[0].toUpperCase() + key.slice(1),
+                  normalizedDocument.recipe.adjustments[key],
+                  0,
+                  200,
+                  (value) => updateRecipe({
+                    ...normalizedDocument.recipe,
+                    adjustments: {
+                      ...normalizedDocument.recipe.adjustments,
+                      [key]: clampImageAdjustment(key, value),
+                    },
+                  }),
+                  '%',
+                )}
+              </React.Fragment>
+            ))}
+            {renderSliderRow('Hue', normalizedDocument.recipe.adjustments.hue, -180, 180, (value) => updateRecipe({
+              ...normalizedDocument.recipe,
+              adjustments: {
+                ...normalizedDocument.recipe.adjustments,
+                hue: clampImageAdjustment('hue', value),
+              },
+            }), 'deg')}
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-100">Crop</h3>
+            <div className="flex items-center justify-between gap-2">
+              <label className="inline-flex items-center gap-2 text-xs font-medium text-gray-300">
+                <input
+                  type="checkbox"
+                  checked={normalizedDocument.recipe.crop.enabled}
+                  onChange={(event) => updateRecipe({
+                    ...normalizedDocument.recipe,
+                    crop: {
+                      ...normalizedDocument.recipe.crop,
+                      enabled: event.target.checked,
+                      rect: event.target.checked
+                        ? normalizedDocument.recipe.crop.rect || createDefaultCropRect(normalizedDocument.sourceDimensions, normalizedDocument.recipe.crop.aspect)
+                        : normalizedDocument.recipe.crop.rect,
+                    },
+                  })}
+                  className="h-4 w-4 accent-cyan-500"
+                />
+                Enable
+              </label>
+              <select
+                value={normalizedDocument.recipe.crop.aspect}
+                onChange={(event) => updateRecipe({
+                  ...normalizedDocument.recipe,
+                  crop: {
+                    enabled: normalizedDocument.recipe.crop.enabled,
+                    aspect: event.target.value as ImageEditCropAspect,
+                    rect: normalizedDocument.recipe.crop.enabled
+                      ? createDefaultCropRect(normalizedDocument.sourceDimensions, event.target.value as ImageEditCropAspect)
+                      : normalizedDocument.recipe.crop.rect,
+                  },
+                })}
+                className="h-8 rounded-md border border-gray-700 bg-gray-950 px-2 text-xs text-gray-100 outline-none focus:border-cyan-500"
+                aria-label="Crop aspect ratio"
+              >
+                {CROP_ASPECTS.map((aspect) => <option key={aspect} value={aspect}>{ASPECT_LABELS[aspect]}</option>)}
+              </select>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              {(['x', 'y', 'width', 'height'] as const).map((key) => (
+                <label key={key} className="space-y-1 text-xs text-gray-400">
+                  <span className="capitalize">{key}</span>
+                  <input
+                    type="number"
+                    min={key === 'x' || key === 'y' ? 0 : 1}
+                    value={cropRect?.[key] ?? 0}
+                    disabled={!normalizedDocument.recipe.crop.enabled}
+                    onChange={(event) => updateRecipe({
+                      ...normalizedDocument.recipe,
+                      crop: {
+                        ...normalizedDocument.recipe.crop,
+                        enabled: true,
+                        rect: clampImageEditCropRect({
+                          ...(cropRect || createDefaultCropRect(normalizedDocument.sourceDimensions, normalizedDocument.recipe.crop.aspect) || { x: 0, y: 0, width: 1, height: 1 }),
+                          [key]: Number(event.target.value),
+                        }, normalizedDocument.sourceDimensions),
+                      },
+                    })}
+                    className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100 outline-none focus:border-cyan-500 disabled:opacity-50"
+                    aria-label={`Crop ${key}`}
+                  />
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-100">Transform</h3>
+            <div className="grid grid-cols-2 gap-2">
+              <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, rotation: normalizeImageEditRotation(normalizedDocument.recipe.transform.rotation - 90) } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
+                <RotateCcw className="h-3.5 w-3.5" /> Left
+              </button>
+              <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, rotation: normalizeImageEditRotation(normalizedDocument.recipe.transform.rotation + 90) } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
+                <RotateCw className="h-3.5 w-3.5" /> Right
+              </button>
+              <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, flipHorizontal: !normalizedDocument.recipe.transform.flipHorizontal } })} className={`inline-flex items-center justify-center gap-1 rounded-md border px-2 py-2 text-xs ${normalizedDocument.recipe.transform.flipHorizontal ? 'border-cyan-400/40 bg-cyan-500/20 text-cyan-100' : 'border-gray-700 hover:bg-gray-800'}`}>
+                <FlipHorizontal className="h-3.5 w-3.5" /> Flip H
+              </button>
+              <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, flipVertical: !normalizedDocument.recipe.transform.flipVertical } })} className={`inline-flex items-center justify-center gap-1 rounded-md border px-2 py-2 text-xs ${normalizedDocument.recipe.transform.flipVertical ? 'border-cyan-400/40 bg-cyan-500/20 text-cyan-100' : 'border-gray-700 hover:bg-gray-800'}`}>
+                <FlipVertical className="h-3.5 w-3.5" /> Flip V
+              </button>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              {(['sharpen', 'blur'] as const).map((key) => (
+                <label key={key} className="space-y-1 text-xs text-gray-400">
+                  <span className="capitalize">{key}</span>
+                  <input
+                    type="number"
+                    value={normalizedDocument.recipe.effects[key]}
+                    min={0}
+                    max={key === 'blur' ? 20 : 100}
+                    onChange={(event) => updateRecipe({
+                      ...normalizedDocument.recipe,
+                      effects: {
+                        ...normalizedDocument.recipe.effects,
+                        [key]: clampImageEditEffect(key, Number(event.target.value)),
+                      },
+                    })}
+                    className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100"
+                  />
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-100">Resize</h3>
+            <label className="inline-flex items-center gap-2 text-xs font-medium text-gray-300">
+              <input
+                type="checkbox"
+                checked={normalizedDocument.recipe.resize.enabled}
+                onChange={(event) => updateRecipe({ ...normalizedDocument.recipe, resize: { ...normalizedDocument.recipe.resize, enabled: event.target.checked } })}
+                className="h-4 w-4 accent-cyan-500"
+              />
+              Enable
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {(['width', 'height'] as const).map((key) => (
+                <label key={key} className="space-y-1 text-xs text-gray-400">
+                  <span className="capitalize">{key}</span>
+                  <input
+                    type="number"
+                    min={1}
+                    value={normalizedDocument.recipe.resize[key]}
+                    onChange={(event) => {
+                      const nextValue = Math.max(1, Math.round(Number(event.target.value)) || 1);
+                      const base = baseOutputDimensions || normalizedDocument.sourceDimensions;
+                      const ratio = base.width / Math.max(1, base.height);
+                      const width = key === 'width'
+                        ? nextValue
+                        : normalizedDocument.recipe.resize.lockAspectRatio
+                          ? Math.max(1, Math.round(nextValue * ratio))
+                          : normalizedDocument.recipe.resize.width;
+                      const height = key === 'height'
+                        ? nextValue
+                        : normalizedDocument.recipe.resize.lockAspectRatio
+                          ? Math.max(1, Math.round(nextValue / ratio))
+                          : normalizedDocument.recipe.resize.height;
+                      updateRecipe({ ...normalizedDocument.recipe, resize: { ...normalizedDocument.recipe.resize, enabled: true, width, height } });
+                    }}
+                    className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100"
+                  />
+                </label>
+              ))}
+            </div>
+            <label className="inline-flex items-center gap-2 text-xs text-gray-400">
+              <input
+                type="checkbox"
+                checked={normalizedDocument.recipe.resize.lockAspectRatio}
+                onChange={(event) => updateRecipe({ ...normalizedDocument.recipe, resize: { ...normalizedDocument.recipe.resize, lockAspectRatio: event.target.checked } })}
+                className="h-4 w-4 accent-cyan-500"
+              />
+              Lock ratio
+            </label>
+          </section>
+        </div>
+      );
+    }
+
+    if (inspectorTab === 'style') {
+      if (selectedCount > 1) {
+        return (
+          <div className="space-y-4">
+            <section className="rounded-md border border-gray-800 bg-gray-950 p-3">
+              <h3 className="text-sm font-semibold text-gray-100">{selectedCount} objects selected</h3>
+              <p className="mt-1 text-xs text-gray-500">Shared style controls are hidden for mixed selections.</p>
+            </section>
+            <div className="grid grid-cols-2 gap-2">
+              <button type="button" onClick={flattenSelection} className="rounded-md border border-gray-700 px-2 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800">Flatten</button>
+              <button type="button" onClick={deleteSelected} className="rounded-md border border-red-500/30 bg-red-500/10 px-2 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/20">Delete</button>
+            </div>
+          </div>
+        );
+      }
+
+      if (!styleTargetType) {
+        return (
+          <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-500">
+            Select an object or choose an annotation tool to show its style.
+          </div>
+        );
+      }
+
+      return (
+        <div className="space-y-4">
+          <section className="space-y-3">
+            <div>
+              <h3 className="text-sm font-semibold text-gray-100">{selectedObject ? `${selectedObject.type} style` : `${styleTargetType} defaults`}</h3>
+              <p className="mt-1 text-xs text-gray-500">{selectedObject ? 'Editing the selected object.' : 'Applies to the next object you draw.'}</p>
+            </div>
+            {selectedObject?.type === 'text' && (
+              <label className="block space-y-1 text-xs text-gray-400">
+                <span>Content</span>
+                <input
+                  type="text"
+                  value={selectedObject.text || ''}
+                  onChange={(event) => updateSelectedObjectText(event.target.value)}
+                  className="h-9 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-sm text-gray-100 outline-none focus:border-cyan-500"
+                />
+              </label>
+            )}
+            <div className="grid grid-cols-2 gap-2">
+              {canUseStrokeColor && renderColorSwatch('Stroke', displayedStyle.strokeColor, (value) => setActiveOrSelectedStyle({ strokeColor: value }))}
+              {canUseFillColor && renderColorSwatch('Fill', displayedStyle.fillColor, (value) => setActiveOrSelectedStyle({ fillColor: value }))}
+              {canUseTextColor && renderColorSwatch('Text', displayedStyle.textColor, (value) => setActiveOrSelectedStyle({ textColor: value }))}
+            </div>
+            {canUseStrokeWidth && renderSliderRow(
+              styleTargetType === 'blur' || styleTargetType === 'pixelate' ? 'Strength' : 'Width',
+              displayedStyle.strokeWidth,
+              1,
+              80,
+              (value) => setActiveOrSelectedStyle({ strokeWidth: clamp(Math.round(value) || 1, 1, 80) }),
+            )}
+            {canUseFontSize && renderSliderRow(
+              'Font',
+              displayedStyle.fontSize,
+              8,
+              240,
+              (value) => setActiveOrSelectedStyle({ fontSize: clamp(Math.round(value) || 32, 8, 240) }),
+              'px',
+            )}
+            {styleTargetType === 'spotlight' && renderSliderRow(
+              'Intensity',
+              Math.round(displayedStyle.opacity * 100),
+              10,
+              100,
+              (value) => setActiveOrSelectedStyle({ opacity: clamp(value, 10, 100) / 100 }),
+              '%',
+            )}
+          </section>
+
+          {selectedObject && (
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold text-gray-100">Object</h3>
+              <div className="grid grid-cols-4 gap-1">
+                <button type="button" onClick={() => moveSelected('front')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Front</button>
+                <button type="button" onClick={() => moveSelected('forward')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Up</button>
+                <button type="button" onClick={() => moveSelected('backward')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Down</button>
+                <button type="button" onClick={() => moveSelected('back')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Back</button>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <button type="button" onClick={duplicateSelected} className="rounded-md border border-gray-700 px-2 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800">Duplicate</button>
+                <button type="button" onClick={deleteSelected} className="rounded-md border border-red-500/30 bg-red-500/10 px-2 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/20">Delete</button>
+              </div>
+            </section>
+          )}
+        </div>
+      );
+    }
+
+    if (inspectorTab === 'canvas') {
+      return (
+        <div className="space-y-4">
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-100">Background</h3>
+            <select value={normalizedDocument.background.kind} onChange={(event) => updateBackground({ kind: event.target.value as ImageEditorDocument['background']['kind'] })} className="h-9 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-sm text-gray-100 outline-none focus:border-cyan-500">
+              <option value="transparent">Transparent</option>
+              <option value="color">Color</option>
+              <option value="gradient">Gradient</option>
+            </select>
+            <div className="grid grid-cols-2 gap-2">
+              {renderColorSwatch('Color', normalizedDocument.background.color, (value) => updateBackground({ color: value }))}
+              {renderColorSwatch('From', normalizedDocument.background.gradientFrom, (value) => updateBackground({ gradientFrom: value }))}
+              {renderColorSwatch('To', normalizedDocument.background.gradientTo, (value) => updateBackground({ gradientTo: value }))}
+            </div>
+          </section>
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-100">Spacing</h3>
+            {renderSliderRow('Margin', normalizedDocument.background.margin, 0, 2000, (value) => updateBackground({ margin: Math.round(value) }))}
+            {renderSliderRow('Padding', normalizedDocument.background.padding, 0, 2000, (value) => updateBackground({ padding: Math.round(value) }))}
+            {renderSliderRow('Corner', normalizedDocument.background.roundedCorner, 0, 400, (value) => updateBackground({ roundedCorner: Math.round(value) }))}
+            {renderSliderRow('Shadow', normalizedDocument.background.shadowRadius, 0, 500, (value) => updateBackground({ shadowRadius: Math.round(value) }))}
+            <label className="inline-flex items-center gap-2 text-xs text-gray-300">
+              <input type="checkbox" checked={normalizedDocument.background.smartPadding} onChange={(event) => updateBackground({ smartPadding: event.target.checked })} className="h-4 w-4 accent-cyan-500" />
+              Smart padding
+            </label>
+          </section>
+        </div>
+      );
+    }
+
+    if (inspectorTab === 'ai') {
+      return (
+        <div className="space-y-4">
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-100">AI Transform</h3>
+            <button type="button" onClick={handleAIUpscale} disabled={isUpscaling} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-purple-400/30 bg-purple-500/15 px-3 py-2 text-xs font-semibold text-purple-100 hover:bg-purple-500/25 disabled:opacity-50">
+              <Sparkles className="h-4 w-4" />
+              {isUpscaling ? 'Queueing...' : 'AI Upscale'}
+            </button>
+            <div className="grid grid-cols-2 gap-1 text-xs">
+              {['Detail Restore', 'Face Restore', 'Img2Img', 'Inpaint', 'Outpaint'].map((label) => (
+                <button key={label} type="button" disabled className="rounded-md border border-gray-800 px-2 py-1.5 text-gray-600">
+                  {label}
+                </button>
+              ))}
+            </div>
+          </section>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-4">
+        <section className="space-y-2">
+          <h3 className="text-sm font-semibold text-gray-100">Source</h3>
+          <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-400">
+            <div className="flex items-center gap-2 text-gray-200">
+              <ImageIcon className="h-4 w-4 text-cyan-300" />
+              <span className="truncate">{image.name}</span>
+            </div>
+            <div className="mt-2">{normalizedDocument.sourceDimensions.width}x{normalizedDocument.sourceDimensions.height}</div>
+            <div>{normalizedDocument.objects.length} objects</div>
+            {navigationImages.length > 1 && <div>{navigationImages.length} images in navigation scope</div>}
+          </div>
+        </section>
+        <section className="space-y-2">
+          <h3 className="text-sm font-semibold text-gray-100">Output</h3>
+          <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-400">
+            <div>{activeOutputDimensions?.width || normalizedDocument.canvasDimensions.width}x{activeOutputDimensions?.height || normalizedDocument.canvasDimensions.height}</div>
+            <div>{hasChanges ? 'Unsaved edits' : 'No editor changes'}</div>
+          </div>
+        </section>
+        {onOpenComfyUIWorkflow && (
+          <button type="button" onClick={() => onOpenComfyUIWorkflow(image)} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800">
+            <Workflow className="h-4 w-4" />
+            Open Workflow
+          </button>
+        )}
+        <button type="button" onClick={restoreOriginal} disabled={!hasChanges} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-40">
+          <RotateCcw className="h-4 w-4" />
+          Restore Original
+        </button>
+      </div>
+    );
+  };
 
   if (!normalizedDocument || !sourceUrl) {
     return (
@@ -1552,12 +2039,12 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
           <button type="button" onClick={flattenSelection} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Flatten">
             <Layers className="h-4 w-4" />
           </button>
-          <button type="button" onClick={restoreOriginal} disabled={!hasChanges} className="inline-flex items-center gap-1 rounded-md px-2 py-2 text-xs font-semibold text-gray-300 hover:bg-gray-800 disabled:opacity-40" title="Restore Original">
-            <RotateCcw className="h-4 w-4" />
-            Restore
-          </button>
           <button type="button" onClick={handleCopy} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Copy image">
             <Copy className="h-4 w-4" />
+          </button>
+          <button type="button" onClick={() => setIsInspectorOpen(true)} className="inline-flex items-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 xl:hidden" title="Open inspector">
+            <Layers className="h-4 w-4" />
+            Inspector
           </button>
           <button type="button" onClick={handleSave} disabled={isSaving || !hasChanges} className="inline-flex items-center gap-1 rounded-md bg-cyan-600 px-3 py-2 text-xs font-semibold text-white hover:bg-cyan-500 disabled:bg-gray-800 disabled:text-gray-500" title={canOverwrite ? 'Save' : 'Save As'}>
             <Save className="h-4 w-4" />
@@ -1705,7 +2192,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                         stroke={style.strokeColor}
                         strokeWidth={style.strokeWidth}
                         opacity={style.opacity}
-                        strokeDasharray={object.type === 'spotlight' || object.type === 'magnify' ? '10 8' : undefined}
+                        strokeDasharray={object.type === 'magnify' ? '10 8' : undefined}
                       />
                     );
                   }
@@ -1950,256 +2437,50 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
           </div>
         </div>
 
-        <aside className="w-80 shrink-0 overflow-y-auto border-l border-gray-800 bg-gray-900 p-4">
-          <div className="space-y-5">
-            <section className="space-y-3">
-              <h3 className="text-sm font-semibold text-gray-100">Tool</h3>
-              <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-sm">
-                <div className="font-medium text-cyan-100">{TOOL_DEFS.find((tool) => tool.id === activeTool)?.label}</div>
-                <p className="mt-1 text-xs text-gray-500">{TOOL_HINTS[activeTool]}</p>
+        {isInspectorOpen && (
+          <button
+            type="button"
+            className="fixed inset-0 z-30 bg-black/60 xl:hidden"
+            onClick={() => setIsInspectorOpen(false)}
+            aria-label="Close inspector overlay"
+          />
+        )}
+        <aside className={`fixed inset-y-0 right-0 z-40 flex w-[min(22rem,calc(100vw-4rem))] shrink-0 flex-col border-l border-gray-800 bg-gray-900 transition-transform xl:static xl:z-auto xl:w-80 xl:translate-x-0 ${
+          isInspectorOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}>
+          <div className="flex shrink-0 items-center justify-between gap-2 border-b border-gray-800 px-3 py-3">
+            <div className="min-w-0">
+              <div className="text-sm font-semibold text-gray-100">Inspector</div>
+              <div className="truncate text-xs text-gray-500">
+                {selectedCount > 1
+                  ? `${selectedCount} selected`
+                  : selectedObject
+                    ? selectedObject.type
+                    : TOOL_DEFS.find((tool) => tool.id === activeTool)?.label}
               </div>
-            </section>
-
-            <section className="space-y-3">
-              <h3 className="text-sm font-semibold text-gray-100">Local Edits</h3>
-              <div className="grid grid-cols-2 gap-2">
-                <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, rotation: ((normalizedDocument.recipe.transform.rotation + 270) % 360) as 0 | 90 | 180 | 270 } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
-                  <RotateCcw className="h-3.5 w-3.5" /> Left
-                </button>
-                <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, rotation: ((normalizedDocument.recipe.transform.rotation + 90) % 360) as 0 | 90 | 180 | 270 } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
-                  <RotateCw className="h-3.5 w-3.5" /> Right
-                </button>
-                <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, flipHorizontal: !normalizedDocument.recipe.transform.flipHorizontal } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
-                  <FlipHorizontal className="h-3.5 w-3.5" /> Flip H
-                </button>
-                <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, flipVertical: !normalizedDocument.recipe.transform.flipVertical } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
-                  <FlipVertical className="h-3.5 w-3.5" /> Flip V
-                </button>
-              </div>
-              {(['brightness', 'contrast', 'saturation'] as const).map((key) => (
-                <label key={key} className="block space-y-1 text-xs text-gray-400">
-                  <span className="capitalize">{key}</span>
-                  <input
-                    type="range"
-                    min={0}
-                    max={200}
-                    value={normalizedDocument.recipe.adjustments[key]}
-                    onChange={(event) => updateRecipe({
-                      ...normalizedDocument.recipe,
-                      adjustments: {
-                        ...normalizedDocument.recipe.adjustments,
-                        [key]: clampImageAdjustment(key, Number(event.target.value)),
-                      },
-                    })}
-                    className="w-full accent-cyan-500"
-                  />
-                </label>
-              ))}
-              <div className="grid grid-cols-2 gap-2">
-                {(['sharpen', 'blur'] as const).map((key) => (
-                  <label key={key} className="space-y-1 text-xs text-gray-400">
-                    <span className="capitalize">{key}</span>
-                    <input
-                      type="number"
-                      value={normalizedDocument.recipe.effects[key]}
-                      min={0}
-                      max={key === 'blur' ? 20 : 100}
-                      onChange={(event) => updateRecipe({
-                        ...normalizedDocument.recipe,
-                        effects: {
-                          ...normalizedDocument.recipe.effects,
-                          [key]: clampImageEditEffect(key, Number(event.target.value)),
-                        },
-                      })}
-                      className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100"
-                    />
-                  </label>
-                ))}
-              </div>
-            </section>
-
-            <section className="space-y-3">
-              <h3 className="text-sm font-semibold text-gray-100">{selectedObject ? 'Selected Object' : 'Tool Style'}</h3>
-              {styleTargetType ? (
-                <>
-                  <div className="grid grid-cols-2 gap-2">
-                    {selectedObject?.type === 'text' && (
-                      <label className="col-span-2 space-y-1 text-xs text-gray-400">
-                        <span>Text</span>
-                        <input
-                          type="text"
-                          value={selectedObject.text || ''}
-                          onChange={(event) => updateSelectedObjectText(event.target.value)}
-                          className="h-9 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-sm text-gray-100"
-                        />
-                      </label>
-                    )}
-                    {canUseStrokeColor && (
-                      <label className="space-y-1 text-xs text-gray-400">
-                        <span>Stroke</span>
-                        <input
-                          type="color"
-                          value={displayedStyle.strokeColor}
-                          onChange={(event) => {
-                            setActiveStyle({ ...activeStyle, strokeColor: event.target.value });
-                            updateSelectedObjectStyle({ strokeColor: event.target.value });
-                          }}
-                          className="h-8 w-full rounded border border-gray-700 bg-gray-950"
-                        />
-                      </label>
-                    )}
-                    {canUseFillColor && (
-                      <label className="space-y-1 text-xs text-gray-400">
-                        <span>Fill</span>
-                        <input
-                          type="color"
-                          value={toColorInputValue(displayedStyle.fillColor)}
-                          onChange={(event) => {
-                            setActiveStyle({ ...activeStyle, fillColor: event.target.value });
-                            updateSelectedObjectStyle({ fillColor: event.target.value });
-                          }}
-                          className="h-8 w-full rounded border border-gray-700 bg-gray-950"
-                        />
-                      </label>
-                    )}
-                    {canUseTextColor && (
-                      <label className="space-y-1 text-xs text-gray-400">
-                        <span>Text</span>
-                        <input
-                          type="color"
-                          value={displayedStyle.textColor}
-                          onChange={(event) => {
-                            setActiveStyle({ ...activeStyle, textColor: event.target.value });
-                            updateSelectedObjectStyle({ textColor: event.target.value });
-                          }}
-                          className="h-8 w-full rounded border border-gray-700 bg-gray-950"
-                        />
-                      </label>
-                    )}
-                    {canUseStrokeWidth && (
-                      <label className="space-y-1 text-xs text-gray-400">
-                        <span>{styleTargetType === 'blur' || styleTargetType === 'pixelate' ? 'Strength' : 'Width'}</span>
-                        <input
-                          type="number"
-                          value={displayedStyle.strokeWidth}
-                          min={1}
-                          max={80}
-                          onChange={(event) => {
-                            const value = clamp(Math.round(Number(event.target.value) || 1), 1, 80);
-                            setActiveStyle({ ...activeStyle, strokeWidth: value });
-                            updateSelectedObjectStyle({ strokeWidth: value });
-                          }}
-                          className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100"
-                        />
-                      </label>
-                    )}
-                    {canUseFontSize && (
-                      <label className="space-y-1 text-xs text-gray-400">
-                        <span>Font</span>
-                        <input
-                          type="number"
-                          value={displayedStyle.fontSize}
-                          min={8}
-                          max={240}
-                          onChange={(event) => {
-                            const value = clamp(Math.round(Number(event.target.value) || 32), 8, 240);
-                            setActiveStyle({ ...activeStyle, fontSize: value });
-                            updateSelectedObjectStyle({ fontSize: value });
-                          }}
-                          className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100"
-                        />
-                      </label>
-                    )}
-                  </div>
-                  {selectedObject && (
-                    <>
-                      <div className="grid grid-cols-4 gap-1">
-                        <button type="button" onClick={() => moveSelected('front')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Front</button>
-                        <button type="button" onClick={() => moveSelected('forward')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Up</button>
-                        <button type="button" onClick={() => moveSelected('backward')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Down</button>
-                        <button type="button" onClick={() => moveSelected('back')} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800">Back</button>
-                      </div>
-                      <button type="button" onClick={deleteSelected} className="w-full rounded-md border border-red-500/30 bg-red-500/10 px-2 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/20">
-                        Delete Selected
-                      </button>
-                    </>
-                  )}
-                </>
-              ) : (
-                <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-500">
-                  Pick an annotation tool or select an object to edit its style.
-                </div>
-              )}
-            </section>
-
-            <section className="space-y-3">
-              <h3 className="text-sm font-semibold text-gray-100">Background</h3>
-              <select value={normalizedDocument.background.kind} onChange={(event) => updateBackground({ kind: event.target.value as ImageEditorDocument['background']['kind'] })} className="h-9 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-sm">
-                <option value="transparent">Transparent</option>
-                <option value="color">Color</option>
-                <option value="gradient">Gradient</option>
-              </select>
-              <div className="grid grid-cols-2 gap-2">
-                <label className="space-y-1 text-xs text-gray-400">
-                  <span>Color</span>
-                  <input type="color" value={normalizedDocument.background.color} onChange={(event) => updateBackground({ color: event.target.value })} className="h-8 w-full rounded border border-gray-700 bg-gray-950" />
-                </label>
-                <label className="space-y-1 text-xs text-gray-400">
-                  <span>Shadow</span>
-                  <input type="number" value={normalizedDocument.background.shadowRadius} min={0} max={500} onChange={(event) => updateBackground({ shadowRadius: Number(event.target.value) })} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
-                </label>
-                <label className="space-y-1 text-xs text-gray-400">
-                  <span>Margin</span>
-                  <input type="number" value={normalizedDocument.background.margin} min={0} max={2000} onChange={(event) => updateBackground({ margin: Number(event.target.value) })} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
-                </label>
-                <label className="space-y-1 text-xs text-gray-400">
-                  <span>Padding</span>
-                  <input type="number" value={normalizedDocument.background.padding} min={0} max={2000} onChange={(event) => updateBackground({ padding: Number(event.target.value) })} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
-                </label>
-              </div>
-              <label className="inline-flex items-center gap-2 text-xs text-gray-300">
-                <input type="checkbox" checked={normalizedDocument.background.smartPadding} onChange={(event) => updateBackground({ smartPadding: event.target.checked })} className="h-4 w-4 accent-cyan-500" />
-                Smart padding
-              </label>
-            </section>
-
-            <section className="space-y-3">
-              <h3 className="text-sm font-semibold text-gray-100">AI Transform</h3>
-              <button type="button" onClick={handleAIUpscale} disabled={isUpscaling} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-purple-400/30 bg-purple-500/15 px-3 py-2 text-xs font-semibold text-purple-100 hover:bg-purple-500/25 disabled:opacity-50">
-                <Sparkles className="h-4 w-4" />
-                {isUpscaling ? 'Queueing...' : 'AI Upscale'}
-              </button>
-              <div className="grid grid-cols-2 gap-1 text-xs">
-                {['Detail Restore', 'Face Restore', 'Img2Img', 'Inpaint', 'Outpaint'].map((label) => (
-                  <button key={label} type="button" disabled className="rounded-md border border-gray-800 px-2 py-1.5 text-gray-600">
-                    {label}
-                  </button>
-                ))}
-              </div>
-              {onOpenComfyUIWorkflow && (
-                <button type="button" onClick={() => onOpenComfyUIWorkflow(image)} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800">
-                  <Workflow className="h-4 w-4" />
-                  Open Workflow
-                </button>
-              )}
-            </section>
-
-            <section className="space-y-2">
-              <h3 className="text-sm font-semibold text-gray-100">Source</h3>
-              <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-400">
-                <div className="flex items-center gap-2 text-gray-200">
-                  <ImageIcon className="h-4 w-4 text-cyan-300" />
-                  <span className="truncate">{image.name}</span>
-                </div>
-                <div className="mt-2">{normalizedDocument.sourceDimensions.width}x{normalizedDocument.sourceDimensions.height}</div>
-                {navigationImages.length > 1 && <div>{navigationImages.length} images in navigation scope</div>}
-              </div>
-            </section>
-
-            <button type="button" onClick={restoreOriginal} disabled={!hasChanges} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-40">
-              <RotateCcw className="h-4 w-4" />
-              Restore Original
+            </div>
+            <button type="button" onClick={() => setIsInspectorOpen(false)} className="rounded-md p-2 text-gray-300 hover:bg-gray-800 xl:hidden" title="Close inspector">
+              <X className="h-4 w-4" />
             </button>
+          </div>
+          <div className="grid shrink-0 grid-cols-5 gap-1 border-b border-gray-800 bg-gray-900 p-2">
+            {INSPECTOR_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setInspectorTab(tab.id)}
+                className={`rounded-md px-1.5 py-1.5 text-xs font-medium transition-colors ${
+                  inspectorTab === tab.id
+                    ? 'bg-cyan-500/20 text-cyan-100'
+                    : 'text-gray-400 hover:bg-gray-800 hover:text-gray-200'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto p-4">
+            {renderInspectorContent()}
           </div>
         </aside>
       </div>

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -2522,6 +2522,11 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                   onBlur={() => setEditingTextObjectId(null)}
                   onPointerDown={(event) => event.stopPropagation()}
                   onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.preventDefault();
+                      setEditingTextObjectId(null);
+                      return;
+                    }
                     if (event.key === 'Escape') {
                       event.preventDefault();
                       setEditingTextObjectId(null);

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -118,13 +118,40 @@ const TOOL_HINTS: Record<ImageEditorTool, string> = {
 
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
 
+const clampZoom = (value: number) => clamp(Math.round(value * 100) / 100, 0.1, 6);
+
 const cloneDocument = (document: ImageEditorDocument): ImageEditorDocument => JSON.parse(JSON.stringify(document));
 
 const createObjectId = () => `editor_obj_${Date.now()}_${Math.random().toString(16).slice(2, 8)}`;
 
+const isEditableShortcutTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return target.isContentEditable || tagName === 'input' || tagName === 'textarea' || tagName === 'select';
+};
+
 const isAnnotationTool = (tool: ImageEditorTool): tool is ImageEditorObject['type'] => (
   tool !== 'select' && tool !== 'crop'
 );
+
+const TOOL_SHORTCUTS: Partial<Record<string, ImageEditorTool>> = {
+  v: 'select',
+  c: 'crop',
+  r: 'rectangle',
+  e: 'ellipse',
+  l: 'line',
+  a: 'arrow',
+  f: 'freehand',
+  t: 'text',
+  n: 'step',
+  h: 'highlight',
+  b: 'blur',
+  p: 'pixelate',
+  s: 'spotlight',
+  m: 'magnify',
+};
 
 const getUsableNormalizedMetadata = (image: IndexedImage): BaseMetadata | undefined => (
   image.metadata?.normalizedMetadata as BaseMetadata | undefined
@@ -152,12 +179,15 @@ const objectFromDrag = (
   const text = tool === 'text'
     ? window.prompt('Text annotation', 'Text') || 'Text'
     : undefined;
+  const directionalPoints = tool === 'line' || tool === 'arrow'
+    ? [drag.start, drag.current]
+    : undefined;
 
   return {
     id: createObjectId(),
     type: tool,
     bounds: resolvedBounds,
-    points: tool === 'freehand' ? drag.points : undefined,
+    points: tool === 'freehand' ? drag.points : directionalPoints,
     text,
     stepNumber: tool === 'step' ? nextStepNumber : undefined,
     zIndex: Date.now(),
@@ -197,6 +227,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const [isRendering, setIsRendering] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [dragState, setDragState] = useState<DragState | null>(null);
+  const [zoom, setZoom] = useState(1);
   const [hydratedImage, setHydratedImage] = useState<IndexedImage | null>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
 
@@ -220,6 +251,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const hasChanges = normalizedDocument ? hasImageEditorDocumentChanges(normalizedDocument) : false;
   const selectedObject = normalizedDocument?.objects.find((object) => normalizedDocument.selectedObjectIds.includes(object.id)) || null;
   const canOverwrite = getFileExtension(image.name) === '.png';
+  const displayWidth = Math.max(160, Math.round(1080 * zoom));
 
   const commitDocument = useCallback((updater: (current: ImageEditorDocument) => ImageEditorDocument, label: string) => {
     setDocumentState((current) => {
@@ -677,6 +709,240 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     }, 'Layer order');
   }, [commitDocument, selectedObject]);
 
+  const duplicateSelected = useCallback(() => {
+    if (!selectedObject) return;
+    commitDocument((current) => {
+      const source = current.objects.find((object) => object.id === selectedObject.id);
+      if (!source) return current;
+      const cloneId = createObjectId();
+      const maxZIndex = current.objects.reduce((max, object) => Math.max(max, object.zIndex), 0);
+      const clone: ImageEditorObject = {
+        ...JSON.parse(JSON.stringify(source)) as ImageEditorObject,
+        id: cloneId,
+        zIndex: maxZIndex + 1,
+        bounds: {
+          ...source.bounds,
+          x: clamp(source.bounds.x + 16, 0, Math.max(0, current.canvasDimensions.width - source.bounds.width)),
+          y: clamp(source.bounds.y + 16, 0, Math.max(0, current.canvasDimensions.height - source.bounds.height)),
+        },
+        points: source.points?.map((point) => ({
+          x: clamp(point.x + 16, 0, current.canvasDimensions.width),
+          y: clamp(point.y + 16, 0, current.canvasDimensions.height),
+        })),
+      };
+      return {
+        ...current,
+        objects: [...current.objects, clone],
+        selectedObjectIds: [cloneId],
+      };
+    }, 'Duplicate object');
+  }, [commitDocument, selectedObject]);
+
+  const deleteAllObjects = useCallback(() => {
+    if (!normalizedDocument?.objects.length) return;
+    commitDocument((current) => ({ ...current, objects: [], selectedObjectIds: [] }), 'Delete all objects');
+  }, [commitDocument, normalizedDocument?.objects.length]);
+
+  const moveSelectedBy = useCallback((deltaX: number, deltaY: number) => {
+    if (!selectedObject) return;
+    commitDocument((current) => ({
+      ...current,
+      objects: current.objects.map((object) => {
+        if (object.id !== selectedObject.id) {
+          return object;
+        }
+        const x = clamp(object.bounds.x + deltaX, 0, Math.max(0, current.canvasDimensions.width - object.bounds.width));
+        const y = clamp(object.bounds.y + deltaY, 0, Math.max(0, current.canvasDimensions.height - object.bounds.height));
+        return {
+          ...object,
+          bounds: { ...object.bounds, x, y },
+          points: object.points?.map((point) => ({
+            x: clamp(point.x + deltaX, 0, current.canvasDimensions.width),
+            y: clamp(point.y + deltaY, 0, current.canvasDimensions.height),
+          })),
+        };
+      }),
+    }), 'Move object');
+  }, [commitDocument, selectedObject]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableShortcutTarget(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      const hasCommandModifier = event.ctrlKey || event.metaKey;
+
+      if (hasCommandModifier) {
+        if (key === 'z') {
+          event.preventDefault();
+          if (event.shiftKey) {
+            redo();
+          } else {
+            undo();
+          }
+          return;
+        }
+        if (key === 'y') {
+          event.preventDefault();
+          redo();
+          return;
+        }
+        if (key === 's') {
+          event.preventDefault();
+          if (event.shiftKey) {
+            void handleSaveAs();
+          } else {
+            void handleSave();
+          }
+          return;
+        }
+        if (key === 'c') {
+          event.preventDefault();
+          void handleCopy();
+          return;
+        }
+        if (key === 'd') {
+          event.preventDefault();
+          duplicateSelected();
+          return;
+        }
+        if (key === 'a') {
+          event.preventDefault();
+          commitDocument((current) => ({
+            ...current,
+            selectedObjectIds: current.objects.map((object) => object.id),
+          }), 'Select all');
+          return;
+        }
+        if (key === 'f' && event.shiftKey) {
+          event.preventDefault();
+          flattenSelection();
+          return;
+        }
+        if (key === '=' || key === '+') {
+          event.preventDefault();
+          setZoom((current) => clampZoom(current * 1.15));
+          return;
+        }
+        if (key === '-' || key === '_') {
+          event.preventDefault();
+          setZoom((current) => clampZoom(current / 1.15));
+          return;
+        }
+        if (key === '0' || key === '1') {
+          event.preventDefault();
+          setZoom(1);
+          return;
+        }
+        if (key === ']' && event.shiftKey) {
+          event.preventDefault();
+          moveSelected('front');
+          return;
+        }
+        if (key === '[' && event.shiftKey) {
+          event.preventDefault();
+          moveSelected('back');
+          return;
+        }
+        if (key === ']') {
+          event.preventDefault();
+          moveSelected('forward');
+          return;
+        }
+        if (key === '[') {
+          event.preventDefault();
+          moveSelected('backward');
+          return;
+        }
+      }
+
+      if (!event.altKey && !hasCommandModifier && !event.shiftKey && TOOL_SHORTCUTS[key]) {
+        event.preventDefault();
+        setActiveTool(TOOL_SHORTCUTS[key]);
+        return;
+      }
+
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        event.preventDefault();
+        if (event.shiftKey) {
+          deleteAllObjects();
+        } else {
+          deleteSelected();
+        }
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        if (dragState) {
+          setDragState(null);
+          return;
+        }
+        commitDocument((current) => ({ ...current, selectedObjectIds: [] }), 'Deselect');
+        return;
+      }
+
+      if (event.key === 'Home') {
+        event.preventDefault();
+        moveSelected('front');
+        return;
+      }
+      if (event.key === 'End') {
+        event.preventDefault();
+        moveSelected('back');
+        return;
+      }
+      if (event.key === 'PageUp') {
+        event.preventDefault();
+        moveSelected('forward');
+        return;
+      }
+      if (event.key === 'PageDown') {
+        event.preventDefault();
+        moveSelected('backward');
+        return;
+      }
+      if (event.key.startsWith('Arrow')) {
+        const amount = event.shiftKey ? 10 : 1;
+        const delta = {
+          ArrowLeft: [-amount, 0],
+          ArrowRight: [amount, 0],
+          ArrowUp: [0, -amount],
+          ArrowDown: [0, amount],
+        }[event.key] as [number, number] | undefined;
+        if (delta) {
+          event.preventDefault();
+          moveSelectedBy(delta[0], delta[1]);
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    commitDocument,
+    deleteAllObjects,
+    deleteSelected,
+    dragState,
+    duplicateSelected,
+    flattenSelection,
+    handleCopy,
+    handleSave,
+    handleSaveAs,
+    moveSelected,
+    moveSelectedBy,
+    redo,
+    undo,
+  ]);
+
+  const handleWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const factor = event.deltaY < 0 ? 1.1 : 1 / 1.1;
+    setZoom((current) => clampZoom(current * factor));
+  }, []);
+
   const activeOutputDimensions = normalizedDocument
     ? getImageEditOutputDimensions(normalizedDocument.recipe, normalizedDocument.sourceDimensions)
     : null;
@@ -755,19 +1021,38 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
               className="relative max-h-full max-w-full touch-none select-none overflow-hidden rounded-sm border border-gray-800 bg-[linear-gradient(45deg,#1f2937_25%,transparent_25%),linear-gradient(-45deg,#1f2937_25%,transparent_25%),linear-gradient(45deg,transparent_75%,#1f2937_75%),linear-gradient(-45deg,transparent_75%,#1f2937_75%)] bg-[length:20px_20px] bg-[position:0_0,0_10px,10px_-10px,-10px_0px]"
               style={{
                 aspectRatio: `${Math.max(1, normalizedDocument.canvasDimensions.width)} / ${Math.max(1, normalizedDocument.canvasDimensions.height)}`,
-                width: 'min(100%, 1080px)',
+                width: `${displayWidth}px`,
               }}
               onPointerDown={pointerDown}
               onPointerMove={pointerMove}
               onPointerUp={pointerUp}
               onPointerCancel={() => setDragState(null)}
+              onWheel={handleWheel}
             >
               {previewUrl ? (
                 <img src={previewUrl} alt={image.name} className="block h-full w-full object-contain" draggable={false} />
               ) : (
                 <img src={sourceUrl} alt={image.name} className="block h-full w-full object-contain opacity-80" draggable={false} />
               )}
-              {dragState && (
+              {dragState && (dragState.tool === 'line' || dragState.tool === 'arrow') ? (
+                <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible">
+                  <line
+                    x1={`${(dragState.start.x / normalizedDocument.canvasDimensions.width) * 100}%`}
+                    y1={`${(dragState.start.y / normalizedDocument.canvasDimensions.height) * 100}%`}
+                    x2={`${(dragState.current.x / normalizedDocument.canvasDimensions.width) * 100}%`}
+                    y2={`${(dragState.current.y / normalizedDocument.canvasDimensions.height) * 100}%`}
+                    stroke="rgb(103 232 249)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    markerEnd={dragState.tool === 'arrow' ? 'url(#image-editor-arrow-preview)' : undefined}
+                  />
+                  <defs>
+                    <marker id="image-editor-arrow-preview" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth">
+                      <path d="M 0 0 L 10 5 L 0 10 z" fill="rgb(103 232 249)" />
+                    </marker>
+                  </defs>
+                </svg>
+              ) : dragState && (
                 <div
                   className="pointer-events-none absolute border-2 border-cyan-300 bg-cyan-300/10"
                   style={{
@@ -778,7 +1063,20 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                   }}
                 />
               )}
-              {selectedObject && (
+              {selectedObject && (selectedObject.type === 'line' || selectedObject.type === 'arrow') && selectedObject.points?.[0] && selectedObject.points?.[1] ? (
+                <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible">
+                  <line
+                    x1={`${(selectedObject.points[0].x / normalizedDocument.canvasDimensions.width) * 100}%`}
+                    y1={`${(selectedObject.points[0].y / normalizedDocument.canvasDimensions.height) * 100}%`}
+                    x2={`${(selectedObject.points[1].x / normalizedDocument.canvasDimensions.width) * 100}%`}
+                    y2={`${(selectedObject.points[1].y / normalizedDocument.canvasDimensions.height) * 100}%`}
+                    stroke="rgb(103 232 249)"
+                    strokeWidth="2"
+                    strokeDasharray="6 5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              ) : selectedObject && (
                 <div
                   className="pointer-events-none absolute border-2 border-cyan-300"
                   style={{
@@ -793,7 +1091,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
           </div>
           <div className="flex h-9 shrink-0 items-center justify-between border-t border-gray-800 bg-gray-900 px-4 text-xs text-gray-400">
             <span>{TOOL_HINTS[activeTool]}</span>
-            <span>{isRendering ? 'Rendering preview...' : `${normalizedDocument.objects.length} objects · ${selectedCount} selected`}</span>
+            <span>{isRendering ? 'Rendering preview...' : `${Math.round(zoom * 100)}% · ${normalizedDocument.objects.length} objects · ${selectedCount} selected`}</span>
           </div>
         </div>
 

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -1,0 +1,974 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  Circle,
+  Copy,
+  Crop,
+  Download,
+  Eye,
+  FlipHorizontal,
+  FlipVertical,
+  Highlighter,
+  Image as ImageIcon,
+  Layers,
+  Minus,
+  MousePointer2,
+  Pencil,
+  Redo2,
+  RotateCcw,
+  RotateCw,
+  Save,
+  Scissors,
+  Search,
+  Shield,
+  Sparkles,
+  Square,
+  Type,
+  Undo2,
+  Workflow,
+  ZoomIn,
+} from 'lucide-react';
+import type {
+  BaseMetadata,
+  ImageEditorDocument,
+  ImageEditorObject,
+  ImageEditorObjectStyle,
+  ImageEditorTool,
+  IndexedImage,
+} from '../types';
+import {
+  DEFAULT_IMAGE_EDIT_RECIPE,
+  DEFAULT_IMAGE_EDITOR_BACKGROUND,
+  DEFAULT_IMAGE_EDITOR_OBJECT_STYLE,
+  clampImageAdjustment,
+  clampImageEditEffect,
+  createImageEditorDocument,
+  embedMetaHubMetadataInPngBytes,
+  getImageEditOutputDimensions,
+  hasImageEditorDocumentChanges,
+  normalizeImageEditRecipe,
+  normalizeImageEditorDocument,
+  renderImageEditorDocumentToPngBlob,
+  renderImageEditorDocumentToPngBytes,
+} from '../services/imageEditingService';
+import { mediaSourceCache } from '../services/mediaSourceCache';
+import { hasCompactedRuntimeMetadata, hydrateImageRawMetadata } from '../services/rawMetadataHydration';
+import { getRelativeImagePath, splitRelativePath } from '../utils/imagePaths';
+import { getFileExtension } from '../utils/mediaTypes.js';
+import { indexImageFileAtPath, reparseIndexedImage } from '../services/fileIndexer';
+import cacheManager from '../services/cacheManager';
+import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
+import { useFeatureAccess } from '../hooks/useFeatureAccess';
+
+interface ImageEditorWorkspaceProps {
+  image: IndexedImage;
+  navigationImages?: IndexedImage[];
+  directoryPath?: string;
+  onBack: () => void;
+  onOpenComfyUIWorkflow?: (image: IndexedImage) => void;
+}
+
+type HistoryState = {
+  past: ImageEditorDocument[];
+  future: ImageEditorDocument[];
+};
+
+type DragState = {
+  tool: ImageEditorTool;
+  start: { x: number; y: number };
+  current: { x: number; y: number };
+  points?: { x: number; y: number }[];
+};
+
+const TOOL_DEFS: Array<{ id: ImageEditorTool; label: string; icon: React.ReactNode }> = [
+  { id: 'select', label: 'Select', icon: <MousePointer2 className="h-4 w-4" /> },
+  { id: 'crop', label: 'Crop', icon: <Crop className="h-4 w-4" /> },
+  { id: 'rectangle', label: 'Rectangle', icon: <Square className="h-4 w-4" /> },
+  { id: 'ellipse', label: 'Ellipse', icon: <Circle className="h-4 w-4" /> },
+  { id: 'line', label: 'Line', icon: <Minus className="h-4 w-4" /> },
+  { id: 'arrow', label: 'Arrow', icon: <ArrowLeft className="h-4 w-4 rotate-180" /> },
+  { id: 'freehand', label: 'Freehand', icon: <Pencil className="h-4 w-4" /> },
+  { id: 'text', label: 'Text', icon: <Type className="h-4 w-4" /> },
+  { id: 'step', label: 'Step', icon: <span className="text-xs font-bold">1</span> },
+  { id: 'highlight', label: 'Highlight', icon: <Highlighter className="h-4 w-4" /> },
+  { id: 'blur', label: 'Blur', icon: <Eye className="h-4 w-4" /> },
+  { id: 'pixelate', label: 'Pixelate', icon: <Shield className="h-4 w-4" /> },
+  { id: 'spotlight', label: 'Spotlight', icon: <Search className="h-4 w-4" /> },
+  { id: 'magnify', label: 'Magnify', icon: <ZoomIn className="h-4 w-4" /> },
+];
+
+const TOOL_HINTS: Record<ImageEditorTool, string> = {
+  select: 'Click an object to select it.',
+  crop: 'Drag a crop area. The crop is editable in the inspector.',
+  rectangle: 'Drag to create a rectangle annotation.',
+  ellipse: 'Drag to create an ellipse annotation.',
+  line: 'Drag to draw a line.',
+  arrow: 'Drag toward the arrow tip.',
+  freehand: 'Drag to sketch a freehand stroke.',
+  text: 'Click or drag, then enter text.',
+  step: 'Click or drag to place a numbered step marker.',
+  highlight: 'Drag to highlight an area.',
+  blur: 'Drag over a region to blur it on export.',
+  pixelate: 'Drag over a region to pixelate it on export.',
+  spotlight: 'Drag the spotlight focus area.',
+  magnify: 'Drag the magnified lens area.',
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const cloneDocument = (document: ImageEditorDocument): ImageEditorDocument => JSON.parse(JSON.stringify(document));
+
+const createObjectId = () => `editor_obj_${Date.now()}_${Math.random().toString(16).slice(2, 8)}`;
+
+const isAnnotationTool = (tool: ImageEditorTool): tool is ImageEditorObject['type'] => (
+  tool !== 'select' && tool !== 'crop'
+);
+
+const getUsableNormalizedMetadata = (image: IndexedImage): BaseMetadata | undefined => (
+  image.metadata?.normalizedMetadata as BaseMetadata | undefined
+);
+
+const objectFromDrag = (
+  tool: ImageEditorTool,
+  drag: DragState,
+  style: ImageEditorObjectStyle,
+  nextStepNumber: number,
+): ImageEditorObject | null => {
+  if (!isAnnotationTool(tool)) {
+    return null;
+  }
+
+  const x = Math.min(drag.start.x, drag.current.x);
+  const y = Math.min(drag.start.y, drag.current.y);
+  const width = Math.max(1, Math.abs(drag.current.x - drag.start.x));
+  const height = Math.max(1, Math.abs(drag.current.y - drag.start.y));
+  const isPointTool = tool === 'text' || tool === 'step';
+  const resolvedBounds = isPointTool
+    ? { x: drag.start.x, y: drag.start.y, width: tool === 'step' ? 44 : Math.max(160, width), height: tool === 'step' ? 44 : Math.max(48, height) }
+    : { x, y, width, height };
+
+  const text = tool === 'text'
+    ? window.prompt('Text annotation', 'Text') || 'Text'
+    : undefined;
+
+  return {
+    id: createObjectId(),
+    type: tool,
+    bounds: resolvedBounds,
+    points: tool === 'freehand' ? drag.points : undefined,
+    text,
+    stepNumber: tool === 'step' ? nextStepNumber : undefined,
+    zIndex: Date.now(),
+    style: { ...style },
+  };
+};
+
+const getCanvasPoint = (
+  event: React.PointerEvent<HTMLDivElement>,
+  canvasElement: HTMLDivElement | null,
+  document: ImageEditorDocument,
+) => {
+  const rect = canvasElement?.getBoundingClientRect();
+  if (!rect) {
+    return { x: 0, y: 0 };
+  }
+  return {
+    x: clamp(((event.clientX - rect.left) / rect.width) * document.canvasDimensions.width, 0, document.canvasDimensions.width),
+    y: clamp(((event.clientY - rect.top) / rect.height) * document.canvasDimensions.height, 0, document.canvasDimensions.height),
+  };
+};
+
+const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
+  image,
+  navigationImages = [],
+  directoryPath,
+  onBack,
+  onOpenComfyUIWorkflow,
+}) => {
+  const [sourceUrl, setSourceUrl] = useState<string | null>(null);
+  const [sourceReady, setSourceReady] = useState(false);
+  const [documentState, setDocumentState] = useState<ImageEditorDocument | null>(null);
+  const [activeTool, setActiveTool] = useState<ImageEditorTool>('select');
+  const [activeStyle, setActiveStyle] = useState<ImageEditorObjectStyle>(DEFAULT_IMAGE_EDITOR_OBJECT_STYLE);
+  const [history, setHistory] = useState<HistoryState>({ past: [], future: [] });
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [isRendering, setIsRendering] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const [hydratedImage, setHydratedImage] = useState<IndexedImage | null>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  const directories = useImageStore((state) => state.directories);
+  const addImages = useImageStore((state) => state.addImages);
+  const mergeImages = useImageStore((state) => state.mergeImages);
+  const setImageThumbnail = useImageStore((state) => state.setImageThumbnail);
+  const setError = useImageStore((state) => state.setError);
+  const setSuccess = useImageStore((state) => state.setSuccess);
+  const scanSubfolders = useImageStore((state) => state.scanSubfolders);
+  const allImages = useImageStore((state) => state.images);
+  const comfyUIEnabled = useSettingsStore((state) => state.comfyUIEnabled);
+  const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
+  const { canUseComfyUI, showProModal } = useFeatureAccess();
+  const { generateWithComfyUI, isGenerating: isUpscaling } = useGenerateWithComfyUI();
+
+  const normalizedDocument = useMemo(
+    () => documentState ? normalizeImageEditorDocument(documentState) : null,
+    [documentState],
+  );
+  const hasChanges = normalizedDocument ? hasImageEditorDocumentChanges(normalizedDocument) : false;
+  const selectedObject = normalizedDocument?.objects.find((object) => normalizedDocument.selectedObjectIds.includes(object.id)) || null;
+  const canOverwrite = getFileExtension(image.name) === '.png';
+
+  const commitDocument = useCallback((updater: (current: ImageEditorDocument) => ImageEditorDocument, label: string) => {
+    setDocumentState((current) => {
+      if (!current) {
+        return current;
+      }
+      const before = cloneDocument(current);
+      const after = normalizeImageEditorDocument(updater(before));
+      setHistory((historyState) => ({
+        past: [...historyState.past, current].slice(-80),
+        future: [],
+      }));
+      return after;
+    });
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+    setSourceReady(false);
+    setSourceUrl(null);
+    setPreviewUrl((current) => {
+      if (current) URL.revokeObjectURL(current);
+      return null;
+    });
+    setDocumentState(null);
+    setHistory({ past: [], future: [] });
+    setHydratedImage(null);
+
+    const load = async () => {
+      try {
+        const source = await mediaSourceCache.getOrLoad(image, directoryPath, { prioritize: true });
+        if (!mounted) return;
+        setSourceUrl(source);
+        const dimensions = await new Promise<{ width: number; height: number }>((resolve, reject) => {
+          const element = new Image();
+          element.onload = () => resolve({ width: element.naturalWidth || element.width, height: element.naturalHeight || element.height });
+          element.onerror = () => reject(new Error('Failed to load image dimensions.'));
+          element.src = source;
+        });
+        if (!mounted) return;
+        setDocumentState(createImageEditorDocument({
+          imageId: image.id,
+          name: image.name,
+          width: dimensions.width,
+          height: dimensions.height,
+        }));
+        setSourceReady(true);
+      } catch (error) {
+        if (mounted) {
+          setError(error instanceof Error ? error.message : 'Failed to open image editor.');
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, [directoryPath, image, setError]);
+
+  useEffect(() => () => {
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+  }, [previewUrl]);
+
+  useEffect(() => {
+    if (!sourceUrl || !normalizedDocument || !sourceReady) {
+      return;
+    }
+    let canceled = false;
+    setIsRendering(true);
+    const timeoutId = window.setTimeout(async () => {
+      try {
+        const blob = await renderImageEditorDocumentToPngBlob(sourceUrl, normalizedDocument);
+        if (canceled) return;
+        const nextUrl = URL.createObjectURL(blob);
+        setPreviewUrl((current) => {
+          if (current) URL.revokeObjectURL(current);
+          return nextUrl;
+        });
+      } catch (error) {
+        if (!canceled) {
+          console.warn('[ImageEditorWorkspace] Failed to render preview:', error);
+        }
+      } finally {
+        if (!canceled) {
+          setIsRendering(false);
+        }
+      }
+    }, 80);
+
+    return () => {
+      canceled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [normalizedDocument, sourceReady, sourceUrl]);
+
+  const ensureHydratedImage = useCallback(async () => {
+    if (hydratedImage?.id === image.id) {
+      return hydratedImage;
+    }
+    if (!hasCompactedRuntimeMetadata(image)) {
+      setHydratedImage(image);
+      return image;
+    }
+    const hydrated = await hydrateImageRawMetadata(image, directoryPath);
+    setHydratedImage(hydrated);
+    return hydrated;
+  }, [directoryPath, hydratedImage, image]);
+
+  const findDirectoryForAbsolutePath = useCallback((filePath: string) => {
+    const normalize = (value: string) => value.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+    const normalizedFile = normalize(filePath);
+    return directories.find((directory) => normalizedFile.startsWith(`${normalize(directory.path)}/`)) ?? null;
+  }, [directories]);
+
+  const buildDefaultSavePath = useCallback(async () => {
+    const relativePath = getRelativeImagePath(image);
+    const { folderPath, fileName } = splitRelativePath(relativePath);
+    const dotIndex = fileName.lastIndexOf('.');
+    const basename = dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName;
+    const editedRelativePath = folderPath ? `${folderPath}/${basename}-editor.png` : `${basename}-editor.png`;
+    if (!directoryPath || !window.electronAPI?.joinPaths) {
+      return `${basename}-editor.png`;
+    }
+    const joined = await window.electronAPI.joinPaths(directoryPath, editedRelativePath);
+    return joined.success && joined.path ? joined.path : `${basename}-editor.png`;
+  }, [directoryPath, image]);
+
+  const renderExportBytes = useCallback(async () => {
+    if (!sourceUrl || !normalizedDocument) {
+      throw new Error('The editor source image is still loading.');
+    }
+    const bytes = await renderImageEditorDocumentToPngBytes(sourceUrl, normalizedDocument);
+    const sourceImage = await ensureHydratedImage();
+    const sourceMetadata = getUsableNormalizedMetadata(sourceImage);
+    const rawMetadata = sourceImage.metadata as Record<string, unknown> | undefined;
+    const outputDimensions = {
+      width: normalizedDocument.canvasDimensions.width,
+      height: normalizedDocument.canvasDimensions.height,
+    };
+    return embedMetaHubMetadataInPngBytes(
+      bytes,
+      sourceMetadata,
+      normalizedDocument.recipe,
+      rawMetadata,
+      outputDimensions,
+      {
+        tool: 'image-editor-workspace-v1',
+        annotationCount: normalizedDocument.objects.length,
+        background: normalizedDocument.background,
+        sourceImageId: normalizedDocument.sourceImageId,
+      },
+    );
+  }, [ensureHydratedImage, normalizedDocument, sourceUrl]);
+
+  const saveToPath = useCallback(async (targetPath: string, mode: 'save_as' | 'overwrite') => {
+    if (!window.electronAPI?.writeFile) {
+      throw new Error('Saving edited images is only available in the desktop app.');
+    }
+    const outputBytes = await renderExportBytes();
+    const result = await window.electronAPI.writeFile(targetPath, outputBytes);
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to write edited image.');
+    }
+
+    const sourceDirectory = mode === 'overwrite'
+      ? directories.find((directory) => directory.id === image.directoryId) ?? null
+      : findDirectoryForAbsolutePath(targetPath);
+    if (!sourceDirectory) {
+      return null;
+    }
+
+    const indexedImage = mode === 'overwrite'
+      ? await reparseIndexedImage(image, sourceDirectory.path)
+      : await indexImageFileAtPath(targetPath, sourceDirectory);
+    if (!indexedImage) {
+      return null;
+    }
+
+    if (mode === 'overwrite') {
+      mergeImages([indexedImage]);
+      setImageThumbnail(image.id, { thumbnailUrl: null, thumbnailHandle: null, status: 'pending', error: null });
+      await cacheManager.updateCachedImages(sourceDirectory.path, sourceDirectory.name, [indexedImage], scanSubfolders);
+    } else if (allImages.some((candidate) => candidate.id === indexedImage.id)) {
+      mergeImages([indexedImage]);
+      await cacheManager.updateCachedImages(sourceDirectory.path, sourceDirectory.name, [indexedImage], scanSubfolders);
+    } else {
+      addImages([indexedImage]);
+      await cacheManager.appendToCache(sourceDirectory.path, sourceDirectory.name, [indexedImage], scanSubfolders);
+    }
+    return indexedImage;
+  }, [
+    addImages,
+    allImages,
+    directories,
+    findDirectoryForAbsolutePath,
+    image,
+    mergeImages,
+    renderExportBytes,
+    scanSubfolders,
+    setImageThumbnail,
+  ]);
+
+  const handleSaveAs = useCallback(async () => {
+    if (!window.electronAPI?.showSaveDialog) {
+      setError('Save As is only available in the desktop app.');
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const defaultPath = await buildDefaultSavePath();
+      const saveResult = await window.electronAPI.showSaveDialog({
+        title: 'Save edited image',
+        defaultPath,
+        filters: [{ name: 'PNG Image', extensions: ['png'] }],
+      });
+      if (saveResult.canceled || !saveResult.path) {
+        return;
+      }
+      await saveToPath(saveResult.path, 'save_as');
+      setSuccess('Saved editor image.');
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to save editor image.');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [buildDefaultSavePath, saveToPath, setError, setSuccess]);
+
+  const handleSave = useCallback(async () => {
+    if (!canOverwrite) {
+      await handleSaveAs();
+      return;
+    }
+    if (!window.electronAPI?.joinPaths) {
+      setError('Save is only available in the desktop app.');
+      return;
+    }
+    const sourceDirectory = directories.find((directory) => directory.id === image.directoryId);
+    if (!sourceDirectory) {
+      setError('Cannot save because the source directory is unavailable.');
+      return;
+    }
+    if (!window.confirm('Overwrite the original image with the editor output? This cannot be undone.')) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const joined = await window.electronAPI.joinPaths(sourceDirectory.path, getRelativeImagePath(image));
+      if (!joined.success || !joined.path) {
+        throw new Error(joined.error || 'Failed to resolve original image path.');
+      }
+      await saveToPath(joined.path, 'overwrite');
+      setSuccess('Saved editor output over the original PNG.');
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to overwrite editor image.');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [canOverwrite, directories, handleSaveAs, image, saveToPath, setError, setSuccess]);
+
+  const handleCopy = useCallback(async () => {
+    if (!sourceUrl || !normalizedDocument) return;
+    try {
+      const blob = await renderImageEditorDocumentToPngBlob(sourceUrl, normalizedDocument);
+      const ClipboardItemCtor = window.ClipboardItem;
+      if (!navigator.clipboard || !ClipboardItemCtor) {
+        throw new Error('Image clipboard is not available in this browser.');
+      }
+      await navigator.clipboard.write([new ClipboardItemCtor({ 'image/png': blob })]);
+      setSuccess('Copied editor image to clipboard.');
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to copy editor image.');
+    }
+  }, [normalizedDocument, setError, setSuccess, sourceUrl]);
+
+  const handleAIUpscale = useCallback(async () => {
+    if (!canUseComfyUI) {
+      showProModal('comfyui');
+      return;
+    }
+    if (!comfyUIEnabled || !comfyUIServerUrl) {
+      setError('AI Upscale needs ComfyUI enabled and a server URL in Settings.');
+      return;
+    }
+    if (!image.handle) {
+      setError('AI Upscale needs desktop file access to upload the source image.');
+      return;
+    }
+    await generateWithComfyUI(image, {
+      workflowMode: 'upscale',
+      customMetadata: { prompt: image.prompt || 'ComfyUI upscale' },
+    });
+  }, [canUseComfyUI, comfyUIEnabled, comfyUIServerUrl, generateWithComfyUI, image, setError, showProModal]);
+
+  const handleBack = useCallback(() => {
+    if (hasChanges && !window.confirm('Leave the image editor and discard the current editor state?')) {
+      return;
+    }
+    onBack();
+  }, [hasChanges, onBack]);
+
+  const undo = useCallback(() => {
+    setHistory((current) => {
+      const previous = current.past[current.past.length - 1];
+      if (!previous || !documentState) return current;
+      setDocumentState(previous);
+      return {
+        past: current.past.slice(0, -1),
+        future: [documentState, ...current.future],
+      };
+    });
+  }, [documentState]);
+
+  const redo = useCallback(() => {
+    setHistory((current) => {
+      const next = current.future[0];
+      if (!next || !documentState) return current;
+      setDocumentState(next);
+      return {
+        past: [...current.past, documentState],
+        future: current.future.slice(1),
+      };
+    });
+  }, [documentState]);
+
+  const resetDocument = useCallback(() => {
+    if (!normalizedDocument) return;
+    commitDocument(() => createImageEditorDocument({
+      imageId: image.id,
+      name: image.name,
+      width: normalizedDocument.sourceDimensions.width,
+      height: normalizedDocument.sourceDimensions.height,
+    }), 'Reset');
+  }, [commitDocument, image, normalizedDocument]);
+
+  const updateRecipe = useCallback((recipe: ImageEditorDocument['recipe']) => {
+    commitDocument((current) => ({ ...current, recipe: normalizeImageEditRecipe(recipe, current.sourceDimensions) }), 'Edit recipe');
+  }, [commitDocument]);
+
+  const updateBackground = useCallback((background: Partial<ImageEditorDocument['background']>) => {
+    commitDocument((current) => ({ ...current, background: { ...current.background, ...background } }), 'Background');
+  }, [commitDocument]);
+
+  const updateSelectedObjectStyle = useCallback((style: Partial<ImageEditorObjectStyle>) => {
+    if (!selectedObject) return;
+    commitDocument((current) => ({
+      ...current,
+      objects: current.objects.map((object) => object.id === selectedObject.id ? { ...object, style: { ...object.style, ...style } } : object),
+    }), 'Object style');
+  }, [commitDocument, selectedObject]);
+
+  const deleteSelected = useCallback(() => {
+    if (!normalizedDocument?.selectedObjectIds.length) return;
+    const ids = new Set(normalizedDocument.selectedObjectIds);
+    commitDocument((current) => ({
+      ...current,
+      objects: current.objects.filter((object) => !ids.has(object.id)),
+      selectedObjectIds: [],
+    }), 'Delete object');
+  }, [commitDocument, normalizedDocument?.selectedObjectIds]);
+
+  const flattenSelection = useCallback(() => {
+    if (!normalizedDocument) return;
+    commitDocument((current) => ({ ...current, selectedObjectIds: [] }), 'Flatten');
+    setSuccess('Flatten will be applied in the saved PNG output.');
+  }, [commitDocument, normalizedDocument, setSuccess]);
+
+  const pointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!normalizedDocument || event.button !== 0) return;
+    const point = getCanvasPoint(event, canvasRef.current, normalizedDocument);
+    event.currentTarget.setPointerCapture(event.pointerId);
+
+    if (activeTool === 'select') {
+      const selected = [...normalizedDocument.objects]
+        .reverse()
+        .find((object) => point.x >= object.bounds.x && point.x <= object.bounds.x + object.bounds.width && point.y >= object.bounds.y && point.y <= object.bounds.y + object.bounds.height);
+      commitDocument((current) => ({ ...current, selectedObjectIds: selected ? [selected.id] : [] }), 'Select');
+      return;
+    }
+
+    setDragState({
+      tool: activeTool,
+      start: point,
+      current: point,
+      points: activeTool === 'freehand' ? [point] : undefined,
+    });
+  }, [activeTool, commitDocument, normalizedDocument]);
+
+  const pointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragState || !normalizedDocument) return;
+    const point = getCanvasPoint(event, canvasRef.current, normalizedDocument);
+    setDragState((current) => current ? {
+      ...current,
+      current: point,
+      points: current.points ? [...current.points, point] : undefined,
+    } : current);
+  }, [dragState, normalizedDocument]);
+
+  const pointerUp = useCallback(() => {
+    if (!dragState || !normalizedDocument) return;
+    const completedDrag = dragState;
+    setDragState(null);
+
+    if (completedDrag.tool === 'crop') {
+      const x = Math.min(completedDrag.start.x, completedDrag.current.x);
+      const y = Math.min(completedDrag.start.y, completedDrag.current.y);
+      const width = Math.max(1, Math.abs(completedDrag.current.x - completedDrag.start.x));
+      const height = Math.max(1, Math.abs(completedDrag.current.y - completedDrag.start.y));
+      commitDocument((current) => ({
+        ...current,
+        recipe: {
+          ...current.recipe,
+          crop: {
+            enabled: true,
+            aspect: 'free',
+            rect: { x, y, width, height },
+          },
+        },
+      }), 'Crop');
+      return;
+    }
+
+    const nextObject = objectFromDrag(
+      completedDrag.tool,
+      completedDrag,
+      activeStyle,
+      normalizedDocument.objects.filter((object) => object.type === 'step').length + 1,
+    );
+    if (!nextObject) return;
+
+    commitDocument((current) => ({
+      ...current,
+      objects: [...current.objects, { ...nextObject, zIndex: current.objects.length + 1 }],
+      selectedObjectIds: [nextObject.id],
+    }), 'Add annotation');
+  }, [activeStyle, commitDocument, dragState, normalizedDocument]);
+
+  const moveSelected = useCallback((direction: 'front' | 'forward' | 'backward' | 'back') => {
+    if (!selectedObject) return;
+    commitDocument((current) => {
+      const objects = current.objects.map((object) => ({ ...object }));
+      const target = objects.find((object) => object.id === selectedObject.id);
+      if (!target) return current;
+      const zValues = objects.map((object) => object.zIndex);
+      const min = Math.min(...zValues);
+      const max = Math.max(...zValues);
+      target.zIndex = direction === 'front'
+        ? max + 1
+        : direction === 'back'
+          ? min - 1
+          : target.zIndex + (direction === 'forward' ? 1 : -1);
+      return { ...current, objects };
+    }, 'Layer order');
+  }, [commitDocument, selectedObject]);
+
+  const activeOutputDimensions = normalizedDocument
+    ? getImageEditOutputDimensions(normalizedDocument.recipe, normalizedDocument.sourceDimensions)
+    : null;
+  const selectedCount = normalizedDocument?.selectedObjectIds.length || 0;
+
+  if (!normalizedDocument || !sourceUrl) {
+    return (
+      <div className="flex h-full items-center justify-center bg-gray-950 text-gray-300">
+        Opening editor...
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-gray-950 text-gray-100">
+      <div className="flex h-14 shrink-0 items-center justify-between border-b border-gray-800 bg-gray-900 px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <button type="button" onClick={handleBack} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Back">
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold">{image.name}</div>
+            <div className="text-xs text-gray-500">
+              {activeOutputDimensions?.width || normalizedDocument.canvasDimensions.width}x{activeOutputDimensions?.height || normalizedDocument.canvasDimensions.height}
+              {hasChanges ? ' · Unsaved edits' : ' · Clean'}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button type="button" onClick={undo} disabled={!history.past.length} className="rounded-md p-2 text-gray-300 hover:bg-gray-800 disabled:opacity-40" title="Undo">
+            <Undo2 className="h-4 w-4" />
+          </button>
+          <button type="button" onClick={redo} disabled={!history.future.length} className="rounded-md p-2 text-gray-300 hover:bg-gray-800 disabled:opacity-40" title="Redo">
+            <Redo2 className="h-4 w-4" />
+          </button>
+          <button type="button" onClick={flattenSelection} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Flatten">
+            <Layers className="h-4 w-4" />
+          </button>
+          <button type="button" onClick={handleCopy} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Copy image">
+            <Copy className="h-4 w-4" />
+          </button>
+          <button type="button" onClick={handleSave} disabled={isSaving || !hasChanges} className="inline-flex items-center gap-1 rounded-md bg-cyan-600 px-3 py-2 text-xs font-semibold text-white hover:bg-cyan-500 disabled:bg-gray-800 disabled:text-gray-500" title={canOverwrite ? 'Save' : 'Save As'}>
+            <Save className="h-4 w-4" />
+            Save
+          </button>
+          <button type="button" onClick={handleSaveAs} disabled={isSaving || !hasChanges} className="inline-flex items-center gap-1 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-40">
+            <Download className="h-4 w-4" />
+            Save As
+          </button>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        <div className="flex w-16 shrink-0 flex-col gap-1 border-r border-gray-800 bg-gray-900 p-2">
+          {TOOL_DEFS.map((tool) => (
+            <button
+              key={tool.id}
+              type="button"
+              onClick={() => setActiveTool(tool.id)}
+              className={`flex h-10 w-10 items-center justify-center rounded-md border text-gray-300 transition-colors ${
+                activeTool === tool.id ? 'border-cyan-400/40 bg-cyan-500/20 text-cyan-100' : 'border-transparent hover:bg-gray-800'
+              }`}
+              title={tool.label}
+              aria-label={tool.label}
+            >
+              {tool.icon}
+            </button>
+          ))}
+        </div>
+
+        <div className="relative flex min-w-0 flex-1 flex-col bg-gray-950">
+          <div className="flex flex-1 items-center justify-center overflow-auto p-8">
+            <div
+              ref={canvasRef}
+              data-testid="image-editor-canvas"
+              className="relative max-h-full max-w-full touch-none select-none overflow-hidden rounded-sm border border-gray-800 bg-[linear-gradient(45deg,#1f2937_25%,transparent_25%),linear-gradient(-45deg,#1f2937_25%,transparent_25%),linear-gradient(45deg,transparent_75%,#1f2937_75%),linear-gradient(-45deg,transparent_75%,#1f2937_75%)] bg-[length:20px_20px] bg-[position:0_0,0_10px,10px_-10px,-10px_0px]"
+              style={{
+                aspectRatio: `${Math.max(1, normalizedDocument.canvasDimensions.width)} / ${Math.max(1, normalizedDocument.canvasDimensions.height)}`,
+                width: 'min(100%, 1080px)',
+              }}
+              onPointerDown={pointerDown}
+              onPointerMove={pointerMove}
+              onPointerUp={pointerUp}
+              onPointerCancel={() => setDragState(null)}
+            >
+              {previewUrl ? (
+                <img src={previewUrl} alt={image.name} className="block h-full w-full object-contain" draggable={false} />
+              ) : (
+                <img src={sourceUrl} alt={image.name} className="block h-full w-full object-contain opacity-80" draggable={false} />
+              )}
+              {dragState && (
+                <div
+                  className="pointer-events-none absolute border-2 border-cyan-300 bg-cyan-300/10"
+                  style={{
+                    left: `${(Math.min(dragState.start.x, dragState.current.x) / normalizedDocument.canvasDimensions.width) * 100}%`,
+                    top: `${(Math.min(dragState.start.y, dragState.current.y) / normalizedDocument.canvasDimensions.height) * 100}%`,
+                    width: `${(Math.abs(dragState.current.x - dragState.start.x) / normalizedDocument.canvasDimensions.width) * 100}%`,
+                    height: `${(Math.abs(dragState.current.y - dragState.start.y) / normalizedDocument.canvasDimensions.height) * 100}%`,
+                  }}
+                />
+              )}
+              {selectedObject && (
+                <div
+                  className="pointer-events-none absolute border-2 border-cyan-300"
+                  style={{
+                    left: `${(selectedObject.bounds.x / normalizedDocument.canvasDimensions.width) * 100}%`,
+                    top: `${(selectedObject.bounds.y / normalizedDocument.canvasDimensions.height) * 100}%`,
+                    width: `${(selectedObject.bounds.width / normalizedDocument.canvasDimensions.width) * 100}%`,
+                    height: `${(selectedObject.bounds.height / normalizedDocument.canvasDimensions.height) * 100}%`,
+                  }}
+                />
+              )}
+            </div>
+          </div>
+          <div className="flex h-9 shrink-0 items-center justify-between border-t border-gray-800 bg-gray-900 px-4 text-xs text-gray-400">
+            <span>{TOOL_HINTS[activeTool]}</span>
+            <span>{isRendering ? 'Rendering preview...' : `${normalizedDocument.objects.length} objects · ${selectedCount} selected`}</span>
+          </div>
+        </div>
+
+        <aside className="w-80 shrink-0 overflow-y-auto border-l border-gray-800 bg-gray-900 p-4">
+          <div className="space-y-5">
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold text-gray-100">Tool</h3>
+              <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-sm">
+                <div className="font-medium text-cyan-100">{TOOL_DEFS.find((tool) => tool.id === activeTool)?.label}</div>
+                <p className="mt-1 text-xs text-gray-500">{TOOL_HINTS[activeTool]}</p>
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold text-gray-100">Local Edits</h3>
+              <div className="grid grid-cols-2 gap-2">
+                <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, rotation: ((normalizedDocument.recipe.transform.rotation + 270) % 360) as 0 | 90 | 180 | 270 } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
+                  <RotateCcw className="h-3.5 w-3.5" /> Left
+                </button>
+                <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, rotation: ((normalizedDocument.recipe.transform.rotation + 90) % 360) as 0 | 90 | 180 | 270 } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
+                  <RotateCw className="h-3.5 w-3.5" /> Right
+                </button>
+                <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, flipHorizontal: !normalizedDocument.recipe.transform.flipHorizontal } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
+                  <FlipHorizontal className="h-3.5 w-3.5" /> Flip H
+                </button>
+                <button type="button" onClick={() => updateRecipe({ ...normalizedDocument.recipe, transform: { ...normalizedDocument.recipe.transform, flipVertical: !normalizedDocument.recipe.transform.flipVertical } })} className="inline-flex items-center justify-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs hover:bg-gray-800">
+                  <FlipVertical className="h-3.5 w-3.5" /> Flip V
+                </button>
+              </div>
+              {(['brightness', 'contrast', 'saturation'] as const).map((key) => (
+                <label key={key} className="block space-y-1 text-xs text-gray-400">
+                  <span className="capitalize">{key}</span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={200}
+                    value={normalizedDocument.recipe.adjustments[key]}
+                    onChange={(event) => updateRecipe({
+                      ...normalizedDocument.recipe,
+                      adjustments: {
+                        ...normalizedDocument.recipe.adjustments,
+                        [key]: clampImageAdjustment(key, Number(event.target.value)),
+                      },
+                    })}
+                    className="w-full accent-cyan-500"
+                  />
+                </label>
+              ))}
+              <div className="grid grid-cols-2 gap-2">
+                {(['sharpen', 'blur'] as const).map((key) => (
+                  <label key={key} className="space-y-1 text-xs text-gray-400">
+                    <span className="capitalize">{key}</span>
+                    <input
+                      type="number"
+                      value={normalizedDocument.recipe.effects[key]}
+                      min={0}
+                      max={key === 'blur' ? 20 : 100}
+                      onChange={(event) => updateRecipe({
+                        ...normalizedDocument.recipe,
+                        effects: {
+                          ...normalizedDocument.recipe.effects,
+                          [key]: clampImageEditEffect(key, Number(event.target.value)),
+                        },
+                      })}
+                      className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100"
+                    />
+                  </label>
+                ))}
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold text-gray-100">Object Style</h3>
+              <div className="grid grid-cols-2 gap-2">
+                <label className="space-y-1 text-xs text-gray-400">
+                  <span>Stroke</span>
+                  <input type="color" value={activeStyle.strokeColor} onChange={(event) => { setActiveStyle({ ...activeStyle, strokeColor: event.target.value }); updateSelectedObjectStyle({ strokeColor: event.target.value }); }} className="h-8 w-full rounded border border-gray-700 bg-gray-950" />
+                </label>
+                <label className="space-y-1 text-xs text-gray-400">
+                  <span>Text</span>
+                  <input type="color" value={activeStyle.textColor} onChange={(event) => { setActiveStyle({ ...activeStyle, textColor: event.target.value }); updateSelectedObjectStyle({ textColor: event.target.value }); }} className="h-8 w-full rounded border border-gray-700 bg-gray-950" />
+                </label>
+                <label className="space-y-1 text-xs text-gray-400">
+                  <span>Width</span>
+                  <input type="number" value={activeStyle.strokeWidth} min={1} max={80} onChange={(event) => { const value = clamp(Math.round(Number(event.target.value) || 1), 1, 80); setActiveStyle({ ...activeStyle, strokeWidth: value }); updateSelectedObjectStyle({ strokeWidth: value }); }} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
+                </label>
+                <label className="space-y-1 text-xs text-gray-400">
+                  <span>Font</span>
+                  <input type="number" value={activeStyle.fontSize} min={8} max={240} onChange={(event) => { const value = clamp(Math.round(Number(event.target.value) || 32), 8, 240); setActiveStyle({ ...activeStyle, fontSize: value }); updateSelectedObjectStyle({ fontSize: value }); }} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
+                </label>
+              </div>
+              <div className="grid grid-cols-4 gap-1">
+                <button type="button" onClick={() => moveSelected('front')} disabled={!selectedObject} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800 disabled:opacity-40">Front</button>
+                <button type="button" onClick={() => moveSelected('forward')} disabled={!selectedObject} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800 disabled:opacity-40">Up</button>
+                <button type="button" onClick={() => moveSelected('backward')} disabled={!selectedObject} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800 disabled:opacity-40">Down</button>
+                <button type="button" onClick={() => moveSelected('back')} disabled={!selectedObject} className="rounded border border-gray-700 px-1 py-1 text-xs hover:bg-gray-800 disabled:opacity-40">Back</button>
+              </div>
+              <button type="button" onClick={deleteSelected} disabled={!selectedObject} className="w-full rounded-md border border-red-500/30 bg-red-500/10 px-2 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/20 disabled:opacity-40">
+                Delete Selected
+              </button>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold text-gray-100">Background</h3>
+              <select value={normalizedDocument.background.kind} onChange={(event) => updateBackground({ kind: event.target.value as ImageEditorDocument['background']['kind'] })} className="h-9 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-sm">
+                <option value="transparent">Transparent</option>
+                <option value="color">Color</option>
+                <option value="gradient">Gradient</option>
+              </select>
+              <div className="grid grid-cols-2 gap-2">
+                <label className="space-y-1 text-xs text-gray-400">
+                  <span>Color</span>
+                  <input type="color" value={normalizedDocument.background.color} onChange={(event) => updateBackground({ color: event.target.value })} className="h-8 w-full rounded border border-gray-700 bg-gray-950" />
+                </label>
+                <label className="space-y-1 text-xs text-gray-400">
+                  <span>Shadow</span>
+                  <input type="number" value={normalizedDocument.background.shadowRadius} min={0} max={500} onChange={(event) => updateBackground({ shadowRadius: Number(event.target.value) })} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
+                </label>
+                <label className="space-y-1 text-xs text-gray-400">
+                  <span>Margin</span>
+                  <input type="number" value={normalizedDocument.background.margin} min={0} max={2000} onChange={(event) => updateBackground({ margin: Number(event.target.value) })} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
+                </label>
+                <label className="space-y-1 text-xs text-gray-400">
+                  <span>Padding</span>
+                  <input type="number" value={normalizedDocument.background.padding} min={0} max={2000} onChange={(event) => updateBackground({ padding: Number(event.target.value) })} className="h-8 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-right text-xs text-gray-100" />
+                </label>
+              </div>
+              <label className="inline-flex items-center gap-2 text-xs text-gray-300">
+                <input type="checkbox" checked={normalizedDocument.background.smartPadding} onChange={(event) => updateBackground({ smartPadding: event.target.checked })} className="h-4 w-4 accent-cyan-500" />
+                Smart padding
+              </label>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold text-gray-100">AI Transform</h3>
+              <button type="button" onClick={handleAIUpscale} disabled={isUpscaling} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-purple-400/30 bg-purple-500/15 px-3 py-2 text-xs font-semibold text-purple-100 hover:bg-purple-500/25 disabled:opacity-50">
+                <Sparkles className="h-4 w-4" />
+                {isUpscaling ? 'Queueing...' : 'AI Upscale'}
+              </button>
+              <div className="grid grid-cols-2 gap-1 text-xs">
+                {['Detail Restore', 'Face Restore', 'Img2Img', 'Inpaint', 'Outpaint'].map((label) => (
+                  <button key={label} type="button" disabled className="rounded-md border border-gray-800 px-2 py-1.5 text-gray-600">
+                    {label}
+                  </button>
+                ))}
+              </div>
+              {onOpenComfyUIWorkflow && (
+                <button type="button" onClick={() => onOpenComfyUIWorkflow(image)} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800">
+                  <Workflow className="h-4 w-4" />
+                  Open Workflow
+                </button>
+              )}
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-gray-100">Source</h3>
+              <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-400">
+                <div className="flex items-center gap-2 text-gray-200">
+                  <ImageIcon className="h-4 w-4 text-cyan-300" />
+                  <span className="truncate">{image.name}</span>
+                </div>
+                <div className="mt-2">{normalizedDocument.sourceDimensions.width}x{normalizedDocument.sourceDimensions.height}</div>
+                {navigationImages.length > 1 && <div>{navigationImages.length} images in navigation scope</div>}
+              </div>
+            </section>
+
+            <button type="button" onClick={resetDocument} disabled={!hasChanges} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-40">
+              <Scissors className="h-4 w-4" />
+              Reset Editor
+            </button>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default ImageEditorWorkspace;

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -86,6 +86,7 @@ type DragState = {
   current: { x: number; y: number };
   points?: { x: number; y: number }[];
   movingObjectId?: string;
+  movingObjectIds?: string[];
   resizeHandle?: ResizeHandle;
   keepAspectRatio?: boolean;
 };
@@ -178,6 +179,33 @@ const getUsableNormalizedMetadata = (image: IndexedImage): BaseMetadata | undefi
   image.metadata?.normalizedMetadata as BaseMetadata | undefined
 );
 
+const boundsFromPoints = (points: Array<{ x: number; y: number }>): ImageEditorObject['bounds'] => {
+  const minX = Math.min(...points.map((point) => point.x));
+  const minY = Math.min(...points.map((point) => point.y));
+  const maxX = Math.max(...points.map((point) => point.x));
+  const maxY = Math.max(...points.map((point) => point.y));
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+  };
+};
+
+const boundsFromDrag = (drag: DragState): ImageEditorObject['bounds'] => ({
+  x: Math.min(drag.start.x, drag.current.x),
+  y: Math.min(drag.start.y, drag.current.y),
+  width: Math.max(1, Math.abs(drag.current.x - drag.start.x)),
+  height: Math.max(1, Math.abs(drag.current.y - drag.start.y)),
+});
+
+const boundsIntersect = (first: ImageEditorObject['bounds'], second: ImageEditorObject['bounds']) => (
+  first.x < second.x + second.width &&
+  first.x + first.width > second.x &&
+  first.y < second.y + second.height &&
+  first.y + first.height > second.y
+);
+
 const objectFromDrag = (
   tool: ImageEditorTool,
   drag: DragState,
@@ -188,12 +216,15 @@ const objectFromDrag = (
     return null;
   }
 
-  const x = Math.min(drag.start.x, drag.current.x);
-  const y = Math.min(drag.start.y, drag.current.y);
-  const width = Math.max(1, Math.abs(drag.current.x - drag.start.x));
-  const height = Math.max(1, Math.abs(drag.current.y - drag.start.y));
+  const dragBounds = boundsFromDrag(drag);
+  const x = dragBounds.x;
+  const y = dragBounds.y;
+  const width = dragBounds.width;
+  const height = dragBounds.height;
   const isPointTool = tool === 'text' || tool === 'step';
-  const resolvedBounds = isPointTool
+  const resolvedBounds = tool === 'freehand' && drag.points?.length
+    ? boundsFromPoints(drag.points)
+    : isPointTool
     ? { x: drag.start.x, y: drag.start.y, width: tool === 'step' ? 44 : Math.max(160, width), height: tool === 'step' ? 44 : Math.max(48, height) }
     : { x, y, width, height };
 
@@ -899,18 +930,26 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       .find((object) => point.x >= object.bounds.x && point.x <= object.bounds.x + object.bounds.width && point.y >= object.bounds.y && point.y <= object.bounds.y + object.bounds.height);
 
     if (selected && (activeTool === 'select' || activeTool === selected.type || normalizedDocument.selectedObjectIds.includes(selected.id))) {
+      const selectedIds = normalizedDocument.selectedObjectIds.includes(selected.id)
+        ? normalizedDocument.selectedObjectIds
+        : [selected.id];
       setDragState({
         tool: 'select',
         start: point,
         current: point,
         movingObjectId: selected.id,
+        movingObjectIds: selectedIds,
       });
-      commitDocument((current) => ({ ...current, selectedObjectIds: selected ? [selected.id] : [] }), 'Select');
+      commitDocument((current) => ({ ...current, selectedObjectIds: selectedIds }), 'Select');
       return;
     }
 
     if (activeTool === 'select') {
-      commitDocument((current) => ({ ...current, selectedObjectIds: [] }), 'Select');
+      setDragState({
+        tool: 'select',
+        start: point,
+        current: point,
+      });
       return;
     }
 
@@ -951,17 +990,30 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     const completedDrag = dragState;
     setDragState(null);
 
+    if (completedDrag.tool === 'select' && !completedDrag.movingObjectId && !completedDrag.resizeHandle) {
+      const selectionBounds = boundsFromDrag(completedDrag);
+      const hasMarqueeSize = selectionBounds.width > 3 || selectionBounds.height > 3;
+      commitDocument((current) => ({
+        ...current,
+        selectedObjectIds: hasMarqueeSize
+          ? current.objects.filter((object) => boundsIntersect(selectionBounds, object.bounds)).map((object) => object.id)
+          : [],
+      }), 'Select objects');
+      return;
+    }
+
     if (completedDrag.tool === 'select' && completedDrag.movingObjectId) {
       const deltaX = completedDrag.current.x - completedDrag.start.x;
       const deltaY = completedDrag.current.y - completedDrag.start.y;
+      const movingIds = new Set(completedDrag.movingObjectIds?.length ? completedDrag.movingObjectIds : [completedDrag.movingObjectId]);
       if (Math.abs(deltaX) > 0.5 || Math.abs(deltaY) > 0.5) {
         commitDocument((current) => ({
           ...current,
           objects: current.objects.map((object) => {
-            if (object.id !== completedDrag.movingObjectId) {
+            if (!movingIds.has(object.id)) {
               return object;
             }
-            if (completedDrag.resizeHandle) {
+            if (completedDrag.resizeHandle && object.id === completedDrag.movingObjectId) {
               const resizedBounds = resizeBoundsFromHandle(
                 object.bounds,
                 completedDrag.resizeHandle,
@@ -988,7 +1040,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
               })),
             };
           }),
-          selectedObjectIds: [completedDrag.movingObjectId],
+          selectedObjectIds: [...movingIds],
         }), 'Move object');
       }
       return;
@@ -1299,7 +1351,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     : null;
   const selectedCount = normalizedDocument?.selectedObjectIds.length || 0;
   const canvasDimensionsForOverlay = normalizedDocument?.canvasDimensions ?? { width: 1, height: 1 };
-  const selectedDragOffset = dragState?.tool === 'select' && !dragState.resizeHandle && selectedObject && dragState.movingObjectId === selectedObject.id
+  const selectedDragOffset = dragState?.tool === 'select' && !dragState.resizeHandle && selectedObject && (dragState.movingObjectIds?.includes(selectedObject.id) || dragState.movingObjectId === selectedObject.id)
     ? {
       x: dragState.current.x - dragState.start.x,
       y: dragState.current.y - dragState.start.y,
@@ -1334,13 +1386,32 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const canUseFontSize = Boolean(styleTargetType && ['text', 'step'].includes(styleTargetType));
   const displayedObjects = [...(normalizedDocument?.objects ?? [])]
     .sort((first, second) => first.zIndex - second.zIndex)
-    .map((object) => object.id === selectedObject?.id
-      ? {
-        ...object,
-        bounds: selectedDisplayBounds ?? object.bounds,
-        points: selectedDisplayPoints ?? object.points,
+    .map((object) => {
+      const shouldMoveWithSelection = dragState?.tool === 'select' && !dragState.resizeHandle && (dragState.movingObjectIds?.includes(object.id) || dragState.movingObjectId === object.id);
+      if (object.id === selectedObject?.id) {
+        return {
+          ...object,
+          bounds: selectedDisplayBounds ?? object.bounds,
+          points: selectedDisplayPoints ?? object.points,
+        };
       }
-      : object);
+      if (shouldMoveWithSelection) {
+        return {
+          ...object,
+          bounds: {
+            ...object.bounds,
+            x: object.bounds.x + selectedDragOffset.x,
+            y: object.bounds.y + selectedDragOffset.y,
+          },
+          points: object.points?.map((point) => ({
+            x: point.x + selectedDragOffset.x,
+            y: point.y + selectedDragOffset.y,
+          })),
+        };
+      }
+      return object;
+    });
+  const selectedDisplayedObjects = displayedObjects.filter((object) => normalizedDocument?.selectedObjectIds.includes(object.id));
 
   if (!normalizedDocument || !sourceUrl) {
     return (
@@ -1571,14 +1642,14 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                     y1={dragState.start.y}
                     x2={dragState.current.x}
                     y2={dragState.current.y}
-                    stroke="rgb(103 232 249)"
-                    strokeWidth="2"
+                    stroke={activeStyle.strokeColor}
+                    strokeWidth={activeStyle.strokeWidth}
                     strokeLinecap="round"
                     markerEnd={dragState.tool === 'arrow' ? 'url(#image-editor-arrow-preview)' : undefined}
                   />
                   <defs>
                     <marker id="image-editor-arrow-preview" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth">
-                      <path d="M 0 0 L 10 5 L 0 10 z" fill="rgb(103 232 249)" />
+                      <path d="M 0 0 L 10 5 L 0 10 z" fill={activeStyle.strokeColor} />
                     </marker>
                   </defs>
                 </svg>
@@ -1587,13 +1658,13 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                   <polyline
                     points={dragState.points.map((point) => `${point.x},${point.y}`).join(' ')}
                     fill="none"
-                    stroke="rgb(103 232 249)"
-                    strokeWidth="2"
+                    stroke={activeStyle.strokeColor}
+                    strokeWidth={activeStyle.strokeWidth}
                     strokeLinecap="round"
                     strokeLinejoin="round"
                   />
                 </svg>
-              ) : dragState && (
+              ) : dragState && !(dragState.tool === 'select' && (dragState.movingObjectId || dragState.resizeHandle)) && (
                 <div
                   className="pointer-events-none absolute border-2 border-cyan-300 bg-cyan-300/10"
                   style={{
@@ -1604,30 +1675,37 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                   }}
                 />
               )}
-              {selectedObject && (selectedObject.type === 'line' || selectedObject.type === 'arrow') && selectedDisplayPoints?.[0] && selectedDisplayPoints?.[1] ? (
-                <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
-                  <line
-                    x1={selectedDisplayPoints[0].x}
-                    y1={selectedDisplayPoints[0].y}
-                    x2={selectedDisplayPoints[1].x}
-                    y2={selectedDisplayPoints[1].y}
-                    stroke="rgb(103 232 249)"
-                    strokeWidth="2"
-                    strokeDasharray="6 5"
-                    strokeLinecap="round"
+              {selectedDisplayedObjects.map((object) => {
+                if ((object.type === 'line' || object.type === 'arrow') && object.points?.[0] && object.points?.[1]) {
+                  return (
+                    <svg key={`selection-${object.id}`} className="pointer-events-none absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${normalizedDocument.canvasDimensions.width} ${normalizedDocument.canvasDimensions.height}`} preserveAspectRatio="none">
+                      <line
+                        x1={object.points[0].x}
+                        y1={object.points[0].y}
+                        x2={object.points[1].x}
+                        y2={object.points[1].y}
+                        stroke="rgb(103 232 249)"
+                        strokeWidth="2"
+                        strokeDasharray="6 5"
+                        strokeLinecap="round"
+                      />
+                    </svg>
+                  );
+                }
+
+                return (
+                  <div
+                    key={`selection-${object.id}`}
+                    className="pointer-events-none absolute border-2 border-cyan-300 bg-cyan-300/5"
+                    style={{
+                      left: `${(object.bounds.x / normalizedDocument.canvasDimensions.width) * 100}%`,
+                      top: `${(object.bounds.y / normalizedDocument.canvasDimensions.height) * 100}%`,
+                      width: `${(object.bounds.width / normalizedDocument.canvasDimensions.width) * 100}%`,
+                      height: `${(object.bounds.height / normalizedDocument.canvasDimensions.height) * 100}%`,
+                    }}
                   />
-                </svg>
-              ) : selectedDisplayBounds && (
-                <div
-                  className="pointer-events-none absolute border-2 border-cyan-300"
-                  style={{
-                    left: `${(selectedDisplayBounds.x / normalizedDocument.canvasDimensions.width) * 100}%`,
-                    top: `${(selectedDisplayBounds.y / normalizedDocument.canvasDimensions.height) * 100}%`,
-                    width: `${(selectedDisplayBounds.width / normalizedDocument.canvasDimensions.width) * 100}%`,
-                    height: `${(selectedDisplayBounds.height / normalizedDocument.canvasDimensions.height) * 100}%`,
-                  }}
-                />
-              )}
+                );
+              })}
               {selectedDisplayBounds && selectedObject && isResizableObjectType(selectedObject.type) && (
                 <>
                   {RESIZE_HANDLES.map((handle) => {

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -19,9 +19,7 @@ import {
   RotateCcw,
   RotateCw,
   Save,
-  Search,
   Shield,
-  Sparkles,
   Square,
   Type,
   Undo2,
@@ -62,9 +60,6 @@ import { getFileExtension } from '../utils/mediaTypes.js';
 import { indexImageFileAtPath, reparseIndexedImage } from '../services/fileIndexer';
 import cacheManager from '../services/cacheManager';
 import { useImageStore } from '../store/useImageStore';
-import { useSettingsStore } from '../store/useSettingsStore';
-import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
-import { useFeatureAccess } from '../hooks/useFeatureAccess';
 
 interface ImageEditorWorkspaceProps {
   image: IndexedImage;
@@ -100,7 +95,7 @@ type DragState = {
 
 type ResizeHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
 
-type InspectorTab = 'edit' | 'style' | 'canvas' | 'ai' | 'info';
+type InspectorTab = 'edit' | 'style' | 'ai';
 
 type PanState = {
   pointerId: number;
@@ -125,15 +120,12 @@ const TOOL_DEFS: Array<{ id: ImageEditorTool; label: string; icon: React.ReactNo
   { id: 'highlight', label: 'Highlight', icon: <Highlighter className="h-4 w-4" /> },
   { id: 'blur', label: 'Blur', icon: <Eye className="h-4 w-4" /> },
   { id: 'pixelate', label: 'Pixelate', icon: <Shield className="h-4 w-4" /> },
-  { id: 'spotlight', label: 'Spotlight', icon: <Search className="h-4 w-4" /> },
 ];
 
 const INSPECTOR_TABS: Array<{ id: InspectorTab; label: string }> = [
   { id: 'edit', label: 'Edit' },
   { id: 'style', label: 'Style' },
-  { id: 'canvas', label: 'Canvas' },
   { id: 'ai', label: 'AI' },
-  { id: 'info', label: 'Info' },
 ];
 
 const ASPECT_LABELS: Record<ImageEditCropAspect, string> = {
@@ -145,6 +137,16 @@ const ASPECT_LABELS: Record<ImageEditCropAspect, string> = {
   '16:9': '16:9',
   '9:16': '9:16',
 };
+
+const FONT_FAMILY_OPTIONS = [
+  { label: 'System', value: 'system-ui, sans-serif' },
+  { label: 'Arial', value: 'Arial, sans-serif' },
+  { label: 'Verdana', value: 'Verdana, sans-serif' },
+  { label: 'Georgia', value: 'Georgia, serif' },
+  { label: 'Times', value: '"Times New Roman", serif' },
+  { label: 'Courier', value: '"Courier New", monospace' },
+  { label: 'Impact', value: 'Impact, sans-serif' },
+];
 
 const isEnabledEditorTool = (tool: ImageEditorTool) => TOOL_DEFS.some((definition) => definition.id === tool);
 
@@ -162,7 +164,7 @@ const TOOL_HINTS: Record<ImageEditorTool, string> = {
   highlight: 'Drag to highlight an area.',
   blur: 'Drag over a region to blur it on export.',
   pixelate: 'Drag over a region to pixelate it on export.',
-  spotlight: 'Drag the spotlight focus area.',
+  spotlight: 'Spotlight annotations can be edited when opening older documents.',
   magnify: 'Drag the magnified lens area.',
 };
 
@@ -199,7 +201,6 @@ const TOOL_SHORTCUTS: Partial<Record<string, ImageEditorTool>> = {
   h: 'highlight',
   b: 'blur',
   p: 'pixelate',
-  s: 'spotlight',
 };
 
 const parseDimensions = (value?: string): { width: number; height: number } => {
@@ -344,7 +345,7 @@ const objectFromDrag = (
 };
 
 const getCanvasPoint = (
-  event: React.PointerEvent<HTMLDivElement>,
+  event: { clientX: number; clientY: number },
   canvasElement: HTMLDivElement | null,
   document: ImageEditorDocument,
 ) => {
@@ -361,6 +362,10 @@ const getCanvasPoint = (
 const colorComponentToHex = (value: number) => Math.round(value).toString(16).padStart(2, '0');
 const rgbToHex = (red: number, green: number, blue: number) => `#${colorComponentToHex(red)}${colorComponentToHex(green)}${colorComponentToHex(blue)}`;
 const toColorInputValue = (value: string | undefined) => /^#[0-9a-f]{6}$/i.test(value || '') ? value as string : '#000000';
+const isTransparentColor = (value: string | undefined) => {
+  const normalized = String(value || '').replace(/\s+/g, '').toLowerCase();
+  return normalized === 'transparent' || normalized === 'rgba(0,0,0,0)' || normalized === '#00000000';
+};
 const toCanvasPercentBounds = (bounds: ImageEditorObject['bounds'], dimensions: { width: number; height: number }) => ({
   left: `${(bounds.x / dimensions.width) * 100}%`,
   top: `${(bounds.y / dimensions.height) * 100}%`,
@@ -563,7 +568,6 @@ const PixelatePreview: React.FC<{
 
 const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   image,
-  navigationImages = [],
   directoryPath,
   onBack,
   onOpenComfyUIWorkflow,
@@ -581,11 +585,13 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const [isPanning, setIsPanning] = useState(false);
   const [zoom, setZoom] = useState(1);
   const [hydratedImage, setHydratedImage] = useState<IndexedImage | null>(null);
-  const [inspectorTab, setInspectorTab] = useState<InspectorTab>('info');
+  const [inspectorTab, setInspectorTab] = useState<InspectorTab>('edit');
   const [isInspectorOpen, setIsInspectorOpen] = useState(false);
+  const [editingTextObjectId, setEditingTextObjectId] = useState<string | null>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const previewImageRef = useRef<HTMLImageElement>(null);
+  const textEditorRef = useRef<HTMLTextAreaElement>(null);
   const sessionRef = useRef<EditorSessionState | null>(null);
   const panStateRef = useRef<PanState | null>(null);
 
@@ -597,10 +603,6 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const setSuccess = useImageStore((state) => state.setSuccess);
   const scanSubfolders = useImageStore((state) => state.scanSubfolders);
   const allImages = useImageStore((state) => state.images);
-  const comfyUIEnabled = useSettingsStore((state) => state.comfyUIEnabled);
-  const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
-  const { canUseComfyUI, showProModal } = useFeatureAccess();
-  const { generateWithComfyUI, isGenerating: isUpscaling } = useGenerateWithComfyUI();
 
   const normalizedDocument = useMemo(
     () => documentState ? normalizeImageEditorDocument(documentState) : null,
@@ -644,7 +646,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
 
   useEffect(() => {
     if (!normalizedDocument) {
-      setInspectorTab('info');
+      setInspectorTab('edit');
       return;
     }
     if (activeTool === 'crop') {
@@ -656,9 +658,24 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       return;
     }
     if (activeTool === 'select' || activeTool === 'color-picker') {
-      setInspectorTab('info');
+      setInspectorTab('edit');
     }
   }, [activeTool, normalizedDocument?.selectedObjectIds.length]);
+
+  useEffect(() => {
+    if (!editingTextObjectId || !textEditorRef.current) {
+      return;
+    }
+    textEditorRef.current.focus();
+    textEditorRef.current.select();
+  }, [editingTextObjectId]);
+
+  useEffect(() => {
+    if (!editingTextObjectId || normalizedDocument?.objects.some((object) => object.id === editingTextObjectId)) {
+      return;
+    }
+    setEditingTextObjectId(null);
+  }, [editingTextObjectId, normalizedDocument?.objects]);
 
   useEffect(() => {
     if (!documentState) {
@@ -959,25 +976,6 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     }
   }, [normalizedDocument, setError, setSuccess, sourceUrl]);
 
-  const handleAIUpscale = useCallback(async () => {
-    if (!canUseComfyUI) {
-      showProModal('comfyui');
-      return;
-    }
-    if (!comfyUIEnabled || !comfyUIServerUrl) {
-      setError('AI Upscale needs ComfyUI enabled and a server URL in Settings.');
-      return;
-    }
-    if (!image.handle) {
-      setError('AI Upscale needs desktop file access to upload the source image.');
-      return;
-    }
-    await generateWithComfyUI(image, {
-      workflowMode: 'upscale',
-      customMetadata: { prompt: image.prompt || 'ComfyUI upscale' },
-    });
-  }, [canUseComfyUI, comfyUIEnabled, comfyUIServerUrl, generateWithComfyUI, image, setError, showProModal]);
-
   const handleBack = useCallback(() => {
     if (hasChanges && !window.confirm('Leave the image editor and discard the current editor state?')) {
       return;
@@ -1011,10 +1009,6 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
 
   const updateRecipe = useCallback((recipe: ImageEditorDocument['recipe']) => {
     commitDocument((current) => ({ ...current, recipe: normalizeImageEditRecipe(recipe, current.sourceDimensions) }), 'Edit recipe');
-  }, [commitDocument]);
-
-  const updateBackground = useCallback((background: Partial<ImageEditorDocument['background']>) => {
-    commitDocument((current) => ({ ...current, background: { ...current.background, ...background } }), 'Background');
   }, [commitDocument]);
 
   const updateSelectedObjectStyle = useCallback((style: Partial<ImageEditorObjectStyle>) => {
@@ -1112,6 +1106,13 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     const point = getCanvasPoint(event, canvasRef.current, normalizedDocument);
     event.currentTarget.setPointerCapture(event.pointerId);
 
+    if (editingTextObjectId && activeTool === 'text') {
+      setEditingTextObjectId(null);
+      setActiveTool('select');
+      commitDocument((current) => ({ ...current, selectedObjectIds: [] }), 'Deselect');
+      return;
+    }
+
     if (selectedObject && isResizableObjectType(selectedObject.type)) {
       const tolerance = Math.max(8, normalizedDocument.canvasDimensions.width / Math.max(1, displayWidth) * 10);
       const resizeHandle = getResizeHandleAtPoint(point, selectedObject.bounds, tolerance);
@@ -1138,9 +1139,19 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       .find((object) => point.x >= object.bounds.x && point.x <= object.bounds.x + object.bounds.width && point.y >= object.bounds.y && point.y <= object.bounds.y + object.bounds.height);
 
     if (selected && (activeTool === 'select' || activeTool === selected.type || normalizedDocument.selectedObjectIds.includes(selected.id))) {
-      const selectedIds = normalizedDocument.selectedObjectIds.includes(selected.id)
-        ? normalizedDocument.selectedObjectIds
-        : [selected.id];
+      const isMultiSelectClick = activeTool === 'select' && (event.ctrlKey || event.metaKey);
+      const isAlreadySelected = normalizedDocument.selectedObjectIds.includes(selected.id);
+      const selectedIds = isMultiSelectClick
+        ? isAlreadySelected
+          ? normalizedDocument.selectedObjectIds.filter((id) => id !== selected.id)
+          : [...normalizedDocument.selectedObjectIds, selected.id]
+        : isAlreadySelected
+          ? normalizedDocument.selectedObjectIds
+          : [selected.id];
+      if (isMultiSelectClick) {
+        commitDocument((current) => ({ ...current, selectedObjectIds: selectedIds }), 'Select');
+        return;
+      }
       setDragState({
         tool: 'select',
         start: point,
@@ -1167,7 +1178,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       current: point,
       points: activeTool === 'freehand' ? [point] : undefined,
     });
-  }, [activeTool, commitDocument, displayWidth, normalizedDocument, pickColorAtPoint, selectedObject]);
+  }, [activeTool, commitDocument, displayWidth, editingTextObjectId, normalizedDocument, pickColorAtPoint, selectedObject]);
 
   const pointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     const panState = panStateRef.current;
@@ -1287,7 +1298,24 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       objects: [...current.objects, { ...nextObject, zIndex: current.objects.length + 1 }],
       selectedObjectIds: [nextObject.id],
     }), 'Add annotation');
+    if (nextObject.type === 'text') {
+      setEditingTextObjectId(nextObject.id);
+      setActiveTool('select');
+    }
   }, [activeStyle, commitDocument, dragState, normalizedDocument]);
+
+  const handleCanvasDoubleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (!normalizedDocument) return;
+    const point = getCanvasPoint(event, canvasRef.current, normalizedDocument);
+    const textObject = [...normalizedDocument.objects]
+      .reverse()
+      .find((object) => object.type === 'text' && point.x >= object.bounds.x && point.x <= object.bounds.x + object.bounds.width && point.y >= object.bounds.y && point.y <= object.bounds.y + object.bounds.height);
+    if (!textObject) return;
+    event.preventDefault();
+    commitDocument((current) => ({ ...current, selectedObjectIds: [textObject.id] }), 'Select');
+    setEditingTextObjectId(textObject.id);
+    setActiveTool('select');
+  }, [commitDocument, normalizedDocument]);
 
   const moveSelected = useCallback((direction: 'front' | 'forward' | 'backward' | 'back') => {
     if (!selectedObject) return;
@@ -1602,6 +1630,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
   const canUseTextColor = Boolean(styleTargetType && ['text', 'step'].includes(styleTargetType));
   const canUseStrokeWidth = Boolean(styleTargetType && styleTargetType !== 'text' && styleTargetType !== 'step');
   const canUseFontSize = Boolean(styleTargetType && ['text', 'step'].includes(styleTargetType));
+  const canUseFontFamily = styleTargetType === 'text';
   const displayedObjects = [...(normalizedDocument?.objects ?? [])]
     .sort((first, second) => first.zIndex - second.zIndex)
     .map((object) => {
@@ -1684,18 +1713,40 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     label: string,
     value: string,
     onChange: (value: string) => void,
-  ) => (
+    options?: { allowTransparent?: boolean },
+  ) => {
+    const isTransparent = isTransparentColor(value);
+    return (
     <label className="flex items-center justify-between gap-3 rounded-md border border-gray-800 bg-gray-950 px-2 py-2 text-xs text-gray-300">
       <span>{label}</span>
-      <input
-        type="color"
-        value={toColorInputValue(value)}
-        onChange={(event) => onChange(event.target.value)}
-        className="h-6 w-8 cursor-pointer rounded border border-gray-700 bg-gray-950 p-0.5"
-        aria-label={label}
-      />
+      <span className="flex items-center gap-1.5">
+        {options?.allowTransparent && (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.preventDefault();
+              onChange('rgba(0, 0, 0, 0)');
+            }}
+            className={`h-6 rounded border px-2 text-[11px] font-medium ${
+              isTransparent
+                ? 'border-cyan-400/50 bg-cyan-500/20 text-cyan-100'
+                : 'border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-gray-200'
+            }`}
+          >
+            Transparent
+          </button>
+        )}
+        <input
+          type="color"
+          value={toColorInputValue(value)}
+          onChange={(event) => onChange(event.target.value)}
+          className="h-6 w-8 cursor-pointer rounded border border-gray-700 bg-gray-950 p-0.5"
+          aria-label={label}
+        />
+      </span>
     </label>
-  );
+    );
+  };
 
   const renderInspectorContent = () => {
     if (!normalizedDocument) return null;
@@ -1941,7 +1992,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
             )}
             <div className="grid grid-cols-2 gap-2">
               {canUseStrokeColor && renderColorSwatch('Stroke', displayedStyle.strokeColor, (value) => setActiveOrSelectedStyle({ strokeColor: value }))}
-              {canUseFillColor && renderColorSwatch('Fill', displayedStyle.fillColor, (value) => setActiveOrSelectedStyle({ fillColor: value }))}
+              {canUseFillColor && renderColorSwatch('Fill', displayedStyle.fillColor, (value) => setActiveOrSelectedStyle({ fillColor: value }), { allowTransparent: true })}
               {canUseTextColor && renderColorSwatch('Text', displayedStyle.textColor, (value) => setActiveOrSelectedStyle({ textColor: value }))}
             </div>
             {canUseStrokeWidth && renderSliderRow(
@@ -1958,6 +2009,22 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
               240,
               (value) => setActiveOrSelectedStyle({ fontSize: clamp(Math.round(value) || 32, 8, 240) }),
               'px',
+            )}
+            {canUseFontFamily && (
+              <label className="block space-y-1.5 text-xs text-gray-400">
+                <span>Font family</span>
+                <select
+                  value={displayedStyle.fontFamily}
+                  onChange={(event) => setActiveOrSelectedStyle({ fontFamily: event.target.value })}
+                  className="h-9 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-sm text-gray-100 outline-none focus:border-cyan-500"
+                >
+                  {FONT_FAMILY_OPTIONS.map((font) => (
+                    <option key={font.value} value={font.value}>
+                      {font.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
             )}
             {styleTargetType === 'spotlight' && renderSliderRow(
               'Intensity',
@@ -1988,91 +2055,39 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       );
     }
 
-    if (inspectorTab === 'canvas') {
-      return (
-        <div className="space-y-4">
-          <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-gray-100">Background</h3>
-            <select value={normalizedDocument.background.kind} onChange={(event) => updateBackground({ kind: event.target.value as ImageEditorDocument['background']['kind'] })} className="h-9 w-full rounded-md border border-gray-700 bg-gray-950 px-2 text-sm text-gray-100 outline-none focus:border-cyan-500">
-              <option value="transparent">Transparent</option>
-              <option value="color">Color</option>
-              <option value="gradient">Gradient</option>
-            </select>
-            <div className="grid grid-cols-2 gap-2">
-              {renderColorSwatch('Color', normalizedDocument.background.color, (value) => updateBackground({ color: value }))}
-              {renderColorSwatch('From', normalizedDocument.background.gradientFrom, (value) => updateBackground({ gradientFrom: value }))}
-              {renderColorSwatch('To', normalizedDocument.background.gradientTo, (value) => updateBackground({ gradientTo: value }))}
-            </div>
-          </section>
-          <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-gray-100">Spacing</h3>
-            {renderSliderRow('Margin', normalizedDocument.background.margin, 0, 2000, (value) => updateBackground({ margin: Math.round(value) }))}
-            {renderSliderRow('Padding', normalizedDocument.background.padding, 0, 2000, (value) => updateBackground({ padding: Math.round(value) }))}
-            {renderSliderRow('Corner', normalizedDocument.background.roundedCorner, 0, 400, (value) => updateBackground({ roundedCorner: Math.round(value) }))}
-            {renderSliderRow('Shadow', normalizedDocument.background.shadowRadius, 0, 500, (value) => updateBackground({ shadowRadius: Math.round(value) }))}
-            <label className="inline-flex items-center gap-2 text-xs text-gray-300">
-              <input type="checkbox" checked={normalizedDocument.background.smartPadding} onChange={(event) => updateBackground({ smartPadding: event.target.checked })} className="h-4 w-4 accent-cyan-500" />
-              Smart padding
-            </label>
-          </section>
-        </div>
-      );
-    }
-
     if (inspectorTab === 'ai') {
       return (
         <div className="space-y-4">
-          <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-gray-100">AI Transform</h3>
-            <button type="button" onClick={handleAIUpscale} disabled={isUpscaling} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-purple-400/30 bg-purple-500/15 px-3 py-2 text-xs font-semibold text-purple-100 hover:bg-purple-500/25 disabled:opacity-50">
-              <Sparkles className="h-4 w-4" />
-              {isUpscaling ? 'Queueing...' : 'AI Upscale'}
-            </button>
-            <div className="grid grid-cols-2 gap-1 text-xs">
-              {['Detail Restore', 'Face Restore', 'Img2Img', 'Inpaint', 'Outpaint'].map((label) => (
-                <button key={label} type="button" disabled className="rounded-md border border-gray-800 px-2 py-1.5 text-gray-600">
+          <section className="rounded-md border border-gray-800 bg-gray-950 p-3">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold text-gray-100">AI Transform</h3>
+              <span className="rounded-full border border-purple-400/30 bg-purple-500/15 px-2 py-0.5 text-[11px] font-semibold uppercase text-purple-200">
+                Planned
+              </span>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-gray-400">
+              AI-assisted editor tools are being prepared for a later update.
+            </p>
+            <div className="mt-3 grid grid-cols-2 gap-1 text-xs">
+              {['Upscale', 'Detail Restore', 'Face Restore', 'Inpaint', 'Outpaint'].map((label) => (
+                <div key={label} className="rounded-md border border-gray-800 px-2 py-1.5 text-gray-500">
                   {label}
-                </button>
+                </div>
               ))}
             </div>
+          </section>
+          <section className="space-y-3">
+            {onOpenComfyUIWorkflow && (
+              <button type="button" onClick={() => onOpenComfyUIWorkflow(image)} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800">
+                <Workflow className="h-4 w-4" />
+                Open Workflow
+              </button>
+            )}
           </section>
         </div>
       );
     }
-
-    return (
-      <div className="space-y-4">
-        <section className="space-y-2">
-          <h3 className="text-sm font-semibold text-gray-100">Source</h3>
-          <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-400">
-            <div className="flex items-center gap-2 text-gray-200">
-              <ImageIcon className="h-4 w-4 text-cyan-300" />
-              <span className="truncate">{image.name}</span>
-            </div>
-            <div className="mt-2">{normalizedDocument.sourceDimensions.width}x{normalizedDocument.sourceDimensions.height}</div>
-            <div>{normalizedDocument.objects.length} objects</div>
-            {navigationImages.length > 1 && <div>{navigationImages.length} images in navigation scope</div>}
-          </div>
-        </section>
-        <section className="space-y-2">
-          <h3 className="text-sm font-semibold text-gray-100">Output</h3>
-          <div className="rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-400">
-            <div>{activeOutputDimensions?.width || normalizedDocument.canvasDimensions.width}x{activeOutputDimensions?.height || normalizedDocument.canvasDimensions.height}</div>
-            <div>{hasChanges ? 'Unsaved edits' : 'No editor changes'}</div>
-          </div>
-        </section>
-        {onOpenComfyUIWorkflow && (
-          <button type="button" onClick={() => onOpenComfyUIWorkflow(image)} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800">
-            <Workflow className="h-4 w-4" />
-            Open Workflow
-          </button>
-        )}
-        <button type="button" onClick={restoreOriginal} disabled={!hasChanges} className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 px-3 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 disabled:opacity-40">
-          <RotateCcw className="h-4 w-4" />
-          Restore Original
-        </button>
-      </div>
-    );
+    return null;
   };
 
   if (!normalizedDocument || !sourceUrl) {
@@ -2164,6 +2179,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                 panStateRef.current = null;
                 setIsPanning(false);
               }}
+              onDoubleClick={handleCanvasDoubleClick}
               onAuxClick={(event) => event.preventDefault()}
             >
               {previewUrl ? (
@@ -2312,10 +2328,10 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                         y={bounds.y + style.fontSize}
                         fill={style.textColor}
                         fontSize={style.fontSize}
-                        fontFamily="system-ui, sans-serif"
+                        fontFamily={style.fontFamily}
                         opacity={style.opacity}
                       >
-                        {object.text || 'Text'}
+                        {object.text || (editingTextObjectId === object.id ? '' : 'Text')}
                       </text>
                     );
                   }
@@ -2332,7 +2348,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                           fontWeight={700}
                           textAnchor="middle"
                           dominantBaseline="middle"
-                          fontFamily="system-ui, sans-serif"
+                          fontFamily={style.fontFamily}
                         >
                           {object.stepNumber || 1}
                         </text>
@@ -2498,6 +2514,34 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                   })}
                 </>
               )}
+              {editingTextObjectId && selectedObject?.type === 'text' && (
+                <textarea
+                  ref={textEditorRef}
+                  value={selectedObject.text || ''}
+                  onChange={(event) => updateSelectedObjectText(event.target.value)}
+                  onBlur={() => setEditingTextObjectId(null)}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      event.preventDefault();
+                      setEditingTextObjectId(null);
+                    }
+                    event.stopPropagation();
+                  }}
+                  className="absolute resize-none overflow-hidden border border-cyan-300/70 bg-gray-950/80 px-1 py-0 text-gray-100 outline-none ring-2 ring-cyan-400/20"
+                  style={{
+                    left: `${(selectedObject.bounds.x / normalizedDocument.canvasDimensions.width) * 100}%`,
+                    top: `${(selectedObject.bounds.y / normalizedDocument.canvasDimensions.height) * 100}%`,
+                    width: `${(selectedObject.bounds.width / normalizedDocument.canvasDimensions.width) * 100}%`,
+                    height: `${(selectedObject.bounds.height / normalizedDocument.canvasDimensions.height) * 100}%`,
+                    color: selectedObject.style.textColor,
+                    fontSize: `${selectedObject.style.fontSize * (displayWidth / normalizedDocument.canvasDimensions.width)}px`,
+                    fontFamily: selectedObject.style.fontFamily,
+                    opacity: selectedObject.style.opacity,
+                  }}
+                  aria-label="Edit text annotation"
+                />
+              )}
             </div>
           </div>
           <div className="flex h-9 shrink-0 items-center justify-between border-t border-gray-800 bg-gray-900 px-4 text-xs text-gray-400">
@@ -2532,7 +2576,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
               <X className="h-4 w-4" />
             </button>
           </div>
-          <div className="grid shrink-0 grid-cols-5 gap-1 border-b border-gray-800 bg-gray-900 p-2">
+          <div className="grid shrink-0 grid-cols-3 gap-1 border-b border-gray-800 bg-gray-900 p-2">
             {INSPECTOR_TABS.map((tab) => (
               <button
                 key={tab.id}
@@ -2550,6 +2594,18 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
             {renderInspectorContent()}
+          </div>
+          <div className="shrink-0 border-t border-gray-800 bg-gray-950/60 px-4 py-3 text-xs text-gray-400">
+            <div className="flex min-w-0 items-center gap-2 text-gray-200">
+              <ImageIcon className="h-4 w-4 shrink-0 text-cyan-300" />
+              <span className="truncate">{image.name}</span>
+            </div>
+            <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1">
+              <span>Source {normalizedDocument.sourceDimensions.width}x{normalizedDocument.sourceDimensions.height}</span>
+              <span>Output {activeOutputDimensions?.width || normalizedDocument.canvasDimensions.width}x{activeOutputDimensions?.height || normalizedDocument.canvasDimensions.height}</span>
+              <span>{normalizedDocument.objects.length} objects</span>
+              <span>{hasChanges ? 'Unsaved edits' : 'No editor changes'}</span>
+            </div>
           </div>
         </aside>
       </div>

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -122,6 +122,26 @@ const TOOL_DEFS: Array<{ id: ImageEditorTool; label: string; icon: React.ReactNo
   { id: 'pixelate', label: 'Pixelate', icon: <Shield className="h-4 w-4" /> },
 ];
 
+const readPngDimensions = (bytes: Uint8Array): { width: number; height: number } | null => {
+  const isPng = bytes.byteLength >= 24
+    && bytes[0] === 0x89
+    && bytes[1] === 0x50
+    && bytes[2] === 0x4e
+    && bytes[3] === 0x47
+    && bytes[12] === 0x49
+    && bytes[13] === 0x48
+    && bytes[14] === 0x44
+    && bytes[15] === 0x52;
+  if (!isPng) {
+    return null;
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset + 16, 8);
+  const width = view.getUint32(0, false);
+  const height = view.getUint32(4, false);
+  return width > 0 && height > 0 ? { width, height } : null;
+};
+
 const INSPECTOR_TABS: Array<{ id: InspectorTab; label: string }> = [
   { id: 'edit', label: 'Edit' },
   { id: 'style', label: 'Style' },
@@ -870,7 +890,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     const sourceImage = await ensureHydratedImage();
     const sourceMetadata = getUsableNormalizedMetadata(sourceImage);
     const rawMetadata = sourceImage.metadata as Record<string, unknown> | undefined;
-    const outputDimensions = {
+    const outputDimensions = readPngDimensions(bytes) || {
       width: normalizedDocument.canvasDimensions.width,
       height: normalizedDocument.canvasDimensions.height,
     };

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1210,6 +1210,10 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     }
   }, [getGridScrollElement]);
 
+  const getScrollRestoreKey = useCallback((scrollTop: number) => (
+    `${scrollResetKey ?? 'grid'}:${isInfinite ? 'virtual' : 'static'}:${Math.round(Math.max(0, scrollTop))}`
+  ), [isInfinite, scrollResetKey]);
+
   useEffect(() => {
     if (lastScrollResetKeyRef.current === scrollResetKey) {
       return;
@@ -1220,12 +1224,13 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       return;
     }
 
+    lastRestoredScrollKeyRef.current = getScrollRestoreKey(initialScrollTop);
     restoreGridScrollPosition(0);
     onScrollPositionChange?.(0);
-  }, [onScrollPositionChange, restoreGridScrollPosition, scrollResetKey]);
+  }, [getScrollRestoreKey, initialScrollTop, onScrollPositionChange, restoreGridScrollPosition, scrollResetKey]);
 
   useEffect(() => {
-    const restoreKey = `${scrollResetKey ?? 'grid'}:${isInfinite ? 'virtual' : 'static'}:${Math.round(Math.max(0, initialScrollTop))}`;
+    const restoreKey = getScrollRestoreKey(initialScrollTop);
     if (lastRestoredScrollKeyRef.current === restoreKey) {
       return;
     }
@@ -1247,7 +1252,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       window.cancelAnimationFrame(firstFrame);
       window.cancelAnimationFrame(secondFrame);
     };
-  }, [initialScrollTop, isInfinite, restoreGridScrollPosition, scrollResetKey]);
+  }, [getScrollRestoreKey, initialScrollTop, restoreGridScrollPosition]);
 
   const getActiveColumnCount = useCallback(() => {
     if (isInfinite) {

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1043,6 +1043,9 @@ interface ImageGridProps {
   groupBy?: ImageGroupByMode;
   groupSortOrder?: ImageGroupingSortOrder;
   jumpToGroupRequest?: { groupId: string; requestId: number } | null;
+  initialScrollTop?: number;
+  onScrollPositionChange?: (scrollTop: number) => void;
+  scrollResetKey?: string;
 }
 
 const InnerGridElement = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => (
@@ -1068,6 +1071,9 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   groupBy = 'none',
   groupSortOrder = 'date-desc',
   jumpToGroupRequest = null,
+  initialScrollTop = 0,
+  onScrollPositionChange,
+  scrollResetKey,
 }) => {
   const imageSize = useSettingsStore((state) => state.imageSize);
   const itemsPerPage = useSettingsStore((state) => state.itemsPerPage);
@@ -1103,6 +1109,8 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const cardRefCallbacksRef = useRef<Map<string, (el: HTMLDivElement | null) => void>>(new Map());
   const columnCountRef = useRef<number>(1);
   const lastWarmupWindowRef = useRef<string>('');
+  const lastScrollResetKeyRef = useRef<string | undefined>(scrollResetKey);
+  const lastRestoredScrollKeyRef = useRef<string>('');
   const releasePaginatedBackgroundPauseRef = useRef<(() => void) | null>(null);
   const lastScrollSampleRef = useRef<{ top: number; at: number }>({ top: 0, at: 0 });
   const focusedImageIndexRef = useRef<number | null>(null);
@@ -1189,6 +1197,57 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const submenuHorizontalClass = contextMenu.horizontalDirection === 'left' ? 'right-full' : 'left-full';
 
   const getGridScrollElement = useCallback(() => gridScrollRef.current ?? gridScopeRef.current, []);
+
+  const restoreGridScrollPosition = useCallback((scrollTop: number) => {
+    const nextScrollTop = Math.max(0, scrollTop);
+
+    virtualGridRef.current?.scrollTo({ scrollTop: nextScrollTop, scrollLeft: 0 });
+
+    const scrollElement = getGridScrollElement();
+    if (scrollElement) {
+      scrollElement.scrollTop = nextScrollTop;
+      scrollElement.scrollLeft = 0;
+    }
+  }, [getGridScrollElement]);
+
+  useEffect(() => {
+    if (lastScrollResetKeyRef.current === scrollResetKey) {
+      return;
+    }
+
+    lastScrollResetKeyRef.current = scrollResetKey;
+    if (!scrollResetKey) {
+      return;
+    }
+
+    restoreGridScrollPosition(0);
+    onScrollPositionChange?.(0);
+  }, [onScrollPositionChange, restoreGridScrollPosition, scrollResetKey]);
+
+  useEffect(() => {
+    const restoreKey = `${scrollResetKey ?? 'grid'}:${isInfinite ? 'virtual' : 'static'}:${Math.round(Math.max(0, initialScrollTop))}`;
+    if (lastRestoredScrollKeyRef.current === restoreKey) {
+      return;
+    }
+
+    lastRestoredScrollKeyRef.current = restoreKey;
+    if (initialScrollTop <= 0) {
+      return;
+    }
+
+    let firstFrame = 0;
+    let secondFrame = 0;
+    firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => {
+        restoreGridScrollPosition(initialScrollTop);
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      window.cancelAnimationFrame(secondFrame);
+    };
+  }, [initialScrollTop, isInfinite, restoreGridScrollPosition, scrollResetKey]);
 
   const getActiveColumnCount = useCallback(() => {
     if (isInfinite) {
@@ -2668,6 +2727,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                     width={width}
                     outerRef={gridScrollRef}
                     className="no-scrollbar-if-needed"
+                    initialScrollTop={Math.max(0, initialScrollTop)}
                     itemData={cellData}
                     itemKey={({ columnIndex, rowIndex, data }) => {
                       const itemIndex = rowIndex * safeColumnCount + columnIndex;
@@ -2686,6 +2746,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                     style={{ overflowX: 'hidden' }}
                     innerElementType={InnerGridElement}
                     onScroll={({ scrollTop, scrollUpdateWasRequested }) => {
+                      onScrollPositionChange?.(scrollTop);
                       const currentAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
                       const previousSample = lastScrollSampleRef.current;
                       const deltaMs = Math.max(1, currentAt - previousSample.at);
@@ -2830,6 +2891,9 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
+        onScroll={(event) => {
+          onScrollPositionChange?.(event.currentTarget.scrollTop);
+        }}
       >
         <div
           className="flex flex-wrap gap-4"

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -2273,7 +2273,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
               title="Open this image in the editor workspace"
             >
               <ImageIcon className="w-4 h-4" />
-              <span className="flex-1">Edit Image</span>
+              <span className="flex-1">Open in Editor</span>
             </button>
           )}
 

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -41,7 +41,7 @@ import { transferIndexedImages } from '../services/fileTransferService';
 import { thumbnailManager } from '../services/thumbnailManager';
 import { getContextMenuRatingTargetIds } from '../utils/ratingSelection';
 import { getRenameBasename, renameIndexedImage } from '../services/imageRenameService';
-import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
+import { getFileExtension, isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 import { groupImages, type ImageGroup, type ImageGroupByMode, type ImageGroupingSortOrder } from '../utils/imageGrouping';
 import {
   beginPerformanceFlow,
@@ -1409,6 +1409,13 @@ const ImageGrid: React.FC<ImageGridProps> = ({
 
   const openImageEditor = useCallback(() => {
     if (!contextMenu.image || !onOpenImageEditor) return;
+    if (
+      isVideoFileName(contextMenu.image.name, contextMenu.image.fileType) ||
+      isAudioFileName(contextMenu.image.name, contextMenu.image.fileType) ||
+      getFileExtension(contextMenu.image.name) === '.gif'
+    ) {
+      return;
+    }
     onOpenImageEditor(contextMenu.image);
     hideContextMenu();
   }, [contextMenu.image, hideContextMenu, onOpenImageEditor]);
@@ -1453,6 +1460,13 @@ const ImageGrid: React.FC<ImageGridProps> = ({
 
   const contextImagePrompt = contextMenu.image?.prompt || contextMenu.image?.metadata?.normalizedMetadata?.prompt;
   const canFindSimilar = Boolean(contextImagePrompt) && Boolean(onFindSimilar);
+  const canOpenContextImageEditor = Boolean(
+    onOpenImageEditor &&
+    contextMenu.image &&
+    !isVideoFileName(contextMenu.image.name, contextMenu.image.fileType) &&
+    !isAudioFileName(contextMenu.image.name, contextMenu.image.fileType) &&
+    getFileExtension(contextMenu.image.name) !== '.gif',
+  );
 
   const getContextTargetImages = useCallback(() => {
     if (!contextMenu.image) {
@@ -2330,7 +2344,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             <span className="flex-1">Find similar...</span>
           </button>
 
-          {onOpenImageEditor && (
+          {canOpenContextImageEditor && (
             <button
               onClick={openImageEditor}
               className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -19,6 +19,7 @@ import { Heart, Info, Copy, Folder, Download, Clipboard, Sparkles, GitCompare, S
   Tag,
   RefreshCw,
   Pencil,
+  Image as ImageIcon,
   Workflow
 } from 'lucide-react';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
@@ -1035,6 +1036,7 @@ interface ImageGridProps {
   isCollectionsView?: boolean;
   onImageRenamed?: (oldImageId: string, newImageId: string) => void;
   onFindSimilar?: (image: IndexedImage) => void;
+  onOpenImageEditor?: (image: IndexedImage) => void;
   onOpenComfyUIWorkspace?: (image: IndexedImage) => void;
   markedBestIds?: Set<string>;      // IDs of images marked as best
   markedArchivedIds?: Set<string>;  // IDs of images marked for archive
@@ -1059,6 +1061,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   isCollectionsView = false,
   onImageRenamed,
   onFindSimilar,
+  onOpenImageEditor,
   onOpenComfyUIWorkspace,
   markedBestIds,
   markedArchivedIds,
@@ -1339,6 +1342,12 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     onOpenComfyUIWorkspace(contextMenu.image);
     hideContextMenu();
   }, [contextMenu.image, hideContextMenu, onOpenComfyUIWorkspace, canUseComfyUI, showProModal]);
+
+  const openImageEditor = useCallback(() => {
+    if (!contextMenu.image || !onOpenImageEditor) return;
+    onOpenImageEditor(contextMenu.image);
+    hideContextMenu();
+  }, [contextMenu.image, hideContextMenu, onOpenImageEditor]);
 
   const selectForComparison = useCallback(() => {
     if (!contextMenu.image) return;
@@ -2256,6 +2265,17 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             <Search className="w-4 h-4" />
             <span className="flex-1">Find similar...</span>
           </button>
+
+          {onOpenImageEditor && (
+            <button
+              onClick={openImageEditor}
+              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+              title="Open this image in the editor workspace"
+            >
+              <ImageIcon className="w-4 h-4" />
+              <span className="flex-1">Edit Image</span>
+            </button>
+          )}
 
           <div className="border-t border-gray-600 my-1"></div>
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -3,7 +3,7 @@ import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollecti
 import { FileOperations } from '../services/fileOperations';
 import { getRenameBasename, renameIndexedImage } from '../services/imageRenameService';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
-import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw, SlidersHorizontal, Workflow, Image as ImageIcon } from 'lucide-react';
+import { AlertTriangle, Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw, SlidersHorizontal, Workflow, Image as ImageIcon, ExternalLink } from 'lucide-react';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
@@ -527,21 +527,28 @@ const VideoPlayer: React.FC<{
   onCanPlay?: React.ReactEventHandler<HTMLVideoElement>;
   onPlaying?: React.ReactEventHandler<HTMLVideoElement>;
   onEnded?: React.ReactEventHandler<HTMLVideoElement>;
+  externalPath?: string | null;
   diagnostics?: Omit<MediaDiagnosticsContext, 'mediaKind' | 'src'>;
-}> = ({ src, poster, onContextMenu, onLoadedMetadata, onCanPlay, onPlaying, onEnded, diagnostics }) => {
+}> = ({ src, poster, onContextMenu, onLoadedMetadata, onCanPlay, onPlaying, onEnded, externalPath, diagnostics }) => {
   const videoRef = React.useRef<HTMLVideoElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const [audioRendererFailed, setAudioRendererFailed] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [isHovering, setIsHovering] = useState(false);
+  const handleAudioRendererError = useCallback(() => {
+    setAudioRendererFailed(true);
+    setIsPlaying(false);
+  }, []);
   const mediaDiagnostics = useMediaDiagnostics({
     mediaKind: 'video',
     fileName: diagnostics?.fileName ?? '',
     surface: diagnostics?.surface ?? 'image-modal',
     src,
+    onAudioRendererError: handleAudioRendererError,
   });
-  
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [duration, setDuration] = useState(0);
-  const [isHovering, setIsHovering] = useState(false);
   
   const [volume, setVolume] = useState(() => {
     const saved = localStorage.getItem('video_player_volume');
@@ -553,6 +560,11 @@ const VideoPlayer: React.FC<{
   const [isLooping, setIsLooping] = useState(() => {
     return localStorage.getItem('video_player_loop') === 'true';
   });
+
+  useEffect(() => {
+    setAudioRendererFailed(false);
+    setOpenError(null);
+  }, [src]);
 
   useEffect(() => {
     if (videoRef.current) {
@@ -616,6 +628,45 @@ const VideoPlayer: React.FC<{
       setIsMuted(false);
     }
   };
+
+  const openExternally = useCallback(async (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (!externalPath) return;
+    const result = await window.electronAPI?.openPath?.(externalPath);
+    if (!result?.success) {
+      setOpenError(result?.error || 'Failed to open media externally.');
+    }
+  }, [externalPath]);
+
+  if (audioRendererFailed) {
+    return (
+      <div
+        ref={containerRef}
+        className="relative flex h-full w-full flex-col items-center justify-center gap-5 bg-black p-8 text-center text-gray-100"
+        onContextMenu={onContextMenu}
+      >
+        <div className="rounded-full border border-amber-400/30 bg-amber-400/10 p-6 text-amber-200">
+          <AlertTriangle className="h-16 w-16" />
+        </div>
+        <div>
+          <p className="text-lg font-medium text-gray-100">Audio playback failed in Electron</p>
+          <p className="mt-1 max-w-md text-sm text-gray-400">
+            The macOS audio service reported an audio renderer error.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={openExternally}
+          disabled={!externalPath}
+          className="inline-flex items-center gap-2 rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm font-medium text-gray-100 transition-colors hover:border-gray-500 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <ExternalLink className="h-4 w-4" />
+          Open Externally
+        </button>
+        {openError && <p className="max-w-md text-xs text-red-300">{openError}</p>}
+      </div>
+    );
+  }
 
   return (
     <div
@@ -801,6 +852,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const [isShowingOriginalForAdjustmentCompare, setIsShowingOriginalForAdjustmentCompare] = useState(false);
   const [isSavingEditedImage, setIsSavingEditedImage] = useState(false);
   const [isFullImageSourceReady, setIsFullImageSourceReady] = useState(false);
+  const [externalMediaPath, setExternalMediaPath] = useState<string | null>(null);
   const [modalWindow, setModalWindow] = useState<ModalWindowState>(() => {
     if (initialWindowState) {
       return clampModalWindowToViewport(initialWindowState);
@@ -1015,6 +1067,39 @@ const ImageModal: React.FC<ImageModalProps> = ({
     !isShowingOriginalForAdjustmentCompare &&
     !(imageEditorTab === 'crop' && normalizedImageEditRecipe.crop.enabled);
   const displayedImageUrl = shouldShowEditedPreview && editedPreviewUrl ? editedPreviewUrl : imageUrl;
+
+  useEffect(() => {
+    let isMounted = true;
+    setExternalMediaPath(null);
+
+    const resolveExternalMediaPath = async () => {
+      if (!isPlayableMedia) {
+        return;
+      }
+
+      const handlePath = window.electronAPI ? getElectronAbsoluteMediaPath(liveImage) : null;
+      if (handlePath) {
+        if (isMounted) setExternalMediaPath(handlePath);
+        return;
+      }
+
+      if (!directoryPath || !window.electronAPI?.joinPaths) {
+        return;
+      }
+
+      const joined = await window.electronAPI.joinPaths(directoryPath, getRelativeImagePath(liveImage));
+      if (isMounted && joined.success && joined.path) {
+        setExternalMediaPath(joined.path);
+      }
+    };
+
+    void resolveExternalMediaPath();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [directoryPath, isPlayableMedia, liveImage]);
+
   const cropOverlayStyle = useMemo(() => {
     const rect = normalizedImageEditRecipe.crop.rect;
     if (!cropImageBounds || !imageEditSourceDimensions || !rect) {
@@ -2993,6 +3078,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   src={imageUrl}
                   title={image.name}
                   autoPlay
+                  externalPath={externalMediaPath}
                   diagnostics={{ fileName: image.name, surface: isSlideshowMode ? 'slideshow' : 'image-modal' }}
                   onContextMenu={handleContextMenu}
                   onLoadedMetadata={() => markPerformanceFlow(diagnosticsFlowId, 'audio-loadedmetadata', { imageId: image.id })}
@@ -3016,6 +3102,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   key={image.id}
                   src={imageUrl}
                   poster={preferredThumbnailUrl ?? undefined}
+                  externalPath={externalMediaPath}
                   diagnostics={{ fileName: image.name, surface: isSlideshowMode ? 'slideshow' : 'image-modal' }}
                   onContextMenu={handleContextMenu}
                   onLoadedMetadata={(event) => {

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -3,7 +3,7 @@ import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollecti
 import { FileOperations } from '../services/fileOperations';
 import { getRenameBasename, renameIndexedImage } from '../services/imageRenameService';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
-import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw, SlidersHorizontal, Workflow } from 'lucide-react';
+import { Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw, SlidersHorizontal, Workflow, Image as ImageIcon } from 'lucide-react';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
@@ -149,6 +149,7 @@ interface ImageModalProps {
   onClose: () => void;
   onFindSimilar?: (image: IndexedImage) => void;
   onOpenComfyUIWorkflow?: (image: IndexedImage) => void;
+  onOpenImageEditor?: (image: IndexedImage) => void;
   onImageDeleted?: (imageId: string) => void;
   onImageRenamed?: (oldImageId: string, newImageId: string, newRelativePath: string) => void;
   currentIndex?: number;
@@ -737,6 +738,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   onClose,
   onFindSimilar,
   onOpenComfyUIWorkflow,
+  onOpenImageEditor,
   onImageDeleted,
   onImageRenamed,
   currentIndex = 0,
@@ -3226,6 +3228,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
               </div>
             ) : (
               <div className="flex flex-row items-center gap-2">
+                {canEditImage && onOpenImageEditor && (
+                  <button
+                    onClick={() => onOpenImageEditor(liveImage)}
+                    className="rounded-full border border-white/10 bg-black/35 p-2 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/55"
+                    title="Open Image Editor"
+                  >
+                    <ImageIcon className="h-4 w-4" />
+                  </button>
+                )}
                 {canEditImage && (
                   <button
                     onClick={() => {
@@ -3307,6 +3318,17 @@ const ImageModal: React.FC<ImageModalProps> = ({
           <div className="p-6 space-y-4 overflow-y-auto flex-1">
           {canEditImage && (
             <>
+              {onOpenImageEditor && (
+                <button
+                  type="button"
+                  onClick={() => onOpenImageEditor(liveImage)}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-indigo-500/30 bg-indigo-500/10 px-3 py-2 text-sm font-medium text-indigo-100 transition-colors hover:border-indigo-400/50 hover:bg-indigo-500/20"
+                >
+                  <ImageIcon className="h-4 w-4" />
+                  Open Image Editor
+                </button>
+              )}
+
               {!isAdjustmentPanelOpen && (
                 <button
                   type="button"
@@ -4360,7 +4382,8 @@ export default React.memo(ImageModal, (prevProps, nextProps) => {
     prevProps.startSlideshow === nextProps.startSlideshow &&
     prevProps.closeOnSlideshowExit === nextProps.closeOnSlideshowExit &&
     prevProps.diagnosticsFlowId === nextProps.diagnosticsFlowId &&
-    prevProps.onOpenComfyUIWorkflow === nextProps.onOpenComfyUIWorkflow;
+    prevProps.onOpenComfyUIWorkflow === nextProps.onOpenComfyUIWorkflow &&
+    prevProps.onOpenImageEditor === nextProps.onOpenImageEditor;
 
   return propsEqual;
 });

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useLayoutEffect, useState, FC, useCallback, useMemo, useRef } from 'react';
-import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollection, type ImageAdjustments } from '../types';
+import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollection, type ImageEditRecipe } from '../types';
 import { FileOperations } from '../services/fileOperations';
 import { getRenameBasename, renameIndexedImage } from '../services/imageRenameService';
 import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
@@ -25,11 +25,14 @@ import cacheManager from '../services/cacheManager';
 import { indexImageFileAtPath, reparseIndexedImage } from '../services/fileIndexer';
 import { hasCompactedRuntimeMetadata, hydrateImageRawMetadata } from '../services/rawMetadataHydration';
 import {
-  DEFAULT_IMAGE_ADJUSTMENTS,
-  buildImageAdjustmentFilter,
+  DEFAULT_IMAGE_EDIT_RECIPE,
+  clampImageEditCropRect,
   embedMetaHubMetadataInPngBytes,
-  hasImageAdjustments,
-  renderAdjustedImageToPngBytes,
+  getImageEditOutputDimensions,
+  hasImageEditRecipeChanges,
+  normalizeImageEditRecipe,
+  renderEditedImageToPngBlob,
+  renderEditedImageToPngBytes,
 } from '../services/imageEditingService';
 
 import { bulkSaveShadowMetadata } from '../services/imageAnnotationsStorage';
@@ -787,7 +790,12 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
   const [isAdjustmentPanelOpen, setIsAdjustmentPanelOpen] = useState(false);
-  const [imageAdjustments, setImageAdjustments] = useState<ImageAdjustments>(DEFAULT_IMAGE_ADJUSTMENTS);
+  const [imageEditRecipe, setImageEditRecipe] = useState<ImageEditRecipe>(DEFAULT_IMAGE_EDIT_RECIPE);
+  const [imageEditorTab, setImageEditorTab] = useState<'adjust' | 'crop' | 'transform' | 'enhance'>('adjust');
+  const [imageEditSourceDimensions, setImageEditSourceDimensions] = useState<{ width: number; height: number } | null>(null);
+  const [cropImageBounds, setCropImageBounds] = useState<{ left: number; top: number; width: number; height: number } | null>(null);
+  const [editedPreviewUrl, setEditedPreviewUrl] = useState<string | null>(null);
+  const [isRenderingEditedPreview, setIsRenderingEditedPreview] = useState(false);
   const [isShowingOriginalForAdjustmentCompare, setIsShowingOriginalForAdjustmentCompare] = useState(false);
   const [isSavingEditedImage, setIsSavingEditedImage] = useState(false);
   const [isFullImageSourceReady, setIsFullImageSourceReady] = useState(false);
@@ -809,6 +817,13 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const liveModalWindowRef = useRef<ModalWindowState>(modalWindow);
   const modalPaintFrameRef = useRef<number | null>(null);
   const slideshowTimeoutRef = useRef<number | null>(null);
+  const fullImageElementRef = useRef<HTMLImageElement>(null);
+  const cropDragRef = useRef<{
+    pointerId: number;
+    startClientX: number;
+    startClientY: number;
+    startRect: NonNullable<ImageEditRecipe['crop']['rect']>;
+  } | null>(null);
   const restoredModalWindowRef = useRef<ModalWindowState | null>(null);
   const isMinimizeAnimatingRef = useRef(false);
   const wasMinimizedRef = useRef(isMinimized);
@@ -935,6 +950,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const currentRating = liveImage.rating ?? null;
   const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
   const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
+  const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
   const preferredThumbnailUrl = thumbnail?.thumbnailUrl ?? null;
   const recentTagSuggestions = useMemo(() => getRecentTagChips({
     recentTags,
@@ -980,12 +996,43 @@ const ImageModal: React.FC<ImageModalProps> = ({
     ? `${directoryPath}${/[\\/]$/.test(directoryPath) ? '' : '\\'}${image.name}`
     : image.name;
   const mediaOverlayVisibilityClass = isMediaOverlayVisible ? 'opacity-100' : 'opacity-0 pointer-events-none';
-  const adjustmentFilter = useMemo(
-    () => buildImageAdjustmentFilter(imageAdjustments),
-    [imageAdjustments]
+  const normalizedImageEditRecipe = useMemo(
+    () => normalizeImageEditRecipe(imageEditRecipe, imageEditSourceDimensions || undefined),
+    [imageEditRecipe, imageEditSourceDimensions]
   );
-  const hasAdjustmentChanges = hasImageAdjustments(imageAdjustments);
-  const shouldApplyAdjustmentFilter = canEditImage && hasAdjustmentChanges && !isShowingOriginalForAdjustmentCompare;
+  const hasImageEditChanges = hasImageEditRecipeChanges(normalizedImageEditRecipe);
+  const imageEditOutputDimensions = useMemo(
+    () => imageEditSourceDimensions
+      ? getImageEditOutputDimensions(normalizedImageEditRecipe, imageEditSourceDimensions)
+      : null,
+    [imageEditSourceDimensions, normalizedImageEditRecipe]
+  );
+  const shouldShowEditedPreview =
+    canEditImage &&
+    hasImageEditChanges &&
+    !isShowingOriginalForAdjustmentCompare &&
+    !(imageEditorTab === 'crop' && normalizedImageEditRecipe.crop.enabled);
+  const displayedImageUrl = shouldShowEditedPreview && editedPreviewUrl ? editedPreviewUrl : imageUrl;
+  const cropOverlayStyle = useMemo(() => {
+    const rect = normalizedImageEditRecipe.crop.rect;
+    if (!cropImageBounds || !imageEditSourceDimensions || !rect) {
+      return null;
+    }
+
+    const scaleX = cropImageBounds.width / Math.max(1, imageEditSourceDimensions.width);
+    const scaleY = cropImageBounds.height / Math.max(1, imageEditSourceDimensions.height);
+    return {
+      left: cropImageBounds.left + (rect.x * scaleX),
+      top: cropImageBounds.top + (rect.y * scaleY),
+      width: rect.width * scaleX,
+      height: rect.height * scaleY,
+    };
+  }, [cropImageBounds, imageEditSourceDimensions, normalizedImageEditRecipe.crop.rect]);
+  const showCropOverlay =
+    canEditImage &&
+    imageEditorTab === 'crop' &&
+    normalizedImageEditRecipe.crop.enabled &&
+    cropOverlayStyle;
   const rawMetadataImage = hydratedRawMetadataImage?.id === liveImage.id ? hydratedRawMetadataImage : liveImage;
 
   const ensureFullRawMetadata = useCallback(async (): Promise<IndexedImage> => {
@@ -1007,12 +1054,76 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [directoryPath, hydratedRawMetadataImage, liveImage]);
 
   useEffect(() => {
-    setImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS);
+    setImageEditRecipe(DEFAULT_IMAGE_EDIT_RECIPE);
+    setImageEditorTab('adjust');
+    setImageEditSourceDimensions(null);
+    setCropImageBounds(null);
+    setEditedPreviewUrl(null);
+    setIsRenderingEditedPreview(false);
     setIsShowingOriginalForAdjustmentCompare(false);
     setIsAdjustmentPanelOpen(false);
     setHydratedRawMetadataImage(null);
     setIsHydratingRawMetadata(false);
   }, [image.id]);
+
+  useEffect(() => () => {
+    if (editedPreviewUrl) {
+      URL.revokeObjectURL(editedPreviewUrl);
+    }
+  }, [editedPreviewUrl]);
+
+  useEffect(() => {
+    if (!canEditImage || !hasImageEditChanges || !isFullImageSourceReady) {
+      setEditedPreviewUrl((current) => {
+        if (current) {
+          URL.revokeObjectURL(current);
+        }
+        return null;
+      });
+      setIsRenderingEditedPreview(false);
+      return;
+    }
+
+    let canceled = false;
+    setIsRenderingEditedPreview(true);
+    const timeoutId = window.setTimeout(async () => {
+      const editableSource = await mediaSourceCache.getRendererOwnedObjectUrl(liveImage, directoryPath);
+      try {
+        const blob = await renderEditedImageToPngBlob(editableSource.url, normalizedImageEditRecipe);
+        if (canceled) {
+          return;
+        }
+        const nextUrl = URL.createObjectURL(blob);
+        setEditedPreviewUrl((current) => {
+          if (current) {
+            URL.revokeObjectURL(current);
+          }
+          return nextUrl;
+        });
+      } catch (error) {
+        if (!canceled) {
+          console.warn('[ImageModal] Failed to render edited preview:', error);
+        }
+      } finally {
+        editableSource.revoke();
+        if (!canceled) {
+          setIsRenderingEditedPreview(false);
+        }
+      }
+    }, 120);
+
+    return () => {
+      canceled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [
+    canEditImage,
+    directoryPath,
+    hasImageEditChanges,
+    isFullImageSourceReady,
+    liveImage,
+    normalizedImageEditRecipe,
+  ]);
 
   useEffect(() => {
     const mountStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -1724,15 +1835,102 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, []);
 
   const showOriginalForAdjustmentCompare = useCallback((event: React.PointerEvent<HTMLImageElement>) => {
-    if (!hasAdjustmentChanges || event.button !== 0) {
+    if (!hasImageEditChanges || event.button !== 0 || imageEditorTab === 'crop') {
       return;
     }
 
     setIsShowingOriginalForAdjustmentCompare(true);
-  }, [hasAdjustmentChanges]);
+  }, [hasImageEditChanges, imageEditorTab]);
 
   const hideOriginalForAdjustmentCompare = useCallback(() => {
     setIsShowingOriginalForAdjustmentCompare(false);
+  }, []);
+
+  const updateCropImageBounds = useCallback(() => {
+    const imageElement = fullImageElementRef.current;
+    const containerElement = imageContainerRef.current;
+    if (!imageElement || !containerElement) {
+      setCropImageBounds(null);
+      return;
+    }
+
+    const imageRect = imageElement.getBoundingClientRect();
+    const containerRect = containerElement.getBoundingClientRect();
+    setCropImageBounds({
+      left: imageRect.left - containerRect.left,
+      top: imageRect.top - containerRect.top,
+      width: imageRect.width,
+      height: imageRect.height,
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    updateCropImageBounds();
+  }, [
+    updateCropImageBounds,
+    image.id,
+    imageEditorTab,
+    normalizedImageEditRecipe.crop.enabled,
+    normalizedImageEditRecipe.crop.rect,
+    zoom,
+    pan.x,
+    pan.y,
+    displayedImageUrl,
+  ]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.addEventListener('resize', updateCropImageBounds);
+    return () => window.removeEventListener('resize', updateCropImageBounds);
+  }, [updateCropImageBounds]);
+
+  const handleCropDragStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!imageEditSourceDimensions || !normalizedImageEditRecipe.crop.rect) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    cropDragRef.current = {
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startRect: normalizedImageEditRecipe.crop.rect,
+    };
+  }, [imageEditSourceDimensions, normalizedImageEditRecipe.crop.rect]);
+
+  const handleCropDragMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = cropDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId || !cropImageBounds || !imageEditSourceDimensions) {
+      return;
+    }
+
+    const scaleX = imageEditSourceDimensions.width / Math.max(1, cropImageBounds.width);
+    const scaleY = imageEditSourceDimensions.height / Math.max(1, cropImageBounds.height);
+    const nextRect = clampImageEditCropRect({
+      ...drag.startRect,
+      x: drag.startRect.x + ((event.clientX - drag.startClientX) * scaleX),
+      y: drag.startRect.y + ((event.clientY - drag.startClientY) * scaleY),
+    }, imageEditSourceDimensions);
+
+    if (nextRect) {
+      setImageEditRecipe((current) => normalizeImageEditRecipe({
+        ...current,
+        crop: {
+          ...current.crop,
+          enabled: true,
+          rect: nextRect,
+        },
+      }, imageEditSourceDimensions));
+    }
+  }, [cropImageBounds, imageEditSourceDimensions]);
+
+  const handleCropDragEnd = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (cropDragRef.current?.pointerId === event.pointerId) {
+      cropDragRef.current = null;
+    }
   }, []);
 
   const handleDragStart = useCallback((e: React.DragEvent<HTMLImageElement>) => {
@@ -1802,6 +2000,38 @@ const ImageModal: React.FC<ImageModalProps> = ({
     return joined.success && joined.path ? joined.path : `${basename}-edited.png`;
   }, [directoryPath, liveImage]);
 
+  const handleAIUpscale = useCallback(async () => {
+    if (!canUseComfyUI) {
+      showProModal('comfyui');
+      return;
+    }
+
+    if (!comfyUIEnabled || !comfyUIServerUrl) {
+      setError('ComfyUI Upscale needs ComfyUI enabled and a server URL in Settings.');
+      return;
+    }
+
+    if (!liveImage.handle) {
+      setError('ComfyUI Upscale needs desktop file access to upload the source image.');
+      return;
+    }
+
+    await generateWithComfyUI(liveImage, {
+      workflowMode: 'upscale',
+      customMetadata: {
+        prompt: liveImage.prompt || 'ComfyUI upscale',
+      },
+    });
+  }, [
+    canUseComfyUI,
+    comfyUIEnabled,
+    comfyUIServerUrl,
+    generateWithComfyUI,
+    liveImage,
+    setError,
+    showProModal,
+  ]);
+
   const findDirectoryForAbsolutePath = useCallback((filePath: string) => {
     const normalize = (value: string) => value.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
     const normalizedFile = normalize(filePath);
@@ -1827,22 +2057,28 @@ const ImageModal: React.FC<ImageModalProps> = ({
     const editableSource = await mediaSourceCache.getRendererOwnedObjectUrl(liveImage, directoryPath);
     let pngBytes: Uint8Array;
     try {
-      pngBytes = await renderAdjustedImageToPngBytes(editableSource.url, imageAdjustments);
+      pngBytes = await renderEditedImageToPngBytes(editableSource.url, normalizedImageEditRecipe);
     } finally {
       editableSource.revoke();
     }
 
-    const outputBytes = embedMetaHubMetadataInPngBytes(pngBytes, sourceMetadata, imageAdjustments, sourceRawMetadata);
+    const outputBytes = embedMetaHubMetadataInPngBytes(
+      pngBytes,
+      sourceMetadata,
+      normalizedImageEditRecipe,
+      sourceRawMetadata,
+      imageEditOutputDimensions || undefined,
+    );
     const result = await window.electronAPI.writeFile(targetPath, outputBytes);
     if (!result.success) {
       throw new Error(result.error || 'Failed to write edited image.');
     }
 
     return pngBytes;
-  }, [directoryPath, imageAdjustments, imageUrl, isFullImageSourceReady, liveImage]);
+  }, [directoryPath, imageEditOutputDimensions, imageUrl, isFullImageSourceReady, liveImage, normalizedImageEditRecipe]);
 
   const handleSaveEditedImageAs = useCallback(async () => {
-    if (!canEditImage || !hasAdjustmentChanges || isSavingEditedImage) {
+    if (!canEditImage || !hasImageEditChanges || isSavingEditedImage) {
       return;
     }
 
@@ -1923,7 +2159,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     canEditImage,
     ensureFullRawMetadata,
     findDirectoryForAbsolutePath,
-    hasAdjustmentChanges,
+    hasImageEditChanges,
     isSavingEditedImage,
     liveImage,
     mergeImages,
@@ -1934,7 +2170,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   ]);
 
   const handleOverwriteEditedImage = useCallback(async () => {
-    if (!canEditImage || !hasAdjustmentChanges || isSavingEditedImage) {
+    if (!canEditImage || !hasImageEditChanges || isSavingEditedImage) {
       return;
     }
 
@@ -2024,7 +2260,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         error: null,
       });
       await cacheManager.updateCachedImages(sourceDirectory.path, sourceDirectory.name, [preservedMetadataImage], scanSubfolders);
-      setImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS);
+      setImageEditRecipe(DEFAULT_IMAGE_EDIT_RECIPE);
       setSuccess('Overwrote original image with edits.');
     } catch (error) {
       setError(error instanceof Error ? error.message : 'Failed to overwrite edited image.');
@@ -2036,7 +2272,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     canOverwriteEditedImage,
     directories,
     ensureFullRawMetadata,
-    hasAdjustmentChanges,
+    hasImageEditChanges,
     isSavingEditedImage,
     liveImage,
     mergeImages,
@@ -2801,35 +3037,66 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 />
               </div>
             ) : (
-              <img
-                src={imageUrl}
-                alt={image.name}
-                className="max-w-full max-h-full object-contain select-none image-alpha-grid"
-                onLoad={() => {
-                  if (!hasMarkedFullMediaReadyRef.current) {
-                    hasMarkedFullMediaReadyRef.current = true;
-                    markPerformanceFlow(diagnosticsFlowId, 'image-onload', { imageId: image.id });
-                    finishPerformanceFlow(diagnosticsFlowId, {
-                      imageId: image.id,
-                      mediaType: 'image',
-                      status: 'onload',
-                    });
-                  }
-                }}
-                onContextMenu={handleContextMenu}
-                onPointerDown={showOriginalForAdjustmentCompare}
-                onPointerUp={hideOriginalForAdjustmentCompare}
-                onPointerCancel={hideOriginalForAdjustmentCompare}
-                onPointerLeave={hideOriginalForAdjustmentCompare}
-                onDragStart={handleDragStart}
-                style={{
-                  transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
-                  filter: shouldApplyAdjustmentFilter ? adjustmentFilter : undefined,
-                  transition: isDragging ? 'none' : 'transform 0.1s ease-out',
-                }}
-                title={hasAdjustmentChanges ? 'Hold to compare with the original image' : undefined}
-                draggable={canDragExternally && zoom === 1}
-              />
+              <>
+                <img
+                  ref={fullImageElementRef}
+                  src={displayedImageUrl}
+                  alt={image.name}
+                  className="max-w-full max-h-full object-contain select-none image-alpha-grid"
+                  onLoad={(event) => {
+                    const target = event.currentTarget;
+                    const naturalWidth = target.naturalWidth || target.width;
+                    const naturalHeight = target.naturalHeight || target.height;
+                    if (isFullImageSourceReady && naturalWidth > 0 && naturalHeight > 0) {
+                      setImageEditSourceDimensions({ width: naturalWidth, height: naturalHeight });
+                    }
+                    updateCropImageBounds();
+                    if (!hasMarkedFullMediaReadyRef.current) {
+                      hasMarkedFullMediaReadyRef.current = true;
+                      markPerformanceFlow(diagnosticsFlowId, 'image-onload', { imageId: image.id });
+                      finishPerformanceFlow(diagnosticsFlowId, {
+                        imageId: image.id,
+                        mediaType: 'image',
+                        status: 'onload',
+                      });
+                    }
+                  }}
+                  onContextMenu={handleContextMenu}
+                  onPointerDown={showOriginalForAdjustmentCompare}
+                  onPointerUp={hideOriginalForAdjustmentCompare}
+                  onPointerCancel={hideOriginalForAdjustmentCompare}
+                  onPointerLeave={hideOriginalForAdjustmentCompare}
+                  onDragStart={handleDragStart}
+                  style={{
+                    transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+                    transition: isDragging ? 'none' : 'transform 0.1s ease-out',
+                  }}
+                  title={hasImageEditChanges && editedPreviewUrl ? 'Hold to compare with the original image' : undefined}
+                  draggable={canDragExternally && zoom === 1}
+                />
+                {showCropOverlay && cropOverlayStyle && (
+                  <div
+                    data-no-window-drag="true"
+                    className="absolute z-30 cursor-move border-2 border-cyan-300 bg-cyan-300/10 shadow-[0_0_0_9999px_rgba(0,0,0,0.38)]"
+                    style={cropOverlayStyle}
+                    onPointerDown={handleCropDragStart}
+                    onPointerMove={handleCropDragMove}
+                    onPointerUp={handleCropDragEnd}
+                    onPointerCancel={handleCropDragEnd}
+                    title="Drag to move crop"
+                  >
+                    <div className="absolute left-1/3 top-0 h-full w-px bg-cyan-200/45" />
+                    <div className="absolute left-2/3 top-0 h-full w-px bg-cyan-200/45" />
+                    <div className="absolute left-0 top-1/3 h-px w-full bg-cyan-200/45" />
+                    <div className="absolute left-0 top-2/3 h-px w-full bg-cyan-200/45" />
+                  </div>
+                )}
+                {isRenderingEditedPreview && hasImageEditChanges && (
+                  <div className="absolute bottom-4 right-4 z-30 rounded-md border border-white/10 bg-black/60 px-2 py-1 text-xs text-white/80 backdrop-blur-sm">
+                    Rendering preview...
+                  </div>
+                )}
+              </>
             )
           ) : (
             <div className="w-full h-full animate-pulse bg-gray-700 rounded-md"></div>
@@ -3053,15 +3320,22 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
               {isAdjustmentPanelOpen && (
                 <ImageAdjustmentPanel
-                  adjustments={imageAdjustments}
-                  onChange={setImageAdjustments}
-                  onReset={() => setImageAdjustments(DEFAULT_IMAGE_ADJUSTMENTS)}
+                  recipe={normalizedImageEditRecipe}
+                  onChange={setImageEditRecipe}
+                  onReset={() => setImageEditRecipe(DEFAULT_IMAGE_EDIT_RECIPE)}
                   onSaveAs={() => void handleSaveEditedImageAs()}
                   onOverwrite={() => void handleOverwriteEditedImage()}
+                  sourceDimensions={imageEditSourceDimensions || undefined}
+                  activeTab={imageEditorTab}
+                  onActiveTabChange={setImageEditorTab}
                   canOverwrite={canOverwriteEditedImage}
                   overwriteUnavailableReason="Overwrite is only available for PNG images. Use Save As to create an edited PNG copy."
                   isSaving={isSavingEditedImage}
                   disabled={!isFullImageSourceReady}
+                  onAIUpscale={() => void handleAIUpscale()}
+                  canAIUpscale={canUseComfyUI}
+                  aiUpscaleDisabledReason="Enable ComfyUI and configure the server URL in Settings."
+                  isAIUpscaling={isGeneratingComfyUI}
                 />
               )}
             </>

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -63,6 +63,7 @@ import {
 
 
 const TAG_SUGGESTION_LIMIT = 5;
+type ViewerZoomMode = 'fit' | 'actual' | 'manual';
 
 const buildTagSuggestions = (
   recentTags: string[],
@@ -967,6 +968,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [enableAnimations, isMinimized, modalId, zIndex]);
 
   const [zoom, setZoom] = useState(1);
+  const [viewerZoomMode, setViewerZoomMode] = useState<ViewerZoomMode>('fit');
+  const [windowZoomFactor, setWindowZoomFactor] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
@@ -1913,6 +1916,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   useEffect(() => {
     setZoom(1);
+    setViewerZoomMode('fit');
     setPan({ x: 0, y: 0 });
     setSlideshowVideoDuration(null);
     revealMediaOverlay();
@@ -1924,46 +1928,78 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }
 
     setZoom(1);
+    setViewerZoomMode('fit');
     setPan({ x: 0, y: 0 });
   }, [image.id, isSlideshowMode]);
 
   useEffect(() => {
     setZoom(1);
+    setViewerZoomMode('fit');
     setPan({ x: 0, y: 0 });
     setIsMediaOverlayVisible(false);
     clearMediaOverlayHideTimer();
   }, [clearMediaOverlayHideTimer, isFullscreen]);
 
+  useEffect(() => {
+    const applyWindowZoomFactor = (nextZoomFactor: number) => {
+      setWindowZoomFactor(Number.isFinite(nextZoomFactor) && nextZoomFactor > 0 ? nextZoomFactor : 1);
+    };
+
+    void window.electronAPI?.getZoomFactor?.().then(applyWindowZoomFactor);
+    return window.electronAPI?.onZoomFactorChanged?.(applyWindowZoomFactor);
+  }, []);
+
   const getActualSizeZoom = useCallback(() => {
-    const container = imageContainerRef.current;
+    const imageElement = fullImageElementRef.current;
     const naturalSize = displayedImageNaturalSize;
-    if (!container || !naturalSize || naturalSize.width <= 0 || naturalSize.height <= 0) {
+    if (!imageElement || !naturalSize || naturalSize.width <= 0 || naturalSize.height <= 0) {
       return 1;
     }
 
-    const containerWidth = Math.max(1, container.clientWidth - (isFullViewportModal ? 0 : 16));
-    const containerHeight = Math.max(1, container.clientHeight - (isFullViewportModal ? 0 : 16));
-    const fitScale = Math.min(1, containerWidth / naturalSize.width, containerHeight / naturalSize.height);
-    return Math.max(1 / Math.max(fitScale, 0.01), 1);
-  }, [displayedImageNaturalSize, isFullViewportModal]);
+    const renderedWidth = imageElement.clientWidth;
+    const renderedHeight = imageElement.clientHeight;
+    if (renderedWidth <= 0 || renderedHeight <= 0) {
+      return 1;
+    }
+
+    const safeWindowZoomFactor = Math.max(windowZoomFactor, 0.01);
+    const widthZoom = naturalSize.width / (renderedWidth * safeWindowZoomFactor);
+    const heightZoom = naturalSize.height / (renderedHeight * safeWindowZoomFactor);
+    return Math.max(widthZoom, heightZoom, 0.1);
+  }, [displayedImageNaturalSize, windowZoomFactor]);
 
   const actualSizeZoom = getActualSizeZoom();
+  const minViewerZoom = Math.min(1, actualSizeZoom);
   const maxViewerZoom = Math.max(5, actualSizeZoom);
-  const isActualSizeZoom = actualSizeZoom > 1 && Math.abs(zoom - actualSizeZoom) < 0.05;
-  const zoomLabel = zoom <= 1.01 ? 'Fit' : isActualSizeZoom ? '1:1' : `${Math.round(zoom * 100)}%`;
+  const isActualSizeZoom = viewerZoomMode === 'actual' && Math.abs(zoom - actualSizeZoom) < 0.05;
+  const isFitZoom = viewerZoomMode === 'fit' && Math.abs(zoom - 1) < 0.05;
+  const zoomLabel = isFitZoom ? 'Fit' : isActualSizeZoom ? '1:1' : `${Math.round(zoom * 100)}%`;
+
+  useLayoutEffect(() => {
+    if (viewerZoomMode !== 'actual' || typeof window === 'undefined') {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      setZoom(getActualSizeZoom());
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [getActualSizeZoom, viewerZoomMode, windowZoomFactor]);
 
   const handleWheel = useCallback((e: WheelEvent) => {
     e.preventDefault();
 
     const delta = e.deltaY * -0.01;
-    const newZoom = Math.min(Math.max(1, zoom + delta), maxViewerZoom);
+    const newZoom = Math.min(Math.max(minViewerZoom, zoom + delta), maxViewerZoom);
 
+    setViewerZoomMode('manual');
     setZoom(newZoom);
 
     if (newZoom === 1) {
       setPan({ x: 0, y: 0 });
     }
-  }, [maxViewerZoom, zoom]);
+  }, [maxViewerZoom, minViewerZoom, zoom]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (!(e.target instanceof Element) || !e.target.closest('img, video, audio, canvas, [data-media-element="true"]')) {
@@ -2125,26 +2161,30 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [hideOriginalForAdjustmentCompare, isShowingOriginalForAdjustmentCompare]);
 
   const handleZoomIn = () => {
+    setViewerZoomMode('manual');
     setZoom(prev => Math.min(prev + 0.5, maxViewerZoom));
   };
 
   const handleZoomOut = () => {
-    const newZoom = Math.max(zoom - 0.5, 1);
+    const newZoom = Math.max(zoom - 0.5, minViewerZoom);
+    setViewerZoomMode('manual');
     setZoom(newZoom);
-    if (newZoom === 1) {
+    if (Math.abs(newZoom - 1) < 0.01) {
       setPan({ x: 0, y: 0 });
     }
   };
 
   const handleFitToScreen = () => {
+    setViewerZoomMode('fit');
     setZoom(1);
     setPan({ x: 0, y: 0 });
   };
 
   const handleActualSize = () => {
     const nextZoom = getActualSizeZoom();
+    setViewerZoomMode('actual');
     setZoom(nextZoom);
-    if (nextZoom === 1) {
+    if (Math.abs(nextZoom - 1) < 0.01) {
       setPan({ x: 0, y: 0 });
     }
   };
@@ -3379,7 +3419,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
               <div className="min-w-10 text-center font-mono text-xs text-white/80">{zoomLabel}</div>
               <button
                 onClick={handleZoomOut}
-                disabled={zoom <= 1}
+                disabled={zoom <= minViewerZoom}
                 className="rounded p-2 text-white/90 transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30"
                 title="Zoom Out"
               >
@@ -3389,16 +3429,14 @@ const ImageModal: React.FC<ImageModalProps> = ({
               </button>
               <button
                 onClick={handleActualSize}
-                disabled={actualSizeZoom <= 1 || isActualSizeZoom}
-                className="rounded p-2 text-white/90 transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30 text-xs"
+                className={`rounded p-2 text-xs text-white/90 transition-all hover:bg-white/10 ${isActualSizeZoom ? 'bg-white/15 ring-1 ring-white/25' : ''}`}
                 title="Actual Size"
               >
                 1:1
               </button>
               <button
                 onClick={handleFitToScreen}
-                disabled={zoom <= 1}
-                className="rounded p-2 text-white/90 transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30 text-xs"
+                className={`rounded p-2 text-xs text-white/90 transition-all hover:bg-white/10 ${isFitZoom ? 'bg-white/15 ring-1 ring-white/25' : ''}`}
                 title="Fit to Screen"
               >
                 Fit

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -872,6 +872,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const [imageEditRecipe, setImageEditRecipe] = useState<ImageEditRecipe>(DEFAULT_IMAGE_EDIT_RECIPE);
   const [imageEditorTab, setImageEditorTab] = useState<'adjust' | 'crop' | 'transform' | 'enhance'>('adjust');
   const [imageEditSourceDimensions, setImageEditSourceDimensions] = useState<{ width: number; height: number } | null>(null);
+  const [displayedImageNaturalSize, setDisplayedImageNaturalSize] = useState<{ width: number; height: number } | null>(null);
   const [cropImageBounds, setCropImageBounds] = useState<{ left: number; top: number; width: number; height: number } | null>(null);
   const [editedPreviewUrl, setEditedPreviewUrl] = useState<string | null>(null);
   const [isRenderingEditedPreview, setIsRenderingEditedPreview] = useState(false);
@@ -1176,6 +1177,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     setImageEditRecipe(DEFAULT_IMAGE_EDIT_RECIPE);
     setImageEditorTab('adjust');
     setImageEditSourceDimensions(null);
+    setDisplayedImageNaturalSize(null);
     setCropImageBounds(null);
     setEditedPreviewUrl(null);
     setIsRenderingEditedPreview(false);
@@ -1932,18 +1934,36 @@ const ImageModal: React.FC<ImageModalProps> = ({
     clearMediaOverlayHideTimer();
   }, [clearMediaOverlayHideTimer, isFullscreen]);
 
+  const getActualSizeZoom = useCallback(() => {
+    const container = imageContainerRef.current;
+    const naturalSize = displayedImageNaturalSize;
+    if (!container || !naturalSize || naturalSize.width <= 0 || naturalSize.height <= 0) {
+      return 1;
+    }
+
+    const containerWidth = Math.max(1, container.clientWidth - (isFullViewportModal ? 0 : 16));
+    const containerHeight = Math.max(1, container.clientHeight - (isFullViewportModal ? 0 : 16));
+    const fitScale = Math.min(1, containerWidth / naturalSize.width, containerHeight / naturalSize.height);
+    return Math.max(1 / Math.max(fitScale, 0.01), 1);
+  }, [displayedImageNaturalSize, isFullViewportModal]);
+
+  const actualSizeZoom = getActualSizeZoom();
+  const maxViewerZoom = Math.max(5, actualSizeZoom);
+  const isActualSizeZoom = actualSizeZoom > 1 && Math.abs(zoom - actualSizeZoom) < 0.05;
+  const zoomLabel = zoom <= 1.01 ? 'Fit' : isActualSizeZoom ? '1:1' : `${Math.round(zoom * 100)}%`;
+
   const handleWheel = useCallback((e: WheelEvent) => {
     e.preventDefault();
 
     const delta = e.deltaY * -0.01;
-    const newZoom = Math.min(Math.max(1, zoom + delta), 5);
+    const newZoom = Math.min(Math.max(1, zoom + delta), maxViewerZoom);
 
     setZoom(newZoom);
 
     if (newZoom === 1) {
       setPan({ x: 0, y: 0 });
     }
-  }, [zoom]);
+  }, [maxViewerZoom, zoom]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (!(e.target instanceof Element) || !e.target.closest('img, video, audio, canvas, [data-media-element="true"]')) {
@@ -2105,7 +2125,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [hideOriginalForAdjustmentCompare, isShowingOriginalForAdjustmentCompare]);
 
   const handleZoomIn = () => {
-    setZoom(prev => Math.min(prev + 0.5, 5));
+    setZoom(prev => Math.min(prev + 0.5, maxViewerZoom));
   };
 
   const handleZoomOut = () => {
@@ -2116,9 +2136,17 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }
   };
 
-  const handleResetZoom = () => {
+  const handleFitToScreen = () => {
     setZoom(1);
     setPan({ x: 0, y: 0 });
+  };
+
+  const handleActualSize = () => {
+    const nextZoom = getActualSizeZoom();
+    setZoom(nextZoom);
+    if (nextZoom === 1) {
+      setPan({ x: 0, y: 0 });
+    }
   };
 
   const buildEditedDefaultPath = useCallback(async () => {
@@ -3238,6 +3266,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
                     const target = event.currentTarget;
                     const naturalWidth = target.naturalWidth || target.width;
                     const naturalHeight = target.naturalHeight || target.height;
+                    if (naturalWidth > 0 && naturalHeight > 0) {
+                      setDisplayedImageNaturalSize({ width: naturalWidth, height: naturalHeight });
+                    }
                     if (isFullImageSourceReady && naturalWidth > 0 && naturalHeight > 0) {
                       setImageEditSourceDimensions({ width: naturalWidth, height: naturalHeight });
                     }
@@ -3337,7 +3368,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
             <div data-no-window-drag="true" className={`absolute bottom-4 left-4 z-30 flex flex-col gap-2 rounded-lg border border-white/10 bg-black/35 p-2 backdrop-blur-sm transition-opacity duration-300 ease-out ${mediaOverlayVisibilityClass}`}>
               <button
                 onClick={handleZoomIn}
-                disabled={zoom >= 5}
+                disabled={zoom >= maxViewerZoom}
                 className="rounded p-2 text-white/90 transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30"
                 title="Zoom In"
               >
@@ -3345,7 +3376,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
               </button>
-              <div className="text-center font-mono text-xs text-white/80">{Math.round(zoom * 100)}%</div>
+              <div className="min-w-10 text-center font-mono text-xs text-white/80">{zoomLabel}</div>
               <button
                 onClick={handleZoomOut}
                 disabled={zoom <= 1}
@@ -3357,12 +3388,20 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 </svg>
               </button>
               <button
-                onClick={handleResetZoom}
+                onClick={handleActualSize}
+                disabled={actualSizeZoom <= 1 || isActualSizeZoom}
+                className="rounded p-2 text-white/90 transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30 text-xs"
+                title="Actual Size"
+              >
+                1:1
+              </button>
+              <button
+                onClick={handleFitToScreen}
                 disabled={zoom <= 1}
                 className="rounded p-2 text-white/90 transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30 text-xs"
-                title="Reset Zoom"
+                title="Fit to Screen"
               >
-                Reset
+                Fit
               </button>
             </div>
           )}

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1288,10 +1288,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
     let canceled = false;
     setIsRenderingEditedPreview(true);
     const timeoutId = window.setTimeout(async () => {
-      const editableSource = await mediaSourceCache.getRendererOwnedObjectUrl(liveImage, directoryPath);
       try {
+        const editableSource = await mediaSourceCache.getRendererOwnedObjectUrl(liveImage, directoryPath);
         const blob = await renderEditedImageToPngBlob(editableSource.url, normalizedImageEditRecipe);
         if (canceled) {
+          editableSource.revoke();
           return;
         }
         const nextUrl = URL.createObjectURL(blob);
@@ -1301,12 +1302,12 @@ const ImageModal: React.FC<ImageModalProps> = ({
           }
           return nextUrl;
         });
+        editableSource.revoke();
       } catch (error) {
         if (!canceled) {
           console.warn('[ImageModal] Failed to render edited preview:', error);
         }
       } finally {
-        editableSource.revoke();
         if (!canceled) {
           setIsRenderingEditedPreview(false);
         }

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -143,6 +143,30 @@ const getUsableNormalizedMetadata = (image: IndexedImage): BaseMetadata | undefi
   };
 };
 
+const scheduleEditedImageCacheUpsert = (
+  directory: { path: string; name: string },
+  image: IndexedImage,
+  scanSubfolders: boolean,
+) => {
+  window.setTimeout(() => {
+    const cacheModes = Array.from(new Set([scanSubfolders, !scanSubfolders]));
+    Promise.all(
+      cacheModes.map((scanSubfoldersMode) =>
+        cacheManager.applyChunkedCacheDelta(
+          directory.path,
+          directory.name,
+          [image],
+          [],
+          [],
+          scanSubfoldersMode,
+        )
+      )
+    ).catch((error) => {
+      console.error('Failed to update cache after edited image save:', error);
+    });
+  }, 0);
+};
+
 interface ImageModalProps {
   modalId?: string;
   image: IndexedImage;
@@ -2222,11 +2246,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
           const targetAlreadyIndexed = allImages.some((candidate) => candidate.id === savedImage.id);
           if (targetAlreadyIndexed) {
             mergeImages([savedImage]);
-            await cacheManager.updateCachedImages(targetDirectory.path, targetDirectory.name, [savedImage], scanSubfolders);
           } else {
             addImages([savedImage]);
-            await cacheManager.appendToCache(targetDirectory.path, targetDirectory.name, [savedImage], scanSubfolders);
           }
+          scheduleEditedImageCacheUpsert(targetDirectory, savedImage, scanSubfolders);
           setSuccess(`Saved edited image as ${savedImage.name}.`);
         } else {
           setSuccess('Saved edited image.');
@@ -2346,7 +2369,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         status: 'pending',
         error: null,
       });
-      await cacheManager.updateCachedImages(sourceDirectory.path, sourceDirectory.name, [preservedMetadataImage], scanSubfolders);
+      scheduleEditedImageCacheUpsert(sourceDirectory, preservedMetadataImage, scanSubfolders);
       setImageEditRecipe(DEFAULT_IMAGE_EDIT_RECIPE);
       setSuccess('Overwrote original image with edits.');
     } catch (error) {

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -144,6 +144,64 @@ const getUsableNormalizedMetadata = (image: IndexedImage): BaseMetadata | undefi
   };
 };
 
+const firstNonBlankString = (...values: Array<string | undefined | null>): string | undefined => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const firstNonEmptyArray = <T,>(...values: Array<T[] | undefined | null>): T[] | undefined => {
+  for (const value of values) {
+    if (Array.isArray(value) && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const firstDefined = <T,>(...values: Array<T | undefined | null>): T | undefined => {
+  for (const value of values) {
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const mergeEditedNormalizedMetadata = (
+  parsedMetadata?: BaseMetadata,
+  sourceMetadata?: BaseMetadata,
+): BaseMetadata | undefined => {
+  if (!parsedMetadata) {
+    return sourceMetadata;
+  }
+  if (!sourceMetadata) {
+    return parsedMetadata;
+  }
+
+  const merged: BaseMetadata = {
+    ...sourceMetadata,
+    ...parsedMetadata,
+    prompt: firstNonBlankString(parsedMetadata.prompt, sourceMetadata.prompt) || '',
+    negativePrompt: firstNonBlankString(parsedMetadata.negativePrompt, sourceMetadata.negativePrompt) || '',
+    model: firstNonBlankString(parsedMetadata.model, sourceMetadata.model) || '',
+    models: firstNonEmptyArray(parsedMetadata.models, sourceMetadata.models) || [],
+    loras: firstNonEmptyArray(parsedMetadata.loras, sourceMetadata.loras) || [],
+    sampler: firstNonBlankString(parsedMetadata.sampler, sourceMetadata.sampler) || '',
+    scheduler: firstNonBlankString(parsedMetadata.scheduler, sourceMetadata.scheduler) || '',
+    board: firstNonBlankString(parsedMetadata.board, sourceMetadata.board),
+    cfgScale: firstDefined(parsedMetadata.cfgScale, parsedMetadata.cfg_scale, sourceMetadata.cfgScale, sourceMetadata.cfg_scale),
+    cfg_scale: firstDefined(parsedMetadata.cfg_scale, parsedMetadata.cfgScale, sourceMetadata.cfg_scale, sourceMetadata.cfgScale),
+    steps: firstDefined(parsedMetadata.steps, sourceMetadata.steps) || 0,
+    seed: firstDefined(parsedMetadata.seed, sourceMetadata.seed),
+  };
+
+  return merged;
+};
+
 const scheduleEditedImageCacheUpsert = (
   directory: { path: string; name: string },
   image: IndexedImage,
@@ -2234,13 +2292,14 @@ const ImageModal: React.FC<ImageModalProps> = ({
       return;
     }
 
-    if (!liveImage.handle) {
+    if (!liveImage.handle && !directoryPath) {
       setError('ComfyUI Upscale needs desktop file access to upload the source image.');
       return;
     }
 
     await generateWithComfyUI(liveImage, {
       workflowMode: 'upscale',
+      directoryPath,
       customMetadata: {
         prompt: liveImage.prompt || 'ComfyUI upscale',
       },
@@ -2250,6 +2309,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     comfyUIEnabled,
     comfyUIServerUrl,
     generateWithComfyUI,
+    directoryPath,
     liveImage,
     setError,
     showProModal,
@@ -2332,26 +2392,27 @@ const ImageModal: React.FC<ImageModalProps> = ({
       if (targetDirectory) {
         const indexedImage = await indexImageFileAtPath(saveResult.path, targetDirectory);
         if (indexedImage) {
-          const savedMetadata = sourceMetadata
-            ? {
-                ...indexedImage.metadata,
-                normalizedMetadata: sourceMetadata,
-              }
+          const savedNormalizedMetadata = mergeEditedNormalizedMetadata(
+            indexedImage.metadata?.normalizedMetadata as BaseMetadata | undefined,
+            sourceMetadata,
+          );
+          const savedMetadata = savedNormalizedMetadata
+            ? { ...indexedImage.metadata, normalizedMetadata: savedNormalizedMetadata }
             : indexedImage.metadata;
           const savedImage: IndexedImage = {
             ...indexedImage,
             metadata: savedMetadata,
-            metadataString: sourceMetadata ? JSON.stringify(savedMetadata) : liveImage.metadataString,
-            models: sourceMetadata?.models || liveImage.models,
-            loras: sourceMetadata?.loras || liveImage.loras,
-            sampler: sourceMetadata?.sampler || liveImage.sampler,
-            scheduler: sourceMetadata?.scheduler || liveImage.scheduler,
-            board: sourceMetadata?.board || liveImage.board,
-            prompt: sourceMetadata?.prompt || liveImage.prompt,
-            negativePrompt: sourceMetadata?.negativePrompt || liveImage.negativePrompt,
-            cfgScale: sourceMetadata?.cfgScale ?? sourceMetadata?.cfg_scale ?? liveImage.cfgScale,
-            steps: sourceMetadata?.steps || liveImage.steps,
-            seed: sourceMetadata?.seed ?? liveImage.seed,
+            metadataString: savedNormalizedMetadata ? JSON.stringify(savedMetadata) : liveImage.metadataString,
+            models: savedNormalizedMetadata?.models || liveImage.models,
+            loras: savedNormalizedMetadata?.loras || liveImage.loras,
+            sampler: savedNormalizedMetadata?.sampler || liveImage.sampler,
+            scheduler: savedNormalizedMetadata?.scheduler || liveImage.scheduler,
+            board: savedNormalizedMetadata?.board || liveImage.board,
+            prompt: savedNormalizedMetadata?.prompt || liveImage.prompt,
+            negativePrompt: savedNormalizedMetadata?.negativePrompt || liveImage.negativePrompt,
+            cfgScale: savedNormalizedMetadata?.cfgScale ?? savedNormalizedMetadata?.cfg_scale ?? liveImage.cfgScale,
+            steps: savedNormalizedMetadata?.steps || liveImage.steps,
+            seed: savedNormalizedMetadata?.seed ?? liveImage.seed,
             workflowNodes: liveImage.workflowNodes,
             enrichmentState: 'enriched',
           };
@@ -2435,27 +2496,28 @@ const ImageModal: React.FC<ImageModalProps> = ({
         throw new Error('The edited image was saved, but metadata reparsing returned no image.');
       }
 
-      const preservedMetadata = sourceMetadata
-        ? {
-            ...reparsed.metadata,
-            normalizedMetadata: sourceMetadata,
-          }
+      const preservedNormalizedMetadata = mergeEditedNormalizedMetadata(
+        reparsed.metadata?.normalizedMetadata as BaseMetadata | undefined,
+        sourceMetadata,
+      );
+      const preservedMetadata = preservedNormalizedMetadata
+        ? { ...reparsed.metadata, normalizedMetadata: preservedNormalizedMetadata }
         : reparsed.metadata;
       const preservedMetadataImage: IndexedImage = {
         ...liveImage,
         ...reparsed,
         metadata: preservedMetadata,
-        metadataString: sourceMetadata ? JSON.stringify(preservedMetadata) : liveImage.metadataString,
-        models: sourceMetadata?.models || liveImage.models,
-        loras: sourceMetadata?.loras || liveImage.loras,
-        sampler: sourceMetadata?.sampler || liveImage.sampler,
-        scheduler: sourceMetadata?.scheduler || liveImage.scheduler,
-        board: sourceMetadata?.board || liveImage.board,
-        prompt: sourceMetadata?.prompt || liveImage.prompt,
-        negativePrompt: sourceMetadata?.negativePrompt || liveImage.negativePrompt,
-        cfgScale: sourceMetadata?.cfgScale ?? sourceMetadata?.cfg_scale ?? liveImage.cfgScale,
-        steps: sourceMetadata?.steps || liveImage.steps,
-        seed: sourceMetadata?.seed ?? liveImage.seed,
+        metadataString: preservedNormalizedMetadata ? JSON.stringify(preservedMetadata) : liveImage.metadataString,
+        models: preservedNormalizedMetadata?.models || liveImage.models,
+        loras: preservedNormalizedMetadata?.loras || liveImage.loras,
+        sampler: preservedNormalizedMetadata?.sampler || liveImage.sampler,
+        scheduler: preservedNormalizedMetadata?.scheduler || liveImage.scheduler,
+        board: preservedNormalizedMetadata?.board || liveImage.board,
+        prompt: preservedNormalizedMetadata?.prompt || liveImage.prompt,
+        negativePrompt: preservedNormalizedMetadata?.negativePrompt || liveImage.negativePrompt,
+        cfgScale: preservedNormalizedMetadata?.cfgScale ?? preservedNormalizedMetadata?.cfg_scale ?? liveImage.cfgScale,
+        steps: preservedNormalizedMetadata?.steps || liveImage.steps,
+        seed: preservedNormalizedMetadata?.seed ?? liveImage.seed,
         workflowNodes: liveImage.workflowNodes,
         handle: liveImage.handle,
         thumbnailHandle: liveImage.thumbnailHandle,

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -3328,7 +3328,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
                     if (naturalWidth > 0 && naturalHeight > 0) {
                       setDisplayedImageNaturalSize({ width: naturalWidth, height: naturalHeight });
                     }
-                    if (isFullImageSourceReady && naturalWidth > 0 && naturalHeight > 0) {
+                    const loadedUrl = target.currentSrc || target.src;
+                    const loadedSourceImage = Boolean(imageUrl && loadedUrl === imageUrl);
+                    if (isFullImageSourceReady && loadedSourceImage && naturalWidth > 0 && naturalHeight > 0) {
                       setImageEditSourceDimensions({ width: naturalWidth, height: naturalHeight });
                     }
                     updateCropImageBounds();

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState, FC } from 'react';
-import { Clipboard, Sparkles, ChevronDown, ChevronRight, Heart, X, Zap, CheckCircle, ArrowUp, Copy, Search, Pencil, Download, Eye, EyeOff } from 'lucide-react';
+import { AlertTriangle, Clipboard, Sparkles, ChevronDown, ChevronRight, Heart, X, Zap, CheckCircle, ArrowUp, Copy, Search, Pencil, Download, Eye, EyeOff, ExternalLink } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { type BaseMetadata, type IndexedImage, type LoRAInfo } from '../types';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
@@ -12,7 +12,7 @@ import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } fr
 import { ComfyUIGenerateModal, type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGenerateModal';
 import ProBadge from './ProBadge';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
-import { mediaSourceCache } from '../services/mediaSourceCache';
+import { getElectronAbsoluteMediaPath, getRelativeImagePath, mediaSourceCache } from '../services/mediaSourceCache';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import ImageLineageSection from './ImageLineageSection';
 import { getGenerationTypeLabel } from '../utils/imageLineage';
@@ -169,6 +169,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const [showOriginal, setShowOriginal] = useState(false);
   const [isMetadataEditorOpen, setIsMetadataEditorOpen] = useState(false);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
+  const [mediaRendererFailed, setMediaRendererFailed] = useState(false);
+  const [externalMediaPath, setExternalMediaPath] = useState<string | null>(null);
+  const [openExternalMediaError, setOpenExternalMediaError] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     x: 0,
     y: 0,
@@ -191,6 +194,9 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const thumbnail = useResolvedThumbnail(activeImage);
   const isVideo = !!activeImage && isVideoFileName(activeImage.name, activeImage.fileType);
   const isAudio = !!activeImage && isAudioFileName(activeImage.name, activeImage.fileType);
+  const activeImageDirectoryPath = activeImage
+    ? directories.find((directory) => directory.id === activeImage.directoryId)?.path
+    : undefined;
   const showA1111Actions = !isVideo && !isAudio && a1111Enabled;
   const showComfyUIActions = !isVideo && !isAudio && comfyUIEnabled;
   const showComfyUIHeading = showA1111Actions && visibleProviders.length > 1;
@@ -202,6 +208,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     fileName: activeImage?.name ?? '',
     surface: 'preview-sidebar',
     src: imageUrl,
+    onAudioRendererError: () => setMediaRendererFailed(true),
   });
   const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
   const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
@@ -276,9 +283,6 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   // Calculate these BEFORE the early return to maintain hook order
   const nMeta: BaseMetadata | undefined = activeImage?.metadata?.normalizedMetadata;
   const effectiveMetadata = activeImage ? buildEffectiveMetadata(nMeta, shadowMetadata, showOriginal) : undefined;
-  const activeImageDirectoryPath = activeImage
-    ? directories.find((directory) => directory.id === activeImage.directoryId)?.path
-    : undefined;
   const rawMetadataImage = hydratedRawMetadataImage?.id === activeImage?.id ? hydratedRawMetadataImage : activeImage;
   const ensureFullRawMetadata = useCallback(async (): Promise<IndexedImage | null> => {
     if (!activeImage) {
@@ -305,6 +309,49 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     setHydratedRawMetadataImage(null);
     setIsHydratingRawMetadata(false);
   }, [activeImage?.id]);
+
+  useEffect(() => {
+    let isMounted = true;
+    setMediaRendererFailed(false);
+    setOpenExternalMediaError(null);
+    setExternalMediaPath(null);
+
+    const resolveExternalMediaPath = async () => {
+      if (!activeImage || (!isVideo && !isAudio)) {
+        return;
+      }
+
+      const handlePath = getElectronAbsoluteMediaPath(activeImage);
+      if (handlePath) {
+        if (isMounted) setExternalMediaPath(handlePath);
+        return;
+      }
+
+      if (!activeImageDirectoryPath || !window.electronAPI?.joinPaths) {
+        return;
+      }
+
+      const joined = await window.electronAPI.joinPaths(activeImageDirectoryPath, getRelativeImagePath(activeImage));
+      if (isMounted && joined.success && joined.path) {
+        setExternalMediaPath(joined.path);
+      }
+    };
+
+    void resolveExternalMediaPath();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [activeImage, activeImageDirectoryPath, isAudio, isVideo]);
+
+  const openExternalMedia = useCallback(async () => {
+    if (!externalMediaPath) return;
+    const result = await window.electronAPI?.openPath?.(externalMediaPath);
+    if (!result?.success) {
+      setOpenExternalMediaError(result?.error || 'Failed to open media externally.');
+    }
+  }, [externalMediaPath]);
+
   const generationImage: IndexedImage = activeImage && effectiveMetadata
     ? {
         ...activeImage,
@@ -482,8 +529,29 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 src={imageUrl}
                 title={activeImage.name}
                 compact
+                externalPath={externalMediaPath}
                 diagnostics={{ fileName: activeImage.name, surface: 'preview-sidebar' }}
               />
+            ) : isVideo && mediaRendererFailed ? (
+              <div data-media-element="true" className="flex w-full flex-col items-center justify-center gap-3 bg-black p-4 text-center text-gray-100">
+                <div className="rounded-full border border-amber-400/30 bg-amber-400/10 p-3 text-amber-200">
+                  <AlertTriangle className="h-8 w-8" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-100">Audio playback failed in Electron</p>
+                  <p className="mt-1 max-w-md text-xs text-gray-400">The macOS audio service reported an audio renderer error.</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={openExternalMedia}
+                  disabled={!externalMediaPath}
+                  className="inline-flex items-center gap-2 rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm font-medium text-gray-100 transition-colors hover:border-gray-500 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                  Open Externally
+                </button>
+                {openExternalMediaError && <p className="max-w-md text-xs text-red-300">{openExternalMediaError}</p>}
+              </div>
             ) : isVideo ? (
               <video
                 src={imageUrl}

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -5,7 +5,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { type IndexedImage, type Directory, SmartCollection } from '../types';
 import { useContextMenu } from '../hooks/useContextMenu';
 import { useImageStore } from '../store/useImageStore';
-import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Search, Star, Pencil, Workflow } from 'lucide-react';
+import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Search, Star, Pencil, Workflow, Image as ImageIcon } from 'lucide-react';
 import { useThumbnail } from '../hooks/useThumbnail';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -30,6 +30,7 @@ interface ImageTableProps {
   isCollectionsView?: boolean;
   onImageRenamed?: (oldImageId: string, newImageId: string) => void;
   onFindSimilar?: (image: IndexedImage) => void;
+  onOpenImageEditor?: (image: IndexedImage) => void;
   onOpenComfyUIWorkspace?: (image: IndexedImage) => void;
   groupBy?: ImageGroupByMode;
   groupSortOrder?: ImageGroupingSortOrder;
@@ -78,6 +79,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
   isCollectionsView = false,
   onImageRenamed,
   onFindSimilar,
+  onOpenImageEditor,
   onOpenComfyUIWorkspace,
   groupBy = 'none',
   groupSortOrder = 'date-desc',
@@ -170,6 +172,15 @@ const ImageTable: React.FC<ImageTableProps> = ({
     onOpenComfyUIWorkspace(contextMenu.image);
     hideContextMenu();
   }, [canUseComfyUI, contextMenu.image, hideContextMenu, onOpenComfyUIWorkspace, showProModal]);
+
+  const openImageEditor = useCallback(() => {
+    if (!contextMenu.image || !onOpenImageEditor) {
+      return;
+    }
+
+    onOpenImageEditor(contextMenu.image);
+    hideContextMenu();
+  }, [contextMenu.image, hideContextMenu, onOpenImageEditor]);
 
   const getContextTargetImages = useCallback(() => {
     if (!contextMenu.image) {
@@ -775,6 +786,17 @@ const ImageTable: React.FC<ImageTableProps> = ({
             <Search className="w-4 h-4" />
             Find similar...
           </button>
+
+          {onOpenImageEditor && (
+            <button
+              onClick={openImageEditor}
+              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+              title="Open this image in the Image Editor workspace"
+            >
+              <ImageIcon className="w-4 h-4" />
+              Edit Image
+            </button>
+          )}
 
           {onOpenComfyUIWorkspace && (
             <button

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -18,7 +18,7 @@ import { getContextMenuRatingTargetIds } from '../utils/ratingSelection';
 import { useReparseMetadata } from '../hooks/useReparseMetadata';
 import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal';
 import RenameImageModal from './RenameImageModal';
-import { isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
+import { getFileExtension, isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 import { groupImages, type ImageGroupByMode, type ImageGroupingSortOrder, type ImageGroupRenderItem } from '../utils/imageGrouping';
 
 interface ImageTableProps {
@@ -177,6 +177,13 @@ const ImageTable: React.FC<ImageTableProps> = ({
     if (!contextMenu.image || !onOpenImageEditor) {
       return;
     }
+    if (
+      isVideoFileName(contextMenu.image.name, contextMenu.image.fileType) ||
+      isAudioFileName(contextMenu.image.name, contextMenu.image.fileType) ||
+      getFileExtension(contextMenu.image.name) === '.gif'
+    ) {
+      return;
+    }
 
     onOpenImageEditor(contextMenu.image);
     hideContextMenu();
@@ -196,6 +203,13 @@ const ImageTable: React.FC<ImageTableProps> = ({
 
   const contextImagePrompt = contextMenu.image?.prompt || contextMenu.image?.metadata?.normalizedMetadata?.prompt;
   const canFindSimilar = Boolean(contextImagePrompt) && Boolean(onFindSimilar);
+  const canOpenContextImageEditor = Boolean(
+    onOpenImageEditor &&
+    contextMenu.image &&
+    !isVideoFileName(contextMenu.image.name, contextMenu.image.fileType) &&
+    !isAudioFileName(contextMenu.image.name, contextMenu.image.fileType) &&
+    getFileExtension(contextMenu.image.name) !== '.gif',
+  );
 
   const handleSetRating = useCallback((rating: 1 | 2 | 3 | 4 | 5 | null) => {
     const targetImageIds = getContextMenuRatingTargetIds(selectedImages, contextMenu.image?.id);
@@ -787,7 +801,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
             Find similar...
           </button>
 
-          {onOpenImageEditor && (
+          {canOpenContextImageEditor && (
             <button
               onClick={openImageEditor}
               className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"

--- a/components/ModelCard.tsx
+++ b/components/ModelCard.tsx
@@ -10,9 +10,10 @@ interface ModelCardProps {
   imageCount: number;
   onClick: () => void;
   onFindMatchingPrompts?: () => void;
+  isActive?: boolean;
 }
 
-const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, onClick, onFindMatchingPrompts }) => {
+const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, onClick, onFindMatchingPrompts, isActive = false }) => {
   const cardRef = useRef<HTMLButtonElement | null>(null);
   const [previewIndex, setPreviewIndex] = useState(0);
   const rafRef = useRef<number | null>(null);
@@ -63,7 +64,9 @@ const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, on
       onClick={onClick}
       onPointerMove={handlePointerMove}
       onPointerLeave={handlePointerLeave}
-      className="group text-left bg-gray-900/60 border border-gray-800 rounded-2xl overflow-hidden shadow-lg transition-all hover:shadow-xl hover:shadow-blue-500/20 hover:border-blue-500/30 cursor-pointer"
+      className={`group text-left bg-gray-900/60 border rounded-2xl overflow-hidden shadow-lg transition-all hover:shadow-xl hover:shadow-blue-500/20 hover:border-blue-500/30 cursor-pointer ${
+        isActive ? 'border-blue-400/70 shadow-blue-500/20' : 'border-gray-800'
+      }`}
       type="button"
     >
       <div className="relative aspect-[4/5] overflow-hidden">
@@ -129,8 +132,9 @@ const ModelCard: React.FC<ModelCardProps> = ({ modelName, images, imageCount, on
         <p className="text-sm font-semibold text-gray-100 truncate" title={modelName}>
           {modelName}
         </p>
-        <p className="text-xs text-gray-400 mt-1">
-          {imageCount} image{imageCount !== 1 ? 's' : ''}
+        <p className="mt-1 flex items-center justify-between gap-2 text-xs text-gray-400">
+          <span>{imageCount} image{imageCount !== 1 ? 's' : ''}</span>
+          {isActive && <span className="shrink-0 text-blue-300">Selected</span>}
         </p>
       </div>
     </button>

--- a/components/ModelView.tsx
+++ b/components/ModelView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -48,6 +48,7 @@ export const ModelView: React.FC<ModelViewProps> = ({
 
   const [internalPage, setInternalPage] = useState(1);
   const [sortBy] = useState<'count' | 'name'>('count');
+  const previousActiveModelNameRef = useRef(activeModelName);
   const page = controlledPage ?? internalPage;
 
   const modelEntries = useMemo(() => {
@@ -86,6 +87,22 @@ export const ModelView: React.FC<ModelViewProps> = ({
   }, [activeModelName, images, sortBy]);
 
   const totalPages = itemsPerPage === -1 ? 1 : Math.ceil(modelEntries.length / itemsPerPage);
+
+  useEffect(() => {
+    if (previousActiveModelNameRef.current === activeModelName) {
+      return;
+    }
+
+    previousActiveModelNameRef.current = activeModelName;
+    if (!activeModelName) {
+      return;
+    }
+
+    onPageChange?.(1);
+    if (controlledPage == null) {
+      setInternalPage(1);
+    }
+  }, [activeModelName, controlledPage, onPageChange]);
 
   useEffect(() => {
     if (page > totalPages && totalPages > 0) {

--- a/components/ModelView.tsx
+++ b/components/ModelView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -19,10 +19,21 @@ interface ModelViewProps {
   onToggleQueue?: () => void;
   onModelSelect: (modelName: string) => void;
   onFindMatchingPrompts?: (modelName: string) => void;
+  page?: number;
+  onPageChange?: (page: number) => void;
+  activeModelName?: string | null;
 }
 
 
-export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onToggleQueue, onModelSelect, onFindMatchingPrompts }) => {
+export const ModelView: React.FC<ModelViewProps> = ({
+  isQueueOpen = false,
+  onToggleQueue,
+  onModelSelect,
+  onFindMatchingPrompts,
+  page: controlledPage,
+  onPageChange,
+  activeModelName = null,
+}) => {
   const images = useImageStore((state) => state.images);
   const filteredImages = useImageStore((state) => state.filteredImages);
   const selectionTotalImages = useImageStore((state) => state.selectionTotalImages);
@@ -35,8 +46,9 @@ export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onTog
     state.items.filter((item) => item.status === 'waiting' || item.status === 'processing').length
   );
 
-  const [page, setPage] = useState(1);
+  const [internalPage, setInternalPage] = useState(1);
   const [sortBy] = useState<'count' | 'name'>('count');
+  const page = controlledPage ?? internalPage;
 
   const modelEntries = useMemo(() => {
     const models = new Map<string, IndexedImage[]>();
@@ -60,15 +72,29 @@ export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onTog
     }));
 
     return entries.sort((a, b) => {
+      if (activeModelName) {
+        if (a.name === activeModelName) return -1;
+        if (b.name === activeModelName) return 1;
+      }
+
       if (sortBy === 'count') {
         const countDiff = b.count - a.count;
         if (countDiff !== 0) return countDiff;
       }
       return a.name.localeCompare(b.name);
     });
-  }, [images, sortBy]);
+  }, [activeModelName, images, sortBy]);
 
   const totalPages = itemsPerPage === -1 ? 1 : Math.ceil(modelEntries.length / itemsPerPage);
+
+  useEffect(() => {
+    if (page > totalPages && totalPages > 0) {
+      onPageChange?.(1);
+      if (controlledPage == null) {
+        setInternalPage(1);
+      }
+    }
+  }, [controlledPage, onPageChange, page, totalPages]);
   
   const paginatedEntries = useMemo(() => {
     if (itemsPerPage === -1) return modelEntries;
@@ -77,7 +103,10 @@ export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onTog
   }, [modelEntries, page, itemsPerPage]);
 
   const handlePageChange = (newPage: number) => {
-    setPage(newPage);
+    onPageChange?.(newPage);
+    if (controlledPage == null) {
+      setInternalPage(newPage);
+    }
   };
 
   return (
@@ -101,6 +130,7 @@ export const ModelView: React.FC<ModelViewProps> = ({ isQueueOpen = false, onTog
                 modelName={entry.name}
                 images={entry.images}
                 imageCount={entry.count}
+                isActive={entry.name === activeModelName}
                 onClick={() => onModelSelect(entry.name)}
                 onFindMatchingPrompts={onFindMatchingPrompts ? () => onFindMatchingPrompts(entry.name) : undefined}
               />

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -272,7 +272,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           <img src="logo1.png" alt="Image MetaHub" className="h-11 w-11 flex-shrink-0 rounded-xl object-contain" />
           <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
             <h1 className="truncate text-lg font-semibold tracking-tight text-white">Image MetaHub</h1>
-            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.17.0-rc</span>
+            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.17.0</span>
           </div>
           <button
             onClick={onToggleCollapse}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -272,7 +272,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           <img src="logo1.png" alt="Image MetaHub" className="h-11 w-11 flex-shrink-0 rounded-xl object-contain" />
           <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
             <h1 className="truncate text-lg font-semibold tracking-tight text-white">Image MetaHub</h1>
-            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.16.1</span>
+            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.17.0-rc</span>
           </div>
           <button
             onClick={onToggleCollapse}

--- a/electron.mjs
+++ b/electron.mjs
@@ -3390,8 +3390,44 @@ function setupFileOperationHandlers() {
     }
   });
 
-  ipcMain.handle('finalize-cache-write', async (event, { cacheId, record }) => {
+  const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  ipcMain.handle('finalize-cache-write', async (event, { cacheId, sourceCacheId, record }) => {
     try {
+      const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
+      const safeSourceCacheId = sourceCacheId?.replace(/[^a-zA-Z0-9-_]/g, '_');
+      if (safeSourceCacheId && safeSourceCacheId !== safeCacheId) {
+        const rootPath = await getCacheRootPath();
+        const cacheDir = path.join(rootPath, 'json_cache');
+        await fs.mkdir(cacheDir, { recursive: true });
+
+        const files = await fs.readdir(cacheDir).catch(error => {
+          if (error.code === 'ENOENT') return [];
+          throw error;
+        });
+        const targetChunkPattern = new RegExp(`^${escapeRegExp(safeCacheId)}_(\\d+)\\.json$`);
+        const sourceChunkPattern = new RegExp(`^${escapeRegExp(safeSourceCacheId)}_(\\d+)\\.json$`);
+
+        await Promise.all(
+          files
+            .filter(file => targetChunkPattern.test(file))
+            .map(file => fs.unlink(path.join(cacheDir, file)).catch(err => {
+              if (err.code !== 'ENOENT') throw err;
+            }))
+        );
+
+        for (const file of files) {
+          const match = file.match(sourceChunkPattern);
+          if (!match) {
+            continue;
+          }
+          await fs.rename(
+            path.join(cacheDir, file),
+            path.join(cacheDir, `${safeCacheId}_${match[1]}.json`)
+          );
+        }
+      }
+
       const mainCachePath = await getCacheFilePath(cacheId);
       // Add parser version to cache record
       const recordWithVersion = { ...record, parserVersion: PARSER_VERSION };

--- a/electron.mjs
+++ b/electron.mjs
@@ -37,16 +37,34 @@ const __dirname = path.dirname(__filename);
 const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 const gpuMitigationEnabled = process.env.IMH_DISABLE_GPU === '1' || process.env.IMH_DISABLE_GPU === 'true';
 const mediaSafeModeEnabled = process.platform === 'darwin' && (process.env.IMH_MEDIA_SAFE_MODE === '1' || process.env.IMH_MEDIA_SAFE_MODE === 'true');
+const audioDiagnosticModeEnabled = process.platform === 'darwin' && (process.env.IMH_AUDIO_DIAGNOSTIC_MODE === '1' || process.env.IMH_AUDIO_DIAGNOSTIC_MODE === 'true');
+const enabledMediaCommandLineSwitches = [];
+const disabledChromiumFeatures = new Set();
 
 if (gpuMitigationEnabled || mediaSafeModeEnabled) {
   app.disableHardwareAcceleration();
+  enabledMediaCommandLineSwitches.push('disable-hardware-acceleration');
   console.warn(`[GPU] Hardware acceleration disabled via ${mediaSafeModeEnabled ? 'IMH_MEDIA_SAFE_MODE' : 'IMH_DISABLE_GPU'}.`);
 }
 
 if (mediaSafeModeEnabled) {
   app.commandLine.appendSwitch('disable-accelerated-video-decode');
   app.commandLine.appendSwitch('disable-gpu-compositing');
+  enabledMediaCommandLineSwitches.push('disable-accelerated-video-decode', 'disable-gpu-compositing');
+  disabledChromiumFeatures.add('AudioServiceSandbox');
   console.warn('[Media] macOS media safe mode enabled via IMH_MEDIA_SAFE_MODE.');
+}
+
+if (audioDiagnosticModeEnabled) {
+  disabledChromiumFeatures.add('AudioServiceSandbox');
+  disabledChromiumFeatures.add('AudioServiceOutOfProcess');
+  console.warn('[Media] macOS audio diagnostic mode enabled via IMH_AUDIO_DIAGNOSTIC_MODE.');
+}
+
+if (disabledChromiumFeatures.size > 0) {
+  const disableFeaturesValue = Array.from(disabledChromiumFeatures).join(',');
+  app.commandLine.appendSwitch('disable-features', disableFeaturesValue);
+  enabledMediaCommandLineSwitches.push(`disable-features=${disableFeaturesValue}`);
 }
 
 app.commandLine.appendSwitch('js-flags', '--max-old-space-size=4096');
@@ -876,12 +894,35 @@ function logProcessEvent(details = {}) {
   }
 }
 
+const audioServiceCrashSummary = new Map();
+let audioServiceCrashTotal = 0;
+
+function logAudioServiceCrashSummary(details = {}) {
+  const reason = details?.reason ?? 'unknown';
+  const exitCode = details?.exitCode ?? 'unknown';
+  const key = `${reason}:${exitCode}`;
+  const count = (audioServiceCrashSummary.get(key) ?? 0) + 1;
+  audioServiceCrashSummary.set(key, count);
+  audioServiceCrashTotal += 1;
+
+  logProcessEvent({
+    kind: 'audio-service-crash-summary',
+    serviceName: 'audio.mojom.AudioService',
+    reason,
+    exitCode,
+    count,
+    totalCount: audioServiceCrashTotal,
+  });
+}
+
 function registerProcessDiagnostics() {
   logProcessEvent({
     kind: 'app-startup',
     logs: getDiagnosticsLogPaths(),
     gpuMitigationEnabled,
     mediaSafeModeEnabled,
+    audioDiagnosticModeEnabled,
+    mediaCommandLineSwitches: enabledMediaCommandLineSwitches,
     gpuFeatureStatus: app.getGPUFeatureStatus?.() ?? null,
   });
 
@@ -895,6 +936,10 @@ function registerProcessDiagnostics() {
       serviceName: details?.serviceName ?? null,
       name: details?.name ?? null,
     });
+
+    if (details?.serviceName === 'audio.mojom.AudioService') {
+      logAudioServiceCrashSummary(details);
+    }
   });
 
   app.on('gpu-process-crashed', (_event, killed) => {
@@ -3064,6 +3109,33 @@ function setupFileOperationHandlers() {
       return { success: true };
     } catch (error) {
       return { success: false, error: error?.message || 'Failed to open external URL.' };
+    }
+  });
+
+  ipcMain.handle('open-path', async (event, filePath) => {
+    try {
+      if (!filePath) {
+        return { success: false, error: 'No path provided.' };
+      }
+
+      const normalizedFilePath = path.resolve(filePath);
+      if (!isPathAllowed(normalizedFilePath)) {
+        console.error('SECURITY VIOLATION: Attempted to open path outside of allowed directories.');
+        console.error('  [open-path] Requested path:', filePath);
+        console.error('  [open-path] Normalized path:', normalizedFilePath);
+        console.error('  [open-path] Allowed directories:', Array.from(allowedDirectoryPaths));
+        return { success: false, error: 'Access denied', errorType: 'PERMISSION_DENIED' };
+      }
+
+      const openError = await shell.openPath(normalizedFilePath);
+      if (openError) {
+        return { success: false, error: openError };
+      }
+
+      return { success: true };
+    } catch (error) {
+      console.error('Failed to open path:', error);
+      return { success: false, error: error?.message || 'Failed to open path.' };
     }
   });
 

--- a/electron.mjs
+++ b/electron.mjs
@@ -3290,7 +3290,28 @@ function setupFileOperationHandlers() {
     const filePath = await getCacheFilePath(cacheId);
     try {
       const data = await fs.readFile(filePath, 'utf-8');
-      return { success: true, data: JSON.parse(data) };
+      const parsed = JSON.parse(data);
+      const chunkCount = parsed?.chunkCount ?? 0;
+      if (chunkCount > 0) {
+        const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
+        const rootPath = await getCacheRootPath();
+        const cacheDir = path.join(rootPath, 'json_cache');
+        const maxChunkBytes = 64 * 1024 * 1024;
+
+        for (let i = 0; i < chunkCount; i += 1) {
+          const chunkPath = path.join(cacheDir, `${safeCacheId}_${i}.json`);
+          const stats = await fs.stat(chunkPath).catch(error => {
+            if (error.code === 'ENOENT') return null;
+            throw error;
+          });
+
+          if (stats && stats.size > maxChunkBytes) {
+            console.warn(`⚠️ Cache chunk too large for ${cacheId}: chunk=${i}, bytes=${stats.size}. Invalidating cache to avoid renderer freeze.`);
+            return { success: true, data: null };
+          }
+        }
+      }
+      return { success: true, data: parsed };
     } catch (error) {
       if (error.code === 'ENOENT') {
         return { success: true, data: null };
@@ -3322,7 +3343,8 @@ function setupFileOperationHandlers() {
     }
   });
 
-  const CHUNK_SIZE = 5000; // Store 5000 images per chunk file
+  const CHUNK_SIZE = 1024; // Keep cache chunks small enough to parse without freezing the renderer
+  const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
   ipcMain.handle('cache-data', async (event, { cacheId, data }) => {
     const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
@@ -3357,9 +3379,10 @@ function setupFileOperationHandlers() {
 
       try {
         const files = await fs.readdir(cacheDir);
+        const chunkPattern = new RegExp(`^${escapeRegExp(safeCacheId)}_(\\d+)\\.json$`);
         await Promise.all(
           files
-            .filter(file => file.startsWith(`${safeCacheId}_`))
+            .filter(file => chunkPattern.test(file))
             .map(file => fs.unlink(path.join(cacheDir, file)).catch(err => {
               if (err.code !== 'ENOENT') throw err;
             }))
@@ -3389,8 +3412,6 @@ function setupFileOperationHandlers() {
       return { success: false, error: error.message };
     }
   });
-
-  const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
   ipcMain.handle('finalize-cache-write', async (event, { cacheId, sourceCacheId, record }) => {
     try {

--- a/electron.mjs
+++ b/electron.mjs
@@ -2168,7 +2168,7 @@ async function createWindow(startupDirectory = null) {
     mainWindow.setTitle(`Image MetaHub v${appVersion}`);
   } catch {
     // Fallback if app.getVersion is not available
-    mainWindow.setTitle('Image MetaHub v0.17.0-rc');
+    mainWindow.setTitle('Image MetaHub v0.17.0');
   }
 
   // Load the app

--- a/electron.mjs
+++ b/electron.mjs
@@ -73,6 +73,13 @@ app.commandLine.appendSwitch('js-flags', '--max-old-space-size=4096');
 // This ensures cache is invalidated when parsing rules change
 const PARSER_VERSION = 7; // v7: Add audio media indexing and metadata
 
+const logMainPerf = (event, details = {}) => {
+  console.log('[main:perf]', { event, ...details });
+};
+
+const elapsedMs = (start) => Number((Date.now() - start).toFixed(2));
+const isSlowMainOp = (start, thresholdMs = 500) => Date.now() - start >= thresholdMs;
+
 // Get platform-specific icon
 function getIconPath() {
   if (process.platform === 'win32') {
@@ -2467,6 +2474,9 @@ function shouldIgnoreScanDirectory(fullPath, baseDirectory) {
 async function getFilesRecursively(directory, baseDirectory) {
   const files = [];
   const directoriesToVisit = [directory];
+  const start = Date.now();
+  let directoriesVisited = 0;
+  let directoriesSkipped = 0;
 
   while (directoriesToVisit.length > 0) {
     const currentDirectory = directoriesToVisit.pop();
@@ -2475,8 +2485,10 @@ async function getFilesRecursively(directory, baseDirectory) {
     }
 
     if (shouldIgnoreScanDirectory(currentDirectory, baseDirectory)) {
+      directoriesSkipped += 1;
       continue;
     }
+    directoriesVisited += 1;
 
     try {
       const entries = await fs.readdir(currentDirectory, { withFileTypes: true });
@@ -2497,6 +2509,13 @@ async function getFilesRecursively(directory, baseDirectory) {
     }
   }
 
+  logMainPerf('list-directory-files:recursive-walk', {
+    baseDirectory,
+    directoriesVisited,
+    directoriesSkipped,
+    files: files.length,
+    durationMs: elapsedMs(start),
+  });
   return files;
 }
 
@@ -3289,6 +3308,7 @@ function setupFileOperationHandlers() {
   });
 
   ipcMain.handle('get-cache-summary', async (event, cacheId) => {
+    const start = Date.now();
     const filePath = await getCacheFilePath(cacheId);
     try {
       const data = await fs.readFile(filePath, 'utf-8');
@@ -3309,15 +3329,37 @@ function setupFileOperationHandlers() {
 
           if (stats && stats.size > maxChunkBytes) {
             console.warn(`⚠️ Cache chunk too large for ${cacheId}: chunk=${i}, bytes=${stats.size}. Invalidating cache to avoid renderer freeze.`);
+            logMainPerf('get-cache-summary:oversized-chunk', {
+              cacheId,
+              chunkIndex: i,
+              bytes: stats.size,
+              durationMs: elapsedMs(start),
+            });
             return { success: true, data: null };
           }
         }
       }
+      logMainPerf('get-cache-summary:hit', {
+        cacheId,
+        imageCount: parsed?.imageCount ?? 0,
+        chunkCount,
+        mainRecordBytes: data.length,
+        durationMs: elapsedMs(start),
+      });
       return { success: true, data: parsed };
     } catch (error) {
       if (error.code === 'ENOENT') {
+        logMainPerf('get-cache-summary:miss', {
+          cacheId,
+          durationMs: elapsedMs(start),
+        });
         return { success: true, data: null };
       }
+      logMainPerf('get-cache-summary:error', {
+        cacheId,
+        errorCode: error.code,
+        durationMs: elapsedMs(start),
+      });
       return { success: false, error: error.message };
     }
   });
@@ -3349,6 +3391,7 @@ function setupFileOperationHandlers() {
   const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
   ipcMain.handle('cache-data', async (event, { cacheId, data }) => {
+    const start = Date.now();
     const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
     const { metadata, ...cacheRecord } = data;
     const rootPath = await getCacheRootPath();
@@ -3369,10 +3412,17 @@ function setupFileOperationHandlers() {
     cacheRecord.parserVersion = PARSER_VERSION; // Add parser version
     await fs.writeFile(mainCachePath, JSON.stringify(cacheRecord, null, 2));
 
+    logMainPerf('cache-data:complete', {
+      cacheId,
+      records: metadata.length,
+      chunkCount,
+      durationMs: elapsedMs(start),
+    });
     return { success: true };
   });
 
   ipcMain.handle('prepare-cache-write', async (event, { cacheId }) => {
+    const start = Date.now();
     try {
       const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
       const rootPath = await getCacheRootPath();
@@ -3382,40 +3432,72 @@ function setupFileOperationHandlers() {
       try {
         const files = await fs.readdir(cacheDir);
         const chunkPattern = new RegExp(`^${escapeRegExp(safeCacheId)}_(\\d+)\\.json$`);
+        const matchingFiles = files.filter(file => chunkPattern.test(file));
         await Promise.all(
-          files
-            .filter(file => chunkPattern.test(file))
+          matchingFiles
             .map(file => fs.unlink(path.join(cacheDir, file)).catch(err => {
               if (err.code !== 'ENOENT') throw err;
             }))
         );
+        logMainPerf('prepare-cache-write:cleanup', {
+          cacheId,
+          removedChunks: matchingFiles.length,
+          durationMs: elapsedMs(start),
+        });
       } catch (error) {
         if (error.code !== 'ENOENT') {
           throw error;
         }
       }
 
+      logMainPerf('prepare-cache-write:complete', {
+        cacheId,
+        durationMs: elapsedMs(start),
+      });
       return { success: true };
     } catch (error) {
+      logMainPerf('prepare-cache-write:error', {
+        cacheId,
+        errorCode: error.code,
+        durationMs: elapsedMs(start),
+      });
       return { success: false, error: error.message };
     }
   });
 
   ipcMain.handle('write-cache-chunk', async (event, { cacheId, chunkIndex, data }) => {
+    const start = Date.now();
     try {
       const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
       const rootPath = await getCacheRootPath();
       const cacheDir = path.join(rootPath, 'json_cache');
       await fs.mkdir(cacheDir, { recursive: true });
       const chunkPath = path.join(cacheDir, `${safeCacheId}_${chunkIndex}.json`);
-      await fs.writeFile(chunkPath, JSON.stringify(data));
+      const json = JSON.stringify(data);
+      await fs.writeFile(chunkPath, json);
+      if (isSlowMainOp(start) || json.length > 8_000_000) {
+        logMainPerf('write-cache-chunk:slow', {
+          cacheId,
+          chunkIndex,
+          records: Array.isArray(data) ? data.length : null,
+          bytes: json.length,
+          durationMs: elapsedMs(start),
+        });
+      }
       return { success: true };
     } catch (error) {
+      logMainPerf('write-cache-chunk:error', {
+        cacheId,
+        chunkIndex,
+        errorCode: error.code,
+        durationMs: elapsedMs(start),
+      });
       return { success: false, error: error.message };
     }
   });
 
   ipcMain.handle('finalize-cache-write', async (event, { cacheId, sourceCacheId, record }) => {
+    const start = Date.now();
     try {
       const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
       const safeSourceCacheId = sourceCacheId?.replace(/[^a-zA-Z0-9-_]/g, '_');
@@ -3431,14 +3513,15 @@ function setupFileOperationHandlers() {
         const targetChunkPattern = new RegExp(`^${escapeRegExp(safeCacheId)}_(\\d+)\\.json$`);
         const sourceChunkPattern = new RegExp(`^${escapeRegExp(safeSourceCacheId)}_(\\d+)\\.json$`);
 
+        const targetFiles = files.filter(file => targetChunkPattern.test(file));
         await Promise.all(
-          files
-            .filter(file => targetChunkPattern.test(file))
+          targetFiles
             .map(file => fs.unlink(path.join(cacheDir, file)).catch(err => {
               if (err.code !== 'ENOENT') throw err;
             }))
         );
 
+        let renamedChunks = 0;
         for (const file of files) {
           const match = file.match(sourceChunkPattern);
           if (!match) {
@@ -3448,28 +3531,66 @@ function setupFileOperationHandlers() {
             path.join(cacheDir, file),
             path.join(cacheDir, `${safeCacheId}_${match[1]}.json`)
           );
+          renamedChunks += 1;
         }
+        logMainPerf('finalize-cache-write:swap-chunks', {
+          cacheId,
+          sourceCacheId,
+          removedTargetChunks: targetFiles.length,
+          renamedChunks,
+          durationMs: elapsedMs(start),
+        });
       }
 
       const mainCachePath = await getCacheFilePath(cacheId);
       // Add parser version to cache record
       const recordWithVersion = { ...record, parserVersion: PARSER_VERSION };
       await fs.writeFile(mainCachePath, JSON.stringify(recordWithVersion, null, 2));
+      logMainPerf('finalize-cache-write:complete', {
+        cacheId,
+        sourceCacheId: sourceCacheId ?? null,
+        imageCount: recordWithVersion.imageCount,
+        chunkCount: recordWithVersion.chunkCount,
+        durationMs: elapsedMs(start),
+      });
       return { success: true };
     } catch (error) {
+      logMainPerf('finalize-cache-write:error', {
+        cacheId,
+        sourceCacheId: sourceCacheId ?? null,
+        errorCode: error.code,
+        durationMs: elapsedMs(start),
+      });
       return { success: false, error: error.message };
     }
   });
 
   ipcMain.handle('get-cache-chunk', async (event, { cacheId, chunkIndex }) => {
+    const start = Date.now();
     const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
     const rootPath = await getCacheRootPath();
     const cacheDir = path.join(rootPath, 'json_cache');
     const chunkPath = path.join(cacheDir, `${safeCacheId}_${chunkIndex}.json`);
     try {
       const data = await fs.readFile(chunkPath, 'utf-8');
-      return { success: true, data: JSON.parse(data) };
+      const parsed = JSON.parse(data);
+      if (isSlowMainOp(start) || data.length > 8_000_000) {
+        logMainPerf('get-cache-chunk:slow', {
+          cacheId,
+          chunkIndex,
+          bytes: data.length,
+          records: Array.isArray(parsed) ? parsed.length : null,
+          durationMs: elapsedMs(start),
+        });
+      }
+      return { success: true, data: parsed };
     } catch (error) {
+      logMainPerf('get-cache-chunk:error', {
+        cacheId,
+        chunkIndex,
+        errorCode: error.code,
+        durationMs: elapsedMs(start),
+      });
       return { success: false, error: error.message };
     }
   });
@@ -4272,12 +4393,11 @@ function setupFileOperationHandlers() {
 
   // Handle listing directory files
   ipcMain.handle('list-directory-files', async (event, { dirPath, recursive = false }) => {
+    const scanStart = Date.now();
     try {
       if (!dirPath) {
         return { success: false, error: 'No directory path provided' };
       }
-
-      const scanStart = Date.now();
 
       let imageFiles = [];
 
@@ -4289,10 +4409,22 @@ function setupFileOperationHandlers() {
       }
 
       console.log(`[list-directory-files] ${dirPath} (${recursive ? 'recursive' : 'flat'}) -> ${imageFiles.length} files in ${((Date.now() - scanStart) / 1000).toFixed(2)}s`);
+      logMainPerf('list-directory-files:complete', {
+        dirPath,
+        recursive,
+        files: imageFiles.length,
+        durationMs: elapsedMs(scanStart),
+      });
 
       return { success: true, files: imageFiles };
     } catch (error) {
       console.error('Error listing directory files:', error);
+      logMainPerf('list-directory-files:error', {
+        dirPath,
+        recursive,
+        errorCode: error.code,
+        durationMs: elapsedMs(scanStart ?? Date.now()),
+      });
       return { success: false, error: error.message };
     }
   });

--- a/electron.mjs
+++ b/electron.mjs
@@ -3253,6 +3253,8 @@ function setupFileOperationHandlers() {
     };
   });
 
+  ipcMain.handle('get-zoom-factor', () => getMainWindowZoomFactor());
+
   ipcMain.handle('get-app-version', () => {
     return app.getVersion();
   });

--- a/electron.mjs
+++ b/electron.mjs
@@ -2168,7 +2168,7 @@ async function createWindow(startupDirectory = null) {
     mainWindow.setTitle(`Image MetaHub v${appVersion}`);
   } catch {
     // Fallback if app.getVersion is not available
-    mainWindow.setTitle('Image MetaHub v0.16.1');
+    mainWindow.setTitle('Image MetaHub v0.17.0-rc');
   }
 
   // Load the app

--- a/hooks/useGenerateWithComfyUI.ts
+++ b/hooks/useGenerateWithComfyUI.ts
@@ -25,6 +25,7 @@ interface GenerateStatus {
 export interface GenerateParams {
   customMetadata?: Partial<BaseMetadata>;
   overrides?: WorkflowOverrides;
+  directoryPath?: string;
   workflowMode?: ComfyUIWorkflowMode;
   sourceImagePolicy?: ComfyUISourceImagePolicy;
   advancedPromptJson?: string;
@@ -76,6 +77,7 @@ export function useGenerateWithComfyUI() {
           provider: 'comfyui',
           customMetadata: params?.customMetadata,
           overrides: params?.overrides,
+          directoryPath: params?.directoryPath,
           workflowMode: params?.workflowMode,
           sourceImagePolicy: params?.sourceImagePolicy,
           advancedPromptJson: params?.advancedPromptJson,

--- a/hooks/useGenerateWithComfyUI.ts
+++ b/hooks/useGenerateWithComfyUI.ts
@@ -44,7 +44,7 @@ export function useGenerateWithComfyUI() {
       setIsGenerating(true);
       const metadata = mergeNormalizedMetadata(image, params?.customMetadata);
 
-      if (!hasPromptMetadata(metadata)) {
+      if (params?.workflowMode !== 'upscale' && !hasPromptMetadata(metadata)) {
         setIsGenerating(false);
         setGenerateStatus({
           success: false,

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -13,6 +13,16 @@ const log = (...args: any[]) => DEBUG && console.log(...args);
 const warn = (...args: any[]) => DEBUG && console.warn(...args);
 const error = (...args: any[]) => console.error(...args); // Keep error logging for critical issues
 
+const logIndexingPerf = (
+    event: string,
+    details: Record<string, unknown> = {}
+) => {
+    console.log('[indexing:perf]', { event, ...details });
+};
+
+const toFixedMs = (durationMs: number) => Number(durationMs.toFixed(2));
+const isSlowRendererOp = (durationMs: number, thresholdMs = 100) => durationMs >= thresholdMs;
+
 // Throttle function for progress updates to avoid excessive re-renders
 function throttle<T extends (...args: any[]) => any>(func: T, delay: number): T {
   let timeoutId: NodeJS.Timeout | null = null;
@@ -388,6 +398,7 @@ export function useImageLoader() {
             suppressSuccessMessage?: boolean;
         } = {}
     ) => {
+        const finalizeStart = performance.now();
         const suppressIndexingState = options.suppressIndexingState ?? false;
         const suppressSuccessMessage = options.suppressSuccessMessage ?? false;
 
@@ -401,13 +412,23 @@ export function useImageLoader() {
         // Flush any pending batched image inserts before final counts
         const flushPending = useImageStore.getState().flushPendingImages;
         if (flushPending) {
+            const flushPendingStart = performance.now();
             flushPending();
+            logIndexingPerf('finalize:flush-pending-images', {
+                directoryId: directory.id,
+                durationMs: toFixedMs(performance.now() - flushPendingStart),
+            });
         }
         
         // Wait a bit to ensure all images are added to the store
         await new Promise(resolve => setTimeout(resolve, 100));
         
         const finalDirectoryImages = useImageStore.getState().images.filter(img => img.directoryId === directory.id);
+        logIndexingPerf('finalize:count-images', {
+            directoryId: directory.id,
+            finalDirectoryImages: finalDirectoryImages.length,
+            durationMs: toFixedMs(performance.now() - finalizeStart),
+        });
 
         traceCacheDebug('loader:finalizeDirectoryLoad:beforeRefresh', () => ({
             directoryId: directory.id,
@@ -469,6 +490,12 @@ export function useImageLoader() {
             delete (window as any)[finalizationKey];
             completedTimeoutRef.current = null;
         }, 3000);
+        logIndexingPerf('finalize:complete', {
+            directoryId: directory.id,
+            finalDirectoryImages: finalDirectoryImages.length,
+            suppressIndexingState,
+            durationMs: toFixedMs(performance.now() - finalizeStart),
+        });
     }, [refreshLineageDirectorySignature, setSuccess, setLoading, setIndexingState, setProgress, setDirectoryRefreshing]);
 
     const CACHE_HYDRATE_FLUSH_SIZE = 2048;
@@ -496,7 +523,16 @@ export function useImageLoader() {
         }
 
         const shouldScanSubfolders = useImageStore.getState().scanSubfolders;
+        const start = performance.now();
         const summary = await cacheManager.getCacheSummary(directory.path, shouldScanSubfolders);
+        logIndexingPerf('lineage-signature-refresh', {
+            directoryId: directory.id,
+            directoryName: directory.name,
+            durationMs: toFixedMs(performance.now() - start),
+            hasSummary: Boolean(summary),
+            imageCount: summary?.imageCount ?? 0,
+            chunkCount: summary?.chunkCount ?? 0,
+        });
         if (!summary) {
             setLineageDirectorySignature(directory.id, null);
             return;
@@ -531,7 +567,17 @@ export function useImageLoader() {
         const shouldScanSubfolders = useImageStore.getState().scanSubfolders;
         await cacheManager.init();
 
+        const listStart = performance.now();
         const allCurrentFiles = await getDirectoryFiles(activeDirectory.handle, activeDirectory.path, shouldScanSubfolders);
+        logIndexingPerf('startup-reconcile:list-files', {
+            directoryId: activeDirectory.id,
+            directoryName: activeDirectory.name,
+            scanSubfolders: shouldScanSubfolders,
+            files: allCurrentFiles.length,
+            durationMs: toFixedMs(performance.now() - listStart),
+        });
+
+        const statsMapStart = performance.now();
         const fileStatsMap = new Map(
             allCurrentFiles.map(file => [file.name, {
                 size: file.size,
@@ -540,8 +586,14 @@ export function useImageLoader() {
                 contentModifiedMs: file.contentModifiedMs ?? file.lastModified,
             }])
         );
+        logIndexingPerf('startup-reconcile:build-stats-map', {
+            directoryId: activeDirectory.id,
+            files: allCurrentFiles.length,
+            durationMs: toFixedMs(performance.now() - statsMapStart),
+        });
 
         const preferLightweightReconcile = allCurrentFiles.length >= 10000;
+        const diffStart = performance.now();
         const diff = await cacheManager.validateCacheAndGetDiff(
             activeDirectory.path,
             activeDirectory.name,
@@ -550,6 +602,16 @@ export function useImageLoader() {
             undefined,
             { includeCachedImages: !preferLightweightReconcile },
         );
+        logIndexingPerf('startup-reconcile:cache-diff', {
+            directoryId: activeDirectory.id,
+            currentFiles: allCurrentFiles.length,
+            cachedImages: diff.cachedImages.length,
+            newAndModifiedFiles: diff.newAndModifiedFiles.length,
+            deletedFileIds: diff.deletedFileIds.length,
+            needsFullRefresh: diff.needsFullRefresh,
+            lightweightCandidate: preferLightweightReconcile,
+            durationMs: toFixedMs(performance.now() - diffStart),
+        });
         const useLightweightReconcile = preferLightweightReconcile && !diff.needsFullRefresh;
 
         traceCacheDebug('loader:reconcileCachedDirectory:diff', () => ({
@@ -599,7 +661,20 @@ export function useImageLoader() {
                     : [];
 
                 const fileHandles = sortedFilesWithStats.length > 0
-                    ? await getFileHandles(activeDirectory.handle, activeDirectory.path, sortedFilesWithStats)
+                    ? await (() => {
+                        const handlesStart = performance.now();
+                        return getFileHandles(activeDirectory.handle, activeDirectory.path, sortedFilesWithStats)
+                            .then((handles) => {
+                                logIndexingPerf('startup-reconcile:create-handles', {
+                                    directoryId: activeDirectory.id,
+                                    files: sortedFilesWithStats.length,
+                                    handles: handles.length,
+                                    mode: 'lightweight',
+                                    durationMs: toFixedMs(performance.now() - handlesStart),
+                                });
+                                return handles;
+                            });
+                    })()
                     : [];
                 const cacheUpserts: IndexedImage[] = [];
 
@@ -631,7 +706,15 @@ export function useImageLoader() {
                     }
                 );
 
+                const phaseBStart = performance.now();
                 await phaseB;
+                logIndexingPerf('startup-reconcile:phase-b-complete', {
+                    directoryId: activeDirectory.id,
+                    mode: 'lightweight',
+                    cacheUpserts: cacheUpserts.length,
+                    durationMs: toFixedMs(performance.now() - phaseBStart),
+                });
+                const deltaStart = performance.now();
                 await cacheManager.applyChunkedCacheDelta(
                     activeDirectory.path,
                     activeDirectory.name,
@@ -640,6 +723,13 @@ export function useImageLoader() {
                     [],
                     shouldScanSubfolders
                 );
+                logIndexingPerf('startup-reconcile:cache-delta', {
+                    directoryId: activeDirectory.id,
+                    mode: 'lightweight',
+                    upserts: cacheUpserts.length,
+                    removed: diff.deletedFileIds.length + changedIds.length,
+                    durationMs: toFixedMs(performance.now() - deltaStart),
+                });
                 await refreshLineageDirectorySignature(activeDirectory);
                 scheduleLineageRebuild(800);
                 traceCacheDebug('loader:reconcileCachedDirectory:lightweightComplete', () => ({
@@ -685,7 +775,20 @@ export function useImageLoader() {
                 : [];
 
             const fileHandles = sortedFilesWithStats.length > 0
-                ? await getFileHandles(activeDirectory.handle, activeDirectory.path, sortedFilesWithStats)
+                ? await (() => {
+                    const handlesStart = performance.now();
+                    return getFileHandles(activeDirectory.handle, activeDirectory.path, sortedFilesWithStats)
+                        .then((handles) => {
+                            logIndexingPerf('startup-reconcile:create-handles', {
+                                directoryId: activeDirectory.id,
+                                files: sortedFilesWithStats.length,
+                                handles: handles.length,
+                                mode: 'full',
+                                durationMs: toFixedMs(performance.now() - handlesStart),
+                            });
+                            return handles;
+                        });
+                })()
                 : [];
 
             const { phaseB } = await processFiles(
@@ -724,7 +827,13 @@ export function useImageLoader() {
                 }
             );
 
+            const phaseBStart = performance.now();
             await phaseB;
+            logIndexingPerf('startup-reconcile:phase-b-complete', {
+                directoryId: activeDirectory.id,
+                mode: 'full',
+                durationMs: toFixedMs(performance.now() - phaseBStart),
+            });
             await refreshLineageDirectorySignature(activeDirectory);
             scheduleLineageRebuild(800);
             traceCacheDebug('loader:reconcileCachedDirectory:complete', () => ({
@@ -790,10 +899,21 @@ export function useImageLoader() {
 
 
     const loadDirectoryFromCache = useCallback(async (directory: Directory) => {
+        const loadStart = performance.now();
         try {
             await cacheManager.init();
             const shouldScanSubfolders = useImageStore.getState().scanSubfolders;
+            const summaryStart = performance.now();
             const cachedData = await cacheManager.getCacheSummary(directory.path, shouldScanSubfolders);
+            logIndexingPerf('cache-hydrate:summary', {
+                directoryId: directory.id,
+                directoryName: directory.name,
+                scanSubfolders: shouldScanSubfolders,
+                hasCache: Boolean(cachedData),
+                imageCount: cachedData?.imageCount ?? 0,
+                chunkCount: cachedData?.chunkCount ?? 0,
+                durationMs: toFixedMs(performance.now() - summaryStart),
+            });
 
             if (cachedData && cachedData.imageCount > 0) {
                 setLineageDirectorySignature(directory.id, {
@@ -809,6 +929,11 @@ export function useImageLoader() {
                 const hydratedImagesBuffer: IndexedImage[] = [];
                 let hasHydratedDirectory = false;
                 let cacheWarmupScheduled = false;
+                let chunksLoaded = 0;
+                let flushCount = 0;
+                let totalJoinPathsMs = 0;
+                let totalMapImagesMs = 0;
+                let totalFlushMs = 0;
                 setProgress({ current: 0, total: cachedData.imageCount });
                 setDirectoryProgress(directory.id, { current: 0, total: cachedData.imageCount });
 
@@ -818,6 +943,7 @@ export function useImageLoader() {
                     }
 
                     const batch = hydratedImagesBuffer.splice(0, hydratedImagesBuffer.length);
+                    const flushStart = performance.now();
 
                     if (!hasHydratedDirectory) {
                         replaceDirectoryImagesRaw(directory.id, batch);
@@ -833,6 +959,8 @@ export function useImageLoader() {
 
                     // Yield between large cache batches to keep the renderer responsive.
                     await new Promise(resolve => setTimeout(resolve, 0));
+                    flushCount += 1;
+                    totalFlushMs += performance.now() - flushStart;
                 };
 
                 await cacheManager.iterateCachedMetadata(directory.path, shouldScanSubfolders, async (metadataChunk) => {
@@ -846,7 +974,9 @@ export function useImageLoader() {
 
                     // Use batch path joining for optimal performance
                     const fileNames = metadataChunk.map(meta => meta.name);
+                    const joinStart = performance.now();
                     const batchResult = await electronAPI.joinPathsBatch({ basePath: directory.path, fileNames });
+                    totalJoinPathsMs += performance.now() - joinStart;
 
                     let filePaths: string[];
                     if (batchResult.success && batchResult.paths) {
@@ -857,6 +987,7 @@ export function useImageLoader() {
                         filePaths = fileNames.map(name => `${directory.path}/${name}`);
                     }
 
+                    const mapStart = performance.now();
                     const chunkImages: IndexedImage[] = metadataChunk.map((meta, i) => {
                         const filePath = filePaths[i];
 
@@ -871,6 +1002,8 @@ export function useImageLoader() {
                             thumbnailError: null,
                         };
                     });
+                    totalMapImagesMs += performance.now() - mapStart;
+                    chunksLoaded += 1;
 
                     const validImages = chunkImages.filter(image => {
                         const fileHandle = image.thumbnailHandle || image.handle;
@@ -900,9 +1033,26 @@ export function useImageLoader() {
                     log(`Loaded ${totalLoaded} images from cache for ${directory.name}`);
                 }
                 setDirectoryProgress(directory.id, null);
+                logIndexingPerf('cache-hydrate:complete', {
+                    directoryId: directory.id,
+                    directoryName: directory.name,
+                    totalLoaded,
+                    totalFilteredOut,
+                    chunksLoaded,
+                    flushCount,
+                    joinPathsMs: toFixedMs(totalJoinPathsMs),
+                    mapImagesMs: toFixedMs(totalMapImagesMs),
+                    storeFlushMs: toFixedMs(totalFlushMs),
+                    durationMs: toFixedMs(performance.now() - loadStart),
+                });
             } else {
                 setLineageDirectorySignature(directory.id, null);
                 setDirectoryProgress(directory.id, null);
+                logIndexingPerf('cache-hydrate:miss', {
+                    directoryId: directory.id,
+                    directoryName: directory.name,
+                    durationMs: toFixedMs(performance.now() - loadStart),
+                });
             }
         } catch (err) {
             error(`Failed to load directory from cache ${directory.name}:`, err);
@@ -921,6 +1071,7 @@ export function useImageLoader() {
             suppressErrorMessage?: boolean;
         } = {}
     ) => {
+        const loadStart = performance.now();
         const suppressIndexingState = isUpdate;
         const suppressSuccessMessage = options.suppressSuccessMessage ?? false;
         const suppressErrorMessage = options.suppressErrorMessage ?? false;
@@ -958,7 +1109,13 @@ export function useImageLoader() {
             if (getIsElectron()) {
                 const electronAPI = window.electronAPI;
                 const allPaths = useImageStore.getState().directories.map(d => d.path);
+                const allowedPathsStart = performance.now();
                 await electronAPI?.updateAllowedPaths(allPaths);
+                logIndexingPerf('load-directory:update-allowed-paths', {
+                    directoryId: directory.id,
+                    pathCount: allPaths.length,
+                    durationMs: toFixedMs(performance.now() - allowedPathsStart),
+                });
             }
 
             await cacheManager.init();
@@ -968,7 +1125,16 @@ export function useImageLoader() {
             const scanPath = refreshPath || directory.path;
             
             // Get files from disk (either full directory or specific subfolder)
+            const listStart = performance.now();
             let allCurrentFiles = await getDirectoryFiles(directory.handle, scanPath, shouldScanSubfolders);
+            logIndexingPerf('load-directory:list-files', {
+                directoryId: directory.id,
+                directoryName: directory.name,
+                scanPath,
+                scanSubfolders: shouldScanSubfolders,
+                files: allCurrentFiles.length,
+                durationMs: toFixedMs(performance.now() - listStart),
+            });
 
             // If we scanned a subfolder, we need to adjust the file paths to be relative to the ROOT directory
             // because the cache expects paths relative to directory.path, not scanPath
@@ -994,6 +1160,7 @@ export function useImageLoader() {
 
             // Pass the relative prefix as the scopePath to validateCacheAndGetDiff
             // This ensures we only delete files within that scope
+            const diffStart = performance.now();
             const diff = await cacheManager.validateCacheAndGetDiff(
                 directory.path, 
                 directory.name, 
@@ -1001,6 +1168,15 @@ export function useImageLoader() {
                 shouldScanSubfolders,
                 refreshPath ? relativePrefix : undefined
             );
+            logIndexingPerf('load-directory:cache-diff', {
+                directoryId: directory.id,
+                currentFiles: allCurrentFiles.length,
+                cachedImages: diff.cachedImages.length,
+                newAndModifiedFiles: diff.newAndModifiedFiles.length,
+                deletedFileIds: diff.deletedFileIds.length,
+                needsFullRefresh: diff.needsFullRefresh,
+                durationMs: toFixedMs(performance.now() - diffStart),
+            });
 
             const isScopedRefresh = Boolean(refreshPath);
             const changedIds = Array.from(new Set(
@@ -1012,7 +1188,12 @@ export function useImageLoader() {
 
             if (shouldUseWriter) {
                 try {
+                    const writerStart = performance.now();
                     cacheWriter = await cacheManager.createIncrementalWriter(directory.path, directory.name, shouldScanSubfolders);
+                    logIndexingPerf('load-directory:init-cache-writer', {
+                        directoryId: directory.id,
+                        durationMs: toFixedMs(performance.now() - writerStart),
+                    });
                 } catch (err) {
                     console.error('Failed to initialize incremental cache writer:', err);
                 }
@@ -1022,17 +1203,28 @@ export function useImageLoader() {
             const shouldHydratePreloadedImages = !isUpdate || diff.needsFullRefresh;
             const regeneratedCachedImages =
                 shouldHydratePreloadedImages && diff.cachedImages.length > 0
-                    ? await getFileHandles(
-                        directory.handle,
-                        directory.path,
-                        diff.cachedImages.map(img => ({
-                            name: img.name,
-                            lastModified: img.lastModified,
-                            size: fileStatsMap.get(img.name)?.size,
-                            type: fileStatsMap.get(img.name)?.type,
-                            contentModifiedMs: fileStatsMap.get(img.name)?.contentModifiedMs,
-                        }))
-                    )
+                    ? await (() => {
+                        const handlesStart = performance.now();
+                        return getFileHandles(
+                            directory.handle,
+                            directory.path,
+                            diff.cachedImages.map(img => ({
+                                name: img.name,
+                                lastModified: img.lastModified,
+                                size: fileStatsMap.get(img.name)?.size,
+                                type: fileStatsMap.get(img.name)?.type,
+                                contentModifiedMs: fileStatsMap.get(img.name)?.contentModifiedMs,
+                            }))
+                        ).then((handles) => {
+                            logIndexingPerf('load-directory:create-preloaded-handles', {
+                                directoryId: directory.id,
+                                cachedImages: diff.cachedImages.length,
+                                handles: handles.length,
+                                durationMs: toFixedMs(performance.now() - handlesStart),
+                            });
+                            return handles;
+                        });
+                    })()
                     : [];
 
             const handleMap = new Map(regeneratedCachedImages.map(h => [h.path, h.handle]));
@@ -1083,7 +1275,19 @@ export function useImageLoader() {
             }));
 
             const fileHandles = sortedFilesWithStats.length > 0
-                ? await getFileHandles(directory.handle, directory.path, sortedFilesWithStats)
+                ? await (() => {
+                    const handlesStart = performance.now();
+                    return getFileHandles(directory.handle, directory.path, sortedFilesWithStats)
+                        .then((handles) => {
+                            logIndexingPerf('load-directory:create-new-handles', {
+                                directoryId: directory.id,
+                                files: sortedFilesWithStats.length,
+                                handles: handles.length,
+                                durationMs: toFixedMs(performance.now() - handlesStart),
+                            });
+                            return handles;
+                        });
+                })()
                 : [];
 
             const totalCatalogItems = preloadedImages.length + totalNewFiles;
@@ -1093,6 +1297,7 @@ export function useImageLoader() {
             }
 
             const handleBatchProcessed = (batch: IndexedImage[]) => {
+                const batchStart = performance.now();
                 if (isScopedRefresh) {
                     for (const image of batch) {
                         scopedCacheUpsertsById.set(image.id, image);
@@ -1104,6 +1309,16 @@ export function useImageLoader() {
                     setDirectoryProgress(directory.id, {
                         current: Math.min(loadedCatalogItems, totalCatalogItems),
                         total: totalCatalogItems,
+                    });
+                }
+                const durationMs = performance.now() - batchStart;
+                if (isSlowRendererOp(durationMs)) {
+                    logIndexingPerf('load-directory:store-catalog-batch:slow', {
+                        directoryId: directory.id,
+                        batchCount: batch.length,
+                        loadedCatalogItems,
+                        totalCatalogItems,
+                        durationMs: toFixedMs(durationMs),
                     });
                 }
             };
@@ -1156,11 +1371,22 @@ export function useImageLoader() {
                 }
 
                 const indexingConcurrency = useSettingsStore.getState().indexingConcurrency ?? 4;
+                logIndexingPerf('load-directory:pipeline-start', {
+                    directoryId: directory.id,
+                    totalCatalogItems,
+                    totalNewFiles,
+                    preloadedImages: preloadedImages.length,
+                    deletedFileIds: diff.deletedFileIds.length,
+                    cacheWriter: Boolean(cacheWriter),
+                    scopedRefresh: isScopedRefresh,
+                    concurrency: indexingConcurrency,
+                });
 
                 setEnrichmentProgress(null);
                 thumbnailManager.cancelQueuedJobs({ queue: 'low' });
                 releaseBackgroundThumbnailPause = thumbnailManager.pauseBackgroundWork();
 
+                const phaseAStart = performance.now();
                 const { phaseB } = await processFiles(
                     fileHandles,
                     throttledSetProgress,
@@ -1181,6 +1407,12 @@ export function useImageLoader() {
                         hydratePreloadedImages: shouldHydratePreloadedImages,
                     }
                 );
+                logIndexingPerf('load-directory:phase-a-returned', {
+                    directoryId: directory.id,
+                    totalCatalogItems,
+                    totalNewFiles,
+                    durationMs: toFixedMs(performance.now() - phaseAStart),
+                });
 
                 const handlePhaseBComplete = () => {
                     releaseThumbnailPause();
@@ -1188,12 +1420,24 @@ export function useImageLoader() {
                     scheduleDirectoryThumbnailWarmup(`directory:${directory.id}:indexed`, indexedImages);
                     // Keep the progress bar visible for 2 seconds after completion
                     setTimeout(() => setEnrichmentProgress(null), 2000);
+                    logIndexingPerf('load-directory:phase-b-followup', {
+                        directoryId: directory.id,
+                        indexedImages: indexedImages.length,
+                        totalElapsedMs: toFixedMs(performance.now() - loadStart),
+                    });
                 };
 
                 if (isScopedRefresh) {
                     try {
+                        const phaseBStart = performance.now();
                         await phaseB;
+                        logIndexingPerf('load-directory:phase-b-complete', {
+                            directoryId: directory.id,
+                            scopedRefresh: true,
+                            durationMs: toFixedMs(performance.now() - phaseBStart),
+                        });
                         if (shouldApplyScopedCacheDelta && getIsElectron()) {
+                            const deltaStart = performance.now();
                             await cacheManager.applyChunkedCacheDelta(
                                 directory.path,
                                 directory.name,
@@ -1202,6 +1446,12 @@ export function useImageLoader() {
                                 [],
                                 shouldScanSubfolders
                             );
+                            logIndexingPerf('load-directory:scoped-cache-delta', {
+                                directoryId: directory.id,
+                                upserts: scopedCacheUpsertsById.size,
+                                removed: diff.deletedFileIds.length + changedIds.length,
+                                durationMs: toFixedMs(performance.now() - deltaStart),
+                            });
                         }
                         handlePhaseBComplete();
                     } catch (err) {
@@ -1215,8 +1465,16 @@ export function useImageLoader() {
                         finalizeDirectoryLoad(directory, { suppressIndexingState, suppressSuccessMessage });
                     }
                 } else {
+                    const phaseBStart = performance.now();
                     phaseB
-                        .then(handlePhaseBComplete)
+                        .then(() => {
+                            logIndexingPerf('load-directory:phase-b-complete', {
+                                directoryId: directory.id,
+                                scopedRefresh: false,
+                                durationMs: toFixedMs(performance.now() - phaseBStart),
+                            });
+                            handlePhaseBComplete();
+                        })
                         .catch(err => {
                             releaseThumbnailPause();
                             console.error('Phase B enrichment failed', err);
@@ -1231,11 +1489,17 @@ export function useImageLoader() {
             } else {
                 releaseThumbnailPause();
                 if (shouldHydratePreloadedImages && preloadedImages.length > 0) {
+                    const preloadStart = performance.now();
                     addImages(preloadedImages);
                     scheduleDirectoryThumbnailWarmup(`directory:${directory.id}:preloaded`, preloadedImages);
                     setDirectoryProgress(directory.id, {
                         current: preloadedImages.length,
                         total: preloadedImages.length,
+                    });
+                    logIndexingPerf('load-directory:add-preloaded-only', {
+                        directoryId: directory.id,
+                        images: preloadedImages.length,
+                        durationMs: toFixedMs(performance.now() - preloadStart),
                     });
                 }
                 finalizeDirectoryLoad(directory, { suppressIndexingState, suppressSuccessMessage });

--- a/hooks/useMediaDiagnostics.ts
+++ b/hooks/useMediaDiagnostics.ts
@@ -20,6 +20,7 @@ export interface MediaDiagnosticsContext {
   fileName: string;
   surface: string;
   src?: string | null;
+  onAudioRendererError?: () => void;
 }
 
 const getSrcScheme = (src?: string | null): string | null => {
@@ -34,11 +35,15 @@ const getMediaErrorMessage = (error: MediaError | null): string | null => {
   return error.message || null;
 };
 
+export const isAudioRendererErrorMessage = (message?: string | null): boolean =>
+  typeof message === 'string' && message.includes('AUDIO_RENDERER_ERROR');
+
 export function useMediaDiagnostics(context: MediaDiagnosticsContext) {
   const logMediaEvent = useCallback(
     (event: SyntheticEvent<HTMLMediaElement>) => {
       const element = event.currentTarget;
       const mediaError = element.error;
+      const errorMessage = getMediaErrorMessage(mediaError);
 
       window.electronAPI?.logMediaPlaybackEvent?.({
         mediaKind: context.mediaKind,
@@ -50,10 +55,14 @@ export function useMediaDiagnostics(context: MediaDiagnosticsContext) {
         readyState: element.readyState,
         networkState: element.networkState,
         errorCode: mediaError?.code ?? null,
-        errorMessage: getMediaErrorMessage(mediaError),
+        errorMessage,
       });
+
+      if (event.type === 'error' && isAudioRendererErrorMessage(errorMessage)) {
+        context.onAudioRendererError?.();
+      }
     },
-    [context.fileName, context.mediaKind, context.src, context.surface],
+    [context.fileName, context.mediaKind, context.onAudioRendererError, context.src, context.surface],
   );
 
   return useMemo(

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Image MetaHub v0.16.1</title>
+  <title>Image MetaHub v0.17.0-rc</title>
   </head>
   <body class="bg-gray-900 text-gray-100">
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Image MetaHub v0.17.0-rc</title>
+  <title>Image MetaHub v0.17.0</title>
   </head>
   <body class="bg-gray-900 text-gray-100">
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-metahub",
-  "version": "0.16.1",
+  "version": "0.17.0-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-metahub",
-      "version": "0.16.1",
+      "version": "0.17.0-rc",
       "dependencies": {
         "archiver": "^7.0.1",
         "cbor-js": "^0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-metahub",
-  "version": "0.17.0-rc",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-metahub",
-      "version": "0.17.0-rc",
+      "version": "0.17.0",
       "dependencies": {
         "archiver": "^7.0.1",
         "cbor-js": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Image MetaHub",
   "author": "LuqP2 <github.com/LuqP2>",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.17.0-rc",
   "type": "module",
   "main": "electron.mjs",
   "homepage": "./",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Image MetaHub",
   "author": "LuqP2 <github.com/LuqP2>",
   "private": true,
-  "version": "0.17.0-rc",
+  "version": "0.17.0",
   "type": "module",
   "main": "electron.mjs",
   "homepage": "./",

--- a/preload.js
+++ b/preload.js
@@ -159,6 +159,7 @@ const electronAPI = {
   saveSettings: (settings) => ipcRenderer.invoke('save-settings', settings),
   launchGenerator: (payload) => ipcRenderer.invoke('launch-generator', payload),
   openExternalUrl: (url) => ipcRenderer.invoke('open-external-url', url),
+  openPath: (filePath) => ipcRenderer.invoke('open-path', filePath),
   comfyUIViewOpen: (payload) => ipcRenderer.invoke('comfy-view-open', payload),
   comfyUIViewShow: (payload) => ipcRenderer.invoke('comfy-view-show', payload),
   comfyUIViewHide: () => ipcRenderer.invoke('comfy-view-hide'),

--- a/preload.js
+++ b/preload.js
@@ -129,6 +129,7 @@ const electronAPI = {
 
   // --- Invokable renderer-to-main functions ---
   getTheme: () => ipcRenderer.invoke('get-theme'),
+  getZoomFactor: () => ipcRenderer.invoke('get-zoom-factor'),
   trashFile: (filePath) => ipcRenderer.invoke('trash-file', filePath),
   renameFile: (oldPath, newPath) => ipcRenderer.invoke('rename-file', oldPath, newPath),
   setCurrentDirectory: (dirPath) => ipcRenderer.invoke('set-current-directory', dirPath),

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,23 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.0] - [Unreleased]
-
-### Improved
-
-- **Image Modal Navigation Performance**: Improved rapid left/right arrow navigation in the image viewer by coalescing repeated key events, using cheaper navigation indexes, and temporarily keeping heavy sidebar rendering out of the hot path while keys are held.
-
-### Fixed
-
-- **Watched File Deletion Stability**: Fixed watched file deletions so cache pruning no longer blocks the renderer, updates both flat and recursive cache variants, and safely rewrites multi-chunk caches without overwriting chunks that are still being read.
-
-## [0.16.1] - [Unreleased]
+## [0.17.0] - 2026-06-05
 
 ### Added
 
+- **Expanded Compare View**: Added new two-image comparison modes, including slider, hover, flicker, difference map, loupe, and edge comparison.
+- **Built-in Image Editor**: Added a new local image editor for still images, with adjustments, crop, rotate, flip, resize, sharpen, blur, annotations, text, highlights, blur/pixelate regions, undo/redo, zoom, Save As, and Overwrite.
+
+
+### Improved
+
+- **Image Editing Tools**: Expanded the previous adjustment panel into a fuller editing workflow with separate controls for adjustments, crop, transform, resize, and enhance tools.
+- **Performance and Responsiveness**: Improved responsiveness in large libraries, faster image viewer navigation, and reduced UI slowdowns during cache updates, file watching, and rapid browsing.
+- **Image Viewer Navigation**: Improved rapid left/right navigation in the image viewer, especially when holding arrow keys through large folders.
+- **Image Viewer Zoom**: Improved fit/actual-size zoom behavior and zoom limits in the image viewer.
+- **ComfyUI Metadata Parsing**: Improved metadata extraction from ComfyUI workflows, including better support for additional node patterns and workflow graph structures.
+- **Edited Image Saving**: Improved Save As and Overwrite behavior for edited images so saved files are refreshed in the library more reliably.
+- **Media Playback Diagnostics**: Improved audio/video playback diagnostics to help identify desktop media playback issues.
+- **Accessibility**: Added more accessible labels and control descriptions across icon-only buttons and editor/viewer controls.
+
+### Fixed
+
+- **Watched File Deletions**: Fixed watched file deletions so removed files are cleared from library cache more reliably without blocking the app.
+- **Image Viewer Performance**: Fixed slowdowns caused by heavy sidebar updates during fast image navigation.
+- **Edited Image Metadata**: Fixed edited image saves so generated PNGs carry updated output size and edit information more consistently.
+- **Video Metadata Parsing**: Improved validation for MetaHub video metadata so invalid fallback metadata is no longer treated as a prompt.
+- **ComfyUI Seed Parsing**: Fixed explicit ComfyUI seed `0` values being treated as missing in some metadata parsing paths.
+
+## [0.16.1] - [2026-05-23]
+
+### Added
+
+- **Image Library Grouping**: Added Library Group By separators for date, name, and inferred generation sessions, plus Jump To navigation with calendar badges for date/session groups and representative thumbnails.
 - **ComfyUI Workflow Actions**: Added richer ComfyUI workflow entry points across the main app, image viewer, grid, and embedded workspace, including workflow action coverage and desktop IPC support for workspace preview behavior.
 - **ComfyUI Workspace Metadata Copying**: Added copy actions for workspace metadata fields and clearer image dimension display in the ComfyUI Workspace context panel.
-- **Image Library Grouping**: Added Library Group By separators for date, name, and inferred generation sessions, plus Jump To navigation with calendar badges for date/session groups and representative thumbnails.
 - **Media Playback Diagnostics**: Added audio/video playback event diagnostics and imh-media protocol logging to help investigate early Electron Helper crashes on macOS.
 
 ### Improved
@@ -29,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Large Library Performance**: Reduced temporary allocations and queue overhead in large libraries by avoiding `Array.shift()` hot paths, removing intermediate arrays during `Set`/`Map` construction, and optimizing lookup map initialization across store, thumbnail, lineage, and automation flows.
 - **ComfyUI Visual Workflow Performance**: Reworked visual workflow graph depth calculation to avoid recursive stack overflows on long workflows and reduced object iteration overhead for large ComfyUI graphs.
 - **Edited PNG Metadata Preservation**: Improved edited PNG saves so ComfyUI workflow metadata is preserved when image adjustment exports write PNG bytes.
-- **Jump To Group Preview UX**: Improved Jump To Group browsing with larger hover previews that follow the cursor while keeping compact thumbnails visible in the group list.
 - **Workspace Bulk Action UX**: Added clearer disabled-state tooltips for ComfyUI Workspace bulk actions so users can tell what selection is required.
 - **Accessibility**: Added missing accessible labels to icon-only controls across the ComfyUI Workspace, directory list, preview/sidebar, image viewer, automation rules, sidebar, and batch export surfaces.
 - **Hotkey Reset Safety**: Added a confirmation dialog before resetting all custom hotkeys.

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -66,6 +66,24 @@ const DEFAULT_INCREMENTAL_CHUNK_SIZE = 1024;
 const MAX_INLINE_RAW_METADATA_BYTES = 32 * 1024;
 const RAW_METADATA_PREVIEW_BYTES = 4096;
 
+const logCachePerf = (
+  event: string,
+  details: Record<string, unknown> = {}
+) => {
+  console.log('[cache:perf]', { event, ...details });
+};
+
+const toFixedMs = (durationMs: number) => Number(durationMs.toFixed(2));
+const isSlow = (durationMs: number, thresholdMs = 500) => durationMs >= thresholdMs;
+
+const estimateJsonBytes = (value: unknown): number | null => {
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return null;
+  }
+};
+
 const isCurrentParserVersion = (parserVersion: number | undefined): boolean => (
   parserVersion === PARSER_VERSION
 );
@@ -252,10 +270,15 @@ class IncrementalCacheWriter {
   }
 
   async initialize(): Promise<void> {
+    const start = performance.now();
     const result = await window.electronAPI?.prepareCacheWrite?.({ cacheId: this.cacheId });
     if (result && !result.success) {
       throw new Error(result.error || 'Failed to prepare cache write');
     }
+    logCachePerf('incremental-writer:initialize', {
+      cacheId: this.cacheId,
+      durationMs: toFixedMs(performance.now() - start),
+    });
   }
 
   async append(images: IndexedImage[], precomputed?: CacheImageMetadata[]): Promise<CacheImageMetadata[]> {
@@ -270,6 +293,7 @@ class IncrementalCacheWriter {
 
     this.writeQueue = this.writeQueue.then(async () => {
       try {
+        const writeStart = performance.now();
         const result = await window.electronAPI?.writeCacheChunk?.({
           cacheId: this.cacheId,
           chunkIndex: chunkNumber,
@@ -278,10 +302,22 @@ class IncrementalCacheWriter {
         if (result && !result.success) {
           throw new Error(result.error || 'Failed to write cache chunk');
         }
+        const durationMs = performance.now() - writeStart;
+        const estimatedBytes = estimateJsonBytes(preparedMetadata);
+        if (isSlow(durationMs) || (estimatedBytes ?? 0) > 8_000_000) {
+          logCachePerf('incremental-writer:append-chunk:slow', {
+            cacheId: this.cacheId,
+            chunkIndex: chunkNumber,
+            images: images.length,
+            estimatedBytes,
+            durationMs: toFixedMs(durationMs),
+          });
+        }
       } catch (err) {
         if (isCloneError(err)) {
           console.warn('[Cache] Cache chunk serialization failed, retrying with sanitized payload.', err);
           preparedMetadata = sanitizeCacheMetadata(metadata, { forceClone: true });
+          const retryStart = performance.now();
           const retry = await window.electronAPI?.writeCacheChunk?.({
             cacheId: this.cacheId,
             chunkIndex: chunkNumber,
@@ -291,6 +327,13 @@ class IncrementalCacheWriter {
             console.error('[Cache] Failed to write cache chunk after sanitization:', retry.error);
             throw new Error(retry.error || 'Failed to write cache chunk');
           }
+          logCachePerf('incremental-writer:append-chunk-retry', {
+            cacheId: this.cacheId,
+            chunkIndex: chunkNumber,
+            images: images.length,
+            estimatedBytes: estimateJsonBytes(preparedMetadata),
+            durationMs: toFixedMs(performance.now() - retryStart),
+          });
           return;
         }
         throw err;
@@ -309,6 +352,7 @@ class IncrementalCacheWriter {
     const preparedMetadata = sanitizeCacheMetadata(metadata);
     this.writeQueue = this.writeQueue.then(async () => {
       try {
+        const writeStart = performance.now();
         const result = await window.electronAPI?.writeCacheChunk?.({
           cacheId: this.cacheId,
           chunkIndex,
@@ -317,11 +361,23 @@ class IncrementalCacheWriter {
         if (result && !result.success) {
           throw new Error(result.error || 'Failed to rewrite cache chunk');
         }
+        const durationMs = performance.now() - writeStart;
+        const estimatedBytes = estimateJsonBytes(preparedMetadata);
+        if (isSlow(durationMs) || (estimatedBytes ?? 0) > 8_000_000) {
+          logCachePerf('incremental-writer:overwrite-chunk:slow', {
+            cacheId: this.cacheId,
+            chunkIndex,
+            records: metadata.length,
+            estimatedBytes,
+            durationMs: toFixedMs(durationMs),
+          });
+        }
       } catch (err) {
         if (isCloneError(err)) {
           console.warn('[Cache] Cache chunk rewrite serialization failed, retrying with sanitized payload.', err);
           const sanitized = sanitizeCacheMetadata(metadata, { forceClone: true });
           metadata.splice(0, metadata.length, ...sanitized);
+          const retryStart = performance.now();
           const retry = await window.electronAPI?.writeCacheChunk?.({
             cacheId: this.cacheId,
             chunkIndex,
@@ -331,6 +387,13 @@ class IncrementalCacheWriter {
             console.error('[Cache] Failed to rewrite cache chunk after sanitization:', retry.error);
             throw new Error(retry.error || 'Failed to rewrite cache chunk');
           }
+          logCachePerf('incremental-writer:overwrite-chunk-retry', {
+            cacheId: this.cacheId,
+            chunkIndex,
+            records: sanitized.length,
+            estimatedBytes: estimateJsonBytes(sanitized),
+            durationMs: toFixedMs(performance.now() - retryStart),
+          });
           return;
         }
         throw err;
@@ -341,6 +404,7 @@ class IncrementalCacheWriter {
   }
 
   async finalize(): Promise<void> {
+    const start = performance.now();
     await this.writeQueue;
 
     const record = {
@@ -357,6 +421,12 @@ class IncrementalCacheWriter {
     if (result && !result.success) {
       throw new Error(result.error || 'Failed to finalize cache write');
     }
+    logCachePerf('incremental-writer:finalize', {
+      cacheId: this.cacheId,
+      imageCount: this.totalImages,
+      chunkCount: this.chunkIndex,
+      durationMs: toFixedMs(performance.now() - start),
+    });
   }
 }
 
@@ -380,15 +450,24 @@ class CacheManager {
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
+    const start = performance.now();
     const result = await summaryFn(cacheId);
 
     if (!result.success) {
       console.error('Failed to get cached data:', result.error);
+      logCachePerf('get-cached-data:error', {
+        cacheId,
+        durationMs: toFixedMs(performance.now() - start),
+      });
       return null;
     }
 
     const summary = result.data;
     if (!summary) {
+      logCachePerf('get-cached-data:miss', {
+        cacheId,
+        durationMs: toFixedMs(performance.now() - start),
+      });
       return null;
     }
     if (!isCurrentParserVersion(summary.parserVersion)) {
@@ -403,8 +482,11 @@ class CacheManager {
 
     if (metadata.length === 0 && chunkCount > 0) {
       const chunks: CacheImageMetadata[] = [];
+      let chunkReadMs = 0;
       for (let i = 0; i < chunkCount; i++) {
+        const chunkStart = performance.now();
         const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex: i });
+        chunkReadMs += performance.now() - chunkStart;
         if (chunkResult.success && Array.isArray(chunkResult.data)) {
           chunks.push(...compactCacheMetadataEntries(chunkResult.data));
         } else if (!chunkResult.success) {
@@ -412,6 +494,12 @@ class CacheManager {
         }
       }
       metadata = chunks;
+      logCachePerf('get-cached-data:chunks-loaded', {
+        cacheId,
+        chunkCount,
+        records: metadata.length,
+        chunkReadMs: toFixedMs(chunkReadMs),
+      });
     }
 
     const cacheEntry: CacheEntry = {
@@ -425,6 +513,12 @@ class CacheManager {
       parserVersion: summary.parserVersion,
     };
 
+    logCachePerf('get-cached-data:hit', {
+      cacheId,
+      records: metadata.length,
+      chunkCount,
+      durationMs: toFixedMs(performance.now() - start),
+    });
     return cacheEntry;
   }
 
@@ -436,12 +530,17 @@ class CacheManager {
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
+    const start = performance.now();
     const result = await summaryFn(cacheId);
 
     if (!result.success || !result.data) {
       if (!result.success) {
         console.error('Failed to get cache summary:', result.error);
       }
+      logCachePerf(result.success ? 'get-cache-summary:miss' : 'get-cache-summary:error', {
+        cacheId,
+        durationMs: toFixedMs(performance.now() - start),
+      });
       return null;
     }
 
@@ -451,6 +550,13 @@ class CacheManager {
       return null;
     }
 
+    logCachePerf('get-cache-summary:hit', {
+      cacheId,
+      imageCount: summary.imageCount ?? 0,
+      chunkCount: summary.chunkCount ?? 0,
+      hasInlineMetadata: Array.isArray(summary.metadata),
+      durationMs: toFixedMs(performance.now() - start),
+    });
     return {
       id: summary.id,
       directoryPath: summary.directoryPath,
@@ -475,12 +581,17 @@ class CacheManager {
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
+    const start = performance.now();
     const result = await summaryFn(cacheId);
 
     if (!result.success || !result.data) {
       if (!result.success) {
         console.error('Failed to iterate cached metadata:', result.error);
       }
+      logCachePerf(result.success ? 'iterate-cached-metadata:miss' : 'iterate-cached-metadata:error', {
+        cacheId,
+        durationMs: toFixedMs(performance.now() - start),
+      });
       return;
     }
 
@@ -492,18 +603,40 @@ class CacheManager {
 
     if (Array.isArray(summary.metadata) && summary.metadata.length > 0) {
       await onChunk(compactCacheMetadataEntries(summary.metadata));
+      logCachePerf('iterate-cached-metadata:inline-complete', {
+        cacheId,
+        records: summary.metadata.length,
+        durationMs: toFixedMs(performance.now() - start),
+      });
       return;
     }
 
     const chunkCount = summary.chunkCount ?? 0;
+    let records = 0;
+    let chunkReadMs = 0;
+    let callbackMs = 0;
     for (let i = 0; i < chunkCount; i++) {
+      const chunkStart = performance.now();
       const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex: i });
+      chunkReadMs += performance.now() - chunkStart;
       if (chunkResult.success && Array.isArray(chunkResult.data) && chunkResult.data.length > 0) {
-        await onChunk(compactCacheMetadataEntries(chunkResult.data));
+        const compacted = compactCacheMetadataEntries(chunkResult.data);
+        records += compacted.length;
+        const callbackStart = performance.now();
+        await onChunk(compacted);
+        callbackMs += performance.now() - callbackStart;
       } else if (!chunkResult.success) {
         console.error(`Failed to load cache chunk ${i} for ${cacheId}:`, chunkResult.error);
       }
     }
+    logCachePerf('iterate-cached-metadata:chunks-complete', {
+      cacheId,
+      chunkCount,
+      records,
+      chunkReadMs: toFixedMs(chunkReadMs),
+      callbackMs: toFixedMs(callbackMs),
+      durationMs: toFixedMs(performance.now() - start),
+    });
   }
 
 
@@ -517,6 +650,7 @@ class CacheManager {
     if (!this.isElectron) return;
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
+    const start = performance.now();
     const metadata = sanitizeCacheMetadata(toCacheMetadata(images), { forceClone: true });
     
     const cacheEntry: CacheEntry = {
@@ -533,6 +667,12 @@ class CacheManager {
     if (!result.success) {
       console.error("Failed to cache data:", result.error);
     }
+    logCachePerf(result.success ? 'cache-data:complete' : 'cache-data:error', {
+      cacheId,
+      images: images.length,
+      metadataBuildAndWriteMs: toFixedMs(performance.now() - start),
+      estimatedBytes: estimateJsonBytes(metadata),
+    });
   }
 
   async appendToCache(
@@ -547,10 +687,16 @@ class CacheManager {
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
+    const start = performance.now();
     const summaryResult = await summaryFn(cacheId);
 
     if (!summaryResult.success || !summaryResult.data) {
       await this.cacheData(directoryPath, directoryName, images, scanSubfolders);
+      logCachePerf('append-to-cache:fallback-cache-data', {
+        cacheId,
+        images: images.length,
+        durationMs: toFixedMs(performance.now() - start),
+      });
       return;
     }
 
@@ -605,6 +751,12 @@ class CacheManager {
     if (!finalizeResult.success) {
       console.error('Failed to finalize appended cache write:', finalizeResult.error);
     }
+    logCachePerf(finalizeResult.success ? 'append-to-cache:complete' : 'append-to-cache:error', {
+      cacheId,
+      images: images.length,
+      chunkCount: chunkIndex,
+      durationMs: toFixedMs(performance.now() - start),
+    });
   }
 
   async createIncrementalWriter(
@@ -731,15 +883,25 @@ class CacheManager {
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
     const outputCacheId = `${cacheId}-delta-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const start = performance.now();
     const summary = await this.getCacheSummary(directoryPath, scanSubfolders);
     if (!summary) {
       if (imagesToUpsert.length > 0) {
         await this.cacheData(directoryPath, directoryName, imagesToUpsert, scanSubfolders);
       }
+      logCachePerf('chunked-delta:fallback-cache-data', {
+        cacheId,
+        upserts: imagesToUpsert.length,
+        removedIds: removedImageIds.length,
+        removedNames: removedImageNames.length,
+        durationMs: toFixedMs(performance.now() - start),
+      });
       return;
     }
 
+    const buildUpsertsStart = performance.now();
     const upserts = sanitizeCacheMetadata(toCacheMetadata(imagesToUpsert), { forceClone: true });
+    const buildUpsertsMs = performance.now() - buildUpsertsStart;
     const pruneIds = [
       ...removedImageIds,
       ...upserts.map((image) => image.id),
@@ -752,6 +914,10 @@ class CacheManager {
     const outputBuffer: CacheImageMetadata[] = [];
     let outputChunkIndex = 0;
     let imageCount = 0;
+    let readChunks = 0;
+    let readChunkMs = 0;
+    let writeChunkMs = 0;
+    let pruneMs = 0;
 
     const flushOutputChunk = async (force = false) => {
       if (outputBuffer.length === 0 || (!force && outputBuffer.length < outputChunkSize)) {
@@ -759,11 +925,13 @@ class CacheManager {
       }
 
       const chunk = outputBuffer.splice(0, outputBuffer.length);
+      const writeStart = performance.now();
       const result = await window.electronAPI.writeCacheChunk({
         cacheId: outputCacheId,
         chunkIndex: outputChunkIndex,
         data: chunk,
       });
+      writeChunkMs += performance.now() - writeStart;
 
       if (!result.success) {
         throw new Error(result.error || 'Failed to write cache delta chunk');
@@ -781,24 +949,31 @@ class CacheManager {
     };
 
     if (Array.isArray(summary.metadata) && summary.metadata.length > 0) {
+      const pruneStart = performance.now();
       const pruned = pruneCacheMetadata(summary.metadata, {
         ids: pruneIds,
         names: pruneNames,
       });
+      pruneMs += performance.now() - pruneStart;
       await appendOutputEntries(pruned);
     }
 
     const chunkCount = summary.chunkCount ?? 0;
     for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+      const readStart = performance.now();
       const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex });
+      readChunkMs += performance.now() - readStart;
+      readChunks += 1;
       if (!chunkResult.success || !Array.isArray(chunkResult.data)) {
         throw new Error(chunkResult.error || `Failed to read cache chunk ${chunkIndex}`);
       }
 
+      const pruneStart = performance.now();
       const pruned = pruneCacheMetadata(compactCacheMetadataEntries(chunkResult.data), {
         ids: pruneIds,
         names: pruneNames,
       });
+      pruneMs += performance.now() - pruneStart;
       await appendOutputEntries(pruned);
     }
 
@@ -822,6 +997,22 @@ class CacheManager {
     if (!finalizeResult.success) {
       throw new Error(finalizeResult.error || 'Failed to finalize cache delta');
     }
+    logCachePerf('chunked-delta:complete', {
+      cacheId,
+      outputCacheId,
+      upserts: imagesToUpsert.length,
+      removedIds: removedImageIds.length,
+      removedNames: removedImageNames.length,
+      inputChunks: chunkCount,
+      readChunks,
+      outputChunks: outputChunkIndex,
+      finalImageCount: imageCount,
+      buildUpsertsMs: toFixedMs(buildUpsertsMs),
+      readChunkMs: toFixedMs(readChunkMs),
+      pruneMs: toFixedMs(pruneMs),
+      writeChunkMs: toFixedMs(writeChunkMs),
+      durationMs: toFixedMs(performance.now() - start),
+    });
   }
 
   async replaceCachedImages(
@@ -977,7 +1168,13 @@ class CacheManager {
     scopePath?: string,
     options: { includeCachedImages?: boolean } = {}
   ): Promise<CacheDiff> {
+    const start = performance.now();
     if (!this.isElectron) {
+      logCachePerf('validate-diff:browser-full-refresh', {
+        directoryPath,
+        currentFiles: currentFiles.length,
+        durationMs: toFixedMs(performance.now() - start),
+      });
       return {
         newAndModifiedFiles: currentFiles,
         deletedFileIds: [],
@@ -986,10 +1183,21 @@ class CacheManager {
       };
     }
 
+    const summaryStart = performance.now();
     const cachedSummary = await this.getCacheSummary(directoryPath, scanSubfolders);
+    const summaryMs = performance.now() - summaryStart;
     
     // If no cache exists, all files are new
     if (!cachedSummary) {
+      logCachePerf('validate-diff:no-cache', {
+        directoryPath,
+        directoryName,
+        currentFiles: currentFiles.length,
+        scanSubfolders,
+        scopePath: scopePath ?? null,
+        summaryMs: toFixedMs(summaryMs),
+        durationMs: toFixedMs(performance.now() - start),
+      });
       return {
         newAndModifiedFiles: currentFiles,
         deletedFileIds: [],
@@ -1002,17 +1210,24 @@ class CacheManager {
     const newAndModifiedFiles: { name: string; lastModified: number; size?: number; type?: string; birthtimeMs?: number; contentModifiedMs?: number }[] = [];
     const cachedImages: IndexedImage[] = [];
     const deletedFileIds: string[] = [];
+    const mapStart = performance.now();
     const currentFilesMap = new Map<string, { name: string; lastModified: number; size?: number; type?: string; birthtimeMs?: number; contentModifiedMs?: number }>();
     for (const file of currentFiles) {
       currentFilesMap.set(file.name, file);
     }
+    const currentMapMs = performance.now() - mapStart;
     const seenCachedFileNames = new Set<string>();
 
     // Helper to normalize paths for comparison (ensure forward slashes)
     const normalize = (p: string) => p.replace(/\\/g, '/');
     const normalizedScope = scopePath ? normalize(scopePath) : undefined;
 
+    const iterateStart = performance.now();
+    let cachedRecordsScanned = 0;
+    let cachedChunksScanned = 0;
     await this.iterateCachedMetadata(directoryPath, scanSubfolders, async (cachedChunk) => {
+      cachedChunksScanned += 1;
+      cachedRecordsScanned += cachedChunk.length;
       for (const cachedFile of cachedChunk) {
         seenCachedFileNames.add(cachedFile.name);
         const file = currentFilesMap.get(cachedFile.name);
@@ -1050,7 +1265,9 @@ class CacheManager {
         }
       }
     });
+    const iterateMs = performance.now() - iterateStart;
 
+    const newFileScanStart = performance.now();
     for (const file of currentFiles) {
       if (!seenCachedFileNames.has(file.name)) {
         newAndModifiedFiles.push({
@@ -1063,6 +1280,27 @@ class CacheManager {
         });
       }
     }
+    const newFileScanMs = performance.now() - newFileScanStart;
+
+    logCachePerf('validate-diff:complete', {
+      directoryPath,
+      directoryName,
+      currentFiles: currentFiles.length,
+      cachedImageCount: cachedSummary.imageCount ?? 0,
+      cachedChunksScanned,
+      cachedRecordsScanned,
+      cachedImagesReturned: cachedImages.length,
+      newAndModifiedFiles: newAndModifiedFiles.length,
+      deletedFileIds: deletedFileIds.length,
+      includeCachedImages,
+      scanSubfolders,
+      scopePath: scopePath ?? null,
+      summaryMs: toFixedMs(summaryMs),
+      currentMapMs: toFixedMs(currentMapMs),
+      iterateMs: toFixedMs(iterateMs),
+      newFileScanMs: toFixedMs(newFileScanMs),
+      durationMs: toFixedMs(performance.now() - start),
+    });
 
     return {
       newAndModifiedFiles,

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -730,6 +730,7 @@ class CacheManager {
     if (imagesToUpsert.length === 0 && removedImageIds.length === 0 && removedImageNames.length === 0) return;
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
+    const outputCacheId = `${cacheId}-delta-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const summary = await this.getCacheSummary(directoryPath, scanSubfolders);
     if (!summary) {
       if (imagesToUpsert.length > 0) {
@@ -759,7 +760,7 @@ class CacheManager {
 
       const chunk = outputBuffer.splice(0, outputBuffer.length);
       const result = await window.electronAPI.writeCacheChunk({
-        cacheId,
+        cacheId: outputCacheId,
         chunkIndex: outputChunkIndex,
         data: chunk,
       });
@@ -806,6 +807,7 @@ class CacheManager {
 
     const finalizeResult = await window.electronAPI.finalizeCacheWrite({
       cacheId,
+      sourceCacheId: outputCacheId,
       record: {
         id: cacheId,
         directoryPath,

--- a/services/comfyUIApiClient.ts
+++ b/services/comfyUIApiClient.ts
@@ -14,6 +14,8 @@ import {
   buildImageSourceReference,
   prepareOriginalWorkflowForExecution,
 } from './comfyUIWorkflowBuilder';
+import { getElectronAbsoluteMediaPath, getRelativeImagePath } from './mediaSourceCache';
+import { inferMimeTypeFromName } from '../utils/mediaTypes.js';
 
 export interface ComfyUIConfig {
   serverUrl: string;        // e.g., "http://127.0.0.1:8188"
@@ -71,6 +73,34 @@ const getErrorMessage = (error: unknown): string => error instanceof Error ? err
 
 const isString = (value: unknown): value is string => typeof value === 'string';
 
+const createFileFromRendererData = (data: unknown, fileName: string): File => {
+  const mimeType = inferMimeTypeFromName(fileName, 'image/png');
+
+  if (typeof data === 'string') {
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return new File([bytes], fileName, { type: mimeType });
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new File([data], fileName, { type: mimeType });
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    const view = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    return new File([new Uint8Array(view)], fileName, { type: mimeType });
+  }
+
+  if (data && typeof data === 'object' && 'data' in data && Array.isArray((data as { data: unknown }).data)) {
+    return new File([new Uint8Array((data as { data: number[] }).data)], fileName, { type: mimeType });
+  }
+
+  throw new Error('ComfyUI Upscale could not read the source image data.');
+};
+
 const isProgressUpdate = (value: unknown): value is ComfyUIProgressUpdate => {
   if (!value || typeof value !== 'object') {
     return false;
@@ -91,6 +121,7 @@ const isProgressUpdate = (value: unknown): value is ComfyUIProgressUpdate => {
 export interface PrepareWorkflowParams {
   image: IndexedImage;
   metadata: BaseMetadata;
+  directoryPath?: string;
   workflowMode?: ComfyUIWorkflowMode;
   sourceImagePolicy?: ComfyUISourceImagePolicy;
   overrides?: WorkflowOverrides;
@@ -424,15 +455,37 @@ export class ComfyUIApiClient {
     };
   }
 
-  private async buildUpscaleWorkflowFromImage(image: IndexedImage, metadata: BaseMetadata): Promise<{
-    workflow: ComfyUIExecutionPayload;
-    warnings: string[];
-  }> {
-    if (!image.handle) {
+  private async getSourceImageFile(image: IndexedImage, directoryPath?: string): Promise<File> {
+    const handleWithFile = image.handle as { getFile?: () => Promise<File> } | undefined;
+    if (typeof handleWithFile?.getFile === 'function') {
+      return handleWithFile.getFile();
+    }
+
+    let absolutePath = getElectronAbsoluteMediaPath(image);
+    if (!absolutePath && directoryPath && window.electronAPI?.joinPaths) {
+      const joined = await window.electronAPI.joinPaths(directoryPath, getRelativeImagePath(image));
+      if (joined.success && joined.path) {
+        absolutePath = joined.path;
+      }
+    }
+
+    if (!absolutePath || !window.electronAPI?.readFile) {
       throw new Error('ComfyUI Upscale needs access to the source image file.');
     }
 
-    const uploadedImageName = await this.uploadAsset(await image.handle.getFile(), 'image');
+    const result = await window.electronAPI.readFile(absolutePath);
+    if (!result.success || result.data === undefined) {
+      throw new Error(result.error || 'ComfyUI Upscale could not read the source image file.');
+    }
+
+    return createFileFromRendererData(result.data, image.name);
+  }
+
+  private async buildUpscaleWorkflowFromImage(image: IndexedImage, metadata: BaseMetadata, directoryPath?: string): Promise<{
+    workflow: ComfyUIExecutionPayload;
+    warnings: string[];
+  }> {
+    const uploadedImageName = await this.uploadAsset(await this.getSourceImageFile(image, directoryPath), 'image');
     const warnings: string[] = [];
     let upscaleModelName: string | null = null;
 
@@ -522,7 +575,7 @@ export class ComfyUIApiClient {
     warnings: string[];
   }> {
     if (params.workflowMode === 'upscale') {
-      const prepared = await this.buildUpscaleWorkflowFromImage(params.image, params.metadata);
+      const prepared = await this.buildUpscaleWorkflowFromImage(params.image, params.metadata, params.directoryPath);
       return {
         workflow: prepared.workflow,
         modeUsed: 'upscale',

--- a/services/comfyUIApiClient.ts
+++ b/services/comfyUIApiClient.ts
@@ -11,6 +11,7 @@ import {
   type ComfyUIWorkflowMode,
   type ComfyUISourceImagePolicy,
   type ComfyUIWorkflowOverrides,
+  buildImageSourceReference,
   prepareOriginalWorkflowForExecution,
 } from './comfyUIWorkflowBuilder';
 
@@ -423,11 +424,112 @@ export class ComfyUIApiClient {
     };
   }
 
+  private async buildUpscaleWorkflowFromImage(image: IndexedImage, metadata: BaseMetadata): Promise<{
+    workflow: ComfyUIExecutionPayload;
+    warnings: string[];
+  }> {
+    if (!image.handle) {
+      throw new Error('ComfyUI Upscale needs access to the source image file.');
+    }
+
+    const uploadedImageName = await this.uploadAsset(await image.handle.getFile(), 'image');
+    const warnings: string[] = [];
+    let upscaleModelName: string | null = null;
+
+    try {
+      const objectInfo = await this.getObjectInfo();
+      const upscaleModels = objectInfo?.UpscaleModelLoader?.input?.required?.model_name?.[0]
+        || objectInfo?.UpscaleModelLoader?.input?.required?.upscale_model?.[0];
+      if (Array.isArray(upscaleModels)) {
+        upscaleModelName = upscaleModels.find((value: unknown): value is string => typeof value === 'string') || null;
+      }
+    } catch {
+      warnings.push('Could not inspect ComfyUI upscale models. Falling back to built-in scaling.');
+    }
+
+    const workflow: ComfyWorkflowGraph = {
+      "1": {
+        "class_type": "LoadImage",
+        "inputs": {
+          "image": uploadedImageName
+        }
+      }
+    };
+
+    let outputNodeId = "2";
+    if (upscaleModelName) {
+      workflow["2"] = {
+        "class_type": "UpscaleModelLoader",
+        "inputs": {
+          "model_name": upscaleModelName
+        }
+      };
+      workflow["3"] = {
+        "class_type": "ImageUpscaleWithModel",
+        "inputs": {
+          "upscale_model": ["2", 0],
+          "image": ["1", 0]
+        }
+      };
+      outputNodeId = "3";
+    } else {
+      warnings.push('No ComfyUI upscale model was found. Used ComfyUI ImageScaleBy at 2x instead.');
+      workflow["2"] = {
+        "class_type": "ImageScaleBy",
+        "inputs": {
+          "image": ["1", 0],
+          "upscale_method": "lanczos",
+          "scale_by": 2
+        }
+      };
+    }
+
+    workflow["4"] = {
+      "class_type": "MetaHubSaveNode",
+      "inputs": {
+        "images": [outputNodeId, 0],
+        "filename_pattern": "MetaHub_upscale_%date%_%time%_%counter%",
+        "file_format": "PNG",
+        "notes": "ComfyUI Upscale from Image MetaHub",
+        "tags": "upscale, imagemetahub"
+      }
+    };
+
+    return {
+      workflow: {
+        prompt: workflow,
+        client_id: this.clientId,
+        extra_data: {
+          extra_pnginfo: {
+            workflow: {},
+            prompt: workflow,
+            parent_image: buildImageSourceReference(image),
+            metahub_transform: {
+              type: upscaleModelName ? 'ai-upscale' : 'comfyui-scale',
+              upscale_model: upscaleModelName,
+              source_generator: metadata.generator || null,
+            },
+          },
+        },
+      },
+      warnings,
+    };
+  }
+
   async prepareWorkflow(params: PrepareWorkflowParams): Promise<{
     workflow: ComfyUIExecutionPayload;
     modeUsed: ComfyUIWorkflowMode;
     warnings: string[];
   }> {
+    if (params.workflowMode === 'upscale') {
+      const prepared = await this.buildUpscaleWorkflowFromImage(params.image, params.metadata);
+      return {
+        workflow: prepared.workflow,
+        modeUsed: 'upscale',
+        warnings: prepared.warnings,
+      };
+    }
+
     const preferredMode = params.workflowMode || 'original';
     if (preferredMode === 'original') {
       const prepared = await prepareOriginalWorkflowForExecution({

--- a/services/comfyUIWorkflowBuilder.ts
+++ b/services/comfyUIWorkflowBuilder.ts
@@ -8,7 +8,7 @@ import {
 } from '../types';
 import { resolvePromptFromGraph } from './parsers/comfyUIParser';
 
-export type ComfyUIWorkflowMode = 'original' | 'simple';
+export type ComfyUIWorkflowMode = 'original' | 'simple' | 'upscale';
 export type ComfyUISourceImagePolicy =
   | 'reuse_original'
   | 'selected_image'

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -2083,6 +2083,18 @@ export async function processFiles(
   };
 
   performance.mark('indexing:phaseA:start');
+  console.log('[indexing:perf]', {
+    event: 'process-files:start',
+    directoryId,
+    directoryName,
+    newFiles: fileEntries.length,
+    preloadedImages: options.preloadedImages?.length ?? 0,
+    scanSubfolders,
+    concurrency: concurrencyLimit,
+    cacheWriter: Boolean(cacheWriter),
+    flushChunkSize: chunkThreshold,
+    enrichmentBatchSize,
+  });
 
   const catalogState = new Map<string, CatalogEntryState>();
   const chunkRecords: CacheImageMetadata[][] = [];
@@ -2482,6 +2494,7 @@ export async function processFiles(
   performance.mark('indexing:phaseA:complete', {
     detail: { elapsedMs: performance.now() - phaseAStats.startTime, files: phaseAStats.processed }
   });
+  const phaseAElapsedMs = performance.now() - phaseAStats.startTime;
 
   throttledPhaseAProgress.cancel();
   if (totalNewFiles > 0) {
@@ -2491,6 +2504,22 @@ export async function processFiles(
   const ipcPerThousand = totalPhaseAFiles > 0 ? (phaseAStats.ipcCalls / totalPhaseAFiles) * 1000 : 0;
   performance.mark('indexing:phaseA:ipc-per-1k', { detail: { value: ipcPerThousand } });
   const writesPerThousand = totalPhaseAFiles > 0 ? (phaseAStats.diskWrites / totalPhaseAFiles) * 1000 : 0;
+  console.log('[indexing:perf]', {
+    event: 'phase-a:complete',
+    directoryId,
+    files: phaseAStats.processed,
+    newFiles: totalNewFiles,
+    preloadedImages: preloadedImages.length,
+    catalogEntries: catalogState.size,
+    enrichmentQueued: enrichmentQueue.length,
+    chunks: chunkRecords.length,
+    ipcCalls: phaseAStats.ipcCalls,
+    diskWrites: phaseAStats.diskWrites,
+    bytesWritten: phaseAStats.bytesWritten,
+    ipcPerThousand: Number(ipcPerThousand.toFixed(2)),
+    writesPerThousand: Number(writesPerThousand.toFixed(2)),
+    durationMs: Number(phaseAElapsedMs.toFixed(2)),
+  });
 
   if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production' && totalPhaseAFiles > 0) {
     if (ipcPerThousand > 10) {
@@ -2508,6 +2537,12 @@ export async function processFiles(
     performance.mark('indexing:phaseB:start');
     performance.mark('indexing:phaseB:complete', { detail: { elapsedMs: 0, files: 0 } });
     options.onEnrichmentProgress?.(null);
+    console.log('[indexing:perf]', {
+      event: 'phase-b:skipped',
+      directoryId,
+      reason: 'no-enrichment-needed',
+      totalElapsedMs: Number((performance.now() - phaseAStats.startTime).toFixed(2)),
+    });
     return { phaseB: Promise.resolve() };
   }
 
@@ -3163,6 +3198,28 @@ export async function processFiles(
     });
 
     console.log(`[indexing] Phase B complete: ${phaseBStats.processed}/${totalEnrichment} images enriched in ${(elapsedMs / 1000).toFixed(2)}s`);
+    console.log('[indexing:perf]', {
+      event: 'phase-b:complete',
+      directoryId,
+      processed: phaseBStats.processed,
+      totalEnrichment,
+      ipcCalls: phaseBStats.ipcCalls,
+      headReadFiles: phaseBStats.headReadFiles,
+      headReadMs: Number(phaseBStats.headReadMs.toFixed(2)),
+      tailReadFiles: phaseBStats.tailReadFiles,
+      tailReadHits: phaseBStats.tailReadHits,
+      tailReadMs: Number(phaseBStats.tailReadMs.toFixed(2)),
+      fullReadFiles: phaseBStats.fullReadFiles,
+      fullReadMs: Number(phaseBStats.fullReadMs.toFixed(2)),
+      rendererDispatchMs: Number(phaseBStats.rendererDispatchMs.toFixed(2)),
+      rendererDispatchBatches: phaseBStats.rendererDispatchBatches,
+      cacheFlushMs: Number(phaseBStats.flushMs.toFixed(2)),
+      cacheFlushChunks: phaseBStats.flushChunks,
+      metadataKinds: phaseBStats.metadataKinds,
+      fileTypes: phaseBStats.fileTypes,
+      durationMs: Number(elapsedMs.toFixed(2)),
+      totalElapsedMs: Number((performance.now() - phaseAStats.startTime).toFixed(2)),
+    });
     traceCacheDebug('indexer:phaseB:complete', () => ({
       details: {
         elapsedMs: Number(elapsedMs.toFixed(2)),

--- a/services/generationQueueExecutors.ts
+++ b/services/generationQueueExecutors.ts
@@ -222,6 +222,7 @@ export async function executeComfyUIQueueJob(
     image: context.image,
     metadata,
     overrides: payload?.overrides,
+    directoryPath: payload?.directoryPath,
     workflowMode: payload?.workflowMode,
     sourceImagePolicy: payload?.sourceImagePolicy,
     advancedPromptJson: payload?.advancedPromptJson,

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -860,13 +860,15 @@ const drawEditorObject = (
     context.fill();
     context.stroke();
   } else if (object.type === 'line' || object.type === 'arrow') {
+    const start = object.points?.[0] ?? { x: bounds.x, y: bounds.y };
+    const end = object.points?.[1] ?? { x: bounds.x + bounds.width, y: bounds.y + bounds.height };
     context.beginPath();
-    context.moveTo(bounds.x, bounds.y);
-    context.lineTo(bounds.x + bounds.width, bounds.y + bounds.height);
+    context.moveTo(start.x, start.y);
+    context.lineTo(end.x, end.y);
     context.stroke();
     if (object.type === 'arrow') {
       context.fillStyle = style.strokeColor;
-      drawArrowHead(context, bounds.x, bounds.y, bounds.x + bounds.width, bounds.y + bounds.height, Math.max(12, style.strokeWidth * 4));
+      drawArrowHead(context, start.x, start.y, end.x, end.y, Math.max(12, style.strokeWidth * 4));
     }
   } else if (object.type === 'freehand' && object.points && object.points.length > 1) {
     context.beginPath();

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -1,4 +1,16 @@
-import type { BaseMetadata, ImageAdjustments, LoRAInfo } from '../types';
+import type {
+  BaseMetadata,
+  ImageAdjustments,
+  ImageEditCrop,
+  ImageEditCropAspect,
+  ImageEditCropRect,
+  ImageEditEffects,
+  ImageEditRecipe,
+  ImageEditResize,
+  ImageEditRotation,
+  ImageEditTransform,
+  LoRAInfo,
+} from '../types';
 
 export const DEFAULT_IMAGE_ADJUSTMENTS: ImageAdjustments = {
   brightness: 100,
@@ -7,12 +19,45 @@ export const DEFAULT_IMAGE_ADJUSTMENTS: ImageAdjustments = {
   hue: 0,
 };
 
+export const DEFAULT_IMAGE_EDIT_RECIPE: ImageEditRecipe = {
+  adjustments: DEFAULT_IMAGE_ADJUSTMENTS,
+  transform: {
+    rotation: 0,
+    flipHorizontal: false,
+    flipVertical: false,
+  },
+  crop: {
+    enabled: false,
+    aspect: 'free',
+    rect: null,
+  },
+  resize: {
+    enabled: false,
+    width: 0,
+    height: 0,
+    lockAspectRatio: true,
+  },
+  effects: {
+    sharpen: 0,
+    blur: 0,
+  },
+};
+
 const ADJUSTMENT_RANGES: Record<keyof ImageAdjustments, { min: number; max: number }> = {
   brightness: { min: 0, max: 200 },
   contrast: { min: 0, max: 200 },
   saturation: { min: 0, max: 200 },
   hue: { min: -180, max: 180 },
 };
+
+const EFFECT_RANGES: Record<keyof ImageEditEffects, { min: number; max: number }> = {
+  sharpen: { min: 0, max: 100 },
+  blur: { min: 0, max: 20 },
+};
+
+const MAX_OUTPUT_DIMENSION = 20000;
+const ROTATIONS: ImageEditRotation[] = [0, 90, 180, 270];
+export const CROP_ASPECTS: ImageEditCropAspect[] = ['free', 'original', '1:1', '4:3', '3:2', '16:9', '9:16'];
 
 export const clampImageAdjustment = (
   key: keyof ImageAdjustments,
@@ -55,6 +100,267 @@ export const buildImageAdjustmentFilter = (adjustments: Partial<ImageAdjustments
   ].join(' ');
 };
 
+const clampNumber = (value: number, min: number, max: number, fallback: number): number => {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, value));
+};
+
+const clampInteger = (value: number, min: number, max: number, fallback: number): number => (
+  Math.round(clampNumber(value, min, max, fallback))
+);
+
+export const normalizeImageEditRotation = (value: number): ImageEditRotation => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  const normalized = ((Math.round(value / 90) * 90) % 360 + 360) % 360;
+  return (ROTATIONS.includes(normalized as ImageEditRotation) ? normalized : 0) as ImageEditRotation;
+};
+
+export const normalizeImageEditTransform = (
+  transform?: Partial<ImageEditTransform>,
+): ImageEditTransform => ({
+  rotation: normalizeImageEditRotation(transform?.rotation ?? DEFAULT_IMAGE_EDIT_RECIPE.transform.rotation),
+  flipHorizontal: Boolean(transform?.flipHorizontal),
+  flipVertical: Boolean(transform?.flipVertical),
+});
+
+export const clampImageEditEffect = (
+  key: keyof ImageEditEffects,
+  value: number,
+): number => {
+  const range = EFFECT_RANGES[key];
+  return clampInteger(value, range.min, range.max, DEFAULT_IMAGE_EDIT_RECIPE.effects[key]);
+};
+
+export const normalizeImageEditEffects = (
+  effects?: Partial<ImageEditEffects>,
+): ImageEditEffects => ({
+  sharpen: clampImageEditEffect('sharpen', effects?.sharpen ?? DEFAULT_IMAGE_EDIT_RECIPE.effects.sharpen),
+  blur: clampImageEditEffect('blur', effects?.blur ?? DEFAULT_IMAGE_EDIT_RECIPE.effects.blur),
+});
+
+export const getCropAspectRatio = (
+  aspect: ImageEditCropAspect,
+  sourceDimensions?: { width: number; height: number },
+): number | null => {
+  if (aspect === 'free') {
+    return null;
+  }
+  if (aspect === 'original') {
+    const width = sourceDimensions?.width || 0;
+    const height = sourceDimensions?.height || 0;
+    return width > 0 && height > 0 ? width / height : null;
+  }
+
+  const [width, height] = aspect.split(':').map(Number);
+  return width > 0 && height > 0 ? width / height : null;
+};
+
+export const clampImageEditCropRect = (
+  rect: Partial<ImageEditCropRect> | null | undefined,
+  sourceDimensions?: { width: number; height: number },
+): ImageEditCropRect | null => {
+  const sourceWidth = sourceDimensions?.width || 0;
+  const sourceHeight = sourceDimensions?.height || 0;
+  if (!rect || sourceWidth <= 0 || sourceHeight <= 0) {
+    return null;
+  }
+
+  const width = clampInteger(rect.width ?? sourceWidth, 1, sourceWidth, sourceWidth);
+  const height = clampInteger(rect.height ?? sourceHeight, 1, sourceHeight, sourceHeight);
+  const x = clampInteger(rect.x ?? 0, 0, Math.max(0, sourceWidth - width), 0);
+  const y = clampInteger(rect.y ?? 0, 0, Math.max(0, sourceHeight - height), 0);
+  return { x, y, width, height };
+};
+
+export const createDefaultCropRect = (
+  sourceDimensions?: { width: number; height: number },
+  aspect: ImageEditCropAspect = 'free',
+): ImageEditCropRect | null => {
+  const sourceWidth = sourceDimensions?.width || 0;
+  const sourceHeight = sourceDimensions?.height || 0;
+  if (sourceWidth <= 0 || sourceHeight <= 0) {
+    return null;
+  }
+
+  const ratio = getCropAspectRatio(aspect, sourceDimensions);
+  let width = Math.round(sourceWidth * 0.85);
+  let height = Math.round(sourceHeight * 0.85);
+
+  if (ratio) {
+    if (width / height > ratio) {
+      width = Math.round(height * ratio);
+    } else {
+      height = Math.round(width / ratio);
+    }
+  }
+
+  width = Math.max(1, Math.min(sourceWidth, width));
+  height = Math.max(1, Math.min(sourceHeight, height));
+  return {
+    x: Math.round((sourceWidth - width) / 2),
+    y: Math.round((sourceHeight - height) / 2),
+    width,
+    height,
+  };
+};
+
+export const normalizeImageEditCrop = (
+  crop?: Partial<ImageEditCrop>,
+  sourceDimensions?: { width: number; height: number },
+): ImageEditCrop => {
+  const aspect = CROP_ASPECTS.includes(crop?.aspect as ImageEditCropAspect)
+    ? crop?.aspect as ImageEditCropAspect
+    : DEFAULT_IMAGE_EDIT_RECIPE.crop.aspect;
+  if ((!sourceDimensions || sourceDimensions.width <= 0 || sourceDimensions.height <= 0) && crop?.rect) {
+    const rect = {
+      x: Math.max(0, Math.round(crop.rect.x || 0)),
+      y: Math.max(0, Math.round(crop.rect.y || 0)),
+      width: Math.max(1, Math.round(crop.rect.width || 1)),
+      height: Math.max(1, Math.round(crop.rect.height || 1)),
+    };
+    return {
+      enabled: Boolean(crop.enabled),
+      aspect,
+      rect,
+    };
+  }
+
+  const rect = clampImageEditCropRect(crop?.rect, sourceDimensions);
+  return {
+    enabled: Boolean(crop?.enabled && rect),
+    aspect,
+    rect,
+  };
+};
+
+export const getRecipeSourceRect = (
+  recipe: ImageEditRecipe,
+  sourceDimensions: { width: number; height: number },
+): ImageEditCropRect => (
+  recipe.crop.enabled && recipe.crop.rect
+    ? recipe.crop.rect
+    : { x: 0, y: 0, width: sourceDimensions.width, height: sourceDimensions.height }
+);
+
+export const getRecipeBaseOutputDimensions = (
+  recipe: ImageEditRecipe,
+  sourceDimensions: { width: number; height: number },
+): { width: number; height: number } => {
+  const sourceRect = getRecipeSourceRect(recipe, sourceDimensions);
+  const rotated = recipe.transform.rotation === 90 || recipe.transform.rotation === 270;
+  return {
+    width: rotated ? sourceRect.height : sourceRect.width,
+    height: rotated ? sourceRect.width : sourceRect.height,
+  };
+};
+
+export const normalizeImageEditResize = (
+  resize?: Partial<ImageEditResize>,
+  baseDimensions?: { width: number; height: number },
+): ImageEditResize => {
+  const hasBaseDimensions = Boolean(baseDimensions && baseDimensions.width > 0 && baseDimensions.height > 0);
+  if (!hasBaseDimensions && !resize?.enabled) {
+    return {
+      enabled: false,
+      width: clampInteger(resize?.width ?? DEFAULT_IMAGE_EDIT_RECIPE.resize.width, 0, MAX_OUTPUT_DIMENSION, DEFAULT_IMAGE_EDIT_RECIPE.resize.width),
+      height: clampInteger(resize?.height ?? DEFAULT_IMAGE_EDIT_RECIPE.resize.height, 0, MAX_OUTPUT_DIMENSION, DEFAULT_IMAGE_EDIT_RECIPE.resize.height),
+      lockAspectRatio: resize?.lockAspectRatio !== false,
+    };
+  }
+
+  const baseWidth = Math.max(1, Math.round(baseDimensions?.width || resize?.width || 1));
+  const baseHeight = Math.max(1, Math.round(baseDimensions?.height || resize?.height || 1));
+  const width = clampInteger(resize?.width ?? baseWidth, 1, MAX_OUTPUT_DIMENSION, baseWidth);
+  const height = clampInteger(resize?.height ?? baseHeight, 1, MAX_OUTPUT_DIMENSION, baseHeight);
+  return {
+    enabled: Boolean(resize?.enabled && width > 0 && height > 0 && (width !== baseWidth || height !== baseHeight)),
+    width,
+    height,
+    lockAspectRatio: resize?.lockAspectRatio !== false,
+  };
+};
+
+const isRecipeLike = (
+  value: Partial<ImageEditRecipe> | Partial<ImageAdjustments> | undefined,
+): value is Partial<ImageEditRecipe> => (
+  Boolean(value) && (
+    'adjustments' in value ||
+    'transform' in value ||
+    'crop' in value ||
+    'resize' in value ||
+    'effects' in value
+  )
+);
+
+export const normalizeImageEditRecipe = (
+  recipeOrAdjustments?: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
+  sourceDimensions?: { width: number; height: number },
+): ImageEditRecipe => {
+  const recipeInput = isRecipeLike(recipeOrAdjustments) ? recipeOrAdjustments : {};
+  const adjustmentsInput = isRecipeLike(recipeOrAdjustments)
+    ? recipeInput.adjustments
+    : recipeOrAdjustments;
+  const adjustments = normalizeImageAdjustments(adjustmentsInput || DEFAULT_IMAGE_ADJUSTMENTS);
+  const transform = normalizeImageEditTransform(recipeInput.transform);
+  const crop = normalizeImageEditCrop(recipeInput.crop, sourceDimensions);
+  const baseDimensions = sourceDimensions
+    ? getRecipeBaseOutputDimensions({ ...DEFAULT_IMAGE_EDIT_RECIPE, adjustments, transform, crop }, sourceDimensions)
+    : undefined;
+  const resize = normalizeImageEditResize(recipeInput.resize, baseDimensions);
+  const effects = normalizeImageEditEffects(recipeInput.effects);
+
+  return {
+    adjustments,
+    transform,
+    crop,
+    resize,
+    effects,
+  };
+};
+
+export const getImageEditOutputDimensions = (
+  recipeOrAdjustments: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
+  sourceDimensions: { width: number; height: number },
+): { width: number; height: number } => {
+  const recipe = normalizeImageEditRecipe(recipeOrAdjustments, sourceDimensions);
+  const base = getRecipeBaseOutputDimensions(recipe, sourceDimensions);
+  return recipe.resize.enabled
+    ? { width: recipe.resize.width, height: recipe.resize.height }
+    : base;
+};
+
+export const hasImageEditRecipeChanges = (
+  recipeOrAdjustments: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
+): boolean => {
+  const recipe = normalizeImageEditRecipe(recipeOrAdjustments);
+  return (
+    hasImageAdjustments(recipe.adjustments) ||
+    recipe.transform.rotation !== DEFAULT_IMAGE_EDIT_RECIPE.transform.rotation ||
+    recipe.transform.flipHorizontal !== DEFAULT_IMAGE_EDIT_RECIPE.transform.flipHorizontal ||
+    recipe.transform.flipVertical !== DEFAULT_IMAGE_EDIT_RECIPE.transform.flipVertical ||
+    recipe.crop.enabled ||
+    recipe.resize.enabled ||
+    recipe.effects.sharpen !== DEFAULT_IMAGE_EDIT_RECIPE.effects.sharpen ||
+    recipe.effects.blur !== DEFAULT_IMAGE_EDIT_RECIPE.effects.blur
+  );
+};
+
+export const buildImageEditFilter = (
+  recipeOrAdjustments: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
+): string => {
+  const recipe = normalizeImageEditRecipe(recipeOrAdjustments);
+  const filters = [buildImageAdjustmentFilter(recipe.adjustments)];
+  if (recipe.effects.blur > 0) {
+    filters.push(`blur(${recipe.effects.blur}px)`);
+  }
+  return filters.join(' ');
+};
+
 const loadImageElement = (sourceUrl: string): Promise<HTMLImageElement> => new Promise((resolve, reject) => {
   const image = new Image();
   image.onload = () => resolve(image);
@@ -77,6 +383,44 @@ export async function renderAdjustedImageToPngBlob(
   sourceUrl: string,
   adjustments: Partial<ImageAdjustments>,
 ): Promise<Blob> {
+  return renderEditedImageToPngBlob(sourceUrl, { adjustments: normalizeImageAdjustments(adjustments) });
+}
+
+const applySharpen = (context: CanvasRenderingContext2D, width: number, height: number, amount: number): void => {
+  if (amount <= 0 || width <= 1 || height <= 1 || typeof context.getImageData !== 'function') {
+    return;
+  }
+
+  const strength = amount / 100;
+  const imageData = context.getImageData(0, 0, width, height);
+  const source = imageData.data;
+  const output = new Uint8ClampedArray(source);
+  const centerWeight = 1 + (4 * strength);
+  const sideWeight = -strength;
+
+  for (let y = 1; y < height - 1; y += 1) {
+    for (let x = 1; x < width - 1; x += 1) {
+      const index = (y * width + x) * 4;
+      for (let channel = 0; channel < 3; channel += 1) {
+        const value =
+          source[index + channel] * centerWeight +
+          source[index - 4 + channel] * sideWeight +
+          source[index + 4 + channel] * sideWeight +
+          source[index - (width * 4) + channel] * sideWeight +
+          source[index + (width * 4) + channel] * sideWeight;
+        output[index + channel] = Math.min(255, Math.max(0, Math.round(value)));
+      }
+    }
+  }
+
+  imageData.data.set(output);
+  context.putImageData(imageData, 0, 0);
+};
+
+export async function renderEditedImageToPngBlob(
+  sourceUrl: string,
+  recipeOrAdjustments: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
+): Promise<Blob> {
   const image = await loadImageElement(sourceUrl);
   const width = image.naturalWidth || image.width;
   const height = image.naturalHeight || image.height;
@@ -85,17 +429,51 @@ export async function renderAdjustedImageToPngBlob(
     throw new Error('Edited image has invalid dimensions.');
   }
 
+  const recipe = normalizeImageEditRecipe(recipeOrAdjustments, { width, height });
+  const sourceRect = getRecipeSourceRect(recipe, { width, height });
+  const baseDimensions = getRecipeBaseOutputDimensions(recipe, { width, height });
+  const outputDimensions = recipe.resize.enabled
+    ? { width: recipe.resize.width, height: recipe.resize.height }
+    : baseDimensions;
+
   const canvas = document.createElement('canvas');
-  canvas.width = width;
-  canvas.height = height;
+  canvas.width = outputDimensions.width;
+  canvas.height = outputDimensions.height;
 
   const context = canvas.getContext('2d');
   if (!context) {
     throw new Error('Canvas rendering is not available in this browser.');
   }
 
-  context.filter = buildImageAdjustmentFilter(adjustments);
-  context.drawImage(image, 0, 0, width, height);
+  context.imageSmoothingEnabled = true;
+  context.imageSmoothingQuality = 'high';
+  context.filter = buildImageEditFilter(recipe);
+  context.translate(outputDimensions.width / 2, outputDimensions.height / 2);
+  context.rotate((recipe.transform.rotation * Math.PI) / 180);
+  context.scale(recipe.transform.flipHorizontal ? -1 : 1, recipe.transform.flipVertical ? -1 : 1);
+
+  const drawWidth = recipe.transform.rotation === 90 || recipe.transform.rotation === 270
+    ? outputDimensions.height
+    : outputDimensions.width;
+  const drawHeight = recipe.transform.rotation === 90 || recipe.transform.rotation === 270
+    ? outputDimensions.width
+    : outputDimensions.height;
+
+  context.drawImage(
+    image,
+    sourceRect.x,
+    sourceRect.y,
+    sourceRect.width,
+    sourceRect.height,
+    -drawWidth / 2,
+    -drawHeight / 2,
+    drawWidth,
+    drawHeight,
+  );
+
+  context.setTransform(1, 0, 0, 1, 0, 0);
+  context.filter = 'none';
+  applySharpen(context, outputDimensions.width, outputDimensions.height, recipe.effects.sharpen);
   return canvasToBlob(canvas);
 }
 
@@ -103,7 +481,31 @@ export async function renderAdjustedImageToPngBytes(
   sourceUrl: string,
   adjustments: Partial<ImageAdjustments>,
 ): Promise<Uint8Array> {
-  const blob = await renderAdjustedImageToPngBlob(sourceUrl, adjustments);
+  const blob = await renderEditedImageToPngBlob(sourceUrl, { adjustments: normalizeImageAdjustments(adjustments) });
+  if (typeof blob.arrayBuffer === 'function') {
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+
+  const buffer = await new Promise<ArrayBuffer>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) {
+        resolve(reader.result);
+      } else {
+        reject(new Error('Failed to read edited PNG bytes.'));
+      }
+    };
+    reader.onerror = () => reject(reader.error || new Error('Failed to read edited PNG bytes.'));
+    reader.readAsArrayBuffer(blob);
+  });
+  return new Uint8Array(buffer);
+}
+
+export async function renderEditedImageToPngBytes(
+  sourceUrl: string,
+  recipeOrAdjustments: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
+): Promise<Uint8Array> {
+  const blob = await renderEditedImageToPngBlob(sourceUrl, recipeOrAdjustments);
   if (typeof blob.arrayBuffer === 'function') {
     return new Uint8Array(await blob.arrayBuffer());
   }
@@ -304,16 +706,18 @@ const formatMetadataForA1111Compat = (metadata: BaseMetadata): string => {
 
 const buildMetaHubEditPayload = (
   metadata: BaseMetadata,
-  adjustments: ImageAdjustments,
+  recipe: ImageEditRecipe,
   preservedWorkflow?: PreservedComfyWorkflow,
+  outputDimensions?: { width: number; height: number },
 ) => {
   const payload: Record<string, unknown> = {
     generator: 'Image MetaHub',
     source_generator: typeof metadata.generator === 'string' ? metadata.generator : null,
     edited_at: new Date().toISOString(),
     edit: {
-      tool: 'image-adjustments',
-      adjustments,
+      tool: 'image-editor-v2',
+      recipe,
+      output_dimensions: outputDimensions,
     },
     prompt: metadata.prompt || '',
     negativePrompt: metadata.negativePrompt || '',
@@ -391,20 +795,21 @@ const extractPreservedComfyWorkflow = (
 export const embedMetaHubMetadataInPngBytes = (
   pngBytes: Uint8Array,
   metadata: BaseMetadata | undefined,
-  adjustments: Partial<ImageAdjustments>,
+  recipeOrAdjustments: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
   rawMetadata?: Record<string, unknown>,
+  outputDimensions?: { width: number; height: number },
 ): Uint8Array => {
   if (!metadata) {
     return pngBytes;
   }
 
-  const normalizedAdjustments = normalizeImageAdjustments(adjustments);
+  const normalizedRecipe = normalizeImageEditRecipe(recipeOrAdjustments);
   const preservedWorkflow = extractPreservedComfyWorkflow(rawMetadata);
   const chunks = [
     createPngTextChunk('parameters', formatMetadataForA1111Compat(metadata)),
     createPngInternationalTextChunk(
       'imagemetahub_data',
-      JSON.stringify(buildMetaHubEditPayload(metadata, normalizedAdjustments, preservedWorkflow)),
+      JSON.stringify(buildMetaHubEditPayload(metadata, normalizedRecipe, preservedWorkflow, outputDimensions)),
     ),
   ];
 

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -1309,7 +1309,13 @@ export const embedMetaHubMetadataInPngBytes = (
     return pngBytes;
   }
 
-  const normalizedRecipe = normalizeImageEditRecipe(recipeOrAdjustments);
+  const sourceDimensions = metadata && Number.isFinite(metadata.width) && Number.isFinite(metadata.height)
+    ? {
+        width: Math.max(1, Math.round(metadata.width || 1)),
+        height: Math.max(1, Math.round(metadata.height || 1)),
+      }
+    : undefined;
+  const normalizedRecipe = normalizeImageEditRecipe(recipeOrAdjustments, sourceDimensions);
   const chunks: Uint8Array[] = [];
 
   if (metadata) {

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -9,6 +9,10 @@ import type {
   ImageEditResize,
   ImageEditRotation,
   ImageEditTransform,
+  ImageEditorBackground,
+  ImageEditorDocument,
+  ImageEditorObject,
+  ImageEditorObjectStyle,
   LoRAInfo,
 } from '../types';
 
@@ -41,6 +45,27 @@ export const DEFAULT_IMAGE_EDIT_RECIPE: ImageEditRecipe = {
     sharpen: 0,
     blur: 0,
   },
+};
+
+export const DEFAULT_IMAGE_EDITOR_OBJECT_STYLE: ImageEditorObjectStyle = {
+  strokeColor: '#22d3ee',
+  fillColor: 'rgba(34, 211, 238, 0.16)',
+  textColor: '#f8fafc',
+  strokeWidth: 4,
+  fontSize: 32,
+  opacity: 1,
+};
+
+export const DEFAULT_IMAGE_EDITOR_BACKGROUND: ImageEditorBackground = {
+  kind: 'transparent',
+  color: '#111827',
+  gradientFrom: '#111827',
+  gradientTo: '#374151',
+  margin: 0,
+  padding: 0,
+  smartPadding: false,
+  roundedCorner: 0,
+  shadowRadius: 0,
 };
 
 const ADJUSTMENT_RANGES: Record<keyof ImageAdjustments, { min: number; max: number }> = {
@@ -361,6 +386,157 @@ export const buildImageEditFilter = (
   return filters.join(' ');
 };
 
+export const normalizeImageEditorBounds = (
+  bounds: Partial<ImageEditorObject['bounds']> | undefined,
+  canvasDimensions?: { width: number; height: number },
+): ImageEditorObject['bounds'] => {
+  const maxWidth = Math.max(1, canvasDimensions?.width || MAX_OUTPUT_DIMENSION);
+  const maxHeight = Math.max(1, canvasDimensions?.height || MAX_OUTPUT_DIMENSION);
+  const width = clampInteger(bounds?.width ?? 1, 1, maxWidth, 1);
+  const height = clampInteger(bounds?.height ?? 1, 1, maxHeight, 1);
+  return {
+    x: clampInteger(bounds?.x ?? 0, 0, Math.max(0, maxWidth - width), 0),
+    y: clampInteger(bounds?.y ?? 0, 0, Math.max(0, maxHeight - height), 0),
+    width,
+    height,
+  };
+};
+
+export const normalizeImageEditorBackground = (
+  background?: Partial<ImageEditorBackground>,
+): ImageEditorBackground => ({
+  kind: background?.kind === 'color' || background?.kind === 'gradient' || background?.kind === 'transparent'
+    ? background.kind
+    : DEFAULT_IMAGE_EDITOR_BACKGROUND.kind,
+  color: background?.color || DEFAULT_IMAGE_EDITOR_BACKGROUND.color,
+  gradientFrom: background?.gradientFrom || DEFAULT_IMAGE_EDITOR_BACKGROUND.gradientFrom,
+  gradientTo: background?.gradientTo || DEFAULT_IMAGE_EDITOR_BACKGROUND.gradientTo,
+  margin: clampInteger(background?.margin ?? DEFAULT_IMAGE_EDITOR_BACKGROUND.margin, 0, 2000, DEFAULT_IMAGE_EDITOR_BACKGROUND.margin),
+  padding: clampInteger(background?.padding ?? DEFAULT_IMAGE_EDITOR_BACKGROUND.padding, 0, 2000, DEFAULT_IMAGE_EDITOR_BACKGROUND.padding),
+  smartPadding: Boolean(background?.smartPadding),
+  roundedCorner: clampInteger(background?.roundedCorner ?? DEFAULT_IMAGE_EDITOR_BACKGROUND.roundedCorner, 0, 500, DEFAULT_IMAGE_EDITOR_BACKGROUND.roundedCorner),
+  shadowRadius: clampInteger(background?.shadowRadius ?? DEFAULT_IMAGE_EDITOR_BACKGROUND.shadowRadius, 0, 500, DEFAULT_IMAGE_EDITOR_BACKGROUND.shadowRadius),
+});
+
+export const normalizeImageEditorObject = (
+  object: Partial<ImageEditorObject>,
+  canvasDimensions?: { width: number; height: number },
+): ImageEditorObject | null => {
+  const allowedTypes: ImageEditorObject['type'][] = [
+    'rectangle',
+    'ellipse',
+    'line',
+    'arrow',
+    'freehand',
+    'text',
+    'step',
+    'highlight',
+    'blur',
+    'pixelate',
+    'spotlight',
+    'magnify',
+  ];
+  if (!object.id || !object.type || !allowedTypes.includes(object.type)) {
+    return null;
+  }
+
+  return {
+    id: object.id,
+    type: object.type,
+    bounds: normalizeImageEditorBounds(object.bounds, canvasDimensions),
+    points: Array.isArray(object.points)
+      ? object.points
+          .map((point) => ({
+            x: clampInteger(point.x, 0, canvasDimensions?.width || MAX_OUTPUT_DIMENSION, 0),
+            y: clampInteger(point.y, 0, canvasDimensions?.height || MAX_OUTPUT_DIMENSION, 0),
+          }))
+      : undefined,
+    text: object.text || '',
+    stepNumber: Number.isFinite(object.stepNumber) ? Math.max(1, Math.round(object.stepNumber || 1)) : undefined,
+    zIndex: Number.isFinite(object.zIndex) ? Math.round(object.zIndex || 0) : 0,
+    style: {
+      strokeColor: object.style?.strokeColor || DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.strokeColor,
+      fillColor: object.style?.fillColor || DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.fillColor,
+      textColor: object.style?.textColor || DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.textColor,
+      strokeWidth: clampInteger(object.style?.strokeWidth ?? DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.strokeWidth, 1, 80, DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.strokeWidth),
+      fontSize: clampInteger(object.style?.fontSize ?? DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.fontSize, 8, 240, DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.fontSize),
+      opacity: clampNumber(object.style?.opacity ?? DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.opacity, 0, 1, DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.opacity),
+    },
+  };
+};
+
+export const createImageEditorDocument = (
+  source: {
+    imageId: string;
+    name: string;
+    width: number;
+    height: number;
+  },
+): ImageEditorDocument => ({
+  sourceImageId: source.imageId,
+  sourceName: source.name,
+  sourceDimensions: {
+    width: Math.max(1, Math.round(source.width || 1)),
+    height: Math.max(1, Math.round(source.height || 1)),
+  },
+  canvasDimensions: {
+    width: Math.max(1, Math.round(source.width || 1)),
+    height: Math.max(1, Math.round(source.height || 1)),
+  },
+  recipe: normalizeImageEditRecipe(DEFAULT_IMAGE_EDIT_RECIPE, { width: source.width, height: source.height }),
+  background: DEFAULT_IMAGE_EDITOR_BACKGROUND,
+  objects: [],
+  selectedObjectIds: [],
+});
+
+export const normalizeImageEditorDocument = (
+  document: Partial<ImageEditorDocument>,
+): ImageEditorDocument => {
+  const sourceDimensions = {
+    width: Math.max(1, Math.round(document.sourceDimensions?.width || document.canvasDimensions?.width || 1)),
+    height: Math.max(1, Math.round(document.sourceDimensions?.height || document.canvasDimensions?.height || 1)),
+  };
+  const recipe = normalizeImageEditRecipe(document.recipe || DEFAULT_IMAGE_EDIT_RECIPE, sourceDimensions);
+  const outputDimensions = getImageEditOutputDimensions(recipe, sourceDimensions);
+  const canvasDimensions = {
+    width: Math.max(1, Math.round(document.canvasDimensions?.width || outputDimensions.width)),
+    height: Math.max(1, Math.round(document.canvasDimensions?.height || outputDimensions.height)),
+  };
+  const objects = (document.objects || [])
+    .map((object) => normalizeImageEditorObject(object, canvasDimensions))
+    .filter((object): object is ImageEditorObject => Boolean(object))
+    .sort((left, right) => left.zIndex - right.zIndex);
+  const objectIds = new Set(objects.map((object) => object.id));
+
+  return {
+    sourceImageId: document.sourceImageId || '',
+    sourceName: document.sourceName || 'image.png',
+    sourceDimensions,
+    canvasDimensions,
+    recipe,
+    background: normalizeImageEditorBackground(document.background),
+    objects,
+    selectedObjectIds: (document.selectedObjectIds || []).filter((id) => objectIds.has(id)),
+  };
+};
+
+export const hasImageEditorDocumentChanges = (
+  document: Partial<ImageEditorDocument>,
+): boolean => {
+  const normalized = normalizeImageEditorDocument(document);
+  const background = normalized.background;
+  return (
+    hasImageEditRecipeChanges(normalized.recipe) ||
+    normalized.objects.length > 0 ||
+    background.kind !== DEFAULT_IMAGE_EDITOR_BACKGROUND.kind ||
+    background.margin !== DEFAULT_IMAGE_EDITOR_BACKGROUND.margin ||
+    background.padding !== DEFAULT_IMAGE_EDITOR_BACKGROUND.padding ||
+    background.smartPadding !== DEFAULT_IMAGE_EDITOR_BACKGROUND.smartPadding ||
+    background.roundedCorner !== DEFAULT_IMAGE_EDITOR_BACKGROUND.roundedCorner ||
+    background.shadowRadius !== DEFAULT_IMAGE_EDITOR_BACKGROUND.shadowRadius
+  );
+};
+
 const loadImageElement = (sourceUrl: string): Promise<HTMLImageElement> => new Promise((resolve, reject) => {
   const image = new Image();
   image.onload = () => resolve(image);
@@ -506,6 +682,289 @@ export async function renderEditedImageToPngBytes(
   recipeOrAdjustments: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
 ): Promise<Uint8Array> {
   const blob = await renderEditedImageToPngBlob(sourceUrl, recipeOrAdjustments);
+  if (typeof blob.arrayBuffer === 'function') {
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+
+  const buffer = await new Promise<ArrayBuffer>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) {
+        resolve(reader.result);
+      } else {
+        reject(new Error('Failed to read edited PNG bytes.'));
+      }
+    };
+    reader.onerror = () => reject(reader.error || new Error('Failed to read edited PNG bytes.'));
+    reader.readAsArrayBuffer(blob);
+  });
+  return new Uint8Array(buffer);
+}
+
+const loadImageFromBlob = (blob: Blob): Promise<HTMLImageElement> => new Promise((resolve, reject) => {
+  const url = URL.createObjectURL(blob);
+  const image = new Image();
+  image.onload = () => {
+    URL.revokeObjectURL(url);
+    resolve(image);
+  };
+  image.onerror = () => {
+    URL.revokeObjectURL(url);
+    reject(new Error('Failed to load rendered editor image.'));
+  };
+  image.decoding = 'async';
+  image.src = url;
+});
+
+const roundedRectPath = (
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+) => {
+  const resolvedRadius = Math.min(radius, width / 2, height / 2);
+  context.beginPath();
+  context.moveTo(x + resolvedRadius, y);
+  context.lineTo(x + width - resolvedRadius, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + resolvedRadius);
+  context.lineTo(x + width, y + height - resolvedRadius);
+  context.quadraticCurveTo(x + width, y + height, x + width - resolvedRadius, y + height);
+  context.lineTo(x + resolvedRadius, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - resolvedRadius);
+  context.lineTo(x, y + resolvedRadius);
+  context.quadraticCurveTo(x, y, x + resolvedRadius, y);
+  context.closePath();
+};
+
+const drawArrowHead = (
+  context: CanvasRenderingContext2D,
+  fromX: number,
+  fromY: number,
+  toX: number,
+  toY: number,
+  size: number,
+) => {
+  const angle = Math.atan2(toY - fromY, toX - fromX);
+  context.beginPath();
+  context.moveTo(toX, toY);
+  context.lineTo(toX - size * Math.cos(angle - Math.PI / 6), toY - size * Math.sin(angle - Math.PI / 6));
+  context.lineTo(toX - size * Math.cos(angle + Math.PI / 6), toY - size * Math.sin(angle + Math.PI / 6));
+  context.closePath();
+  context.fill();
+};
+
+const drawPixelatedRegion = (
+  context: CanvasRenderingContext2D,
+  bounds: ImageEditorObject['bounds'],
+  pixelSize: number,
+) => {
+  const scratch = document.createElement('canvas');
+  const scratchContext = scratch.getContext('2d');
+  if (!scratchContext) {
+    return;
+  }
+  const smallWidth = Math.max(1, Math.round(bounds.width / pixelSize));
+  const smallHeight = Math.max(1, Math.round(bounds.height / pixelSize));
+  scratch.width = smallWidth;
+  scratch.height = smallHeight;
+  scratchContext.imageSmoothingEnabled = false;
+  scratchContext.drawImage(context.canvas, bounds.x, bounds.y, bounds.width, bounds.height, 0, 0, smallWidth, smallHeight);
+  context.save();
+  context.imageSmoothingEnabled = false;
+  context.drawImage(scratch, 0, 0, smallWidth, smallHeight, bounds.x, bounds.y, bounds.width, bounds.height);
+  context.restore();
+};
+
+const drawEditorObject = (
+  context: CanvasRenderingContext2D,
+  object: ImageEditorObject,
+) => {
+  const { bounds, style } = object;
+  context.save();
+  context.globalAlpha = style.opacity;
+  context.strokeStyle = style.strokeColor;
+  context.fillStyle = style.fillColor;
+  context.lineWidth = style.strokeWidth;
+  context.lineCap = 'round';
+  context.lineJoin = 'round';
+
+  if (object.type === 'blur') {
+    const scratch = document.createElement('canvas');
+    const scratchContext = scratch.getContext('2d');
+    if (scratchContext) {
+      scratch.width = bounds.width;
+      scratch.height = bounds.height;
+      scratchContext.filter = `blur(${Math.max(4, style.strokeWidth * 2)}px)`;
+      scratchContext.drawImage(context.canvas, bounds.x, bounds.y, bounds.width, bounds.height, 0, 0, bounds.width, bounds.height);
+      context.drawImage(scratch, bounds.x, bounds.y);
+    }
+    context.restore();
+    return;
+  }
+
+  if (object.type === 'pixelate') {
+    drawPixelatedRegion(context, bounds, Math.max(6, style.strokeWidth * 3));
+    context.restore();
+    return;
+  }
+
+  if (object.type === 'spotlight') {
+    context.fillStyle = 'rgba(0, 0, 0, 0.48)';
+    context.fillRect(0, 0, context.canvas.width, context.canvas.height);
+    context.globalCompositeOperation = 'destination-out';
+    context.beginPath();
+    context.ellipse(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, bounds.width / 2, bounds.height / 2, 0, 0, Math.PI * 2);
+    context.fill();
+    context.globalCompositeOperation = 'source-over';
+    context.strokeStyle = style.strokeColor;
+    context.stroke();
+    context.restore();
+    return;
+  }
+
+  if (object.type === 'magnify') {
+    context.save();
+    context.beginPath();
+    context.ellipse(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, bounds.width / 2, bounds.height / 2, 0, 0, Math.PI * 2);
+    context.clip();
+    context.drawImage(
+      context.canvas,
+      bounds.x + bounds.width * 0.2,
+      bounds.y + bounds.height * 0.2,
+      bounds.width * 0.6,
+      bounds.height * 0.6,
+      bounds.x,
+      bounds.y,
+      bounds.width,
+      bounds.height,
+    );
+    context.restore();
+    context.beginPath();
+    context.ellipse(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, bounds.width / 2, bounds.height / 2, 0, 0, Math.PI * 2);
+    context.stroke();
+    context.restore();
+    return;
+  }
+
+  if (object.type === 'rectangle' || object.type === 'highlight') {
+    context.fillStyle = object.type === 'highlight' ? 'rgba(250, 204, 21, 0.28)' : style.fillColor;
+    context.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+    if (object.type === 'rectangle') {
+      context.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
+    }
+  } else if (object.type === 'ellipse') {
+    context.beginPath();
+    context.ellipse(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, bounds.width / 2, bounds.height / 2, 0, 0, Math.PI * 2);
+    context.fill();
+    context.stroke();
+  } else if (object.type === 'line' || object.type === 'arrow') {
+    context.beginPath();
+    context.moveTo(bounds.x, bounds.y);
+    context.lineTo(bounds.x + bounds.width, bounds.y + bounds.height);
+    context.stroke();
+    if (object.type === 'arrow') {
+      context.fillStyle = style.strokeColor;
+      drawArrowHead(context, bounds.x, bounds.y, bounds.x + bounds.width, bounds.y + bounds.height, Math.max(12, style.strokeWidth * 4));
+    }
+  } else if (object.type === 'freehand' && object.points && object.points.length > 1) {
+    context.beginPath();
+    context.moveTo(object.points[0].x, object.points[0].y);
+    object.points.slice(1).forEach((point) => context.lineTo(point.x, point.y));
+    context.stroke();
+  } else if (object.type === 'text') {
+    context.fillStyle = style.textColor;
+    context.font = `${style.fontSize}px system-ui, sans-serif`;
+    context.fillText(object.text || 'Text', bounds.x, bounds.y + style.fontSize);
+  } else if (object.type === 'step') {
+    const radius = Math.max(16, Math.min(bounds.width, bounds.height) / 2);
+    context.fillStyle = style.strokeColor;
+    context.beginPath();
+    context.arc(bounds.x + radius, bounds.y + radius, radius, 0, Math.PI * 2);
+    context.fill();
+    context.fillStyle = style.textColor;
+    context.font = `700 ${Math.round(radius)}px system-ui, sans-serif`;
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.fillText(String(object.stepNumber || 1), bounds.x + radius, bounds.y + radius + 1);
+  }
+
+  context.restore();
+};
+
+const drawImageEditorBackground = (
+  context: CanvasRenderingContext2D,
+  background: ImageEditorBackground,
+  width: number,
+  height: number,
+) => {
+  if (background.kind === 'transparent') {
+    return;
+  }
+
+  if (background.kind === 'gradient') {
+    const gradient = context.createLinearGradient(0, 0, width, height);
+    gradient.addColorStop(0, background.gradientFrom);
+    gradient.addColorStop(1, background.gradientTo);
+    context.fillStyle = gradient;
+  } else {
+    context.fillStyle = background.color;
+  }
+  context.fillRect(0, 0, width, height);
+};
+
+export async function renderImageEditorDocumentToPngBlob(
+  sourceUrl: string,
+  editorDocument: Partial<ImageEditorDocument>,
+): Promise<Blob> {
+  const normalized = normalizeImageEditorDocument(editorDocument);
+  const baseBlob = await renderEditedImageToPngBlob(sourceUrl, normalized.recipe);
+  const baseImage = await loadImageFromBlob(baseBlob);
+  const background = normalized.background;
+  const spacing = background.padding + (background.smartPadding ? Math.round(Math.min(baseImage.width, baseImage.height) * 0.06) : 0);
+  const outerMargin = background.margin;
+  const contentX = outerMargin + spacing;
+  const contentY = outerMargin + spacing;
+  const canvas = document.createElement('canvas');
+  canvas.width = baseImage.width + (outerMargin + spacing) * 2;
+  canvas.height = baseImage.height + (outerMargin + spacing) * 2;
+
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Canvas rendering is not available in this browser.');
+  }
+
+  drawImageEditorBackground(context, background, canvas.width, canvas.height);
+  context.save();
+  if (background.shadowRadius > 0) {
+    context.shadowColor = 'rgba(0, 0, 0, 0.42)';
+    context.shadowBlur = background.shadowRadius;
+    context.shadowOffsetY = Math.round(background.shadowRadius / 3);
+  }
+  if (background.roundedCorner > 0) {
+    roundedRectPath(context, contentX, contentY, baseImage.width, baseImage.height, background.roundedCorner);
+    context.clip();
+  }
+  context.drawImage(baseImage, contentX, contentY);
+  context.restore();
+
+  if (contentX || contentY) {
+    context.translate(contentX, contentY);
+  }
+  normalized.objects.forEach((object) => drawEditorObject(context, object));
+  if (contentX || contentY) {
+    context.setTransform(1, 0, 0, 1, 0, 0);
+  }
+
+  return canvasToBlob(canvas);
+}
+
+export async function renderImageEditorDocumentToPngBytes(
+  sourceUrl: string,
+  document: Partial<ImageEditorDocument>,
+): Promise<Uint8Array> {
+  const blob = await renderImageEditorDocumentToPngBlob(sourceUrl, document);
   if (typeof blob.arrayBuffer === 'function') {
     return new Uint8Array(await blob.arrayBuffer());
   }
@@ -709,15 +1168,24 @@ const buildMetaHubEditPayload = (
   recipe: ImageEditRecipe,
   preservedWorkflow?: PreservedComfyWorkflow,
   outputDimensions?: { width: number; height: number },
+  editInfo?: {
+    tool?: string;
+    annotationCount?: number;
+    background?: ImageEditorBackground;
+    sourceImageId?: string;
+  },
 ) => {
   const payload: Record<string, unknown> = {
     generator: 'Image MetaHub',
     source_generator: typeof metadata.generator === 'string' ? metadata.generator : null,
     edited_at: new Date().toISOString(),
     edit: {
-      tool: 'image-editor-v2',
+      tool: editInfo?.tool || 'image-editor-v2',
       recipe,
       output_dimensions: outputDimensions,
+      annotation_count: editInfo?.annotationCount,
+      background: editInfo?.background,
+      source_image_id: editInfo?.sourceImageId,
     },
     prompt: metadata.prompt || '',
     negativePrompt: metadata.negativePrompt || '',
@@ -798,6 +1266,12 @@ export const embedMetaHubMetadataInPngBytes = (
   recipeOrAdjustments: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
   rawMetadata?: Record<string, unknown>,
   outputDimensions?: { width: number; height: number },
+  editInfo?: {
+    tool?: string;
+    annotationCount?: number;
+    background?: ImageEditorBackground;
+    sourceImageId?: string;
+  },
 ): Uint8Array => {
   if (!metadata) {
     return pngBytes;
@@ -809,7 +1283,7 @@ export const embedMetaHubMetadataInPngBytes = (
     createPngTextChunk('parameters', formatMetadataForA1111Compat(metadata)),
     createPngInternationalTextChunk(
       'imagemetahub_data',
-      JSON.stringify(buildMetaHubEditPayload(metadata, normalizedRecipe, preservedWorkflow, outputDimensions)),
+      JSON.stringify(buildMetaHubEditPayload(metadata, normalizedRecipe, preservedWorkflow, outputDimensions, editInfo)),
     ),
   ];
 

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -1253,7 +1253,7 @@ const extractPreservedComfyWorkflow = (
 
   const metaHubPayload = parseMaybeRecord(rawMetadata.imagemetahub_data);
   const workflow = metaHubPayload?.workflow ?? rawMetadata.workflow;
-  const prompt = metaHubPayload?.prompt_api ?? metaHubPayload?.prompt ?? rawMetadata.prompt;
+  const prompt = metaHubPayload?.prompt_api ?? metaHubPayload?.prompt ?? rawMetadata.prompt_api ?? rawMetadata.prompt;
 
   if (workflow === undefined && prompt === undefined) {
     return undefined;
@@ -1275,25 +1275,29 @@ export const embedMetaHubMetadataInPngBytes = (
     sourceImageId?: string;
   },
 ): Uint8Array => {
-  if (!metadata) {
+  const preservedWorkflow = extractPreservedComfyWorkflow(rawMetadata);
+  if (!metadata && !preservedWorkflow) {
     return pngBytes;
   }
 
   const normalizedRecipe = normalizeImageEditRecipe(recipeOrAdjustments);
-  const preservedWorkflow = extractPreservedComfyWorkflow(rawMetadata);
-  const chunks = [
-    createPngTextChunk('parameters', formatMetadataForA1111Compat(metadata)),
-    createPngInternationalTextChunk(
-      'imagemetahub_data',
-      JSON.stringify(buildMetaHubEditPayload(metadata, normalizedRecipe, preservedWorkflow, outputDimensions, editInfo)),
-    ),
-  ];
+  const chunks: Uint8Array[] = [];
+
+  if (metadata) {
+    chunks.push(
+      createPngTextChunk('parameters', formatMetadataForA1111Compat(metadata)),
+      createPngInternationalTextChunk(
+        'imagemetahub_data',
+        JSON.stringify(buildMetaHubEditPayload(metadata, normalizedRecipe, preservedWorkflow, outputDimensions, editInfo)),
+      ),
+    );
+  }
 
   if (preservedWorkflow?.workflow !== undefined) {
-    chunks.push(createPngInternationalTextChunk('workflow', stringifyPngTextValue(preservedWorkflow.workflow)));
+    chunks.push(createPngTextChunk('workflow', stringifyPngTextValue(preservedWorkflow.workflow)));
   }
   if (preservedWorkflow?.prompt !== undefined) {
-    chunks.push(createPngInternationalTextChunk('prompt', stringifyPngTextValue(preservedWorkflow.prompt)));
+    chunks.push(createPngTextChunk('prompt', stringifyPngTextValue(preservedWorkflow.prompt)));
   }
 
   return appendChunksToPngBytes(pngBytes, chunks);

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -379,8 +379,11 @@ export const getImageEditOutputDimensions = (
 
 export const hasImageEditRecipeChanges = (
   recipeOrAdjustments: Partial<ImageEditRecipe> | Partial<ImageAdjustments>,
+  sourceDimensions?: { width: number; height: number },
 ): boolean => {
-  const recipe = normalizeImageEditRecipe(recipeOrAdjustments);
+  const recipe = normalizeImageEditRecipe(recipeOrAdjustments, sourceDimensions);
+  const inputRecipe = isRecipeLike(recipeOrAdjustments) ? recipeOrAdjustments : undefined;
+  const hasExplicitResizeEdit = Boolean(inputRecipe?.resize?.enabled);
   return (
     hasImageAdjustments(recipe.adjustments) ||
     recipe.transform.rotation !== DEFAULT_IMAGE_EDIT_RECIPE.transform.rotation ||
@@ -388,6 +391,7 @@ export const hasImageEditRecipeChanges = (
     recipe.transform.flipVertical !== DEFAULT_IMAGE_EDIT_RECIPE.transform.flipVertical ||
     recipe.crop.enabled ||
     recipe.resize.enabled ||
+    hasExplicitResizeEdit ||
     recipe.effects.sharpen !== DEFAULT_IMAGE_EDIT_RECIPE.effects.sharpen ||
     recipe.effects.blur !== DEFAULT_IMAGE_EDIT_RECIPE.effects.blur
   );
@@ -545,7 +549,7 @@ export const hasImageEditorDocumentChanges = (
   const normalized = normalizeImageEditorDocument(document);
   const background = normalized.background;
   return (
-    hasImageEditRecipeChanges(normalized.recipe) ||
+    hasImageEditRecipeChanges(normalized.recipe, normalized.sourceDimensions) ||
     normalized.objects.length > 0 ||
     background.kind !== DEFAULT_IMAGE_EDITOR_BACKGROUND.kind ||
     background.margin !== DEFAULT_IMAGE_EDITOR_BACKGROUND.margin ||

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -1196,6 +1196,16 @@ const buildMetaHubEditPayload = (
     sourceImageId?: string;
   },
 ) => {
+  const payloadWidth = Number.isFinite(outputDimensions?.width)
+    ? outputDimensions?.width
+    : Number.isFinite(metadata.width)
+      ? metadata.width
+      : 0;
+  const payloadHeight = Number.isFinite(outputDimensions?.height)
+    ? outputDimensions?.height
+    : Number.isFinite(metadata.height)
+      ? metadata.height
+      : 0;
   const payload: Record<string, unknown> = {
     generator: 'Image MetaHub',
     source_generator: typeof metadata.generator === 'string' ? metadata.generator : null,
@@ -1216,8 +1226,8 @@ const buildMetaHubEditPayload = (
     sampler_name: metadata.sampler || '',
     scheduler: metadata.scheduler || '',
     model: metadata.model || metadata.models?.[0] || '',
-    width: Number.isFinite(metadata.width) ? metadata.width : 0,
-    height: Number.isFinite(metadata.height) ? metadata.height : 0,
+    width: payloadWidth,
+    height: payloadHeight,
     loras: toLoraPayload(metadata.loras),
     imh_pro: {
       notes: typeof metadata.notes === 'string' ? metadata.notes : '',

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -53,6 +53,7 @@ export const DEFAULT_IMAGE_EDITOR_OBJECT_STYLE: ImageEditorObjectStyle = {
   textColor: '#f8fafc',
   strokeWidth: 4,
   fontSize: 32,
+  fontFamily: 'system-ui, sans-serif',
   opacity: 1,
 };
 
@@ -78,6 +79,23 @@ const ADJUSTMENT_RANGES: Record<keyof ImageAdjustments, { min: number; max: numb
 const EFFECT_RANGES: Record<keyof ImageEditEffects, { min: number; max: number }> = {
   sharpen: { min: 0, max: 100 },
   blur: { min: 0, max: 20 },
+};
+
+const ALLOWED_IMAGE_EDITOR_FONT_FAMILIES = new Set([
+  'system-ui, sans-serif',
+  'Arial, sans-serif',
+  'Verdana, sans-serif',
+  'Georgia, serif',
+  '"Times New Roman", serif',
+  '"Courier New", monospace',
+  'Impact, sans-serif',
+]);
+
+const normalizeImageEditorFontFamily = (value: unknown): string => {
+  const fontFamily = typeof value === 'string' ? value : '';
+  return ALLOWED_IMAGE_EDITOR_FONT_FAMILIES.has(fontFamily)
+    ? fontFamily
+    : DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.fontFamily;
 };
 
 const MAX_OUTPUT_DIMENSION = 20000;
@@ -460,6 +478,7 @@ export const normalizeImageEditorObject = (
       textColor: object.style?.textColor || DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.textColor,
       strokeWidth: clampInteger(object.style?.strokeWidth ?? DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.strokeWidth, 1, 80, DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.strokeWidth),
       fontSize: clampInteger(object.style?.fontSize ?? DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.fontSize, 8, 240, DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.fontSize),
+      fontFamily: normalizeImageEditorFontFamily(object.style?.fontFamily),
       opacity: clampNumber(object.style?.opacity ?? DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.opacity, 0, 1, DEFAULT_IMAGE_EDITOR_OBJECT_STYLE.opacity),
     },
   };
@@ -877,7 +896,7 @@ const drawEditorObject = (
     context.stroke();
   } else if (object.type === 'text') {
     context.fillStyle = style.textColor;
-    context.font = `${style.fontSize}px system-ui, sans-serif`;
+    context.font = `${style.fontSize}px ${style.fontFamily}`;
     context.fillText(object.text || 'Text', bounds.x, bounds.y + style.fontSize);
   } else if (object.type === 'step') {
     const radius = Math.max(16, Math.min(bounds.width, bounds.height) / 2);
@@ -886,7 +905,7 @@ const drawEditorObject = (
     context.arc(bounds.x + radius, bounds.y + radius, radius, 0, Math.PI * 2);
     context.fill();
     context.fillStyle = style.textColor;
-    context.font = `700 ${Math.round(radius)}px system-ui, sans-serif`;
+    context.font = `700 ${Math.round(radius)}px ${style.fontFamily}`;
     context.textAlign = 'center';
     context.textBaseline = 'middle';
     context.fillText(String(object.stepNumber || 1), bounds.x + radius, bounds.y + radius + 1);

--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -49,7 +49,7 @@ export const DEFAULT_IMAGE_EDIT_RECIPE: ImageEditRecipe = {
 
 export const DEFAULT_IMAGE_EDITOR_OBJECT_STYLE: ImageEditorObjectStyle = {
   strokeColor: '#22d3ee',
-  fillColor: 'rgba(34, 211, 238, 0.16)',
+  fillColor: 'rgba(0, 0, 0, 0)',
   textColor: '#f8fafc',
   strokeWidth: 4,
   fontSize: 32,

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -876,6 +876,8 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
           _detection_method: 'metahub_chunk',
           _metahub_pro: metahubData.imh_pro || null,
           _analytics: metahubData.analytics || null,
+          _metadata_status: metahubData.metadata_status || null,
+          _metadata_sources: metahubData.metadata_sources || null,
         };
       }
     }

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -871,15 +871,18 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
                 : undefined,
             }
           : undefined;
+        const seedSource = metahubData.metadata_sources?.seed;
+        const seedIsExplicit = seedSource === 'detected' || seedSource === 'manual_override' || metahubData.metadata_status === 'complete';
+        const seed = firstNonNullish(
+          metahubData.seed === 0 && !seedIsExplicit && graphMetadata.seed !== undefined ? graphMetadata.seed : metahubData.seed,
+          graphMetadata.seed
+        );
 
         // Map MetaHub chunk fields to expected format
         return {
           prompt: firstNonBlankString(metahubData.prompt, graphMetadata.prompt) || '',
           negativePrompt: firstNonBlankString(metahubData.negativePrompt, graphMetadata.negativePrompt) || '',
-          seed: firstNonNullish(
-            metahubData.seed === 0 && graphMetadata.seed !== undefined ? graphMetadata.seed : metahubData.seed,
-            graphMetadata.seed
-          ),
+          seed,
           steps: firstNonNullish(metahubData.steps, graphMetadata.steps),
           cfg: firstNonNullish(metahubData.cfg, graphMetadata.cfg),
           sampler_name: firstNonBlankString(metahubData.sampler_name, graphMetadata.sampler_name) || '',

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -173,6 +173,24 @@ function normalizePromptWhitespace(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
 }
 
+function firstNonBlankString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function firstNonNullish<T>(...values: Array<T | null | undefined>): T | undefined {
+  for (const value of values) {
+    if (value !== null && value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Advanced Seed Extraction with multiple formats:
  * - Numeric: "seed": 12345
@@ -833,6 +851,9 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
         const graph = workflowGraph || promptGraph
           ? createNodeMap(workflowGraph, promptGraph)
           : null;
+        const graphMetadata = graph
+          ? resolvePromptFromGraph(workflowGraph, promptGraph)
+          : {};
         const inferredLineage = graph
           ? detectComfyLineageFromGraph(graph, findTerminalNode(graph), metahubData.denoise)
           : {};
@@ -853,21 +874,26 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
 
         // Map MetaHub chunk fields to expected format
         return {
-          prompt: metahubData.prompt,
-          negativePrompt: metahubData.negativePrompt,
-          seed: metahubData.seed,
-          steps: metahubData.steps,
-          cfg: metahubData.cfg,
-          sampler_name: metahubData.sampler_name,
-          scheduler: metahubData.scheduler,
-          model: metahubData.model,
+          prompt: firstNonBlankString(metahubData.prompt, graphMetadata.prompt) || '',
+          negativePrompt: firstNonBlankString(metahubData.negativePrompt, graphMetadata.negativePrompt) || '',
+          seed: firstNonNullish(
+            metahubData.seed === 0 && graphMetadata.seed !== undefined ? graphMetadata.seed : metahubData.seed,
+            graphMetadata.seed
+          ),
+          steps: firstNonNullish(metahubData.steps, graphMetadata.steps),
+          cfg: firstNonNullish(metahubData.cfg, graphMetadata.cfg),
+          sampler_name: firstNonBlankString(metahubData.sampler_name, graphMetadata.sampler_name) || '',
+          scheduler: firstNonBlankString(metahubData.scheduler, graphMetadata.scheduler) || '',
+          model: firstNonBlankString(metahubData.model, graphMetadata.model) || '',
           model_hash: metahubData.model_hash,
-          vae: metahubData.vae,
-          denoise: metahubData.denoise,
+          vae: firstNonBlankString(metahubData.vae, graphMetadata.vae) || '',
+          denoise: firstNonNullish(metahubData.denoise, graphMetadata.denoise),
           width: metahubData.width,
           height: metahubData.height,
-          loras: metahubData.loras || [],
-          lora: metahubData.loras?.map((l: any) => l.name) || [], // Backward compatibility
+          loras: Array.isArray(metahubData.loras) && metahubData.loras.length > 0 ? metahubData.loras : (graphMetadata.loras || []),
+          lora: Array.isArray(metahubData.loras) && metahubData.loras.length > 0
+            ? metahubData.loras.map((l: any) => l.name)
+            : graphMetadata.lora || [], // Backward compatibility
           tags: userTags,
           notes: userNotes,
           generator: metahubData.generator === 'ComfyUI' ? 'ComfyUI' : 'Image MetaHub',

--- a/services/parsers/comfyui/nodeRegistry.ts
+++ b/services/parsers/comfyui/nodeRegistry.ts
@@ -204,6 +204,36 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     pass_through_rules: [{ from_input: 'model', to_output: 'MODEL' }],
     widget_order: ['lora_name', 'strength_model']
   },
+  'Lora Loader (LoraManager)': {
+    category: 'LOADING',
+    roles: ['TRANSFORM'],
+    inputs: { model: { type: 'MODEL' }, clip: { type: 'CLIP' }, text: { type: 'STRING' } },
+    outputs: { MODEL: { type: 'MODEL' }, CLIP: { type: 'CLIP' }, trigger_words: { type: 'STRING' }, loaded_loras: { type: 'STRING' } },
+    param_mapping: {
+      lora: {
+        source: 'custom_extractor',
+        extractor: (node: ParserNode) => {
+          const rawLoras = node.inputs?.loras?.__value__;
+          if (Array.isArray(rawLoras)) {
+            return rawLoras
+              .filter((lora: any) => lora && lora.active !== false && (lora.name || lora.lora_name))
+              .map((lora: any) => lora.name || lora.lora_name);
+          }
+
+          const text = typeof node.inputs?.text === 'string' ? node.inputs.text : '';
+          return text ? extractors.extractLorasFromText(text) : [];
+        },
+        accumulate: true,
+      },
+      model: { source: 'trace', input: 'model' },
+      prompt: { source: 'input', key: 'text' },
+    },
+    pass_through_rules: [
+      { from_input: 'model', to_output: 'MODEL' },
+      { from_input: 'clip', to_output: 'CLIP' },
+    ],
+    widget_order: ['__lm_autocomplete_meta_text', 'text', 'loras']
+  },
   'LoRA Stacker': {
     category: 'LOADING', roles: ['TRANSFORM'],
     inputs: {}, outputs: { '*': { type: 'ANY' } },
@@ -231,6 +261,22 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     inputs: { '*': { type: 'ANY' } }, outputs: { '*': { type: 'ANY' } },
     pass_through_rules: [{ from_input: '*', to_output: '*' }],
   },
+  'Any Switch (rgthree)': {
+    category: 'ROUTING', roles: ['PASS_THROUGH'],
+    inputs: { '*': { type: 'ANY' } }, outputs: { '*': { type: 'ANY' } },
+    pass_through_rules: [{ from_input: '*', to_output: '*' }],
+  },
+  'TriggerWord Toggle (LoraManager)': {
+    category: 'ROUTING',
+    roles: ['PASS_THROUGH'],
+    inputs: { trigger_words: { type: 'STRING' } },
+    outputs: { filtered_trigger_words: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'trace', input: 'trigger_words' },
+    },
+    pass_through_rules: [{ from_input: 'trigger_words', to_output: 'filtered_trigger_words' }],
+    widget_order: ['group_mode', 'default_active', 'allow_strength_adjustment', 'toggle_trigger_words', 'orinalMessage']
+  },
   ImpactSwitch: {
     category: 'ROUTING', roles: ['ROUTING'],
     inputs: { select: { type: 'INT' }, input1: { type: 'ANY' }, input2: { type: 'ANY' } },
@@ -257,7 +303,7 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
 
   // Common ComfyUI nodes that might appear in workflows
   SaveImage: {
-    category: 'IO', roles: ['SINK'],
+    category: 'IO', roles: ['SINK', 'PASS_THROUGH'],
     inputs: { images: { type: 'IMAGE' } }, 
     outputs: {},
     param_mapping: {},  // No direct params, but traverse inputs
@@ -265,7 +311,7 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
   },
 
   PreviewImage: {
-    category: 'IO', roles: ['SINK'],
+    category: 'IO', roles: ['SINK', 'PASS_THROUGH'],
     inputs: { images: { type: 'IMAGE' } }, outputs: {},
   },
 
@@ -296,6 +342,14 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     category: 'UTILS', roles: ['SOURCE'],
     inputs: { seed: { type: 'INT' } }, outputs: { INT: { type: 'INT' } },
     param_mapping: { seed: { source: 'input', key: 'seed' }, },
+  },
+  SeedGenerator: {
+    category: 'UTILS',
+    roles: ['SOURCE'],
+    inputs: { seed: { type: 'INT' } },
+    outputs: { seed: { type: 'INT' }, 'seed+1': { type: 'INT' } },
+    param_mapping: { seed: { source: 'input', key: 'seed' } },
+    widget_order: ['seed', 'control_after_generate']
   },
   'Seed (rgthree)': {
     category: 'UTILS',
@@ -556,6 +610,68 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     param_mapping: {},
     pass_through_rules: [{ from_input: 'clip', to_output: 'CLIP' }],
     widget_order: ['mean_pool', 'return_tokens']
+  },
+
+  'easy positive': {
+    category: 'UTILS',
+    roles: ['SOURCE'],
+    inputs: { positive: { type: 'STRING' } },
+    outputs: { positive: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'input', key: 'positive' },
+    },
+    widget_order: ['positive']
+  },
+
+  'easy stylesSelector': {
+    category: 'UTILS',
+    roles: ['PASS_THROUGH'],
+    inputs: { positive: { type: 'STRING' }, negative: { type: 'STRING' } },
+    outputs: { positive: { type: 'STRING' }, negative: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'trace', input: 'positive' },
+      negativePrompt: { source: 'trace', input: 'negative' },
+    },
+    pass_through_rules: [
+      { from_input: 'positive', to_output: 'positive' },
+      { from_input: 'negative', to_output: 'negative' },
+    ],
+    widget_order: ['styles', 'select_styles']
+  },
+
+  JoinStrings: {
+    category: 'UTILS',
+    roles: ['TRANSFORM'],
+    inputs: { string1: { type: 'STRING' }, string2: { type: 'STRING' }, string3: { type: 'STRING' }, string4: { type: 'STRING' } },
+    outputs: { STRING: { type: 'STRING' } },
+    param_mapping: {
+      prompt: {
+        source: 'custom_extractor',
+        extractor: (node, state, graph, traverseFromLink) =>
+          extractors.concatTextExtractor(node, state, graph, traverseFromLink, ['string1', 'string2', 'string3', 'string4'])
+      },
+      negativePrompt: {
+        source: 'custom_extractor',
+        extractor: (node, state, graph, traverseFromLink) =>
+          extractors.concatTextExtractor(node, state, graph, traverseFromLink, ['string1', 'string2', 'string3', 'string4'])
+      },
+    },
+    widget_order: ['delimiter']
+  },
+
+  ConditioningZeroOut: {
+    category: 'CONDITIONING',
+    roles: ['TRANSFORM'],
+    inputs: { conditioning: { type: 'CONDITIONING' } },
+    outputs: { CONDITIONING: { type: 'CONDITIONING' } },
+    param_mapping: {
+      prompt: { source: 'trace', input: 'conditioning' },
+      negativePrompt: {
+        source: 'custom_extractor',
+        extractor: () => '',
+      },
+    },
+    pass_through_rules: [{ from_input: 'conditioning', to_output: 'CONDITIONING' }]
   },
 
   ScaledFP8HybridUNetLoader: {
@@ -1193,6 +1309,16 @@ PerturbedAttention: {
   param_mapping: {},
   widget_order: ['hard_mode', 'boost'],
   pass_through_rules: [{ from_input: 'model', to_output: 'MODEL' }]
+},
+
+PathchSageAttentionKJ: {
+  category: 'TRANSFORM',
+  roles: ['PASS_THROUGH'],
+  inputs: { model: { type: 'MODEL' } },
+  outputs: { MODEL: { type: 'MODEL' } },
+  param_mapping: {},
+  pass_through_rules: [{ from_input: 'model', to_output: 'MODEL' }],
+  widget_order: ['sage_attention', 'allow_compile']
 },
 
 TiledDiffusion: {

--- a/services/parsers/comfyui/nodeRegistry.ts
+++ b/services/parsers/comfyui/nodeRegistry.ts
@@ -657,12 +657,18 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
             ? node.widgets_values[0]
             : (typeof node.inputs?.delimiter === 'string' ? node.inputs.delimiter : ' ');
           return extractors.concatTextExtractor(
-            node,
+            {
+              ...node,
+              inputs: {
+                ...node.inputs,
+                __joinstrings_delimiter: delimiter,
+              },
+            },
             state,
             graph,
             traverseFromLink,
             ['string1', 'string2', 'string3', 'string4'],
-            delimiter
+            '__joinstrings_delimiter'
           );
         }
       },
@@ -673,12 +679,18 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
             ? node.widgets_values[0]
             : (typeof node.inputs?.delimiter === 'string' ? node.inputs.delimiter : ' ');
           return extractors.concatTextExtractor(
-            node,
+            {
+              ...node,
+              inputs: {
+                ...node.inputs,
+                __joinstrings_delimiter: delimiter,
+              },
+            },
             state,
             graph,
             traverseFromLink,
             ['string1', 'string2', 'string3', 'string4'],
-            delimiter
+            '__joinstrings_delimiter'
           );
         }
       },

--- a/services/parsers/comfyui/nodeRegistry.ts
+++ b/services/parsers/comfyui/nodeRegistry.ts
@@ -213,11 +213,16 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
       lora: {
         source: 'custom_extractor',
         extractor: (node: ParserNode) => {
-          const rawLoras = node.inputs?.loras?.__value__;
+          const rawLoras = node.inputs?.loras?.__value__ ?? node.widgets_values?.[2];
           if (Array.isArray(rawLoras)) {
             return rawLoras
-              .filter((lora: any) => lora && lora.active !== false && (lora.name || lora.lora_name))
-              .map((lora: any) => lora.name || lora.lora_name);
+              .filter((lora: any) => {
+                if (typeof lora === 'string') {
+                  return lora.trim().length > 0;
+                }
+                return lora && lora.active !== false && (lora.name || lora.lora_name);
+              })
+              .map((lora: any) => typeof lora === 'string' ? lora : lora.name || lora.lora_name);
           }
 
           const text = typeof node.inputs?.text === 'string' ? node.inputs.text : '';

--- a/services/parsers/comfyui/nodeRegistry.ts
+++ b/services/parsers/comfyui/nodeRegistry.ts
@@ -652,13 +652,35 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     param_mapping: {
       prompt: {
         source: 'custom_extractor',
-        extractor: (node, state, graph, traverseFromLink) =>
-          extractors.concatTextExtractor(node, state, graph, traverseFromLink, ['string1', 'string2', 'string3', 'string4'])
+        extractor: (node, state, graph, traverseFromLink) => {
+          const delimiter = typeof node.widgets_values?.[0] === 'string'
+            ? node.widgets_values[0]
+            : (typeof node.inputs?.delimiter === 'string' ? node.inputs.delimiter : ' ');
+          return extractors.concatTextExtractor(
+            node,
+            state,
+            graph,
+            traverseFromLink,
+            ['string1', 'string2', 'string3', 'string4'],
+            delimiter
+          );
+        }
       },
       negativePrompt: {
         source: 'custom_extractor',
-        extractor: (node, state, graph, traverseFromLink) =>
-          extractors.concatTextExtractor(node, state, graph, traverseFromLink, ['string1', 'string2', 'string3', 'string4'])
+        extractor: (node, state, graph, traverseFromLink) => {
+          const delimiter = typeof node.widgets_values?.[0] === 'string'
+            ? node.widgets_values[0]
+            : (typeof node.inputs?.delimiter === 'string' ? node.inputs.delimiter : ' ');
+          return extractors.concatTextExtractor(
+            node,
+            state,
+            graph,
+            traverseFromLink,
+            ['string1', 'string2', 'string3', 'string4'],
+            delimiter
+          );
+        }
       },
     },
     widget_order: ['delimiter']

--- a/services/parsers/comfyui/traversalEngine.ts
+++ b/services/parsers/comfyui/traversalEngine.ts
@@ -94,17 +94,35 @@ function traverse(
 
   // 4. Travessia Estática (PASS_THROUGH / TRANSFORM)
   if (nodeDef.roles.includes('PASS_THROUGH') || nodeDef.roles.includes('TRANSFORM')) {
+    let matchedTypedInput = false;
+
     // Procura por entradas que correspondam ao tipo de dado esperado para continuar a cadeia
     for (const inputName in nodeDef.inputs) {
       const inputDef = nodeDef.inputs[inputName];
       if (inputDef.type === state.expectedType || inputDef.type === 'ANY') {
         const inputLink = currentNode.inputs[inputName];
         if (inputLink && Array.isArray(inputLink)) {
+           matchedTypedInput = true;
            const result = traverseFromLink(inputLink as NodeLink, state, graph, accumulator);
            // Retorna o primeiro resultado encontrado, a menos que esteja acumulando LoRAs
            if (state.targetParam !== 'lora' && result !== null) {
                return result;
            }
+        }
+      }
+    }
+
+    // Some terminal/output chains expose IMAGE/LATENT links before the sampler
+    // that owns prompt/model/sampling facts. If no typed route exists, keep
+    // walking upstream through connected inputs until a known fact node is found.
+    if (!matchedTypedInput) {
+      for (const inputName in currentNode.inputs) {
+        const inputLink = currentNode.inputs[inputName];
+        if (inputLink && Array.isArray(inputLink)) {
+          const result = traverseFromLink(inputLink as NodeLink, state, graph, accumulator);
+          if (state.targetParam !== 'lora' && result !== null) {
+            return result;
+          }
         }
       }
     }

--- a/services/parsers/metadataParserFactory.ts
+++ b/services/parsers/metadataParserFactory.ts
@@ -140,11 +140,8 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
     const promptCI = getCaseInsensitive<unknown>(rawMetadata, 'prompt');
     const promptLooksLikeGraph = typeof promptCI === 'string' && /"class_type"|"inputs"/.test(promptCI);
     const promptOnlyGraph = isComfyPromptOnlyGraph(rawMetadata);
-    const hasParameters = 'parameters' in metadata &&
-        typeof metadata.parameters === 'string' &&
-        metadata.parameters.trim().length > 0;
 
-    if (!hasParameters && (workflowCI !== undefined || (promptCI && typeof promptCI === 'object') || promptLooksLikeGraph || promptOnlyGraph)) {
+    if (workflowCI !== undefined || (promptCI && typeof promptCI === 'object') || promptLooksLikeGraph || promptOnlyGraph) {
         return {
             parse: (data: ComfyUIMetadata) => {
                 // Parse workflow and prompt if they are strings

--- a/services/parsers/metadataParserFactory.ts
+++ b/services/parsers/metadataParserFactory.ts
@@ -43,7 +43,7 @@ function isComfyPromptOnlyGraph(metadata: UnknownRecord): boolean {
 }
 
 interface ParserModule {
-    parse: (metadata: ImageMetadata, fileBuffer?: ArrayBuffer) => BaseMetadata | Promise<BaseMetadata>;
+    parse: (metadata: ImageMetadata, fileBuffer?: ArrayBuffer) => BaseMetadata | null | Promise<BaseMetadata | null>;
     generator: string;
 }
 
@@ -115,6 +115,8 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
                     lineage: result.lineage,
                     _analytics: result._analytics || null,
                     _metahub_pro: result._metahub_pro || null,
+                    _metadata_status: result._metadata_status || null,
+                    _metadata_sources: result._metadata_sources || null,
                     _detection_method: result._detection_method,
                 } as BaseMetadata;
             },
@@ -127,16 +129,7 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
     if ('videometahub_data' in metadata || rawMetadata.media_type === 'video') {
         return {
             parse: (data: VideoMetadata) => {
-                const result = parseVideoMetaHubMetadata(data);
-                return (result ?? {
-                    prompt: '',
-                    model: '',
-                    width: 0,
-                    height: 0,
-                    steps: 0,
-                    scheduler: '',
-                    media_type: 'video',
-                }) as BaseMetadata;
+                return parseVideoMetaHubMetadata(data);
             },
             generator: 'ComfyUI'
         };
@@ -292,6 +285,9 @@ export async function parseImageMetadata(metadata: ImageMetadata, fileBuffer?: A
     const parser = getMetadataParser(metadata);
     if (parser) {
         const result = await parser.parse(metadata, fileBuffer);
+        if (!result) {
+            return null;
+        }
         result.generator = parser.generator;
         return result;
     }

--- a/services/parsers/videoMetaHubParser.ts
+++ b/services/parsers/videoMetaHubParser.ts
@@ -14,6 +14,25 @@ const parseJsonSafe = (value: unknown): MetaHubVideoPayload | null => {
   }
 };
 
+const isMetaHubVideoPayload = (value: unknown): value is MetaHubVideoPayload => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const payload = value as MetaHubVideoPayload;
+  if (payload.generator !== 'ComfyUI' && payload.generator !== 'Image MetaHub') {
+    return false;
+  }
+  if (payload.media_type !== 'video') {
+    return false;
+  }
+  const video = payload.video && typeof payload.video === 'object'
+    ? payload.video as MetaHubVideoPayload
+    : null;
+  const width = normalizeNumber(video?.width ?? payload.width, 0);
+  const height = normalizeNumber(video?.height ?? payload.height, 0);
+  return width > 0 && height > 0 && Boolean(video);
+};
+
 const extractVideoMetaHubPayload = (rawData: unknown): MetaHubVideoPayload | null => {
   if (!rawData) {
     return null;
@@ -21,22 +40,23 @@ const extractVideoMetaHubPayload = (rawData: unknown): MetaHubVideoPayload | nul
 
   if (typeof rawData === 'object') {
     const data = rawData as MetaHubVideoPayload;
-    if (data.videometahub_data && typeof data.videometahub_data === 'object') {
+    if (isMetaHubVideoPayload(data.videometahub_data)) {
       return data.videometahub_data as MetaHubVideoPayload;
     }
     if (data.comment && typeof data.comment === 'string') {
       const parsed = parseJsonSafe(data.comment);
-      if (parsed) {
+      if (isMetaHubVideoPayload(parsed)) {
         return parsed;
       }
     }
-    if (data.media_type === 'video' || data.video) {
+    if (isMetaHubVideoPayload(data)) {
       return data;
     }
   }
 
   if (typeof rawData === 'string') {
-    return parseJsonSafe(rawData);
+    const parsed = parseJsonSafe(rawData);
+    return isMetaHubVideoPayload(parsed) ? parsed : null;
   }
 
   return null;
@@ -100,5 +120,7 @@ export const parseVideoMetaHubMetadata = (rawData: unknown): BaseMetadata | null
     model_hash: payload.model_hash,
     _analytics: payload.analytics || null,
     _metahub_pro: payload.imh_pro || null,
+    _metadata_status: payload.metadata_status || null,
+    _metadata_sources: payload.metadata_sources || null,
   };
 };

--- a/store/useGenerationQueueStore.ts
+++ b/store/useGenerationQueueStore.ts
@@ -17,6 +17,7 @@ export type ComfyUIQueuePayload = {
   provider: 'comfyui';
   customMetadata?: Partial<BaseMetadata>;
   overrides?: WorkflowOverrides;
+  directoryPath?: string;
   workflowMode?: ComfyUIWorkflowMode;
   sourceImagePolicy?: ComfyUISourceImagePolicy;
   advancedPromptJson?: string;

--- a/types.ts
+++ b/types.ts
@@ -140,6 +140,104 @@ export interface ImageEditRecipe {
   effects: ImageEditEffects;
 }
 
+export type ImageEditorTool =
+  | 'select'
+  | 'crop'
+  | 'rectangle'
+  | 'ellipse'
+  | 'line'
+  | 'arrow'
+  | 'freehand'
+  | 'text'
+  | 'step'
+  | 'highlight'
+  | 'blur'
+  | 'pixelate'
+  | 'spotlight'
+  | 'magnify';
+
+export type ImageEditorObjectType =
+  | 'rectangle'
+  | 'ellipse'
+  | 'line'
+  | 'arrow'
+  | 'freehand'
+  | 'text'
+  | 'step'
+  | 'highlight'
+  | 'blur'
+  | 'pixelate'
+  | 'spotlight'
+  | 'magnify';
+
+export type ImageEditorBackgroundKind = 'transparent' | 'color' | 'gradient';
+
+export interface ImageEditorBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ImageEditorPoint {
+  x: number;
+  y: number;
+}
+
+export interface ImageEditorObjectStyle {
+  strokeColor: string;
+  fillColor: string;
+  textColor: string;
+  strokeWidth: number;
+  fontSize: number;
+  opacity: number;
+}
+
+export interface ImageEditorObject {
+  id: string;
+  type: ImageEditorObjectType;
+  bounds: ImageEditorBounds;
+  points?: ImageEditorPoint[];
+  text?: string;
+  stepNumber?: number;
+  zIndex: number;
+  style: ImageEditorObjectStyle;
+}
+
+export interface ImageEditorBackground {
+  kind: ImageEditorBackgroundKind;
+  color: string;
+  gradientFrom: string;
+  gradientTo: string;
+  margin: number;
+  padding: number;
+  smartPadding: boolean;
+  roundedCorner: number;
+  shadowRadius: number;
+}
+
+export interface ImageEditorDocument {
+  sourceImageId: string;
+  sourceName: string;
+  sourceDimensions: { width: number; height: number };
+  canvasDimensions: { width: number; height: number };
+  recipe: ImageEditRecipe;
+  background: ImageEditorBackground;
+  objects: ImageEditorObject[];
+  selectedObjectIds: string[];
+}
+
+export interface ImageEditorHistoryEntry {
+  id: string;
+  label: string;
+  document: ImageEditorDocument;
+}
+
+export interface ImageEditorExportOptions {
+  flatten: boolean;
+  includeMetadata: boolean;
+}
+
 export type ImageEditSaveMode = 'save_as' | 'overwrite';
 
 export interface ImageEditSaveResult {

--- a/types.ts
+++ b/types.ts
@@ -400,6 +400,7 @@ export interface ElectronAPI {
   saveSettings: (settings: any) => Promise<{ success: boolean; error?: string }>;
   launchGenerator: (payload: { command: string; workingDirectory?: string }) => Promise<{ success: boolean; error?: string; scriptPath?: string }>;
   openExternalUrl: (url: string) => Promise<{ success: boolean; error?: string }>;
+  openPath: (filePath: string) => Promise<{ success: boolean; error?: string; errorType?: string }>;
   comfyUIViewOpen: (payload: { url: string; bounds?: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;
   comfyUIViewShow: (payload?: { bounds?: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;
   comfyUIViewHide: () => Promise<ComfyUIViewResult>;

--- a/types.ts
+++ b/types.ts
@@ -1028,6 +1028,7 @@ export interface ComparisonPaneProps {
   externalZoom?: ZoomState;
   onZoomChange?: (zoom: number, x: number, y: number) => void;
   onHoverChange?: (isHovered: boolean) => void;
+  onRemove?: () => void;
   className?: string;
   imageLabel?: string;
 }

--- a/types.ts
+++ b/types.ts
@@ -437,7 +437,7 @@ export interface ElectronAPI {
   writeJsonCacheData: (args: { cacheId: string; data: any }) => Promise<{ success: boolean; error?: string }>;
   prepareCacheWrite: (args: { cacheId: string }) => Promise<{ success: boolean; error?: string }>;
   writeCacheChunk: (args: { cacheId: string; chunkIndex: number; data: any }) => Promise<{ success: boolean; error?: string }>;
-  finalizeCacheWrite: (args: { cacheId: string; record: any }) => Promise<{ success: boolean; error?: string }>;
+  finalizeCacheWrite: (args: { cacheId: string; record: any; sourceCacheId?: string }) => Promise<{ success: boolean; error?: string }>;
   clearCacheData: (cacheId: string) => Promise<{ success: boolean; error?: string }>;
   resolveThumbnailCacheBatch: (args: {
     candidates: ThumbnailCacheCandidate[];

--- a/types.ts
+++ b/types.ts
@@ -191,6 +191,7 @@ export interface ImageEditorObjectStyle {
   textColor: string;
   strokeWidth: number;
   fontSize: number;
+  fontFamily: string;
   opacity: number;
 }
 

--- a/types.ts
+++ b/types.ts
@@ -468,6 +468,7 @@ export interface ElectronAPI {
   onMenuShowChangelog: (callback: () => void) => () => void;
   testUpdateDialog?: () => Promise<{ success: boolean; response?: number; error?: string }>;
   getTheme: () => Promise<{ shouldUseDarkColors: boolean }>;
+  getZoomFactor: () => Promise<number>;
   onThemeUpdated: (callback: (theme: { shouldUseDarkColors: boolean }) => void) => () => void;
   toggleFullscreen: () => Promise<{ success: boolean; isFullscreen?: boolean; error?: string }>;
   getFullscreenState: () => Promise<{ success: boolean; isFullscreen?: boolean; error?: string }>;

--- a/types.ts
+++ b/types.ts
@@ -142,6 +142,7 @@ export interface ImageEditRecipe {
 
 export type ImageEditorTool =
   | 'select'
+  | 'color-picker'
   | 'crop'
   | 'rectangle'
   | 'ellipse'

--- a/types.ts
+++ b/types.ts
@@ -1000,8 +1000,26 @@ export interface ZoomState {
   y: number;
 }
 
-export type ComparisonViewMode = 'side-by-side' | 'slider' | 'hover';
+export type ComparisonViewMode =
+  | 'side-by-side'
+  | 'slider'
+  | 'hover'
+  | 'difference-map'
+  | 'flicker'
+  | 'loupe'
+  | 'edge-difference';
 export type ComparisonLayoutMode = 'strip' | 'grid';
+export type ComparisonAdvancedBaseMode = 'left' | 'right' | 'diff';
+
+export interface ComparisonAdvancedSettings {
+  threshold: number;
+  opacity: number;
+  baseMode: ComparisonAdvancedBaseMode;
+  flickerSpeedMs: number;
+  loupeSize: number;
+  loupeZoom: number;
+  showLabels: boolean;
+}
 
 export interface ComparisonPaneProps {
   image: IndexedImage;

--- a/types.ts
+++ b/types.ts
@@ -98,6 +98,48 @@ export interface ImageAdjustments {
   hue: number;
 }
 
+export type ImageEditRotation = 0 | 90 | 180 | 270;
+export type ImageEditCropAspect = 'free' | 'original' | '1:1' | '4:3' | '3:2' | '16:9' | '9:16';
+
+export interface ImageEditTransform {
+  rotation: ImageEditRotation;
+  flipHorizontal: boolean;
+  flipVertical: boolean;
+}
+
+export interface ImageEditCropRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ImageEditCrop {
+  enabled: boolean;
+  aspect: ImageEditCropAspect;
+  rect: ImageEditCropRect | null;
+}
+
+export interface ImageEditResize {
+  enabled: boolean;
+  width: number;
+  height: number;
+  lockAspectRatio: boolean;
+}
+
+export interface ImageEditEffects {
+  sharpen: number;
+  blur: number;
+}
+
+export interface ImageEditRecipe {
+  adjustments: ImageAdjustments;
+  transform: ImageEditTransform;
+  crop: ImageEditCrop;
+  resize: ImageEditResize;
+  effects: ImageEditEffects;
+}
+
 export type ImageEditSaveMode = 'save_as' | 'overwrite';
 
 export interface ImageEditSaveResult {

--- a/utils/visualComparison.ts
+++ b/utils/visualComparison.ts
@@ -1,0 +1,247 @@
+export interface VisualDifferenceRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  score: number;
+}
+
+export interface VisualComparisonMetrics {
+  width: number;
+  height: number;
+  changedPixels: number;
+  totalPixels: number;
+  changedPercent: number;
+  averageDelta: number;
+  strongestRegion: VisualDifferenceRegion | null;
+}
+
+export interface VisualComparisonResult {
+  width: number;
+  height: number;
+  left: ImageData;
+  right: ImageData;
+  heatmap: ImageData;
+  edgeMap: ImageData;
+  metrics: VisualComparisonMetrics;
+}
+
+export const DEFAULT_VISUAL_COMPARE_MAX_EDGE = 1280;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const luminance = (data: Uint8ClampedArray, index: number): number =>
+  data[index] * 0.2126 + data[index + 1] * 0.7152 + data[index + 2] * 0.0722;
+
+export const calculatePixelDelta = (
+  left: Uint8ClampedArray,
+  right: Uint8ClampedArray,
+  index: number,
+): number => {
+  const red = Math.abs(left[index] - right[index]);
+  const green = Math.abs(left[index + 1] - right[index + 1]);
+  const blue = Math.abs(left[index + 2] - right[index + 2]);
+  const luma = Math.abs(luminance(left, index) - luminance(right, index));
+  return clamp((red + green + blue) / 3 * 0.65 + luma * 0.35, 0, 255);
+};
+
+export const createHeatmapImageData = (
+  left: ImageData,
+  right: ImageData,
+  threshold: number,
+): { imageData: ImageData; metrics: VisualComparisonMetrics } => {
+  const { width, height } = left;
+  const heatmap = new ImageData(width, height);
+  const heat = heatmap.data;
+  const leftData = left.data;
+  const rightData = right.data;
+  const safeThreshold = clamp(threshold, 0, 255);
+  const bucketCount = 8;
+  const bucketWidth = Math.max(1, Math.ceil(width / bucketCount));
+  const bucketHeight = Math.max(1, Math.ceil(height / bucketCount));
+  const buckets = Array.from({ length: bucketCount * bucketCount }, () => ({ score: 0, count: 0 }));
+  let changedPixels = 0;
+  let totalDelta = 0;
+
+  for (let pixel = 0; pixel < width * height; pixel += 1) {
+    const index = pixel * 4;
+    const delta = calculatePixelDelta(leftData, rightData, index);
+    totalDelta += delta;
+
+    if (delta >= safeThreshold) {
+      changedPixels += 1;
+      const intensity = clamp((delta - safeThreshold) / Math.max(1, 255 - safeThreshold), 0, 1);
+      heat[index] = 255;
+      heat[index + 1] = Math.round(210 * (1 - intensity) + 40 * intensity);
+      heat[index + 2] = Math.round(40 * (1 - intensity) + 120 * intensity);
+      heat[index + 3] = Math.round(105 + intensity * 150);
+
+      const x = pixel % width;
+      const y = Math.floor(pixel / width);
+      const bucketX = Math.min(bucketCount - 1, Math.floor(x / bucketWidth));
+      const bucketY = Math.min(bucketCount - 1, Math.floor(y / bucketHeight));
+      const bucket = buckets[bucketY * bucketCount + bucketX];
+      bucket.score += delta;
+      bucket.count += 1;
+    } else {
+      heat[index] = 0;
+      heat[index + 1] = 0;
+      heat[index + 2] = 0;
+      heat[index + 3] = 0;
+    }
+  }
+
+  let strongestRegion: VisualDifferenceRegion | null = null;
+  buckets.forEach((bucket, bucketIndex) => {
+    if (!bucket.count) return;
+    const score = bucket.score / bucket.count;
+    if (strongestRegion && score <= strongestRegion.score) return;
+    const bucketX = bucketIndex % bucketCount;
+    const bucketY = Math.floor(bucketIndex / bucketCount);
+    strongestRegion = {
+      x: bucketX * bucketWidth,
+      y: bucketY * bucketHeight,
+      width: Math.min(bucketWidth, width - bucketX * bucketWidth),
+      height: Math.min(bucketHeight, height - bucketY * bucketHeight),
+      score,
+    };
+  });
+
+  return {
+    imageData: heatmap,
+    metrics: {
+      width,
+      height,
+      changedPixels,
+      totalPixels: width * height,
+      changedPercent: width * height > 0 ? (changedPixels / (width * height)) * 100 : 0,
+      averageDelta: width * height > 0 ? totalDelta / (width * height) : 0,
+      strongestRegion,
+    },
+  };
+};
+
+const sobelAt = (data: Uint8ClampedArray, width: number, height: number, x: number, y: number): number => {
+  const sample = (offsetX: number, offsetY: number) => {
+    const sx = clamp(x + offsetX, 0, width - 1);
+    const sy = clamp(y + offsetY, 0, height - 1);
+    return luminance(data, (sy * width + sx) * 4);
+  };
+
+  const gx =
+    -sample(-1, -1) + sample(1, -1) -
+    2 * sample(-1, 0) + 2 * sample(1, 0) -
+    sample(-1, 1) + sample(1, 1);
+  const gy =
+    -sample(-1, -1) - 2 * sample(0, -1) - sample(1, -1) +
+    sample(-1, 1) + 2 * sample(0, 1) + sample(1, 1);
+
+  return clamp(Math.sqrt(gx * gx + gy * gy), 0, 255);
+};
+
+export const createEdgeDifferenceImageData = (left: ImageData, right: ImageData, threshold = 40): ImageData => {
+  const { width, height } = left;
+  const output = new ImageData(width, height);
+  const outputData = output.data;
+  const safeThreshold = clamp(threshold, 0, 255);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const index = (y * width + x) * 4;
+      const leftEdge = sobelAt(left.data, width, height, x, y);
+      const rightEdge = sobelAt(right.data, width, height, x, y);
+      const leftVisible = leftEdge >= safeThreshold;
+      const rightVisible = rightEdge >= safeThreshold;
+
+      outputData[index] = rightVisible ? 255 : 0;
+      outputData[index + 1] = leftVisible ? 220 : 0;
+      outputData[index + 2] = leftVisible ? 255 : rightVisible ? 220 : 0;
+      outputData[index + 3] = leftVisible || rightVisible ? 235 : 0;
+    }
+  }
+
+  return output;
+};
+
+export const buildVisualComparisonFromImageData = (
+  left: ImageData,
+  right: ImageData,
+  threshold = 18,
+  edgeThreshold = threshold,
+): VisualComparisonResult => {
+  if (left.width !== right.width || left.height !== right.height) {
+    throw new Error('ImageData dimensions must match for visual comparison');
+  }
+
+  const heatmap = createHeatmapImageData(left, right, threshold);
+  return {
+    width: left.width,
+    height: left.height,
+    left,
+    right,
+    heatmap: heatmap.imageData,
+    edgeMap: createEdgeDifferenceImageData(left, right, edgeThreshold),
+    metrics: heatmap.metrics,
+  };
+};
+
+const loadImageElement = (url: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.decoding = 'async';
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('Unable to decode image for visual comparison'));
+    image.src = url;
+  });
+
+const drawContainedImage = (
+  context: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  width: number,
+  height: number,
+) => {
+  const scale = Math.min(width / image.naturalWidth, height / image.naturalHeight);
+  const drawWidth = image.naturalWidth * scale;
+  const drawHeight = image.naturalHeight * scale;
+  const drawX = (width - drawWidth) / 2;
+  const drawY = (height - drawHeight) / 2;
+  context.clearRect(0, 0, width, height);
+  context.drawImage(image, drawX, drawY, drawWidth, drawHeight);
+};
+
+export const buildVisualComparisonFromUrls = async (
+  leftUrl: string,
+  rightUrl: string,
+  threshold = 18,
+  maxEdge = DEFAULT_VISUAL_COMPARE_MAX_EDGE,
+): Promise<VisualComparisonResult> => {
+  const [leftImage, rightImage] = await Promise.all([loadImageElement(leftUrl), loadImageElement(rightUrl)]);
+  const sourceWidth = Math.max(leftImage.naturalWidth, rightImage.naturalWidth);
+  const sourceHeight = Math.max(leftImage.naturalHeight, rightImage.naturalHeight);
+  const scale = Math.min(1, maxEdge / Math.max(sourceWidth, sourceHeight));
+  const width = Math.max(1, Math.round(sourceWidth * scale));
+  const height = Math.max(1, Math.round(sourceHeight * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) {
+    throw new Error('Canvas is not available for visual comparison');
+  }
+
+  drawContainedImage(context, leftImage, width, height);
+  const left = context.getImageData(0, 0, width, height);
+  drawContainedImage(context, rightImage, width, height);
+  const right = context.getImageData(0, 0, width, height);
+  return buildVisualComparisonFromImageData(left, right, threshold, threshold);
+};
+
+export const imageDataToDataUrl = (imageData: ImageData): string => {
+  const canvas = document.createElement('canvas');
+  canvas.width = imageData.width;
+  canvas.height = imageData.height;
+  const context = canvas.getContext('2d');
+  if (!context) return '';
+  context.putImageData(imageData, 0, 0);
+  return canvas.toDataURL('image/png');
+};

--- a/utils/visualComparison.ts
+++ b/utils/visualComparison.ts
@@ -41,8 +41,10 @@ export const calculatePixelDelta = (
   const red = Math.abs(left[index] - right[index]);
   const green = Math.abs(left[index + 1] - right[index + 1]);
   const blue = Math.abs(left[index + 2] - right[index + 2]);
+  const alpha = Math.abs(left[index + 3] - right[index + 3]);
   const luma = Math.abs(luminance(left, index) - luminance(right, index));
-  return clamp((red + green + blue) / 3 * 0.65 + luma * 0.35, 0, 255);
+  const colorDelta = (red + green + blue) / 3 * 0.65 + luma * 0.35;
+  return clamp(colorDelta * 0.8 + alpha * 0.2, 0, 255);
 };
 
 export const createHeatmapImageData = (

--- a/utils/visualComparison.ts
+++ b/utils/visualComparison.ts
@@ -68,7 +68,7 @@ export const createHeatmapImageData = (
     const delta = calculatePixelDelta(leftData, rightData, index);
     totalDelta += delta;
 
-    if (delta >= safeThreshold) {
+    if (delta > 0 && delta >= safeThreshold) {
       changedPixels += 1;
       const intensity = clamp((delta - safeThreshold) / Math.max(1, 255 - safeThreshold), 0, 1);
       heat[index] = 255;

--- a/utils/visualComparison.ts
+++ b/utils/visualComparison.ts
@@ -144,14 +144,15 @@ export const createEdgeDifferenceImageData = (left: ImageData, right: ImageData,
   const output = new ImageData(width, height);
   const outputData = output.data;
   const safeThreshold = clamp(threshold, 0, 255);
+  const minimumVisibleEdge = 0.5;
 
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
       const index = (y * width + x) * 4;
       const leftEdge = sobelAt(left.data, width, height, x, y);
       const rightEdge = sobelAt(right.data, width, height, x, y);
-      const leftVisible = leftEdge >= safeThreshold;
-      const rightVisible = rightEdge >= safeThreshold;
+      const leftVisible = leftEdge > minimumVisibleEdge && leftEdge >= safeThreshold;
+      const rightVisible = rightEdge > minimumVisibleEdge && rightEdge >= safeThreshold;
 
       outputData[index] = rightVisible ? 255 : 0;
       outputData[index + 1] = leftVisible ? 220 : 0;


### PR DESCRIPTION
## Summary

This brings the `0.17.0-rc` release branch back into `main` for final review. The diff is the accumulated RC work rather than a single narrow feature branch.

Highlights:
- Adds the advanced Image Editor workspace, including crop/resize/transform tools, object editing, inspector controls, color picking, text handling refinements, and metadata-preserving save/overwrite flows.
- Adds Compare v2 with multi-image comparison, loupe sync, normalized layer alignment, flicker, delta/heatmap handling, and related interaction tests.
- Improves ComfyUI support with upscale workflow plumbing, MetaHub graph recovery, workspace navigation fixes, and parser/node registry traversal updates.
- Adds media/audio diagnostics and external media handling, plus the MetaHub video metadata parser contract.
- Hardens cache/save behavior for large chunked caches and background image update scheduling after Save As / Overwrite.
- Updates viewer behavior with natural-size zoom, 1:1/Fit modes, zoom state management, and restored grid/library navigation state.

## Review Notes

- `components/ImageModal.tsx` had the PR conflict against latest `main`; it was resolved by keeping the RC viewer zoom behavior (`1:1`, `Fit`, dynamic min/max zoom) while preserving the accessibility tooltip/ARIA improvements from `main`.
- This PR intentionally includes the release branch merge history so the RC context remains reviewable.

## Validation

- Resolved the `components/ImageModal.tsx` merge conflict locally.
- `git diff --check`
- `npx tsc -b`