### PR TITLE
🎨 Palette: Add ARIA labels to ComparisonOverlayView controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-20 - Descriptive Titles on Disabled States
 **Learning:** Icon-only buttons that change state (like Undo/Redo) can cause confusion when disabled without explanation. Adding dynamic `title` attributes that explain *why* an action is disabled (e.g. "Nothing to undo" instead of just "Undo") provides immediate, helpful feedback to users.
 **Action:** When implementing interactive elements with disabled states, especially icon-only buttons, provide dynamic `title` attributes explaining the disabled reason to improve clarity.
+## 2024-05-15 - ComparisonOverlayView Icon Buttons Missing ARIA Labels
+**Learning:** Icon-only buttons for zooming, resetting zoom, and pausing/resuming the flicker mode in the `ComparisonOverlayView` were missing `aria-label` attributes.
+**Action:** Added descriptive `aria-label` attributes to these icon-only buttons to improve screen reader accessibility. Also added `aria-hidden="true"` to the decorative SVGs to prevent redundant announcements by screen readers.

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -278,8 +278,9 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
               onClick={() => setIsFlickerPaused((current) => !current)}
               className="rounded p-1 text-gray-200 hover:bg-white/10 hover:text-white"
               title={isFlickerPaused ? 'Resume flicker' : 'Pause flicker'}
+              aria-label={isFlickerPaused ? 'Resume flicker' : 'Pause flicker'}
             >
-              {isFlickerPaused ? <Play className="h-3.5 w-3.5" /> : <Pause className="h-3.5 w-3.5" />}
+              {isFlickerPaused ? <Play aria-hidden="true" className="h-3.5 w-3.5" /> : <Pause aria-hidden="true" className="h-3.5 w-3.5" />}
             </button>
             {advancedSettings.showLabels ? <span>{isFlickerShowingRight ? `Image B: ${rightImage.name}` : `Image A: ${leftImage.name}`}</span> : <span>{isFlickerShowingRight ? 'Image B' : 'Image A'}</span>}
           </div>
@@ -553,22 +554,25 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                 onClick={() => zoomIn()}
                 className="p-2 bg-black/60 hover:bg-black/80 rounded-lg backdrop-blur-sm transition-colors"
                 title="Zoom In"
+                aria-label="Zoom In"
               >
-                <ZoomIn className="w-5 h-5 text-white" />
+                <ZoomIn aria-hidden="true" className="w-5 h-5 text-white" />
               </button>
               <button
                 onClick={() => zoomOut()}
                 className="p-2 bg-black/60 hover:bg-black/80 rounded-lg backdrop-blur-sm transition-colors"
                 title="Zoom Out"
+                aria-label="Zoom Out"
               >
-                <ZoomOut className="w-5 h-5 text-white" />
+                <ZoomOut aria-hidden="true" className="w-5 h-5 text-white" />
               </button>
               <button
                 onClick={() => resetTransform()}
                 className="p-2 bg-black/60 hover:bg-black/80 rounded-lg backdrop-blur-sm transition-colors"
                 title="Reset Zoom"
+                aria-label="Reset Zoom"
               >
-                <RotateCcw className="w-5 h-5 text-white" />
+                <RotateCcw aria-hidden="true" className="w-5 h-5 text-white" />
               </button>
             </div>
 


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons (Zoom In, Zoom Out, Reset Zoom, Play/Pause flicker) in the `ComparisonOverlayView` component. Also added `aria-hidden="true"` to their respective decorative SVG icons.
🎯 Why: To improve keyboard and screen reader accessibility for interactive elements, ensuring that icon-only buttons have descriptive labels matching WCAG 2.5.3 standards.
📸 Before/After: Visuals are unchanged as this is an accessibility (ARIA) improvement.
♿ Accessibility: Improved screen reader announcements for the zoom and flicker controls. Redundant announcements of decorative SVGs are prevented by `aria-hidden="true"`.

---
*PR created automatically by Jules for task [1652325037576418776](https://jules.google.com/task/1652325037576418776) started by @LuqP2*