### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -56,3 +56,6 @@
 ## 2026-06-11 - Eliminate Array.map() spreading overhead for Math.max/min
 **Learning:** Using `Math.min(...arr.map())` or `Math.max(...arr.map())` creates O(N) temporary arrays and risks `Maximum call stack size exceeded` errors for large arrays because all array elements are spread into function arguments.
 **Action:** Consolidate `min/max` extraction into a single `for` loop and avoid using the spread operator on unconstrained arrays to achieve safer and more memory-efficient O(N) evaluation.
+## 2026-06-12 - Eliminate Array.map() O(N) tuple allocation for Map initialization
+**Learning:** Initializing a `Map` using `.map()` on a large array (e.g., `new Map(safeDirectories.map(dir => [dir.id, dir.path]))`) inside a `useMemo` allocates a temporary O(N) array of tuples. On heavy re-renders where the source array identity changes, this tuple array is instantly created and discarded, driving up garbage collection pressure and reducing frame rates.
+**Action:** Replace the array-mapping pattern with a pre-instantiated `Map` and populate it directly using a standard `for...of` loop to ensure O(1) intermediate memory scaling and eliminate unnecessary GC thrashing.

--- a/App.tsx
+++ b/App.tsx
@@ -343,10 +343,15 @@ export default function App() {
   const safeDirectories = useMemo(() => Array.isArray(directories) ? directories : [], [directories]);
   const safeSelectedImages = selectedImages instanceof Set ? selectedImages : new Set<string>();
   const hasDirectories = safeDirectories.length > 0;
-  const directoryPathById = useMemo(
-    () => new Map(safeDirectories.map((directory) => [directory.id, directory.path])),
-    [safeDirectories]
-  );
+  const directoryPathById = useMemo(() => {
+    // Optimization: Avoid new Map(arr.map()) temporary tuple array allocation
+    // Impact: Eliminates O(N) intermediate memory allocation and GC pressure on re-renders
+    const map = new Map<string, string>();
+    for (const directory of safeDirectories) {
+      map.set(directory.id, directory.path);
+    }
+    return map;
+  }, [safeDirectories]);
   const imageLookup = useMemo(() => {
     const lookup = new Map<string, IndexedImage>();
 


### PR DESCRIPTION
### What
Replaced `new Map(safeDirectories.map(...))` with a `for...of` loop in `App.tsx`'s `directoryPathById` useMemo calculation.

### Why
Initializing a `Map` using `.map()` on an array creates a temporary O(N) array of `[key, value]` tuples. In heavily active components like `App.tsx`, when `safeDirectories` reference changes, this tuple array is created and immediately discarded, causing unnecessary garbage collection pauses.

### Impact
Eliminates O(N) intermediate array allocation per calculation, reducing GC pressure and execution time for the `useMemo` hook.

### Measurement
Run profiling in Chrome DevTools on render to observe a reduction in minor GC events associated with tuple allocation in `App.tsx`. Tests and linters pass confirming correctness.

---
*PR created automatically by Jules for task [8971672145200022232](https://jules.google.com/task/8971672145200022232) started by @LuqP2*