### PR TITLE
feat: add update notification modal and implement update handling logic

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import Header from './components/Header';
 import Toast from './components/Toast';
 import SettingsModal from './components/SettingsModal';
 import ChangelogModal from './components/ChangelogModal';
+import UpdateNotificationModal, { type UpdateNotificationStatus } from './components/UpdateNotificationModal';
 import ComparisonModal from './components/ComparisonModal';
 import Footer from './components/Footer';
 import cacheManager from './services/cacheManager';
@@ -58,7 +59,7 @@ import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } fr
 import { ComfyUIGenerateModal, type GenerationParams as ComfyUIGenerationParams } from './components/ComfyUIGenerateModal';
 import { useGenerateWithA1111 } from './hooks/useGenerateWithA1111';
 import { useGenerateWithComfyUI } from './hooks/useGenerateWithComfyUI';
-import { type IndexedImage, type BaseMetadata, type SimilarSearchCriteria } from './types';
+import { type IndexedImage, type BaseMetadata, type SimilarSearchCriteria, type UpdateDownloadProgress, type UpdateNotificationPayload } from './types';
 import { type SettingsFocusSection, type SettingsTab, type SettingsTabInput, resolveSettingsTab } from './components/settings/types';
 import { buildSlideshowPlaylist } from './utils/slideshowPlaylist';
 import { getModelPromptOverlapGroups, type ModelPromptOverlapGroup } from './services/similarImageSearch';
@@ -432,6 +433,19 @@ export default function App() {
   const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
   const [isHotkeyHelpOpen, setIsHotkeyHelpOpen] = useState(false);
   const [isChangelogModalOpen, setIsChangelogModalOpen] = useState(false);
+  const [updateModalState, setUpdateModalState] = useState<{
+    isOpen: boolean;
+    status: UpdateNotificationStatus;
+    update: UpdateNotificationPayload | null;
+    progress: UpdateDownloadProgress | null;
+    error: string | null;
+  }>({
+    isOpen: false,
+    status: 'available',
+    update: null,
+    progress: null,
+    error: null,
+  });
   const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false);
   const [currentVersion, setCurrentVersion] = useState<string>('0.10.0');
   const [isQueueOpen, setIsQueueOpen] = useState(false);
@@ -1177,6 +1191,104 @@ export default function App() {
       unsubscribeShowChangelog();
     };
   }, [handleSelectFolder, toggleViewMode]);
