### PR TITLE
Improve Find Similar workflow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -69,7 +69,7 @@ interface OpenImageModalState {
   modalId: string;
   imageId: string;
   navigationImageIds: string[];
-  navigationSource: 'filtered' | 'cluster' | 'scope' | 'slideshow' | 'comfyui';
+  navigationSource: 'filtered' | 'cluster' | 'scope' | 'slideshow' | 'comfyui' | 'find-similar';
   zIndex: number;
   initialWindowOffset: number;
   isMinimized: boolean;
@@ -115,6 +115,7 @@ const SIDEBAR_WIDTH_STORAGE_KEY = 'image-metahub-sidebar-width';
 const RIGHT_SIDEBAR_WIDTH_STORAGE_KEY = 'image-metahub-right-sidebar-width';
 const OPEN_BATCH_EXPORT_EVENT = 'imagemetahub:open-batch-export';
 const COMFYUI_WORKSPACE_APPLY_FILTERS_STORAGE_KEY = 'image-metahub-comfyui-workspace-apply-library-filters';
+const FIND_SIMILAR_IMAGE_MODAL_MIN_Z_INDEX = 151;
 const SIDEBAR_DEFAULT_WIDTH = 320;
 const SIDEBAR_MIN_WIDTH = 280;
 const SIDEBAR_MAX_WIDTH = 640;
@@ -1464,6 +1465,10 @@ export default function App() {
       return modal.navigationImageIds.filter((imageId) => Boolean(getImageByIdFromStore(imageId)));
     }
 
+    if (modal.navigationSource === 'find-similar') {
+      return modal.navigationImageIds.filter((imageId) => Boolean(getImageByIdFromStore(imageId)));
+    }
+
     return modal.navigationImageIds.filter((imageId) => imageLookup.has(imageId));
   }, [activeScopeNavigationImageIds, filteredNavigationImageIds, getImageByIdFromStore, imageLookup]);
 
@@ -2311,10 +2316,51 @@ export default function App() {
     setFindSimilarState(null);
   }, [openComparisonModal, setComparisonImages]);
 
