### PR TITLE
🎨 Palette: Add keyboard focus visible styles to ChangelogModal buttons

### DIFF
--- a/components/ChangelogModal.tsx
+++ b/components/ChangelogModal.tsx
@@ -112,7 +112,7 @@ const ChangelogModal: React.FC<ChangelogModalProps> = ({ isOpen, onClose, curren
           </div>
           <button
             onClick={onClose}
-            className="p-2 rounded-lg hover:bg-gray-700 transition-colors text-gray-400 hover:text-gray-50"
+            className="p-2 rounded-lg hover:bg-gray-700 transition-colors text-gray-400 hover:text-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Close"
             aria-label="Close changelog"
           >
@@ -142,14 +142,14 @@ const ChangelogModal: React.FC<ChangelogModalProps> = ({ isOpen, onClose, curren
         <div className="flex items-center justify-between p-6 border-t border-gray-700 bg-gray-900/50">
           <button
             onClick={openGitHubReleases}
-            className="flex items-center gap-2 text-sm text-gray-400 hover:text-accent transition-colors"
+            className="flex items-center gap-2 text-sm text-gray-400 hover:text-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
           >
             <ExternalLink size={16} />
             View Full Release Notes
           </button>
           <button
             onClick={onClose}
-            className="px-4 py-2 bg-accent hover:bg-blue-700 text-white rounded-lg transition-colors"
+            className="px-4 py-2 bg-accent hover:bg-blue-700 text-white rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           >
             Got it!
           </button>


### PR DESCRIPTION
💡 **What:** Added missing `focus-visible` styles to the buttons in the `ChangelogModal` component.
🎯 **Why:** To improve keyboard accessibility. Previously, users navigating via keyboard (e.g., using Tab) had no visual feedback on which button was currently focused within the modal.
📸 **Before/After:** Not applicable (visual change only affects keyboard focus state).
♿ **Accessibility:** Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` to the Close, View Full Release Notes, and Got it! buttons, along with `rounded` to ensure the focus ring matches the shape. This provides a clear, high-contrast focus ring that adheres to WCAG accessibility guidelines for keyboard navigation.

---
*PR created automatically by Jules for task [10735399303482853584](https://jules.google.com/task/10735399303482853584) started by @LuqP2*