+
+  useEffect(() => {
+    if (!window.electronAPI) return;
+
+    const unsubscribeUpdateAvailable = window.electronAPI.onUpdateAvailable((update) => {
+      setUpdateModalState({
+        isOpen: true,
+        status: 'available',
+        update,
+        progress: null,
+        error: null,
+      });
+    });
+
+    const unsubscribeUpdateProgress = window.electronAPI.onUpdateProgress((progress) => {
+      setUpdateModalState((current) => ({
+        ...current,
+        isOpen: current.update ? true : current.isOpen,
+        status: current.update ? 'downloading' : current.status,
+        progress,
+        error: null,
+      }));
+    });
+
+    const unsubscribeUpdateDownloaded = window.electronAPI.onUpdateDownloaded((update) => {
+      setUpdateModalState((current) => ({
+        isOpen: true,
+        status: 'downloaded',
+        update,
+        progress: current.progress,
+        error: null,
+      }));
+    });
+
+    const unsubscribeUpdateError = window.electronAPI.onUpdateError((error) => {
+      setUpdateModalState((current) => ({
+        ...current,
+        isOpen: current.update ? true : current.isOpen,
+        status: current.update ? 'error' : current.status,
+        error: error.message,
+      }));
+    });
+
+    return () => {
+      unsubscribeUpdateAvailable();
+      unsubscribeUpdateProgress();
+      unsubscribeUpdateDownloaded();
+      unsubscribeUpdateError();
+    };
+  }, []);
+
+  const handleCloseUpdateModal = useCallback(() => {
+    setUpdateModalState((current) => ({
+      ...current,
+      isOpen: false,
+    }));
+  }, []);
+
+  const handleDownloadUpdate = useCallback(async () => {
+    if (!window.electronAPI?.downloadUpdate) return;
+
+    setUpdateModalState((current) => ({
+      ...current,
+      status: 'downloading',
+      progress: current.progress ?? { percent: 0 },
+      error: null,
+    }));
+
+    const result = await window.electronAPI.downloadUpdate();
+    if (!result?.success) {
+      setUpdateModalState((current) => ({
+        ...current,
+        status: 'error',
+        error: result?.error ?? 'The update could not be downloaded. Please try again later.',
+      }));
+    }
+  }, []);
+
+  const handleSkipUpdate = useCallback(async () => {
+    const version = updateModalState.update?.version;
+    if (version && window.electronAPI?.skipUpdateVersion) {
+      await window.electronAPI.skipUpdateVersion(version);
+    }
+    handleCloseUpdateModal();
+  }, [handleCloseUpdateModal, updateModalState.update?.version]);
+
+  const handleInstallUpdateNow = useCallback(async () => {
+    if (!window.electronAPI?.installUpdate) return;
+
+    const result = await window.electronAPI.installUpdate();
+    if (!result?.success) {
+      setUpdateModalState((current) => ({
+        ...current,
+        status: 'error',
+        error: result?.error ?? 'The update could not be installed. Please try again later.',
+      }));
+    }
+  }, []);
 
   useEffect(() => {
     setSearchInputValue(searchQuery);
@@ -2650,6 +2762,7 @@ export default function App() {
     !isHotkeyHelpOpen &&
     !isCommandPaletteOpen &&
     !isChangelogModalOpen &&
+    !updateModalState.isOpen &&
     !isAnalyticsOpen &&
     !isComparisonModalOpen &&
     !isBatchExportModalOpen &&
@@ -3342,6 +3455,18 @@ export default function App() {
           isOpen={isChangelogModalOpen}
           onClose={() => setIsChangelogModalOpen(false)}
           currentVersion={currentVersion}
+        />
+
+        <UpdateNotificationModal
+          isOpen={updateModalState.isOpen}
+          status={updateModalState.status}
+          update={updateModalState.update}
+          progress={updateModalState.progress}
+          error={updateModalState.error}
+          onClose={handleCloseUpdateModal}
+          onDownload={handleDownloadUpdate}
+          onSkip={handleSkipUpdate}
+          onInstallNow={handleInstallUpdateNow}
         />
 
         <Analytics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Find Similar Workflow**: Improved Find Similar with a minimum prompt similarity slider, result-set filtering, scoped result navigation, and a smoother inspect-results flow.
 - **Large Library Performance**: Reduced temporary array, map, and set allocations across collections, file sync, image editing, and large ComfyUI workflow rendering.
 - **Accessibility**: Added clearer labels, titles, and decorative SVG handling across filter controls, the image editor, hotkey help, and browser compatibility surfaces.
+- **Update Notifications**: Replaced the native update dialog with a cleaner in-app update modal that shows release notes, download progress, and clear install options. 
 
 ### Fixed
 

--- a/components/UpdateNotificationModal.tsx
+++ b/components/UpdateNotificationModal.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+import { CheckCircle2, Download, ExternalLink, RefreshCw, RotateCcw, X } from 'lucide-react';
+import { type UpdateDownloadProgress, type UpdateNotificationPayload } from '../types';
+
+export type UpdateNotificationStatus = 'available' | 'downloading' | 'downloaded' | 'error';
+
+interface UpdateNotificationModalProps {
+  isOpen: boolean;
+  status: UpdateNotificationStatus;
+  update: UpdateNotificationPayload | null;
+  progress: UpdateDownloadProgress | null;
+  error?: string | null;
+  onClose: () => void;
+  onDownload: () => void;
+  onSkip: () => void;
+  onInstallNow: () => void;
+}
+
+const formatBytes = (value?: number): string | null => {
+  if (!value || value <= 0) return null;
+
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let size = value;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${size.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+};
+
+const getReleaseNotesText = (update: UpdateNotificationPayload | null): string => {
+  if (!update?.releaseNotes) {
+    return update?.releaseName ? `Release: ${update.releaseName}` : 'No release notes were included with this update.';
+  }
+
+  if (typeof update.releaseNotes === 'string') {
+    return update.releaseNotes;
+  }
+
+  return update.releaseNotes
+    .map((note) => note.note)
+    .filter(Boolean)
+    .join('\n');
+};
+
+const renderReleaseNotes = (text: string) => {
+  const lines = text
+    .replace(/<[^>]*>/g, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 18);
+
+  if (lines.length === 0) {
+    return <p className="text-sm text-gray-400">No release notes were included with this update.</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {lines.map((line, index) => {
+        if (/^#{1,6}\s+/.test(line)) {
+          return (
+            <h3 key={`${line}-${index}`} className="pt-2 text-sm font-semibold text-gray-200">
+              {line.replace(/^#{1,6}\s+/, '')}
+            </h3>
+          );
+        }
+
+        const bulletText = line.replace(/^[-*]\s+/, '').replace(/\*\*/g, '');
+        const isBullet = /^[-*]\s+/.test(line);
+
+        if (isBullet) {
+          return (
+            <div key={`${line}-${index}`} className="flex gap-2 text-sm leading-6 text-gray-300">
+              <span className="mt-[9px] h-1.5 w-1.5 flex-shrink-0 rounded-full bg-gray-500" />
+              <span>{bulletText}</span>
+            </div>
+          );
+        }
+
+        return (
+          <p key={`${line}-${index}`} className="text-sm leading-6 text-gray-300">
+            {bulletText}
+          </p>
+        );
+      })}
+    </div>
+  );
+};
+
+const UpdateNotificationModal: React.FC<UpdateNotificationModalProps> = ({
+  isOpen,
+  status,
+  update,
+  progress,
+  error,
+  onClose,
+  onDownload,
+  onSkip,
+  onInstallNow,
+}) => {
+  if (!isOpen || !update) return null;
+
+  const percent = Math.max(0, Math.min(100, progress?.percent ?? 0));
+  const transferred = formatBytes(progress?.transferred);
+  const total = formatBytes(progress?.total);
+  const releaseNotes = getReleaseNotesText(update);
+  const changelogUrl = update.changelogUrl ?? `https://github.com/LuqP2/Image-MetaHub/releases/tag/v${update.version}`;
+
+  const title = status === 'downloaded' ? 'Update ready to install' : 'Update available';
+  const subtitle =
+    status === 'downloaded'
+      ? `Image MetaHub ${update.version} has been downloaded.`
+      : `Image MetaHub ${update.version} is ready to download.`;
+
+  return (
+    <div className="fixed inset-0 z-[130] flex items-center justify-center bg-black/75 px-4 py-6 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label={title}>
+      <div className="flex max-h-[86vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-gray-700 bg-gray-900 shadow-2xl">
+        <div className="flex items-start justify-between gap-4 border-b border-gray-700 p-6">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="rounded-lg bg-blue-500/15 p-2 text-blue-300">
+              {status === 'downloaded' ? <CheckCircle2 size={22} /> : <Download size={22} />}
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-xl font-semibold text-gray-100">{title}</h2>
+              <p className="mt-1 text-sm text-gray-400">{subtitle}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-800 hover:text-gray-100"
+            title="Close"
+            aria-label="Close update notification"
+            disabled={status === 'downloading'}
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          {status === 'downloading' ? (
+            <div className="space-y-4">
+              <div className="flex items-center gap-3 text-sm text-gray-300">
+                <RefreshCw size={18} className="animate-spin text-blue-300" />
+                Downloading update...
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-gray-800">
+                <div className="h-full rounded-full bg-blue-500 transition-all" style={{ width: `${percent}%` }} />
+              </div>
+              <div className="flex items-center justify-between text-xs text-gray-500">
+                <span>{percent.toFixed(0)}%</span>
+                {transferred && total ? <span>{transferred} of {total}</span> : null}
+              </div>
+            </div>
+          ) : status === 'error' ? (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+              {error || 'The update could not be downloaded. Please try again later.'}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-gray-800 bg-gray-950/40 p-4">
+              {renderReleaseNotes(releaseNotes)}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-3 border-t border-gray-700 bg-gray-950/50 p-6 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            type="button"
+            onClick={() => window.electronAPI?.openExternalUrl(changelogUrl)}
+            className="inline-flex items-center gap-2 text-sm text-gray-400 transition-colors hover:text-blue-300"
+          >
+            <ExternalLink size={16} />
+            View release notes
+          </button>
+
+          {status === 'downloaded' ? (
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-lg border border-gray-700 px-4 py-2 text-sm text-gray-200 transition-colors hover:bg-gray-800"
+              >
+                Install Later
+              </button>
+              <button
+                type="button"
+                onClick={onInstallNow}
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-500"
+              >
+                <RotateCcw size={16} />
+                Restart and Install
+              </button>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <button
+                type="button"
+                onClick={onSkip}
+                className="rounded-lg border border-gray-700 px-4 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-800"
+                disabled={status === 'downloading'}
+              >
+                Skip Version
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-lg border border-gray-700 px-4 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-800"
+                disabled={status === 'downloading'}
+              >
+                Later
+              </button>
+              <button
+                type="button"
+                onClick={onDownload}
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={status === 'downloading'}
+              >
+                <Download size={16} />
+                Download
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UpdateNotificationModal;

--- a/electron.mjs
+++ b/electron.mjs
@@ -375,6 +375,26 @@ let comfyUIViewState = {
 let skippedVersions = new Set();
 let isManualUpdateCheck = false;
 
+function buildUpdateNotificationPayload(info = {}) {
+  const version = info.version || app.getVersion();
+  const releaseNotes = Array.isArray(info.releaseNotes)
+    ? info.releaseNotes.map((note) => ({
+        version: note.version,
+        note: String(note.note || '').trim(),
+      })).filter((note) => note.note)
+    : typeof info.releaseNotes === 'string'
+      ? info.releaseNotes
+      : undefined;
+
+  return {
+    version,
+    releaseName: info.releaseName,
+    releaseNotes,
+    releaseDate: info.releaseDate,
+    changelogUrl: `https://github.com/LuqP2/Image-MetaHub/releases/tag/v${version}`,
+  };
+}
+
 
 // --- Zoom Management ---
 const ZOOM_STEP = 0.1;
@@ -1933,70 +1953,7 @@ if (autoUpdater) {
     }
 
     if (mainWindow) {
-      // Extract and format changelog from release notes
-      let changelogText = 'No release notes available.';
-      
-      if (info.releaseNotes) {
-        if (typeof info.releaseNotes === 'string') {
-          // Clean up markdown formatting for dialog display
-          changelogText = info.releaseNotes
-            .replace(/#{1,6}\s/g, '') // Remove markdown headers
-            .replace(/\*\*/g, '') // Remove bold markers
-            .replace(/\*/g, '•') // Convert asterisks to bullets
-            .replace(/<[^>]*>/g, '') // Remove HTML tags
-            .trim();
-        } else if (Array.isArray(info.releaseNotes)) {
-          changelogText = info.releaseNotes
-            .map(note => note.note || '')
-            .join('\n')
-            .trim();
-        }
-      }
-
-      // Limit changelog length for dialog (show main highlights only)
-      if (changelogText.length > 400) {
-        changelogText = changelogText.substring(0, 397) + '...';
-      }
-
-      // If still "No release notes available", try to extract from other fields
-      if (changelogText === 'No release notes available.' && info.releaseName) {
-        changelogText = `Release: ${info.releaseName}`;
-      }
-
-      // Add link to full changelog
-      const changelogUrl = `https://github.com/LuqP2/image-metahub/releases/tag/v${info.version}`;
-      const fullMessage = `What's new:\n\n${changelogText}\n\nView full changelog: ${changelogUrl}\n\nWould you like to download this update now?`;
-
-      dialog.showMessageBox(mainWindow, {
-        type: 'info',
-        title: '🎉 Update Available',
-        message: `Version ${info.version} is ready to download!`,
-        detail: fullMessage,
-        buttons: ['Download Now', 'Download Later', 'Skip this version'],
-        defaultId: 0,
-        cancelId: 2,
-        noLink: true
-      }).then((result) => {
-        if (result.response === 0) {
-          // User chose to download - START DOWNLOAD NOW
-          console.log('User accepted update download - starting download...');
-          isManualUpdateCheck = true;
-          autoUpdater.downloadUpdate();
-        } else if (result.response === 1) {
-          // User chose "Download Later"
-          console.log('User postponed download - will ask again later');
-          // Ensure no download starts automatically
-        } else {
-          // User chose "Skip this version"
-          console.log('User skipped version', info.version);
-          skippedVersions.add(info.version);
-          // Ensure no download starts automatically
-        }
-      }).catch((error) => {
-        console.error('Error showing update dialog:', error);
-        // If dialog fails, don't download automatically - respect user choice
-        console.log('Dialog failed - not downloading update');
-      });
+      mainWindow.webContents.send('update-available-notification', buildUpdateNotificationPayload(info));
     } else {
       console.log('Main window not available - not downloading update');
       // Don't download if we can't ask for permission
@@ -2016,16 +1973,13 @@ if (autoUpdater) {
       console.log('macOS auto-updater error - this may be due to code signing requirements');
     }
     
-    if (isManualUpdateCheck && mainWindow) {
-      dialog.showMessageBox(mainWindow, {
-        type: 'error',
-        title: 'Update Error',
-        message: 'Failed to check for updates.',
-        detail: err.message || 'Please try again later.',
-        buttons: ['OK']
+    if (mainWindow) {
+      mainWindow.webContents.send('update-error-notification', {
+        message: err.message || 'Failed to check for updates. Please try again later.',
       });
-      isManualUpdateCheck = false;
     }
+
+    isManualUpdateCheck = false;
   });
 
   autoUpdater.on('download-progress', (progressObj) => {
@@ -2054,35 +2008,8 @@ if (autoUpdater) {
     }
 
     if (mainWindow) {
-      dialog.showMessageBox(mainWindow, {
-        type: 'question',
-        title: 'Update Downloaded',
-        message: `Update ${info.version} downloaded successfully!`,
-        detail: 'The update is ready to install. When would you like to apply it?',
-        buttons: ['Install Now', 'Install on Next Start', 'Cancel'],
-        defaultId: 0,
-        cancelId: 2
-      }).then((result) => {
-        if (result.response === 0) {
-          // Install now
-          console.log('User chose to install update now');
-          autoUpdater.quitAndInstall();
-        } else if (result.response === 1) {
-          // Install on next start - don't restart now
-          console.log('User chose to install update on next start');
-          // The update will be installed automatically on next app launch
-          // No need to call quitAndInstall() here
-        } else {
-          // Cancel - user changed their mind
-          console.log('User cancelled update installation');
-          // Update remains downloaded but not installed
-          // User can still install it later if they change their mind
-        }
-      }).catch((error) => {
-        console.error('Error showing installation dialog:', error);
-        // If dialog fails, don't force install - respect user choice
-        console.log('Installation dialog failed - update will install on next start');
-      });
+      mainWindow.webContents.send('update-downloaded-notification', buildUpdateNotificationPayload(info));
+      isManualUpdateCheck = false;
     } else {
       console.log('Main window not available - update will install on next start');
       // Don't force restart if window is not available
@@ -4364,9 +4291,41 @@ function setupFileOperationHandlers() {
     }
   });
 
+  ipcMain.handle('download-update', async () => {
+    if (!autoUpdater) {
+      return { success: false, error: 'Auto-updater not available' };
+    }
+
+    try {
+      console.log('User accepted update download - starting download...');
+      isManualUpdateCheck = true;
+      await autoUpdater.downloadUpdate();
+      return { success: true };
+    } catch (error) {
+      console.error('Error downloading update:', error);
+      isManualUpdateCheck = false;
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('install-update', async () => {
+    if (!autoUpdater) {
+      return { success: false, error: 'Auto-updater not available' };
+    }
+
+    try {
+      console.log('User chose to restart and install update');
+      autoUpdater.quitAndInstall();
+      return { success: true };
+    } catch (error) {
+      console.error('Error installing update:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
   // TEST ONLY: Simulate update available dialog
   ipcMain.handle('test-update-dialog', async () => {
-    if (process.env.NODE_ENV !== 'development') {
+    if (!isDev) {
       return { success: false, error: 'test-update-dialog is only available in development.' };
     }
 
@@ -4391,35 +4350,9 @@ function setupFileOperationHandlers() {
 - **Optimized Rendering**: Improved grid and table view performance for large datasets`
     };
 
-    // Extract and format changelog
-    let changelogText = 'No release notes available.';
-    
-    if (mockUpdateInfo.releaseNotes) {
-      changelogText = mockUpdateInfo.releaseNotes
-        .replace(/#{1,6}\s/g, '') // Remove markdown headers
-        .replace(/\*\*/g, '') // Remove bold markers
-        .replace(/\*/g, '•') // Convert asterisks to bullets
-        .replace(/<[^>]*>/g, '') // Remove HTML tags
-        .trim();
-    }
+    mainWindow.webContents.send('update-available-notification', buildUpdateNotificationPayload(mockUpdateInfo));
 
-    // Limit changelog length
-    if (changelogText.length > 500) {
-      changelogText = changelogText.substring(0, 497) + '...';
-    }
-
-    const result = await dialog.showMessageBox(mainWindow, {
-      type: 'info',
-      title: '🎉 Update Available (TEST)',
-      message: `Version ${mockUpdateInfo.version} is ready to download!`,
-      detail: `What's new:\n\n${changelogText}\n\nWould you like to download this update now?`,
-      buttons: ['Download Now', 'Download Later', 'Skip this version'],
-      defaultId: 0,
-      cancelId: 2,
-      noLink: true
-    });
-
-    return { success: true, response: result.response };
+    return { success: true };
   });
 
   // Handle listing directory files

--- a/packages/metadata-engine/src/core/types.ts
+++ b/packages/metadata-engine/src/core/types.ts
@@ -18,6 +18,9 @@ export interface ElectronAPI {
   writeFile: (filePath: string, data: any) => Promise<{ success: boolean; error?: string }>;
   getSettings: () => Promise<any>;
   saveSettings: (settings: any) => Promise<{ success: boolean; error?: string }>;
+  downloadUpdate: () => Promise<{ success: boolean; error?: string }>;
+  installUpdate: () => Promise<{ success: boolean; error?: string }>;
+  skipUpdateVersion: (version: string) => Promise<{ success: boolean; error?: string }>;
   launchGenerator: (payload: { command: string; workingDirectory?: string }) => Promise<{ success: boolean; error?: string; scriptPath?: string }>;
   openExternalUrl: (url: string) => Promise<{ success: boolean; error?: string }>;
   getDefaultCachePath: () => Promise<{ success: boolean; path?: string; error?: string }>;
@@ -46,6 +49,10 @@ export interface ElectronAPI {
   onMenuOpenSettings: (callback: () => void) => () => void;
   onMenuToggleView: (callback: () => void) => () => void;
   onMenuShowChangelog: (callback: () => void) => () => void;
+  onUpdateAvailable: (callback: (update: { version: string; releaseName?: string; releaseNotes?: string | Array<{ version?: string; note: string }>; releaseDate?: string; changelogUrl?: string }) => void) => () => void;
+  onUpdateProgress: (callback: (progress: { percent: number; transferred?: number; total?: number; bytesPerSecond?: number }) => void) => () => void;
+  onUpdateDownloaded: (callback: (update: { version: string; releaseName?: string; releaseNotes?: string | Array<{ version?: string; note: string }>; releaseDate?: string; changelogUrl?: string }) => void) => () => void;
+  onUpdateError: (callback: (error: { message: string }) => void) => () => void;
   testUpdateDialog?: () => Promise<{ success: boolean; response?: number; error?: string }>;
   getTheme: () => Promise<{ shouldUseDarkColors: boolean }>;
   onThemeUpdated: (callback: (theme: { shouldUseDarkColors: boolean }) => void) => () => void;

--- a/preload.js
+++ b/preload.js
@@ -1,6 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
-const isDevelopment = process.env.NODE_ENV === 'development';
+const isDevelopment = process.env.NODE_ENV === 'development' || process.defaultApp === true;
 
 // Expose protected methods that allow the renderer process to use
 // the ipcRenderer without exposing the entire object
@@ -103,6 +103,38 @@ const electronAPI = {
     };
   },
 
+  onUpdateAvailable: (callback) => {
+    const handler = (event, ...args) => callback(...args);
+    ipcRenderer.on('update-available-notification', handler);
+    return () => {
+      ipcRenderer.removeListener('update-available-notification', handler);
+    };
+  },
+
+  onUpdateProgress: (callback) => {
+    const handler = (event, ...args) => callback(...args);
+    ipcRenderer.on('update-progress', handler);
+    return () => {
+      ipcRenderer.removeListener('update-progress', handler);
+    };
+  },
+
+  onUpdateDownloaded: (callback) => {
+    const handler = (event, ...args) => callback(...args);
+    ipcRenderer.on('update-downloaded-notification', handler);
+    return () => {
+      ipcRenderer.removeListener('update-downloaded-notification', handler);
+    };
+  },
+
+  onUpdateError: (callback) => {
+    const handler = (event, ...args) => callback(...args);
+    ipcRenderer.on('update-error-notification', handler);
+    return () => {
+      ipcRenderer.removeListener('update-error-notification', handler);
+    };
+  },
+
   onFullscreenChanged: (callback) => {
     const handler = (event, ...args) => callback(...args);
     ipcRenderer.on('fullscreen-changed', handler);
@@ -159,6 +191,9 @@ const electronAPI = {
   getSettings: () => ipcRenderer.invoke('get-settings'),
   saveSettings: (settings) => ipcRenderer.invoke('save-settings', settings),
   markChangelogViewed: (version) => ipcRenderer.invoke('mark-changelog-viewed', version),
+  downloadUpdate: () => ipcRenderer.invoke('download-update'),
+  installUpdate: () => ipcRenderer.invoke('install-update'),
+  skipUpdateVersion: (version) => ipcRenderer.invoke('skip-version', version),
   launchGenerator: (payload) => ipcRenderer.invoke('launch-generator', payload),
   openExternalUrl: (url) => ipcRenderer.invoke('open-external-url', url),
   openPath: (filePath) => ipcRenderer.invoke('open-path', filePath),
@@ -245,9 +280,7 @@ const electronAPI = {
 
 };
 
-if (isDevelopment) {
-  electronAPI.testUpdateDialog = () => ipcRenderer.invoke('test-update-dialog');
-}
+electronAPI.testUpdateDialog = () => ipcRenderer.invoke('test-update-dialog');
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI);
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Find Similar Workflow**: Improved Find Similar with a minimum prompt similarity slider, result-set filtering, scoped result navigation, and a smoother inspect-results flow.
 - **Large Library Performance**: Reduced temporary array, map, and set allocations across collections, file sync, image editing, and large ComfyUI workflow rendering.
 - **Accessibility**: Added clearer labels, titles, and decorative SVG handling across filter controls, the image editor, hotkey help, and browser compatibility surfaces.
+- **Update Notifications**: Replaced the native update dialog with a cleaner in-app update modal that shows release notes, download progress, and clear install options. 
 
 ### Fixed
 

--- a/types.ts
+++ b/types.ts
@@ -275,6 +275,26 @@ export interface IndexedImageTransferResultItem {
   type?: string;
 }
 
+export interface UpdateReleaseNote {
+  version?: string;
+  note: string;
+}
+
+export interface UpdateNotificationPayload {
+  version: string;
+  releaseName?: string;
+  releaseNotes?: string | UpdateReleaseNote[];
+  releaseDate?: string;
+  changelogUrl?: string;
+}
+
+export interface UpdateDownloadProgress {
+  percent: number;
+  transferred?: number;
+  total?: number;
+  bytesPerSecond?: number;
+}
+
 export interface PerformanceTraceEvent {
   id: string;
   name: string;
@@ -400,6 +420,9 @@ export interface ElectronAPI {
   getSettings: () => Promise<any>;
   saveSettings: (settings: any) => Promise<{ success: boolean; error?: string }>;
   markChangelogViewed: (version: string) => Promise<{ success: boolean; error?: string }>;
+  downloadUpdate: () => Promise<{ success: boolean; error?: string }>;
+  installUpdate: () => Promise<{ success: boolean; error?: string }>;
+  skipUpdateVersion: (version: string) => Promise<{ success: boolean; error?: string }>;
   launchGenerator: (payload: { command: string; workingDirectory?: string }) => Promise<{ success: boolean; error?: string; scriptPath?: string }>;
   openExternalUrl: (url: string) => Promise<{ success: boolean; error?: string }>;
   openPath: (filePath: string) => Promise<{ success: boolean; error?: string; errorType?: string }>;
@@ -467,6 +490,10 @@ export interface ElectronAPI {
   onMenuOpenSettings: (callback: () => void) => () => void;
   onMenuToggleView: (callback: () => void) => () => void;
   onMenuShowChangelog: (callback: () => void) => () => void;
+  onUpdateAvailable: (callback: (update: UpdateNotificationPayload) => void) => () => void;
+  onUpdateProgress: (callback: (progress: UpdateDownloadProgress) => void) => () => void;
+  onUpdateDownloaded: (callback: (update: UpdateNotificationPayload) => void) => () => void;
+  onUpdateError: (callback: (error: { message: string }) => void) => () => void;
   testUpdateDialog?: () => Promise<{ success: boolean; response?: number; error?: string }>;
   getTheme: () => Promise<{ shouldUseDarkColors: boolean }>;
   getZoomFactor: () => Promise<number>;


### PR DESCRIPTION
## Summary
- Replace native update dialogs with an in-app update notification modal
- Add update download/progress/downloaded IPC handling
- Keep install choices explicit after download: restart and install now or install later

## Validation
- Typecheck and build run locally by maintainer