### PR TITLE
🎨 Palette: Add ARIA labels to ImageEditorWorkspace icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-06-02 - ImageModal Zoom Controls & Overlay Icons Missing ARIA Labels & Disabled Reasons
 **Learning:** Icon-only buttons within the image viewer overlay (like zoom controls, full screen toggle, sidebar toggle) were missing `aria-label` attributes. Additionally, the zoom buttons became disabled at zoom limits but didn't provide a contextual reason in their tooltips.
 **Action:** When implementing or updating disabled states for interactive elements, dynamically update the `title` and `aria-label` to briefly explain why the element is disabled (e.g., "Zoom In (Maximum reached)"). Always include `aria-hidden="true"` on purely decorative SVGs within these buttons.
+
+## 2024-05-24 - ImageEditorWorkspace Icon Buttons Missing ARIA Labels
+**Learning:** Several icon-only buttons in the ImageEditorWorkspace component (such as Back, Undo, Redo, Flatten, Copy, and Close Inspector) lacked `aria-label` attributes, relying only on `title` attributes for tooltips.
+**Action:** Always add descriptive `aria-label` attributes to all icon-only buttons, even when `title` is present, to ensure they meet the WCAG 2.5.3 Label in Name standard and are accessible to screen readers.

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -2196,7 +2196,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
     <div className="flex h-full min-h-0 flex-col bg-gray-950 text-gray-100">
       <div className="flex h-14 shrink-0 items-center justify-between border-b border-gray-800 bg-gray-900 px-3">
         <div className="flex min-w-0 items-center gap-2">
-          <button type="button" onClick={handleBack} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Back">
+          <button type="button" onClick={handleBack} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Back" aria-label="Back">
             <ArrowLeft className="h-4 w-4" />
           </button>
           <div className="min-w-0">
@@ -2208,16 +2208,16 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
           </div>
         </div>
         <div className="flex items-center gap-1">
-          <button type="button" onClick={undo} disabled={!history.past.length} className="rounded-md p-2 text-gray-300 hover:bg-gray-800 disabled:opacity-40" title="Undo">
+          <button type="button" onClick={undo} disabled={!history.past.length} className="rounded-md p-2 text-gray-300 hover:bg-gray-800 disabled:opacity-40" title="Undo" aria-label="Undo">
             <Undo2 className="h-4 w-4" />
           </button>
-          <button type="button" onClick={redo} disabled={!history.future.length} className="rounded-md p-2 text-gray-300 hover:bg-gray-800 disabled:opacity-40" title="Redo">
+          <button type="button" onClick={redo} disabled={!history.future.length} className="rounded-md p-2 text-gray-300 hover:bg-gray-800 disabled:opacity-40" title="Redo" aria-label="Redo">
             <Redo2 className="h-4 w-4" />
           </button>
-          <button type="button" onClick={flattenSelection} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Flatten">
+          <button type="button" onClick={flattenSelection} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Flatten" aria-label="Flatten">
             <Layers className="h-4 w-4" />
           </button>
-          <button type="button" onClick={handleCopy} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Copy image">
+          <button type="button" onClick={handleCopy} className="rounded-md p-2 text-gray-300 hover:bg-gray-800" title="Copy image" aria-label="Copy image">
             <Copy className="h-4 w-4" />
           </button>
           <button type="button" onClick={() => setIsInspectorOpen(true)} className="inline-flex items-center gap-1 rounded-md border border-gray-700 px-2 py-2 text-xs font-semibold text-gray-200 hover:bg-gray-800 xl:hidden" title="Open inspector">
@@ -2671,7 +2671,7 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
                     : TOOL_DEFS.find((tool) => tool.id === activeTool)?.label}
               </div>
             </div>
-            <button type="button" onClick={() => setIsInspectorOpen(false)} className="rounded-md p-2 text-gray-300 hover:bg-gray-800 xl:hidden" title="Close inspector">
+            <button type="button" onClick={() => setIsInspectorOpen(false)} className="rounded-md p-2 text-gray-300 hover:bg-gray-800 xl:hidden" title="Close inspector" aria-label="Close inspector">
               <X className="h-4 w-4" />
             </button>
           </div>


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` attributes to several icon-only buttons in the `ImageEditorWorkspace` component (Back, Undo, Redo, Flatten, Copy, and Close Inspector).

🎯 **Why:** To improve accessibility for users relying on screen readers. Icon-only buttons must have descriptive ARIA labels to communicate their function properly.

📸 **Before/After:** No visual changes.

♿ **Accessibility:** This directly addresses WCAG 2.5.3 (Label in Name) by ensuring screen readers can announce the purpose of these interactive elements.

---
*PR created automatically by Jules for task [1829500371365917571](https://jules.google.com/task/1829500371365917571) started by @LuqP2*