### PR TITLE
performance: avoid O(N) allocation for directory count in collections view

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2026-06-06 - Do not optimize array allocations in cold paths
 **Learning:** Optimizing array allocations (e.g., replacing `new Map(arr.map())` with a `for` loop) inside event handlers or cold paths (like code that uses `.getState()`) provides no measurable performance improvement and violates the "premature optimization of cold paths" constraint.
 **Action:** When acting as Bolt, ensure the optimization targets a hot path, such as a render loop or a heavily accessed store derivation, where the performance impact is actually measurable.
+## 2024-05-24 - Eliminate Array.map().filter() O(N) allocation overhead for directory count
+**Learning:** Chaining array methods like `collectionFilteredImages.map(...).filter(...)` inside JSX inside `App.tsx` creates multiple intermediate array allocations that increase garbage collection overhead and execution time during renders. This is further exacerbated if the result is not memoized and happens on every render.
+**Action:** Extract inline chained array calculations from JSX and replace them with a `useMemo` containing a single `for` or `for...of` loop and use conditional `set.add()` to prevent unnecessary array allocation overhead per pass.

--- a/App.tsx
+++ b/App.tsx
@@ -2032,6 +2032,19 @@ export default function App() {
     return getResolvedFilteredCollectionImages(activeCollection.id);
   }, [activeCollection, getResolvedFilteredCollectionImages, safeFilteredImages]);
 
+  // Optimization: use memoized Set directly over for loop rather than map().filter()
+  // Impact: Avoids multiple O(N) allocations for arrays during directory count calculation on each collection view render
+  const collectionFilteredDirectoryCount = useMemo(() => {
+    const dirSet = new Set<string>();
+    for (let i = 0; i < collectionFilteredImages.length; i++) {
+      const dirId = collectionFilteredImages[i].directoryId;
+      if (dirId) {
+        dirSet.add(dirId);
+      }
+    }
+    return dirSet.size;
+  }, [collectionFilteredImages]);
+
   const handleNodeViewResultImagesChange = useCallback(
     (images: IndexedImage[]) => {
       setNodeViewResultImages(images);
@@ -3156,7 +3169,7 @@ export default function App() {
                   totalCount={libraryView === 'collections' ? collectionTotalImages.length : selectionTotalImages}
                   directoryCount={
                     libraryView === 'collections'
-                      ? new Set(collectionFilteredImages.map((image) => image.directoryId).filter(Boolean)).size
+                      ? collectionFilteredDirectoryCount
                       : selectionDirectoryCount
                   }
                   enrichmentProgress={enrichmentProgress}


### PR DESCRIPTION
This patch optimizes a React render bottleneck in `App.tsx` by replacing `new Set(collectionFilteredImages.map(...).filter(...)).size` with a memoized explicit loop `collectionFilteredDirectoryCount`. This avoids the temporary allocation of multiple intermediate arrays which would otherwise increase garbage collection pressure during renders.

**Why:** The chained `.map()` and `.filter()` operations on arrays create intermediate allocations that exist only to be passed to `new Set(...)`. By migrating this logic to a simple manual `for` loop directly appending to a `Set` within a `useMemo` hook, we decrease the O(N) heap allocations, making collection renders snappier.
**Impact:** Avoids multiple O(N) array allocations every time the active collection changes.
**Measurement:** Re-running the application locally should still properly calculate directory counts for collections without regressing in memory efficiency. Tests pass correctly.

---
*PR created automatically by Jules for task [1383153436213186730](https://jules.google.com/task/1383153436213186730) started by @LuqP2*