### PR TITLE
performance improvement

### DIFF
--- a/services/imageEditingService.ts
+++ b/services/imageEditingService.ts
@@ -529,7 +529,13 @@ export const normalizeImageEditorDocument = (
     .map((object) => normalizeImageEditorObject(object, canvasDimensions))
     .filter((object): object is ImageEditorObject => Boolean(object))
     .sort((left, right) => left.zIndex - right.zIndex);
-  const objectIds = new Set(objects.map((object) => object.id));
+
+  // Optimization: Eliminate Array.map() O(N) temporary array allocation
+  // Impact: Reduces garbage collection overhead when building the ID Set for selected object filtering
+  const objectIds = new Set<string>();
+  for (const object of objects) {
+    objectIds.add(object.id);
+  }
 
   return {
     sourceImageId: document.sourceImageId || '',


### PR DESCRIPTION
What: Replaced `new Set(objects.map(object => object.id))` with a `for...of` loop in `services/imageEditingService.ts`.
Why: To eliminate an unnecessary `O(N)` temporary array allocation when collecting object IDs.
Impact: Reduces memory usage and garbage collection overhead during image editor component updates and serialization.
Measurement: Compare memory allocations and GC pause times when rendering the image editor with many objects.

---
*PR created automatically by Jules for task [13503068076737191144](https://jules.google.com/task/13503068076737191144) started by @LuqP2*