-  const handleOpenFindSimilarImage = useCallback((image: IndexedImage) => {
-    setFindSimilarState(null);
+  const handleOpenFindSimilarImage = useCallback((image: IndexedImage, navigationImages: IndexedImage[]) => {
+    const navigationImageIds = navigationImages.length > 0
+      ? navigationImages.map((entry) => entry.id)
+      : [image.id];
+    const existingModalForImage = openImageModals.find((modal) => modal.imageId === image.id);
+    const modalId = existingModalForImage?.modalId ?? `image-modal-${Date.now()}-${image.id}`;
+
+    setOpenImageModals((current) => {
+      const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;
+      const nextZIndex = Math.max(highestZIndex + 1, FIND_SIMILAR_IMAGE_MODAL_MIN_Z_INDEX);
+      const existingModal = current.find((modal) => modal.imageId === image.id);
+
+      if (existingModal) {
+        return current.map((modal) =>
+          modal.modalId === existingModal.modalId
+            ? {
+                ...modal,
+                navigationImageIds,
+                navigationSource: 'find-similar',
+                zIndex: nextZIndex,
+                isMinimized: false,
+              }
+            : modal
+        );
+      }
+
+      return [
+        ...current,
+        {
+          modalId,
+          imageId: image.id,
+          navigationImageIds,
+          navigationSource: 'find-similar',
+          zIndex: nextZIndex,
+          initialWindowOffset: current.length * 28,
+          isMinimized: false,
+          diagnosticsFlowId: beginModalOpenFlow(image.id, 'find-similar'),
+        },
+      ];
+    });
+
+    setActiveImageModalId(modalId);
+    suppressSelectedImageModalOpenRef.current = image.id;
     setSelectedImage(image);
-  }, [setSelectedImage]);
+  }, [beginModalOpenFlow, openImageModals, setSelectedImage]);
 
   const openModelPromptPicker = useCallback((modelName: string) => {
     setModelPromptPickerState({

--- a/App.tsx
+++ b/App.tsx
@@ -2279,6 +2279,11 @@ export default function App() {
     setFindSimilarState(null);
   }, [openComparisonModal, setComparisonImages]);
 
+  const handleOpenFindSimilarImage = useCallback((image: IndexedImage) => {
+    setFindSimilarState(null);
+    setSelectedImage(image);
+  }, [setSelectedImage]);
+
   const openModelPromptPicker = useCallback((modelName: string) => {
     setModelPromptPickerState({
       modelName,
@@ -3258,6 +3263,7 @@ export default function App() {
           currentViewImages={findSimilarState?.currentViewImages}
           initialCriteria={findSimilarState?.initialCriteria}
           onClose={closeFindSimilar}
+          onOpenImage={handleOpenFindSimilarImage}
           onOpenCompare={handleOpenFindSimilarCompare}
         />
 

--- a/App.tsx
+++ b/App.tsx
@@ -99,6 +99,11 @@ interface FindSimilarState {
   initialCriteria?: Partial<SimilarSearchCriteria>;
 }
 
+interface FindSimilarGridFilterState {
+  sourceImageName: string;
+  imageIds: string[];
+}
+
 type BatchExportSource = 'selected' | 'filtered';
 
 interface BatchExportRequestState {
@@ -455,6 +460,7 @@ export default function App() {
   const [openImageModals, setOpenImageModals] = useState<OpenImageModalState[]>([]);
   const [activeImageModalId, setActiveImageModalId] = useState<string | null>(null);
   const [findSimilarState, setFindSimilarState] = useState<FindSimilarState | null>(null);
+  const [findSimilarGridFilter, setFindSimilarGridFilter] = useState<FindSimilarGridFilterState | null>(null);
   const [modelPromptPickerState, setModelPromptPickerState] = useState<{
     modelName: string;
     groups: ModelPromptOverlapGroup[];
@@ -2040,11 +2046,22 @@ export default function App() {
     [setActiveImageScope],
   );
 
+  const findSimilarFilteredImages = useMemo(() => {
+    if (!findSimilarGridFilter) {
+      return null;
+    }
+
+    const filteredIds = new Set(findSimilarGridFilter.imageIds);
+    return safeFilteredImages.filter((image) => filteredIds.has(image.id));
+  }, [findSimilarGridFilter, safeFilteredImages]);
+
   const displayImages =
     libraryView === 'collections'
       ? collectionFilteredImages
       : libraryView === 'node'
       ? nodeViewResultImages
+      : libraryView === 'library' && findSimilarFilteredImages
+      ? findSimilarFilteredImages
       : safeFilteredImages;
   const comfyUIWorkspaceSourceImages = comfyUIWorkspaceApplyLibraryFilters ? displayImages : safeImages;
 
@@ -2056,6 +2073,7 @@ export default function App() {
       safeFilteredImages.length,
       firstImageId,
       lastImageId,
+      findSimilarGridFilter?.imageIds.join('\u001f') ?? '',
       searchQuery,
       selectedModels.join('\u001f'),
       excludedModels.join('\u001f'),
@@ -2092,6 +2110,7 @@ export default function App() {
     excludedSchedulers,
     excludedTags,
     favoriteFilterMode,
+    findSimilarGridFilter,
     groupBy,
     randomSeed,
     safeFilteredImages,
@@ -2272,6 +2291,19 @@ export default function App() {
   const closeFindSimilar = useCallback(() => {
     setFindSimilarState(null);
   }, []);
+
+  const handleApplyFindSimilarGridFilter = useCallback((images: IndexedImage[]) => {
+    const sourceImage = findSimilarState?.sourceImage;
+    const imageIds = Array.from(new Set(images.map((image) => image.id).filter(Boolean)));
+    setFindSimilarGridFilter({
+      sourceImageName: sourceImage?.name ?? 'similar image',
+      imageIds,
+    });
+    setLibraryView('library');
+    resetLibraryGridScrollPosition();
+    setCurrentPage(1);
+    setFindSimilarState(null);
+  }, [findSimilarState?.sourceImage, resetLibraryGridScrollPosition]);
 
   const handleOpenFindSimilarCompare = useCallback((images: IndexedImage[]) => {
     setComparisonImages(images);
@@ -2716,6 +2748,7 @@ export default function App() {
           onClearAllFilters={() => {
             setSearchInputValue('');
             setSearchQuery('');
+            setFindSimilarGridFilter(null);
             setSelectedFilters({
               models: [],
               excludedModels: [],
@@ -2965,6 +2998,31 @@ export default function App() {
                     groupBy={effectiveLibraryGroupBy}
                     onJumpToGroup={(groupId) => setPendingJumpGroupRequest({ groupId, requestId: Date.now() })}
                   />
+                )}
+
+                {libraryView === 'library' && findSimilarGridFilter && (
+                  <div className="mx-5 mb-2 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-100">
+                    <div className="min-w-0">
+                      <span className="font-medium">Find Similar filter</span>
+                      <span className="text-cyan-200/80"> from </span>
+                      <span className="inline-block max-w-[320px] truncate align-bottom" title={findSimilarGridFilter.sourceImageName}>
+                        {findSimilarGridFilter.sourceImageName}
+                      </span>
+                      <span className="text-cyan-200/80"> · {displayImages.length} match{displayImages.length === 1 ? '' : 'es'} in current filters</span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setFindSimilarGridFilter(null);
+                        resetLibraryGridScrollPosition();
+                        setCurrentPage(1);
+                      }}
+                      className="inline-flex items-center gap-1 rounded-md border border-cyan-400/40 px-2 py-1 text-xs font-medium text-cyan-100 transition-colors hover:bg-cyan-500/20"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                      Clear
+                    </button>
+                  </div>
                 )}
 
               <div className={`flex-1 min-h-0 transition-[filter,opacity] duration-150 ease-out ${libraryContentFocusClass}`}>
@@ -3264,7 +3322,7 @@ export default function App() {
           initialCriteria={findSimilarState?.initialCriteria}
           onClose={closeFindSimilar}
           onOpenImage={handleOpenFindSimilarImage}
-          onOpenCompare={handleOpenFindSimilarCompare}
+          onApplyGridFilter={handleApplyFindSimilarGridFilter}
         />
 
         {/* Generate Modals */}

--- a/__tests__/FindSimilarModal.test.tsx
+++ b/__tests__/FindSimilarModal.test.tsx
@@ -29,8 +29,9 @@ const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
 });
 
 describe('FindSimilarModal', () => {
-  it('opens with compare-oriented defaults and preselects distinct checkpoints first', async () => {
+  it('opens with similarity defaults, ignores checkpoint by default, and can open a result image', async () => {
     const onOpenCompare = vi.fn();
+    const onOpenImage = vi.fn();
     const source = createImage({
       id: 'source',
       name: 'source.png',
@@ -74,6 +75,7 @@ describe('FindSimilarModal', () => {
         allImages={[source, altA, altB, altCNewest, altCOlder]}
         currentViewImages={[source, altA, altB, altCNewest, altCOlder]}
         onClose={vi.fn()}
+        onOpenImage={onOpenImage}
         onOpenCompare={onOpenCompare}
       />,
     );
@@ -82,10 +84,15 @@ describe('FindSimilarModal', () => {
     expect((screen.getByRole('checkbox', { name: /lora names/i }) as HTMLInputElement).checked).toBe(false);
     expect((screen.getByRole('checkbox', { name: /seed/i }) as HTMLInputElement).checked).toBe(false);
     expect(screen.getByText('Current view')).toBeTruthy();
+    expect(screen.getByText('Any checkpoint')).toBeTruthy();
 
     await waitFor(() => {
       expect(screen.getByText('Selected 3 of 3 compare slots.')).toBeTruthy();
     });
+
+    expect(screen.getAllByText('100% prompt match').length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole('button', { name: /open alt-a\.png in image modal/i }));
+    expect(onOpenImage).toHaveBeenCalledWith(altA);
 
     fireEvent.click(screen.getByRole('button', { name: /open in compare/i }));
 

--- a/__tests__/FindSimilarModal.test.tsx
+++ b/__tests__/FindSimilarModal.test.tsx
@@ -30,7 +30,7 @@ const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
 
 describe('FindSimilarModal', () => {
   it('opens with similarity defaults, ignores checkpoint by default, and can open a result image', async () => {
-    const onOpenCompare = vi.fn();
+    const onApplyGridFilter = vi.fn();
     const onOpenImage = vi.fn();
     const source = createImage({
       id: 'source',
@@ -76,7 +76,7 @@ describe('FindSimilarModal', () => {
         currentViewImages={[source, altA, altB, altCNewest, altCOlder]}
         onClose={vi.fn()}
         onOpenImage={onOpenImage}
-        onOpenCompare={onOpenCompare}
+        onApplyGridFilter={onApplyGridFilter}
       />,
     );
 
@@ -85,17 +85,19 @@ describe('FindSimilarModal', () => {
     expect((screen.getByRole('checkbox', { name: /seed/i }) as HTMLInputElement).checked).toBe(false);
     expect(screen.getByText('Current view')).toBeTruthy();
     expect(screen.getByText('Any checkpoint')).toBeTruthy();
+    expect(screen.getByText('Minimum prompt similarity')).toBeTruthy();
+    expect(screen.getByText('87%')).toBeTruthy();
 
     await waitFor(() => {
-      expect(screen.getByText('Selected 3 of 3 compare slots.')).toBeTruthy();
+      expect(screen.getByText('4 matches')).toBeTruthy();
     });
 
     expect(screen.getAllByText('100% prompt match').length).toBeGreaterThan(0);
-    fireEvent.click(screen.getByRole('button', { name: /open alt-a\.png in image modal/i }));
-    expect(onOpenImage).toHaveBeenCalledWith(altA);
+    fireEvent.click(screen.getAllByRole('button', { name: /open alt-a\.png in image modal/i })[0]);
+    expect(onOpenImage).toHaveBeenCalledWith(altA, [altA, altB, altCNewest, altCOlder]);
 
-    fireEvent.click(screen.getByRole('button', { name: /open in compare/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply as grid filter/i }));
 
-    expect(onOpenCompare).toHaveBeenCalledWith([source, altA, altB, altCNewest]);
+    expect(onApplyGridFilter).toHaveBeenCalledWith([altA, altB, altCNewest, altCOlder]);
   });
 });

--- a/__tests__/similarImageSearch.test.ts
+++ b/__tests__/similarImageSearch.test.ts
@@ -32,7 +32,7 @@ describe('similarImageSearch helpers', () => {
     expect(promptsExactlyMatchNormalized('Hello world', 'Hello moon')).toBe(false);
   });
 
-  it('matches prompt-only groups while excluding the source checkpoint in different mode', () => {
+  it('matches prompt-similar groups while ignoring checkpoint by default', () => {
     const source = createImage({
       id: 'source',
       prompt: 'A castle on a hill',
@@ -43,6 +43,7 @@ describe('similarImageSearch helpers', () => {
       source,
       createImage({ id: 'same-model', prompt: 'A castle on a hill', models: ['model-a'], lastModified: 30 }),
       createImage({ id: 'alt-model', prompt: 'a castle   on a hill', models: ['model-b'], lastModified: 20 }),
+      createImage({ id: 'similar-prompt', prompt: 'A castle on hill', models: ['model-c'], lastModified: 10 }),
       createImage({ id: 'no-prompt-match', prompt: 'A forest', models: ['model-c'], lastModified: 40 }),
     ];
 
@@ -53,8 +54,37 @@ describe('similarImageSearch helpers', () => {
       criteria: DEFAULT_SIMILAR_SEARCH_CRITERIA,
     });
 
-    expect(result.results.map((entry) => entry.image.id)).toEqual(['alt-model']);
+    expect(result.effectiveCriteria.checkpointMode).toBe('ignore');
+    expect(result.results.map((entry) => entry.image.id)).toEqual(['same-model', 'alt-model', 'similar-prompt']);
     expect(result.results[0]?.matchedFields).toContain('prompt');
+    expect(result.results[0]?.promptSimilarity).toBe(1);
+    expect(result.results[2]?.promptSimilarity).toBeGreaterThanOrEqual(0.87);
+  });
+
+  it('can still exclude the source checkpoint when requested', () => {
+    const source = createImage({
+      id: 'source',
+      prompt: 'A castle on a hill',
+      models: ['model-a'],
+      lastModified: 10,
+    });
+    const images = [
+      source,
+      createImage({ id: 'same-model', prompt: 'A castle on a hill', models: ['model-a'], lastModified: 30 }),
+      createImage({ id: 'alt-model', prompt: 'a castle   on a hill', models: ['model-b'], lastModified: 20 }),
+    ];
+
+    const result = findSimilarImages({
+      sourceImage: source,
+      allImages: images,
+      currentViewImages: images,
+      criteria: {
+        ...DEFAULT_SIMILAR_SEARCH_CRITERIA,
+        checkpointMode: 'different',
+      },
+    });
+
+    expect(result.results.map((entry) => entry.image.id)).toEqual(['alt-model']);
     expect(result.results[0]?.matchedFields).toContain('checkpoint');
   });
 

--- a/__tests__/similarImageSearch.test.ts
+++ b/__tests__/similarImageSearch.test.ts
@@ -187,6 +187,46 @@ describe('similarImageSearch helpers', () => {
     expect(result.results.map((entry) => entry.image.id)).toEqual(['weight-match']);
   });
 
+  it('disables prompt matching when similarity normalization removes the source prompt', () => {
+    const source = createImage({
+      id: 'source',
+      prompt: '<lora:style-lora:1>',
+      models: ['model-a'],
+      loras: ['style-lora'],
+    });
+    const images = [
+      source,
+      createImage({
+        id: 'lora-match',
+        prompt: '<lora:style-lora:1>',
+        models: ['model-b'],
+        loras: ['style-lora'],
+      }),
+      createImage({
+        id: 'lora-miss',
+        prompt: '<lora:other-lora:1>',
+        models: ['model-c'],
+        loras: ['other-lora'],
+      }),
+    ];
+
+    const result = findSimilarImages({
+      sourceImage: source,
+      allImages: images,
+      currentViewImages: images,
+      criteria: {
+        ...DEFAULT_SIMILAR_SEARCH_CRITERIA,
+        lora: true,
+      },
+    });
+
+    expect(result.availability.prompt).toBe(false);
+    expect(result.effectiveCriteria.prompt).toBe(false);
+    expect(result.effectiveCriteria.lora).toBe(true);
+    expect(result.results.map((entry) => entry.image.id)).toEqual(['lora-match']);
+    expect(result.results[0]?.matchedFields).toEqual(['lora']);
+  });
+
   it('disables unavailable source criteria and falls back to the remaining active rules', () => {
     const source = createImage({
       id: 'source',

--- a/components/FindSimilarModal.tsx
+++ b/components/FindSimilarModal.tsx
@@ -19,7 +19,7 @@ interface FindSimilarModalProps {
   currentViewImages?: IndexedImage[];
   initialCriteria?: Partial<SimilarSearchCriteria>;
   onClose: () => void;
-  onOpenImage: (image: IndexedImage) => void;
+  onOpenImage: (image: IndexedImage, navigationImages: IndexedImage[]) => void;
   onApplyGridFilter: (images: IndexedImage[]) => void;
 }
 
@@ -37,6 +37,8 @@ const formatModelSummary = (image: IndexedImage) => image.models[0] || 'Unknown 
 
 const formatSimilarityPercent = (similarity: number | null) =>
   similarity == null ? null : `${Math.round(similarity * 100)}%`;
+
+const formatThresholdPercent = (threshold: number) => `${Math.round(threshold * 100)}%`;
 
 const formatLoraSummary = (image: IndexedImage) => {
   if (!image.loras || image.loras.length === 0) {
@@ -157,9 +159,14 @@ export default function FindSimilarModal({
       return;
     }
 
-    setCriteria({
+    const nextCriteria = {
       ...DEFAULT_SIMILAR_SEARCH_CRITERIA,
       ...initialCriteria,
+    };
+
+    setCriteria({
+      ...nextCriteria,
+      promptThreshold: nextCriteria.promptThreshold ?? DEFAULT_SIMILAR_SEARCH_CRITERIA.promptThreshold,
     });
   }, [initialCriteria, isOpen, sourceImage]);
 
@@ -256,6 +263,37 @@ export default function FindSimilarModal({
                     />
                     <span className="block font-medium">Prompt</span>
                   </label>
+
+                  <div className="ml-6 rounded-lg border border-gray-800 bg-gray-900/70 p-3">
+                    <div className="mb-2 flex items-center justify-between gap-3 text-xs">
+                      <span className={criteria.prompt && availability.prompt ? 'font-medium text-gray-200' : 'font-medium text-gray-500'}>
+                        Minimum prompt similarity
+                      </span>
+                      <span className={criteria.prompt && availability.prompt ? 'font-semibold text-emerald-300' : 'font-semibold text-gray-500'}>
+                        {formatThresholdPercent(criteria.promptThreshold)}
+                      </span>
+                    </div>
+                    <input
+                      type="range"
+                      min={50}
+                      max={100}
+                      step={1}
+                      value={Math.round(criteria.promptThreshold * 100)}
+                      disabled={!criteria.prompt || !availability.prompt}
+                      onChange={(event) =>
+                        setCriteria((current) => ({
+                          ...current,
+                          promptThreshold: Number(event.target.value) / 100,
+                        }))
+                      }
+                      className="w-full accent-cyan-400 disabled:cursor-not-allowed disabled:opacity-40"
+                      aria-label="Minimum prompt similarity"
+                    />
+                    <div className="mt-1 flex justify-between text-[10px] text-gray-500">
+                      <span>50%</span>
+                      <span>100%</span>
+                    </div>
+                  </div>
 
                   <label className="flex items-start gap-3 text-sm text-gray-200">
                     <input
@@ -392,8 +430,8 @@ export default function FindSimilarModal({
                           {result.primaryCheckpoint ? ` · ${result.primaryCheckpoint}` : ''}
                         </span>
                       }
-                      onClick={() => onOpenImage(result.image)}
-                      onOpenImage={() => onOpenImage(result.image)}
+                      onClick={() => onOpenImage(result.image, resultImages)}
+                      onOpenImage={() => onOpenImage(result.image, resultImages)}
                     />
                   ))}
                 </div>

--- a/components/FindSimilarModal.tsx
+++ b/components/FindSimilarModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Check, Eye, FolderTree, GitCompare, Layers, Search, SlidersHorizontal, X } from 'lucide-react';
-import type { IndexedImage, SimilarSearchCriteria, SimilarSearchResult } from '../types';
+import { Eye, FolderTree, Layers, ListFilter, Search, SlidersHorizontal, X } from 'lucide-react';
+import type { IndexedImage, SimilarSearchCriteria } from '../types';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useThumbnail } from '../hooks/useThumbnail';
 import {
@@ -20,11 +20,11 @@ interface FindSimilarModalProps {
   initialCriteria?: Partial<SimilarSearchCriteria>;
   onClose: () => void;
   onOpenImage: (image: IndexedImage) => void;
-  onOpenCompare: (images: IndexedImage[]) => void;
+  onApplyGridFilter: (images: IndexedImage[]) => void;
 }
 
-const overlayClassName = 'fixed inset-0 z-[150] flex items-center justify-center bg-black/80 px-4 py-6 backdrop-blur-sm';
-const panelClassName = 'flex max-h-[92vh] w-full max-w-7xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl';
+const overlayClassName = 'fixed inset-0 z-[150] flex items-start justify-center overflow-y-auto bg-black/80 px-4 py-6 backdrop-blur-sm';
+const panelClassName = 'flex h-[calc(100dvh-3rem)] max-h-[92dvh] w-full max-w-7xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl';
 const pillButtonClassName = 'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors';
 
 const useThumbnailUrl = (image: IndexedImage | null) => {
@@ -50,14 +50,12 @@ const formatLoraSummary = (image: IndexedImage) => {
 
 const SimilarImageCard = ({
   image,
-  selected,
   badge,
   similarityPercent,
   onClick,
   onOpenImage,
 }: {
   image: IndexedImage;
-  selected: boolean;
   badge: React.ReactNode;
   similarityPercent: string | null;
   onClick?: () => void;
@@ -67,17 +65,13 @@ const SimilarImageCard = ({
 
   return (
     <div
-      className={`group relative overflow-hidden rounded-xl border text-left transition-colors ${
-        selected
-          ? 'border-cyan-400 bg-cyan-500/10 shadow-lg shadow-cyan-500/10'
-          : 'border-gray-700 bg-gray-950/70 hover:border-gray-500 hover:bg-gray-950'
-      }`}
+      className="group relative overflow-hidden rounded-xl border border-gray-700 bg-gray-950/70 text-left transition-colors hover:border-gray-500 hover:bg-gray-950"
     >
       <button
         type="button"
         onClick={onClick}
         className="block w-full text-left"
-        aria-label={`Select ${image.name} for compare`}
+        aria-label={`Open ${image.name} in image modal`}
       >
         <div className="relative aspect-[4/5] overflow-hidden bg-gradient-to-br from-gray-800 via-gray-900 to-gray-950">
           {thumbnailUrl ? (
@@ -88,11 +82,6 @@ const SimilarImageCard = ({
           <div className="absolute left-2 top-2 rounded-full bg-black/70 px-2 py-1 text-[10px] font-semibold text-gray-100">
             {badge}
           </div>
-          {selected && (
-            <div className="absolute right-2 top-2 rounded-full bg-cyan-500 p-1 text-white">
-              <Check className="h-3.5 w-3.5" />
-            </div>
-          )}
         </div>
       </button>
       <div className="space-y-1 p-3">
@@ -159,10 +148,9 @@ export default function FindSimilarModal({
   initialCriteria,
   onClose,
   onOpenImage,
-  onOpenCompare,
+  onApplyGridFilter,
 }: FindSimilarModalProps) {
   const [criteria, setCriteria] = useState<SimilarSearchCriteria>(DEFAULT_SIMILAR_SEARCH_CRITERIA);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (!isOpen || !sourceImage) {
@@ -199,54 +187,18 @@ export default function FindSimilarModal({
     });
   }, [allImages, criteria, currentViewImages, sourceImage]);
 
-  useEffect(() => {
-    if (!execution) {
-      setSelectedIds(new Set());
-      return;
-    }
-
-    // Optimization: Replaced `.filter().map()` with a `for` loop
-    // to eliminate the O(N) allocation of intermediate arrays.
-    // Impact: Reduces garbage collection pauses during modal updates.
-    const nextSelectedIds = new Set<string>();
-    for (const result of execution.results) {
-      if (result.preselected) {
-        nextSelectedIds.add(result.image.id);
-      }
-    }
-    setSelectedIds(nextSelectedIds);
-  }, [execution]);
-
   if (!isOpen || !sourceImage || !availability || !sourceDetails || !execution || typeof document === 'undefined') {
     return null;
   }
 
-  const compareDisabled = selectedIds.size === 0 || !execution.hasActiveCriterion;
+  const filterDisabled = execution.results.length === 0 || !execution.hasActiveCriterion;
   const isResultLimited = execution.results.length >= MAX_SIMILAR_SEARCH_RESULTS;
-
-  const toggleSelection = (result: SimilarSearchResult) => {
-    setSelectedIds((current) => {
-      const next = new Set(current);
-      if (next.has(result.image.id)) {
-        next.delete(result.image.id);
-        return next;
-      }
-
-      if (next.size >= 3) {
-        return current;
-      }
-
-      next.add(result.image.id);
-      return next;
-    });
-  };
-
-  const selectedResults = execution.results.filter((result) => selectedIds.has(result.image.id)).slice(0, 3);
+  const resultImages = execution.results.map((result) => result.image);
 
   return createPortal(
     <div className={overlayClassName} role="dialog" aria-modal="true" aria-label="Find similar images">
       <div className={panelClassName}>
-        <div className="flex items-center justify-between border-b border-gray-800 px-5 py-4">
+        <div className="flex flex-shrink-0 items-center justify-between border-b border-gray-800 px-5 py-4">
           <div className="text-lg font-semibold text-gray-100">Find similar...</div>
           <button
             type="button"
@@ -259,7 +211,7 @@ export default function FindSimilarModal({
         </div>
 
         <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-[320px_minmax(0,1fr)]">
-          <aside className="border-b border-gray-800 p-5 lg:border-b-0 lg:border-r">
+          <aside className="min-h-0 overflow-y-auto border-b border-gray-800 p-5 lg:border-b-0 lg:border-r">
             <div className="mb-5 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Source image</div>
             <div className="overflow-hidden rounded-2xl border border-gray-800 bg-gray-950/80">
               <div className="aspect-[4/5] overflow-hidden bg-gradient-to-br from-gray-800 via-gray-900 to-black">
@@ -273,10 +225,14 @@ export default function FindSimilarModal({
                 <div className="truncate text-sm font-semibold text-gray-100" title={sourceImage.name}>
                   {sourceImage.name}
                 </div>
-                <div className="rounded-lg border border-gray-800 bg-gray-900/80 p-3 text-xs text-gray-300">
-                  <div className="mb-1 font-medium text-cyan-200">{formatModelSummary(sourceImage)}</div>
+                <div className="min-w-0 overflow-hidden rounded-lg border border-gray-800 bg-gray-900/80 p-3 text-xs text-gray-300">
+                  <div className="mb-1 truncate font-medium text-cyan-200" title={formatModelSummary(sourceImage)}>
+                    {formatModelSummary(sourceImage)}
+                  </div>
                   <div className="mb-1">{sourceImage.seed != null ? `Seed ${sourceImage.seed}` : 'No seed'}</div>
-                  <div title={formatLoraSummary(sourceImage)}>{formatLoraSummary(sourceImage)}</div>
+                  <div className="line-clamp-2 break-all" title={formatLoraSummary(sourceImage)}>
+                    {formatLoraSummary(sourceImage)}
+                  </div>
                 </div>
                 <div className="max-h-24 overflow-auto rounded-lg border border-gray-800 bg-gray-900/80 p-3 text-xs leading-relaxed text-gray-300">
                   {sourceImage.prompt || ''}
@@ -405,17 +361,14 @@ export default function FindSimilarModal({
             </div>
           </aside>
 
-          <section className="flex min-h-0 flex-col">
-            <div className="border-b border-gray-800 px-5 py-4">
+          <section className="flex min-h-0 flex-col overflow-hidden">
+            <div className="flex-shrink-0 border-b border-gray-800 px-5 py-4">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <div className="text-sm font-semibold text-gray-100">
                     {isResultLimited ? `Top ${MAX_SIMILAR_SEARCH_RESULTS}` : execution.results.length} match{execution.results.length === 1 ? '' : 'es'}
                   </div>
                   <div className="text-xs text-gray-400">{execution.candidates.length} candidates</div>
-                </div>
-                <div className="text-xs text-gray-400">
-                  Selected {selectedResults.length} of 3 compare slots.
                 </div>
               </div>
             </div>
@@ -432,7 +385,6 @@ export default function FindSimilarModal({
                     <SimilarImageCard
                       key={result.image.id}
                       image={result.image}
-                      selected={selectedIds.has(result.image.id)}
                       similarityPercent={formatSimilarityPercent(result.promptSimilarity)}
                       badge={
                         <span>
@@ -440,7 +392,7 @@ export default function FindSimilarModal({
                           {result.primaryCheckpoint ? ` · ${result.primaryCheckpoint}` : ''}
                         </span>
                       }
-                      onClick={() => toggleSelection(result)}
+                      onClick={() => onOpenImage(result.image)}
                       onOpenImage={() => onOpenImage(result.image)}
                     />
                   ))}
@@ -448,7 +400,7 @@ export default function FindSimilarModal({
               )}
             </div>
 
-            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-gray-800 px-5 py-4">
+            <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-3 border-t border-gray-800 px-5 py-4">
               <div />
               <div className="flex items-center gap-3">
                 <button
@@ -460,12 +412,12 @@ export default function FindSimilarModal({
                 </button>
                 <button
                   type="button"
-                  onClick={() => onOpenCompare([sourceImage, ...selectedResults.map((result) => result.image)].slice(0, 4))}
-                  disabled={compareDisabled}
+                  onClick={() => onApplyGridFilter(resultImages)}
+                  disabled={filterDisabled}
                   className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/60 bg-cyan-500/20 px-4 py-2 text-sm font-semibold text-cyan-100 transition-colors hover:bg-cyan-500/30 disabled:cursor-not-allowed disabled:border-gray-700 disabled:bg-gray-800 disabled:text-gray-500"
                 >
-                  <GitCompare className="h-4 w-4" />
-                  Open in Compare
+                  <ListFilter className="h-4 w-4" />
+                  Apply as Grid Filter
                 </button>
               </div>
             </div>

--- a/components/FindSimilarModal.tsx
+++ b/components/FindSimilarModal.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Check, FolderTree, GitCompare, Layers, Search, SlidersHorizontal, X } from 'lucide-react';
+import { Check, Eye, FolderTree, GitCompare, Layers, Search, SlidersHorizontal, X } from 'lucide-react';
 import type { IndexedImage, SimilarSearchCriteria, SimilarSearchResult } from '../types';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useThumbnail } from '../hooks/useThumbnail';
 import {
   DEFAULT_SIMILAR_SEARCH_CRITERIA,
+  MAX_SIMILAR_SEARCH_RESULTS,
   findSimilarImages,
   getSimilarSearchAvailability,
   getSimilarSearchSourceDetails,
@@ -18,6 +19,7 @@ interface FindSimilarModalProps {
   currentViewImages?: IndexedImage[];
   initialCriteria?: Partial<SimilarSearchCriteria>;
   onClose: () => void;
+  onOpenImage: (image: IndexedImage) => void;
   onOpenCompare: (images: IndexedImage[]) => void;
 }
 
@@ -33,6 +35,9 @@ const useThumbnailUrl = (image: IndexedImage | null) => {
 
 const formatModelSummary = (image: IndexedImage) => image.models[0] || 'Unknown checkpoint';
 
+const formatSimilarityPercent = (similarity: number | null) =>
+  similarity == null ? null : `${Math.round(similarity * 100)}%`;
+
 const formatLoraSummary = (image: IndexedImage) => {
   if (!image.loras || image.loras.length === 0) {
     return 'No LoRAs';
@@ -47,43 +52,68 @@ const SimilarImageCard = ({
   image,
   selected,
   badge,
+  similarityPercent,
   onClick,
+  onOpenImage,
 }: {
   image: IndexedImage;
   selected: boolean;
   badge: React.ReactNode;
+  similarityPercent: string | null;
   onClick?: () => void;
+  onOpenImage: () => void;
 }) => {
   const thumbnailUrl = useThumbnailUrl(image);
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <div
       className={`group relative overflow-hidden rounded-xl border text-left transition-colors ${
         selected
           ? 'border-cyan-400 bg-cyan-500/10 shadow-lg shadow-cyan-500/10'
           : 'border-gray-700 bg-gray-950/70 hover:border-gray-500 hover:bg-gray-950'
       }`}
     >
-      <div className="relative aspect-[4/5] overflow-hidden bg-gradient-to-br from-gray-800 via-gray-900 to-gray-950">
-        {thumbnailUrl ? (
-          <img src={thumbnailUrl} alt={image.name} className="h-full w-full object-cover" loading="lazy" />
-        ) : (
-          <div className="h-full w-full bg-gradient-to-br from-gray-800 via-gray-900 to-gray-950" />
-        )}
-        <div className="absolute left-2 top-2 rounded-full bg-black/70 px-2 py-1 text-[10px] font-semibold text-gray-100">
-          {badge}
-        </div>
-        {selected && (
-          <div className="absolute right-2 top-2 rounded-full bg-cyan-500 p-1 text-white">
-            <Check className="h-3.5 w-3.5" />
+      <button
+        type="button"
+        onClick={onClick}
+        className="block w-full text-left"
+        aria-label={`Select ${image.name} for compare`}
+      >
+        <div className="relative aspect-[4/5] overflow-hidden bg-gradient-to-br from-gray-800 via-gray-900 to-gray-950">
+          {thumbnailUrl ? (
+            <img src={thumbnailUrl} alt={image.name} className="h-full w-full object-cover" loading="lazy" />
+          ) : (
+            <div className="h-full w-full bg-gradient-to-br from-gray-800 via-gray-900 to-gray-950" />
+          )}
+          <div className="absolute left-2 top-2 rounded-full bg-black/70 px-2 py-1 text-[10px] font-semibold text-gray-100">
+            {badge}
           </div>
-        )}
-      </div>
+          {selected && (
+            <div className="absolute right-2 top-2 rounded-full bg-cyan-500 p-1 text-white">
+              <Check className="h-3.5 w-3.5" />
+            </div>
+          )}
+        </div>
+      </button>
       <div className="space-y-1 p-3">
-        <div className="truncate text-sm font-semibold text-gray-100" title={image.name}>
-          {image.name}
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-gray-100" title={image.name}>
+              {image.name}
+            </div>
+            {similarityPercent && (
+              <div className="text-xs font-medium text-emerald-300">{similarityPercent} prompt match</div>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onOpenImage}
+            className="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg border border-gray-700 text-gray-300 transition-colors hover:border-cyan-400/70 hover:text-cyan-100"
+            aria-label={`Open ${image.name} in image modal`}
+            title="Open image"
+          >
+            <Eye className="h-4 w-4" />
+          </button>
         </div>
         <div className="truncate text-xs text-cyan-200" title={formatModelSummary(image)}>
           {formatModelSummary(image)}
@@ -92,7 +122,7 @@ const SimilarImageCard = ({
           {formatLoraSummary(image)}
         </div>
       </div>
-    </button>
+    </div>
   );
 };
 
@@ -128,6 +158,7 @@ export default function FindSimilarModal({
   currentViewImages,
   initialCriteria,
   onClose,
+  onOpenImage,
   onOpenCompare,
 }: FindSimilarModalProps) {
   const [criteria, setCriteria] = useState<SimilarSearchCriteria>(DEFAULT_SIMILAR_SEARCH_CRITERIA);
@@ -191,6 +222,7 @@ export default function FindSimilarModal({
   }
 
   const compareDisabled = selectedIds.size === 0 || !execution.hasActiveCriterion;
+  const isResultLimited = execution.results.length >= MAX_SIMILAR_SEARCH_RESULTS;
 
   const toggleSelection = (result: SimilarSearchResult) => {
     setSelectedIds((current) => {
@@ -312,28 +344,28 @@ export default function FindSimilarModal({
               <div>
                 <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">
                   <Layers className="h-3.5 w-3.5" />
-                  Checkpoint
+                  Checkpoint filter
                 </div>
-                <div className="grid grid-cols-3 gap-2">
-                  <ScopeButton
-                    active={criteria.checkpointMode === 'different'}
-                    disabled={!availability.checkpoint}
-                    onClick={() => setCriteria((current) => ({ ...current, checkpointMode: 'different' }))}
-                  >
-                    Different
-                  </ScopeButton>
+                <div className="grid grid-cols-1 gap-2">
                   <ScopeButton
                     active={criteria.checkpointMode === 'ignore'}
                     onClick={() => setCriteria((current) => ({ ...current, checkpointMode: 'ignore' }))}
                   >
-                    Ignore
+                    Any checkpoint
                   </ScopeButton>
                   <ScopeButton
                     active={criteria.checkpointMode === 'same'}
                     disabled={!availability.checkpoint}
                     onClick={() => setCriteria((current) => ({ ...current, checkpointMode: 'same' }))}
                   >
-                    Same
+                    Only same checkpoint
+                  </ScopeButton>
+                  <ScopeButton
+                    active={criteria.checkpointMode === 'different'}
+                    disabled={!availability.checkpoint}
+                    onClick={() => setCriteria((current) => ({ ...current, checkpointMode: 'different' }))}
+                  >
+                    Exclude same checkpoint
                   </ScopeButton>
                 </div>
               </div>
@@ -378,7 +410,7 @@ export default function FindSimilarModal({
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <div className="text-sm font-semibold text-gray-100">
-                    {execution.results.length} match{execution.results.length === 1 ? '' : 'es'}
+                    {isResultLimited ? `Top ${MAX_SIMILAR_SEARCH_RESULTS}` : execution.results.length} match{execution.results.length === 1 ? '' : 'es'}
                   </div>
                   <div className="text-xs text-gray-400">{execution.candidates.length} candidates</div>
                 </div>
@@ -401,6 +433,7 @@ export default function FindSimilarModal({
                       key={result.image.id}
                       image={result.image}
                       selected={selectedIds.has(result.image.id)}
+                      similarityPercent={formatSimilarityPercent(result.promptSimilarity)}
                       badge={
                         <span>
                           #{index + 1}
@@ -408,6 +441,7 @@ export default function FindSimilarModal({
                         </span>
                       }
                       onClick={() => toggleSelection(result)}
+                      onOpenImage={() => onOpenImage(result.image)}
                     />
                   ))}
                 </div>

--- a/services/similarImageSearch.ts
+++ b/services/similarImageSearch.ts
@@ -6,8 +6,11 @@ import type {
   SimilarSearchScope,
 } from '../types';
 import { normalizeFacetValue } from '../utils/facetNormalization';
+import { normalizePrompt, normalizedLevenshtein, tokenizeForSimilarity } from '../utils/similarityMetrics';
 
 const DEFAULT_SCOPE: SimilarSearchScope = 'current-view';
+export const DEFAULT_SIMILAR_PROMPT_THRESHOLD = 0.87;
+export const MAX_SIMILAR_SEARCH_RESULTS = 250;
 
 type NormalizedLoraEntry = {
   name: string;
@@ -23,6 +26,7 @@ export type SimilarSearchAvailability = {
 
 export type SimilarSearchSourceDetails = {
   normalizedPrompt: string | null;
+  normalizedSimilarityPrompt: string | null;
   loras: NormalizedLoraEntry[];
   seed: number | null;
   checkpoints: string[];
@@ -54,7 +58,7 @@ export const DEFAULT_SIMILAR_SEARCH_CRITERIA: SimilarSearchCriteria = {
   lora: false,
   matchLoraWeight: false,
   seed: false,
-  checkpointMode: 'different',
+  checkpointMode: 'ignore',
   scope: DEFAULT_SCOPE,
 };
 
@@ -196,11 +200,14 @@ export const getSimilarSearchAvailability = (image: IndexedImage): SimilarSearch
 };
 
 export const getSimilarSearchSourceDetails = (image: IndexedImage): SimilarSearchSourceDetails => {
-  const normalizedPrompt = normalizePromptForSimilarSearch(getImagePromptForSimilarSearch(image));
+  const prompt = getImagePromptForSimilarSearch(image);
+  const normalizedPrompt = normalizePromptForSimilarSearch(prompt);
+  const normalizedSimilarityPrompt = normalizePrompt(prompt);
   const checkpoints = normalizeCheckpointList(image);
 
   return {
     normalizedPrompt: normalizedPrompt || null,
+    normalizedSimilarityPrompt: normalizedSimilarityPrompt || null,
     loras: normalizeLoraEntries(image),
     seed: typeof image.seed === 'number' && Number.isFinite(image.seed) ? image.seed : null,
     checkpoints,
@@ -316,6 +323,55 @@ const choosePreselectedIds = (results: Omit<SimilarSearchResult, 'preselected'>[
 
 const compareNewestFirst = (left: IndexedImage, right: IndexedImage) => right.lastModified - left.lastModified;
 
+const jaccardFromTokens = (left: Set<string>, right: Set<string>): number => {
+  if (left.size === 0 && right.size === 0) {
+    return 1;
+  }
+
+  if (left.size === 0 || right.size === 0) {
+    return 0;
+  }
+
+  let intersection = 0;
+  for (const token of left) {
+    if (right.has(token)) {
+      intersection += 1;
+    }
+  }
+
+  const union = left.size + right.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+};
+
+const calculatePromptSimilarity = ({
+  sourcePrompt,
+  sourceTokens,
+  candidatePrompt,
+  threshold,
+}: {
+  sourcePrompt: string;
+  sourceTokens: Set<string>;
+  candidatePrompt: string;
+  threshold: number;
+}): number | null => {
+  if (sourcePrompt === candidatePrompt) {
+    return 1;
+  }
+
+  const candidateTokens = tokenizeForSimilarity(candidatePrompt);
+  const jaccard = jaccardFromTokens(sourceTokens, candidateTokens);
+  const minJaccard = Math.max(0, (threshold - 0.4) / 0.6);
+  if (jaccard < minJaccard) {
+    return null;
+  }
+
+  const requiredLevenshtein = Math.max(0, Math.min(1, (threshold - jaccard * 0.6) / 0.4));
+  const levenshtein = normalizedLevenshtein(sourcePrompt, candidatePrompt, requiredLevenshtein);
+  const similarity = jaccard * 0.6 + levenshtein * 0.4;
+
+  return similarity >= threshold ? similarity : null;
+};
+
 export const findSimilarImages = ({
   sourceImage,
   allImages,
@@ -348,7 +404,8 @@ export const findSimilarImages = ({
     };
   }
 
-  const sourceCheckpointSet = new Set(source.checkpoints);
+  const sourceSimilarityPrompt = source.normalizedSimilarityPrompt;
+  const sourceSimilarityTokens = sourceSimilarityPrompt ? tokenizeForSimilarity(sourceSimilarityPrompt) : null;
 
   const rawResults = candidates
     .filter((image) => image.id !== sourceImage.id)
@@ -357,8 +414,21 @@ export const findSimilarImages = ({
       const candidateCheckpointSet = new Set(candidateSource.checkpoints);
       const sharesCheckpoint = source.checkpoints.some((checkpoint) => candidateCheckpointSet.has(checkpoint));
 
-      if (effectiveCriteria.prompt && candidateSource.normalizedPrompt !== source.normalizedPrompt) {
-        return null;
+      let promptSimilarity: number | null = null;
+      if (effectiveCriteria.prompt) {
+        if (!sourceSimilarityPrompt || !sourceSimilarityTokens || !candidateSource.normalizedSimilarityPrompt) {
+          return null;
+        }
+
+        promptSimilarity = calculatePromptSimilarity({
+          sourcePrompt: sourceSimilarityPrompt,
+          sourceTokens: sourceSimilarityTokens,
+          candidatePrompt: candidateSource.normalizedSimilarityPrompt,
+          threshold: DEFAULT_SIMILAR_PROMPT_THRESHOLD,
+        });
+        if (promptSimilarity == null) {
+          return null;
+        }
       }
 
       if (effectiveCriteria.lora && !haveSameLoraNames(candidateSource.loras, source.loras)) {
@@ -395,28 +465,25 @@ export const findSimilarImages = ({
         }),
         primaryCheckpoint: candidateSource.primaryCheckpoint,
         sharesCheckpoint,
+        promptSimilarity,
       } satisfies Omit<SimilarSearchResult, 'preselected'>;
     })
     .filter((result): result is Omit<SimilarSearchResult, 'preselected'> => Boolean(result))
     .sort((left, right) => {
-      if (left.sharesCheckpoint !== right.sharesCheckpoint) {
-        return left.sharesCheckpoint ? 1 : -1;
-      }
-
-      const leftHasAlternate = left.primaryCheckpoint && !sourceCheckpointSet.has(left.primaryCheckpoint);
-      const rightHasAlternate = right.primaryCheckpoint && !sourceCheckpointSet.has(right.primaryCheckpoint);
-      if (leftHasAlternate !== rightHasAlternate) {
-        return leftHasAlternate ? -1 : 1;
+      if (left.promptSimilarity !== right.promptSimilarity) {
+        return (right.promptSimilarity ?? -1) - (left.promptSimilarity ?? -1);
       }
 
       return compareNewestFirst(left.image, right.image);
     });
 
   const preselectedIds = choosePreselectedIds(rawResults);
-  const results = rawResults.map((result) => ({
-    ...result,
-    preselected: preselectedIds.has(result.image.id),
-  }));
+  const results = rawResults
+    .slice(0, MAX_SIMILAR_SEARCH_RESULTS)
+    .map((result) => ({
+      ...result,
+      preselected: preselectedIds.has(result.image.id),
+    }));
 
   return {
     results,

--- a/services/similarImageSearch.ts
+++ b/services/similarImageSearch.ts
@@ -55,6 +55,7 @@ const LO_RA_WEIGHT_EPSILON = 1e-9;
 
 export const DEFAULT_SIMILAR_SEARCH_CRITERIA: SimilarSearchCriteria = {
   prompt: true,
+  promptThreshold: DEFAULT_SIMILAR_PROMPT_THRESHOLD,
   lora: false,
   matchLoraWeight: false,
   seed: false,
@@ -424,7 +425,7 @@ export const findSimilarImages = ({
           sourcePrompt: sourceSimilarityPrompt,
           sourceTokens: sourceSimilarityTokens,
           candidatePrompt: candidateSource.normalizedSimilarityPrompt,
-          threshold: DEFAULT_SIMILAR_PROMPT_THRESHOLD,
+          threshold: effectiveCriteria.promptThreshold,
         });
         if (promptSimilarity == null) {
           return null;

--- a/services/similarImageSearch.ts
+++ b/services/similarImageSearch.ts
@@ -188,7 +188,7 @@ const haveSameLoraWeights = (left: NormalizedLoraEntry[], right: NormalizedLoraE
 };
 
 export const getSimilarSearchAvailability = (image: IndexedImage): SimilarSearchAvailability => {
-  const normalizedPrompt = normalizePromptForSimilarSearch(getImagePromptForSimilarSearch(image));
+  const normalizedPrompt = normalizePrompt(getImagePromptForSimilarSearch(image));
   const loras = normalizeLoraEntries(image);
   const checkpoints = normalizeCheckpointList(image);
 
@@ -222,7 +222,7 @@ const getEffectiveCriteria = (
   criteria: SimilarSearchCriteria,
 ): SimilarSearchCriteria => ({
   ...criteria,
-  prompt: criteria.prompt && Boolean(source.normalizedPrompt),
+  prompt: criteria.prompt && Boolean(source.normalizedSimilarityPrompt),
   lora: criteria.lora && source.loras.length > 0,
   matchLoraWeight: criteria.lora && criteria.matchLoraWeight && source.loras.length > 0,
   seed: criteria.seed && source.seed != null,

--- a/types.ts
+++ b/types.ts
@@ -780,6 +780,7 @@ export interface SimilarSearchResult {
   preselected: boolean;
   primaryCheckpoint: string | null;
   sharesCheckpoint: boolean;
+  promptSimilarity: number | null;
 }
 
 export interface SelectedFiltersUpdate {

--- a/types.ts
+++ b/types.ts
@@ -767,6 +767,7 @@ export type CheckpointMatchMode = 'ignore' | 'same' | 'different';
 
 export interface SimilarSearchCriteria {
   prompt: boolean;
+  promptThreshold: number;
   lora: boolean;
   matchLoraWeight: boolean;
   seed: boolean;


### PR DESCRIPTION
## Summary
- Updates Find Similar so matches are not preselected and the primary action applies the result set as the active grid filter.
- Adds an instant minimum prompt similarity slider for narrowing modal results.
- Keeps the Find Similar modal open when inspecting a result, opening the image modal above it with navigation scoped to the current matches.
- Fixes modal layout issues around footer visibility, sidebar scrolling, and long checkpoint/LoRA text overflow.

## Validation
- Typecheck and build were run locally by the user before publishing.