### PR TITLE
🎨 Palette: Add aria-label to HotkeyHelp close button & aria-hidden to decorative SVGs

### DIFF
--- a/components/BrowserCompatibilityWarning.tsx
+++ b/components/BrowserCompatibilityWarning.tsx
@@ -46,7 +46,7 @@ const BrowserCompatibilityWarning: React.FC<BrowserCompatibilityWarningProps> = 
     <div className={`bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-4 ${className}`}>
       <div className="flex items-start">
         <div className="flex-shrink-0">
-          <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+          <svg aria-hidden="true" className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
             <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
           </svg>
         </div>

--- a/components/HotkeyHelp.tsx
+++ b/components/HotkeyHelp.tsx
@@ -24,8 +24,8 @@ const HotkeyHelp: React.FC<HotkeyHelpProps> = ({ isOpen, onClose, onOpenSettings
       >
         <div className="p-4 border-b border-gray-700 flex justify-between items-center flex-shrink-0">
           <h2 className="text-xl font-bold text-gray-100">Keyboard Shortcuts</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-50">
-            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd"></path></svg>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-50" aria-label="Close keyboard shortcuts" title="Close">
+            <svg aria-hidden="true" className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd"></path></svg>
           </button>
         </div>
         <div className="p-4 overflow-y-auto">


### PR DESCRIPTION
💡 What: Added `aria-label` to the close button in `HotkeyHelp.tsx` and `aria-hidden="true"` to purely decorative SVGs in `HotkeyHelp.tsx` and `BrowserCompatibilityWarning.tsx`.
🎯 Why: To improve screen reader accessibility by providing context for icon-only buttons and preventing screen readers from uselessly announcing decorative graphics.
📸 Before/After: N/A (no visual changes, strictly accessibility).
♿ Accessibility: Improved screen reader announcements and met WCAG 2.5.3 Label in Name standards.

---
*PR created automatically by Jules for task [12782804349207660397](https://jules.google.com/task/12782804349207660397) started by @LuqP2*