### PR TITLE
🎨 Palette: Add disabled state to Clear finished button

### DIFF
--- a/components/GenerationQueueSidebar.tsx
+++ b/components/GenerationQueueSidebar.tsx
@@ -53,6 +53,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
   onOpenGeneratedOutputs,
 }) => {
   const items = useGenerationQueueStore((state) => state.items);
+  const hasFinishedItems = items.some(item => ['done', 'failed', 'canceled'].includes(item.status));
   const removeJob = useGenerationQueueStore((state) => state.removeJob);
   const clearByStatus = useGenerationQueueStore((state) => state.clearByStatus);
   const setJobStatus = useGenerationQueueStore((state) => state.setJobStatus);
@@ -289,7 +290,9 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
         <div className="flex items-center gap-2 text-xs text-gray-400">
           <button
             onClick={() => clearByStatus(['done', 'failed', 'canceled'])}
-            className="px-2 py-1 rounded bg-gray-700/60 hover:bg-gray-700 text-gray-200 transition-colors"
+            disabled={!hasFinishedItems}
+            title={!hasFinishedItems ? 'No finished items to clear' : 'Clear all finished items'}
+            className="px-2 py-1 rounded bg-gray-700/60 hover:bg-gray-700 text-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Clear finished
           </button>


### PR DESCRIPTION
💡 **What**: Added a disabled state and visually appropriate styling to the "Clear finished" button in the `GenerationQueueSidebar` when there are no finished items to clear.
🎯 **Why**: Prevents users from clicking the button when it has no effect, making the UI's state clearer and following standard UI patterns.
📸 **Before/After**: The button now fades out (`opacity-50`) and shows a `not-allowed` cursor when disabled.
♿ **Accessibility**: Added dynamic `title` attributes that explain *why* the button is disabled ("No finished items to clear") to assist users.

---
*PR created automatically by Jules for task [5403211540963553631](https://jules.google.com/task/5403211540963553631) started by @LuqP2*