### PR TITLE
performance improvement

### DIFF
--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -1227,7 +1227,11 @@ export function useImageLoader() {
                     })()
                     : [];
 
-            const handleMap = new Map(regeneratedCachedImages.map(h => [h.path, h.handle]));
+            // Optimization: Replaced new Map(arr.map()) with a for loop to avoid O(N) allocation overhead
+            const handleMap = new Map();
+            for (const h of regeneratedCachedImages) {
+                handleMap.set(h.path, h.handle);
+            }
 
             if (shouldHydratePreloadedImages) {
                 clearImages(directory.id);


### PR DESCRIPTION
What: Replaced `new Map(regeneratedCachedImages.map(...))` with a `for` loop in `hooks/useImageLoader.ts`.
Why: The previous implementation created a temporary array of tuples during the `.map()` step, which immediately gets discarded after passing it to the `Map` constructor. This created unnecessary garbage collection overhead and an O(N) allocation delay inside the file synchronization flow.
Impact: Avoids the allocation of the temporary array.
Measurement: Compare application memory profiling trace when executing file sync operations.

---
*PR created automatically by Jules for task [7307343688630126580](https://jules.google.com/task/7307343688630126580) started by @LuqP2*