### PR TITLE
Add creator attribution support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -65,6 +65,7 @@ import { buildSlideshowPlaylist } from './utils/slideshowPlaylist';
 import { getModelPromptOverlapGroups, type ModelPromptOverlapGroup } from './services/similarImageSearch';
 import { resolveWatchedRemovalIdsForDirectory, type WatchedFilesRemovedPayload } from './utils/watcherRemovalUtils';
 import { groupImages, type ImageGroup, type ImageGroupingSortOrder } from './utils/imageGrouping';
+import { findLatestCreatorAttributionToken } from './utils/creatorAttribution';
 
 interface OpenImageModalState {
   modalId: string;
@@ -385,7 +386,16 @@ export default function App() {
     globalAutoWatch,
     generatorLaunchCommand,
     comfyUIWorkspaceAutoOpenSelectedImage,
+    creatorAttributionToken,
+    setCreatorAttributionToken,
   } = useSettingsStore();
+
+  useEffect(() => {
+    const latestAttributionToken = findLatestCreatorAttributionToken(safeImages);
+    if (latestAttributionToken && latestAttributionToken !== creatorAttributionToken) {
+      setCreatorAttributionToken(latestAttributionToken);
+    }
+  }, [creatorAttributionToken, safeImages, setCreatorAttributionToken]);
 
   // --- Local UI State ---
   const [currentPage, setCurrentPage] = useState(1);

--- a/__tests__/cache-manager.workflow-nodes.test.ts
+++ b/__tests__/cache-manager.workflow-nodes.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import cacheManager from '../services/cacheManager';
+import cacheManager, { PARSER_VERSION } from '../services/cacheManager';
 
 declare global {
   interface Window {
@@ -23,7 +23,7 @@ describe('cacheManager workflowNodes hydration', () => {
           directoryName: 'Library',
           lastScan: Date.now(),
           imageCount: 1,
-          parserVersion: 7,
+          parserVersion: PARSER_VERSION,
           metadata: [
             {
               id: 'dir-1::a.png',
@@ -68,7 +68,7 @@ describe('cacheManager workflowNodes hydration', () => {
               directoryName: 'Library',
               lastScan: 1,
               imageCount: 1,
-              parserVersion: 7,
+              parserVersion: PARSER_VERSION,
               metadata: [
                 {
                   id: 'dir-1::a.png',
@@ -130,7 +130,7 @@ describe('cacheManager workflowNodes hydration', () => {
               directoryName: 'Library',
               lastScan: 1,
               imageCount: 1,
-              parserVersion: 7,
+              parserVersion: PARSER_VERSION,
               metadata: [
                 {
                   id: 'dir-1::a.png',
@@ -188,7 +188,7 @@ describe('cacheManager workflowNodes hydration', () => {
       directoryName: 'Library',
       lastScan: 1,
       imageCount: 2,
-      parserVersion: 7,
+      parserVersion: PARSER_VERSION,
       metadata: [
         {
           id: 'dir-1::old.png',
@@ -269,7 +269,7 @@ describe('cacheManager workflowNodes hydration', () => {
           directoryName: 'Library',
           lastScan: 1,
           imageCount: 2,
-          parserVersion: 7,
+          parserVersion: PARSER_VERSION,
           metadata: [
             {
               id: 'dir-1::keep.png',
@@ -368,7 +368,7 @@ describe('cacheManager workflowNodes hydration', () => {
           directoryName: 'Library',
           lastScan: 1,
           imageCount: 1025,
-          parserVersion: 7,
+          parserVersion: PARSER_VERSION,
           chunkCount: 2,
         },
       }),
@@ -419,7 +419,7 @@ describe('cacheManager workflowNodes hydration', () => {
           directoryName: 'Library',
           lastScan: 1,
           imageCount: 1,
-          parserVersion: 7,
+          parserVersion: PARSER_VERSION,
           metadata: [
             {
               id: 'dir-1::existing.png',

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -980,6 +980,12 @@ describe('ComfyUI Parser - MetaHub lineage metadata', () => {
         width: 768,
         height: 1024,
         loras: [{ name: 'skin-detail', weight: 0.65 }],
+        imh_attribution: {
+          schema_version: 1,
+          token: 'imhcrt_br_creator_workflow_v1_random',
+          source: 'metahub_save_node',
+          node_version: '1.0.9',
+        },
         imh_pro: {
           user_tags: 'portrait, retouch',
           notes: 'Edited in Image MetaHub',
@@ -1005,6 +1011,7 @@ describe('ComfyUI Parser - MetaHub lineage metadata', () => {
       },
     });
     expect(result?.loras).toEqual([{ name: 'skin-detail', weight: 0.65 }]);
+    expect(result?.imh_attribution?.token).toBe('imhcrt_br_creator_workflow_v1_random');
   });
 
   it('keeps MetaHub payload as canonical when parameters disagree', async () => {

--- a/__tests__/creatorAttribution.test.ts
+++ b/__tests__/creatorAttribution.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { buildProLicenseUrl, findLatestCreatorAttributionToken } from '../utils/creatorAttribution';
+import type { IndexedImage } from '../types';
+
+const createImage = (id: string, lastModified: number, token?: string): IndexedImage => ({
+  id,
+  name: `${id}.png`,
+  handle: {} as FileSystemFileHandle,
+  lastModified,
+  metadataString: '',
+  models: [],
+  loras: [],
+  scheduler: '',
+  metadata: {
+    normalizedMetadata: {
+      prompt: '',
+      negativePrompt: '',
+      width: 512,
+      height: 512,
+      imh_attribution: token
+        ? {
+            schema_version: 1,
+            token,
+            source: 'metahub_save_node',
+          }
+        : null,
+    },
+    rawMetadata: {},
+  },
+} as IndexedImage);
+
+describe('creator attribution', () => {
+  it('builds the Pro URL with imh_ref only when a token exists', () => {
+    expect(buildProLicenseUrl(null)).toBe('https://imagemetahub.com/getpro.html');
+    expect(buildProLicenseUrl('imhcrt_br_creator workflow')).toBe(
+      'https://imagemetahub.com/getpro.html?imh_ref=imhcrt_br_creator+workflow'
+    );
+  });
+
+  it('selects the newest attributed image token', () => {
+    const token = findLatestCreatorAttributionToken([
+      createImage('old', 100, 'imhcrt_old'),
+      createImage('none', 300),
+      createImage('new', 200, 'imhcrt_new'),
+    ]);
+
+    expect(token).toBe('imhcrt_new');
+  });
+});

--- a/__tests__/metadataEngine.metahub.test.ts
+++ b/__tests__/metadataEngine.metahub.test.ts
@@ -136,4 +136,55 @@ describe('metadataEngine MetaHub PNG chunks', () => {
     expect(result.metadata?.model).toBe('fallback-future.safetensors');
     expect(result.metadata?.imh_attribution).toBeUndefined();
   });
+
+  it('falls back to standard parameters when imagemetahub_data has only a generator', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-cli-metahub-empty-'));
+    const filePath = path.join(tempDir, 'empty.png');
+
+    await fs.writeFile(
+      filePath,
+      minimalPng([
+        iTextChunk('imagemetahub_data', JSON.stringify({ generator: 'ComfyUI' })),
+        textChunk('parameters', 'generator-only fallback\nSteps: 8, Sampler: euler, CFG scale: 4, Seed: 77, Size: 512x768, Model: fallback-empty.safetensors'),
+      ])
+    );
+
+    const result = await parseImageFile(filePath);
+
+    expect(result.rawSource).toBe('png');
+    expect((result.rawMetadata as any)?.imagemetahub_data).toBeUndefined();
+    expect(result.rawMetadata).toMatchObject({
+      parameters: expect.stringContaining('generator-only fallback'),
+    });
+    expect(result.metadata?.prompt).toBe('generator-only fallback');
+    expect(result.metadata?.model).toBe('fallback-empty.safetensors');
+    expect(result.metadata?.imh_attribution).toBeUndefined();
+  });
+
+  it('accepts attribution-only imagemetahub_data as usable MetaHub metadata', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-cli-metahub-token-'));
+    const filePath = path.join(tempDir, 'token-only.png');
+
+    await fs.writeFile(
+      filePath,
+      minimalPng([
+        iTextChunk('imagemetahub_data', JSON.stringify({
+          generator: 'ComfyUI',
+          imh_attribution: {
+            schema_version: 1,
+            token: 'imhcrt_token_only',
+            source: 'metahub_save_node',
+            node_version: '1.0.10',
+          },
+        })),
+        textChunk('parameters', 'ignored fallback\nSteps: 1, Seed: 1'),
+      ])
+    );
+
+    const result = await parseImageFile(filePath);
+
+    expect(result.rawSource).toBe('png');
+    expect((result.rawMetadata as any)?.imagemetahub_data?.imh_attribution?.token).toBe('imhcrt_token_only');
+    expect(result.metadata?.imh_attribution?.token).toBe('imhcrt_token_only');
+  });
 });

--- a/__tests__/metadataEngine.metahub.test.ts
+++ b/__tests__/metadataEngine.metahub.test.ts
@@ -88,4 +88,28 @@ describe('metadataEngine MetaHub PNG chunks', () => {
     expect(result.metadata?.prompt).toBe('cli metahub prompt');
     expect(result.metadata?.imh_attribution?.token).toBe('imhcrt_br_creator_workflow_v1_random');
   });
+
+  it('falls back to standard parameters when imagemetahub_data is malformed', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-cli-metahub-bad-'));
+    const filePath = path.join(tempDir, 'fallback.png');
+
+    await fs.writeFile(
+      filePath,
+      minimalPng([
+        iTextChunk('imagemetahub_data', '{"generator":"ComfyUI","prompt":'),
+        textChunk('parameters', 'fallback prompt\nSteps: 12, Sampler: euler, CFG scale: 6, Seed: 99, Size: 512x768, Model: fallback.safetensors'),
+      ])
+    );
+
+    const result = await parseImageFile(filePath);
+
+    expect(result.rawSource).toBe('png');
+    expect((result.rawMetadata as any)?.imagemetahub_data).toBeUndefined();
+    expect(result.rawMetadata).toMatchObject({
+      parameters: expect.stringContaining('fallback prompt'),
+    });
+    expect(result.metadata?.prompt).toBe('fallback prompt');
+    expect(result.metadata?.model).toBe('fallback.safetensors');
+    expect(result.metadata?.imh_attribution).toBeUndefined();
+  });
 });

--- a/__tests__/metadataEngine.metahub.test.ts
+++ b/__tests__/metadataEngine.metahub.test.ts
@@ -187,4 +187,43 @@ describe('metadataEngine MetaHub PNG chunks', () => {
     expect((result.rawMetadata as any)?.imagemetahub_data?.imh_attribution?.token).toBe('imhcrt_token_only');
     expect(result.metadata?.imh_attribution?.token).toBe('imhcrt_token_only');
   });
+
+  it('accepts object prompt graphs as usable MetaHub metadata', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-cli-metahub-prompt-graph-'));
+    const filePath = path.join(tempDir, 'prompt-graph.png');
+
+    await fs.writeFile(
+      filePath,
+      minimalPng([
+        iTextChunk('imagemetahub_data', JSON.stringify({
+          generator: 'ComfyUI',
+          prompt: {
+            '1': {
+              class_type: 'CLIPTextEncode',
+              inputs: { text: 'graph prompt from metahub chunk' },
+            },
+            '2': {
+              class_type: 'KSampler',
+              inputs: {
+                seed: 1234,
+                steps: 22,
+                cfg: 6.5,
+                sampler_name: 'euler',
+                scheduler: 'normal',
+                positive: ['1', 0],
+              },
+            },
+          },
+        })),
+      ])
+    );
+
+    const result = await parseImageFile(filePath);
+
+    expect(result.rawSource).toBe('png');
+    expect((result.rawMetadata as any)?.imagemetahub_data?.prompt).toBeTruthy();
+    expect(result.metadata?.prompt).toBe('graph prompt from metahub chunk');
+    expect(result.metadata?.seed).toBe(1234);
+    expect(result.metadata?.steps).toBe(22);
+  });
 });

--- a/__tests__/metadataEngine.metahub.test.ts
+++ b/__tests__/metadataEngine.metahub.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { parseImageFile } from '../services/metadataEngine';
+
+let tempDir: string | null = null;
+
+afterEach(async () => {
+  if (tempDir) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+const chunk = (type: string, data: Buffer): Buffer => {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  return Buffer.concat([length, Buffer.from(type, 'ascii'), data, Buffer.alloc(4)]);
+};
+
+const textChunk = (keyword: string, text: string): Buffer =>
+  chunk('tEXt', Buffer.concat([Buffer.from(keyword, 'utf8'), Buffer.from([0]), Buffer.from(text, 'utf8')]));
+
+const iTextChunk = (keyword: string, text: string): Buffer =>
+  chunk(
+    'iTXt',
+    Buffer.concat([
+      Buffer.from(keyword, 'utf8'),
+      Buffer.from([0, 0, 0, 0, 0]),
+      Buffer.from(text, 'utf8'),
+    ])
+  );
+
+const minimalPng = (chunks: Buffer[]): Buffer => {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(512, 0);
+  ihdr.writeUInt32BE(768, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 2;
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr),
+    ...chunks,
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+};
+
+describe('metadataEngine MetaHub PNG chunks', () => {
+  it('preserves imagemetahub_data attribution through the CLI parsing path', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-cli-metahub-'));
+    const filePath = path.join(tempDir, 'attributed.png');
+    const payload = {
+      generator: 'ComfyUI',
+      prompt: 'cli metahub prompt',
+      negativePrompt: '',
+      seed: 123,
+      steps: 20,
+      cfg: 7,
+      sampler_name: 'euler',
+      scheduler: 'normal',
+      model: 'model.safetensors',
+      width: 512,
+      height: 768,
+      imh_attribution: {
+        schema_version: 1,
+        token: 'imhcrt_br_creator_workflow_v1_random',
+        source: 'metahub_save_node',
+        node_version: '1.0.10',
+      },
+    };
+
+    await fs.writeFile(
+      filePath,
+      minimalPng([
+        textChunk('parameters', 'fallback prompt\nSteps: 1, Seed: 1'),
+        textChunk('workflow', '{"nodes":[]}'),
+        iTextChunk('imagemetahub_data', JSON.stringify(payload)),
+      ])
+    );
+
+    const result = await parseImageFile(filePath);
+
+    expect(result.rawSource).toBe('png');
+    expect((result.rawMetadata as any)?.imagemetahub_data?.imh_attribution?.token).toBe(
+      'imhcrt_br_creator_workflow_v1_random'
+    );
+    expect(result.metadata?.prompt).toBe('cli metahub prompt');
+    expect(result.metadata?.imh_attribution?.token).toBe('imhcrt_br_creator_workflow_v1_random');
+  });
+});

--- a/__tests__/metadataEngine.metahub.test.ts
+++ b/__tests__/metadataEngine.metahub.test.ts
@@ -112,4 +112,28 @@ describe('metadataEngine MetaHub PNG chunks', () => {
     expect(result.metadata?.model).toBe('fallback.safetensors');
     expect(result.metadata?.imh_attribution).toBeUndefined();
   });
+
+  it('falls back to standard parameters when imagemetahub_data is unsupported', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-cli-metahub-unsupported-'));
+    const filePath = path.join(tempDir, 'unsupported.png');
+
+    await fs.writeFile(
+      filePath,
+      minimalPng([
+        iTextChunk('imagemetahub_data', JSON.stringify({ generator: 'Future MetaHub' })),
+        textChunk('parameters', 'unsupported fallback\nSteps: 10, Sampler: euler, CFG scale: 5, Seed: 88, Size: 512x768, Model: fallback-future.safetensors'),
+      ])
+    );
+
+    const result = await parseImageFile(filePath);
+
+    expect(result.rawSource).toBe('png');
+    expect((result.rawMetadata as any)?.imagemetahub_data).toBeUndefined();
+    expect(result.rawMetadata).toMatchObject({
+      parameters: expect.stringContaining('unsupported fallback'),
+    });
+    expect(result.metadata?.prompt).toBe('unsupported fallback');
+    expect(result.metadata?.model).toBe('fallback-future.safetensors');
+    expect(result.metadata?.imh_attribution).toBeUndefined();
+  });
 });

--- a/__tests__/video-metahub-parser.test.ts
+++ b/__tests__/video-metahub-parser.test.ts
@@ -19,6 +19,12 @@ describe('Video MetaHub parser', () => {
       metadata_sources: {
         prompt: 'default',
       },
+      imh_attribution: {
+        schema_version: 1,
+        token: 'imhcrt_br_creator_video_v1_random',
+        source: 'metahub_save_node',
+        node_version: '1.0.9',
+      },
     });
 
     expect(result).toMatchObject({
@@ -28,6 +34,9 @@ describe('Video MetaHub parser', () => {
       height: 480,
       media_type: 'video',
       _metadata_status: 'partial',
+      imh_attribution: {
+        token: 'imhcrt_br_creator_video_v1_random',
+      },
     });
   });
 

--- a/components/ClusterUpgradeBanner.tsx
+++ b/components/ClusterUpgradeBanner.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Crown, Sparkles, TrendingUp } from 'lucide-react';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
+import { useSettingsStore } from '../store/useSettingsStore';
+import { buildProLicenseUrl } from '../utils/creatorAttribution';
 
 interface ClusterUpgradeBannerProps {
   processedCount: number;
@@ -14,6 +16,8 @@ const ClusterUpgradeBanner: React.FC<ClusterUpgradeBannerProps> = ({
   clusterCount,
 }) => {
   const { showProModal, canStartTrial } = useFeatureAccess();
+  const creatorAttributionToken = useSettingsStore((state) => state.creatorAttributionToken);
+  const proLicenseUrl = buildProLicenseUrl(creatorAttributionToken);
 
   return (
     <div className="mt-6 bg-gradient-to-r from-purple-900/30 to-blue-900/30 border border-purple-500/30 rounded-lg p-4">
@@ -43,7 +47,7 @@ const ClusterUpgradeBanner: React.FC<ClusterUpgradeBannerProps> = ({
             </button>
 
             <a
-              href="https://imagemetahub.com/getpro"
+              href={proLicenseUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 bg-gray-800 hover:bg-gray-700 text-gray-200 font-semibold py-2 px-4 rounded-lg transition-colors border border-gray-700"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,6 +6,7 @@ import { useImageStore } from '../store/useImageStore';
 import { A1111ApiClient } from '../services/a1111ApiClient';
 import { ComfyUIApiClient } from '../services/comfyUIApiClient';
 import { detectGeneratorFromLaunchCommand } from '../utils/detectGeneratorLaunch';
+import { buildProLicenseUrl } from '../utils/creatorAttribution';
 
 type LibraryView = 'library' | 'smart' | 'model' | 'node' | 'collections' | 'comfyui' | 'editor';
 
@@ -50,6 +51,8 @@ const Header: React.FC<HeaderProps> = ({
   const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
   const comfyUILastConnectionStatus = useSettingsStore((state) => state.comfyUILastConnectionStatus);
   const setComfyUIConnectionStatus = useSettingsStore((state) => state.setComfyUIConnectionStatus);
+  const creatorAttributionToken = useSettingsStore((state) => state.creatorAttributionToken);
+  const proLicenseUrl = buildProLicenseUrl(creatorAttributionToken);
   const isStackingEnabled = useImageStore((state) => state.isStackingEnabled);
   const setStackingEnabled = useImageStore((state) => state.setStackingEnabled);
   const viewingStackPrompt = useImageStore((state) => state.viewingStackPrompt);
@@ -460,7 +463,7 @@ const Header: React.FC<HeaderProps> = ({
 
           {!isPro && (
             <a
-              href="https://imagemetahub.com/getpro"
+              href={proLicenseUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="app-top-pill hidden h-9 border-amber-700/30 bg-amber-500/10 px-3 text-xs font-semibold text-amber-200 hover:border-amber-600/40 hover:bg-amber-500/15 hover:text-amber-100 lg:inline-flex"

--- a/components/ProOnlyModal.tsx
+++ b/components/ProOnlyModal.tsx
@@ -3,6 +3,8 @@ import { createPortal } from 'react-dom';
 import { X, Crown, Sparkles, GitCompare, BarChart3, CheckCircle2, Download, Tag, Image as ImageIcon } from 'lucide-react';
 import { ProFeature } from '../hooks/useFeatureAccess';
 import { TRIAL_DURATION_DAYS } from '../store/useLicenseStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+import { buildProLicenseUrl } from '../utils/creatorAttribution';
 
 interface ProOnlyModalProps {
   isOpen: boolean;
@@ -129,6 +131,9 @@ const ProOnlyModal: React.FC<ProOnlyModalProps> = ({
   isExpired,
   isPro,
 }) => {
+  const creatorAttributionToken = useSettingsStore((state) => state.creatorAttributionToken);
+  const proLicenseUrl = buildProLicenseUrl(creatorAttributionToken);
+
   if (!isOpen) return null;
 
   const info = featureInfo[feature] ?? {
@@ -227,7 +232,7 @@ const ProOnlyModal: React.FC<ProOnlyModalProps> = ({
               </button>
             )}
             <a
-              href="https://imagemetahub.com/getpro"
+              href={proLicenseUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="w-full inline-flex items-center justify-center gap-2 bg-purple-500/20 hover:bg-purple-500/30 text-purple-200 font-semibold py-3 px-6 rounded-lg transition-colors border border-purple-500/40"
@@ -235,6 +240,9 @@ const ProOnlyModal: React.FC<ProOnlyModalProps> = ({
               <Crown className="w-5 h-5" />
               Buy Pro license
             </a>
+            {creatorAttributionToken ? (
+              <p className="text-center text-xs text-gray-500">Creator attribution will be included at checkout.</p>
+            ) : null}
             <button
               onClick={onClose}
               className="w-full inline-flex items-center justify-center gap-2 bg-gray-800 hover:bg-gray-700 text-gray-200 font-semibold py-2.5 px-6 rounded-lg transition-colors border border-gray-700"

--- a/components/settings/LicenseSettingsPanel.tsx
+++ b/components/settings/LicenseSettingsPanel.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Crown } from 'lucide-react';
 import { useLicenseStore } from '../../store/useLicenseStore';
+import { useSettingsStore } from '../../store/useSettingsStore';
 import { SettingsPanel } from './SettingsPanel';
 import { SettingsSectionCard } from './SettingsSectionCard';
+import { buildProLicenseUrl } from '../../utils/creatorAttribution';
 
 const licenseStatusClassName: Record<string, string> = {
   free: 'border-gray-700 bg-gray-800 text-gray-300',
@@ -25,6 +27,8 @@ export const LicenseSettingsPanel: React.FC = () => {
   const licenseEmail = useLicenseStore((state) => state.licenseEmail);
   const licenseKey = useLicenseStore((state) => state.licenseKey);
   const activateLicense = useLicenseStore((state) => state.activateLicense);
+  const creatorAttributionToken = useSettingsStore((state) => state.creatorAttributionToken);
+  const proLicenseUrl = buildProLicenseUrl(creatorAttributionToken);
 
   const [licenseEmailInput, setLicenseEmailInput] = useState(licenseEmail ?? '');
   const [licenseKeyInput, setLicenseKeyInput] = useState(licenseKey ?? '');
@@ -118,13 +122,16 @@ export const LicenseSettingsPanel: React.FC = () => {
             {isActivatingLicense ? 'Activating...' : 'Activate license'}
           </button>
           <a
-            href="https://imagemetahub.com/getpro"
+            href={proLicenseUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-blue-300 hover:text-blue-200"
           >
             Get Pro license
           </a>
+          {creatorAttributionToken ? (
+            <span className="text-xs text-gray-500">Creator attribution detected.</span>
+          ) : null}
         </div>
 
         {licenseMessage ? <p className="text-sm text-gray-300">{licenseMessage}</p> : null}

--- a/electron.mjs
+++ b/electron.mjs
@@ -71,7 +71,7 @@ app.commandLine.appendSwitch('js-flags', '--max-old-space-size=4096');
 
 // Parser version - increment when parser logic changes
 // This ensures cache is invalidated when parsing rules change
-const PARSER_VERSION = 7; // v7: Add audio media indexing and metadata
+const PARSER_VERSION = 8; // v8: Add Image MetaHub creator attribution metadata
 
 const logMainPerf = (event, details = {}) => {
   console.log('[main:perf]', { event, ...details });

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -122,6 +122,7 @@ function compactCacheMetadataEntry(entry: CacheImageMetadata): CacheImageMetadat
       _analytics: payload._analytics,
       imh_pro: payload.imh_pro,
       _metahub_pro: payload._metahub_pro,
+      imh_attribution: payload.imh_attribution,
     };
   }
 

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -10,7 +10,7 @@ import {
  * Parser version - increment when parser logic changes significantly
  * This ensures cache is invalidated when parsing rules change
  */
-export const PARSER_VERSION = 7; // v7: Add audio media indexing and metadata
+export const PARSER_VERSION = 8; // v8: Add Image MetaHub creator attribution metadata
 
 // Simplified metadata structure for the JSON cache
 export interface CacheImageMetadata {

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -1291,6 +1291,7 @@ const buildNormalizedMetadataFromMetaHubChunk = async (
                 : undefined,
             }
           : inferredLineage,
+        imh_attribution: payload.imh_attribution || null,
         _analytics: payload.analytics || null,
         _metahub_pro: payload.imh_pro || null,
         _detection_method: 'metahub_chunk_direct',
@@ -1323,6 +1324,7 @@ const buildNormalizedMetadataFromMetaHubChunk = async (
     denoise: enhancedResult.denoise,
     generationType: enhancedResult.generationType,
     lineage: enhancedResult.lineage,
+    imh_attribution: enhancedResult.imh_attribution || null,
     _analytics: enhancedResult._analytics || null,
     _metahub_pro: enhancedResult._metahub_pro || null,
     _detection_method: enhancedResult._detection_method,
@@ -1976,6 +1978,7 @@ function compactRawMetadataForRuntime(
       _analytics: payload._analytics,
       imh_pro: payload.imh_pro,
       _metahub_pro: payload._metahub_pro,
+      imh_attribution: payload.imh_attribution,
     };
   }
 

--- a/services/metadataEngine.ts
+++ b/services/metadataEngine.ts
@@ -126,6 +126,15 @@ const buildAudioInfoFromProbe = (stream: VideoProbeStream, format: VideoProbeFor
   };
 };
 
+const isSupportedMetaHubPayload = (value: unknown): value is MetadataRecord => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const payload = value as MetadataRecord;
+  return payload.generator === 'ComfyUI' || payload.generator === 'Image MetaHub';
+};
+
 async function readMediaMetadataWithFfprobe(filePath: string): Promise<{ comment?: string; description?: string; title?: string; video?: VideoInfo | null; audio?: AudioInfo | null } | null> {
   const ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
 
@@ -252,7 +261,10 @@ async function parsePNGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | nu
 
   if (chunks.imagemetahub_data) {
     try {
-      return { imagemetahub_data: JSON.parse(chunks.imagemetahub_data) } as ImageMetadata;
+      const metaHubPayload = JSON.parse(chunks.imagemetahub_data);
+      if (isSupportedMetaHubPayload(metaHubPayload)) {
+        return { imagemetahub_data: metaHubPayload } as ImageMetadata;
+      }
     } catch {
       // Ignore malformed MetaHub chunks so standard workflow/parameters chunks can be used.
     }

--- a/services/metadataEngine.ts
+++ b/services/metadataEngine.ts
@@ -126,13 +126,64 @@ const buildAudioInfoFromProbe = (stream: VideoProbeStream, format: VideoProbeFor
   };
 };
 
+const isRecord = (value: unknown): value is MetadataRecord =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const hasNonBlankString = (value: unknown): boolean =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const hasFiniteNumber = (value: unknown): boolean =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const hasUsableMetaHubField = (payload: MetadataRecord): boolean => {
+  const attribution = isRecord(payload.imh_attribution) ? payload.imh_attribution : null;
+  if (hasNonBlankString(attribution?.token)) {
+    return true;
+  }
+
+  if (
+    hasNonBlankString(payload.prompt) ||
+    hasNonBlankString(payload.negativePrompt) ||
+    hasNonBlankString(payload.model) ||
+    hasNonBlankString(payload.sampler_name) ||
+    hasNonBlankString(payload.scheduler) ||
+    hasNonBlankString(payload.vae)
+  ) {
+    return true;
+  }
+
+  if (
+    hasFiniteNumber(payload.seed) ||
+    hasFiniteNumber(payload.steps) ||
+    hasFiniteNumber(payload.cfg) ||
+    hasFiniteNumber(payload.width) ||
+    hasFiniteNumber(payload.height) ||
+    hasFiniteNumber(payload.denoise)
+  ) {
+    return true;
+  }
+
+  if (Array.isArray(payload.loras) && payload.loras.length > 0) {
+    return true;
+  }
+
+  if (isRecord(payload.workflow) || isRecord(payload.prompt_api) || isRecord(payload.imh_pro) || isRecord(payload.analytics)) {
+    return true;
+  }
+
+  return false;
+};
+
 const isSupportedMetaHubPayload = (value: unknown): value is MetadataRecord => {
   if (!value || typeof value !== 'object') {
     return false;
   }
 
   const payload = value as MetadataRecord;
-  return payload.generator === 'ComfyUI' || payload.generator === 'Image MetaHub';
+  return (
+    (payload.generator === 'ComfyUI' || payload.generator === 'Image MetaHub') &&
+    hasUsableMetaHubField(payload)
+  );
 };
 
 async function readMediaMetadataWithFfprobe(filePath: string): Promise<{ comment?: string; description?: string; title?: string; video?: VideoInfo | null; audio?: AudioInfo | null } | null> {

--- a/services/metadataEngine.ts
+++ b/services/metadataEngine.ts
@@ -167,7 +167,13 @@ const hasUsableMetaHubField = (payload: MetadataRecord): boolean => {
     return true;
   }
 
-  if (isRecord(payload.workflow) || isRecord(payload.prompt_api) || isRecord(payload.imh_pro) || isRecord(payload.analytics)) {
+  if (
+    isRecord(payload.workflow) ||
+    isRecord(payload.prompt_api) ||
+    isRecord(payload.prompt) ||
+    isRecord(payload.imh_pro) ||
+    isRecord(payload.analytics)
+  ) {
     return true;
   }
 

--- a/services/metadataEngine.ts
+++ b/services/metadataEngine.ts
@@ -185,9 +185,18 @@ async function parsePNGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | nu
   let offset = 8;
   const decoder = new TextDecoder();
   const chunks: Record<string, string> = {};
+  const metadataChunkKeywords = new Set([
+    'invokeai_metadata',
+    'parameters',
+    'Parameters',
+    'workflow',
+    'prompt',
+    'Description',
+    'imagemetahub_data',
+  ]);
 
   let foundChunks = 0;
-  const maxChunks = 5; // invokeai_metadata, parameters, workflow, prompt, Description
+  const maxChunks = 7; // invokeai_metadata, parameters, workflow, prompt, Description, imagemetahub_data
 
   while (offset < view.byteLength && foundChunks < maxChunks) {
     const length = view.getUint32(offset);
@@ -198,7 +207,7 @@ async function parsePNGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | nu
       const chunkString = decoder.decode(chunkData);
       const [keyword, text] = chunkString.split('\0');
 
-      if (['invokeai_metadata', 'parameters', 'Parameters', 'workflow', 'prompt', 'Description'].includes(keyword) && text) {
+      if (metadataChunkKeywords.has(keyword) && text) {
         chunks[keyword.toLowerCase()] = text;
         foundChunks++;
       }
@@ -211,7 +220,7 @@ async function parsePNGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | nu
       }
       const keyword = decoder.decode(chunkData.slice(0, keywordEndIndex));
 
-      if (['invokeai_metadata', 'parameters', 'Parameters', 'workflow', 'prompt', 'Description'].includes(keyword)) {
+      if (metadataChunkKeywords.has(keyword)) {
         const compressionFlag = chunkData[keywordEndIndex + 1];
         let currentIndex = keywordEndIndex + 3; // Skip null separator, compression flag, and method
 
@@ -239,6 +248,14 @@ async function parsePNGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | nu
 
     if (type === 'IEND') break;
     offset += 12 + length;
+  }
+
+  if (chunks.imagemetahub_data) {
+    try {
+      return { imagemetahub_data: JSON.parse(chunks.imagemetahub_data) } as ImageMetadata;
+    } catch {
+      return { imagemetahub_data: chunks.imagemetahub_data } as ImageMetadata;
+    }
   }
 
   if (chunks.workflow) {

--- a/services/metadataEngine.ts
+++ b/services/metadataEngine.ts
@@ -254,7 +254,7 @@ async function parsePNGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | nu
     try {
       return { imagemetahub_data: JSON.parse(chunks.imagemetahub_data) } as ImageMetadata;
     } catch {
-      return { imagemetahub_data: chunks.imagemetahub_data } as ImageMetadata;
+      // Ignore malformed MetaHub chunks so standard workflow/parameters chunks can be used.
     }
   }
 

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -998,6 +998,7 @@ function extractFromMetaHubChunk(rawData: any): Record<string, any> | null {
           lineage,
           _detection_method: 'metahub_chunk',
           _metahub_pro: metahubData.imh_pro || null,
+          imh_attribution: metahubData.imh_attribution || null,
           _analytics: metahubData.analytics || null,
           _metadata_status: metahubData.metadata_status || null,
           _metadata_sources: metahubData.metadata_sources || null,

--- a/services/parsers/metadataParserFactory.ts
+++ b/services/parsers/metadataParserFactory.ts
@@ -141,6 +141,7 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
                     denoise: result.denoise,
                     generationType: result.generationType,
                     lineage: result.lineage,
+                    imh_attribution: result.imh_attribution || null,
                     _analytics: result._analytics || null,
                     _metahub_pro: result._metahub_pro || null,
                     _metadata_status: result._metadata_status || null,

--- a/services/parsers/videoMetaHubParser.ts
+++ b/services/parsers/videoMetaHubParser.ts
@@ -111,6 +111,7 @@ export const parseVideoMetaHubMetadata = (rawData: unknown): BaseMetadata | null
     loras: payload.loras || [],
     tags: userTags,
     notes: payload.imh_pro?.notes || '',
+    imh_attribution: payload.imh_attribution || null,
     generator: payload.generator || 'ComfyUI',
     media_type: payload.media_type || 'video',
     video: payload.video || null,

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -124,6 +124,8 @@ interface SettingsState {
   performanceDiagnosticsEnabled: boolean;
   slideshowIntervalSeconds: number;
   slideshowShowFilename: boolean;
+  creatorAttributionToken: string | null;
+  creatorAttributionUpdatedAt: number | null;
 
   // A1111 Integration settings
   a1111Enabled: boolean;
@@ -171,6 +173,7 @@ interface SettingsState {
   setPerformanceDiagnosticsEnabled: (value: boolean) => void;
   setSlideshowIntervalSeconds: (value: number) => void;
   setSlideshowShowFilename: (value: boolean) => void;
+  setCreatorAttributionToken: (token: string | null) => void;
   setA1111Enabled: (value: boolean) => void;
   setA1111ServerUrl: (url: string) => void;
   toggleA1111AutoStart: () => void;
@@ -223,6 +226,8 @@ export const useSettingsStore = create<SettingsState>()(
       performanceDiagnosticsEnabled: false,
       slideshowIntervalSeconds: DEFAULT_SLIDESHOW_INTERVAL_SECONDS,
       slideshowShowFilename: true,
+      creatorAttributionToken: null,
+      creatorAttributionUpdatedAt: null,
 
       // A1111 Integration initial state
       a1111Enabled: true,
@@ -283,6 +288,13 @@ export const useSettingsStore = create<SettingsState>()(
       setSlideshowIntervalSeconds: (value) =>
         set({ slideshowIntervalSeconds: sanitizeSlideshowIntervalSeconds(value) }),
       setSlideshowShowFilename: (value) => set({ slideshowShowFilename: !!value }),
+      setCreatorAttributionToken: (token) => {
+        const normalizedToken = typeof token === 'string' ? token.trim() : '';
+        set({
+          creatorAttributionToken: normalizedToken || null,
+          creatorAttributionUpdatedAt: normalizedToken ? Date.now() : null,
+        });
+      },
       updateKeybinding: (scope, action, keybinding) =>
         set((state) => ({
           keymap: {
@@ -350,6 +362,8 @@ export const useSettingsStore = create<SettingsState>()(
         performanceDiagnosticsEnabled: false,
         slideshowIntervalSeconds: DEFAULT_SLIDESHOW_INTERVAL_SECONDS,
         slideshowShowFilename: true,
+        creatorAttributionToken: null,
+        creatorAttributionUpdatedAt: null,
         a1111Enabled: true,
         a1111ServerUrl: 'http://127.0.0.1:7860',
         a1111AutoStart: false,
@@ -448,6 +462,16 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.slideshowShowFilename !== 'boolean') {
           state.slideshowShowFilename = true;
+        }
+
+        if (state && typeof state.creatorAttributionToken !== 'string') {
+          state.creatorAttributionToken = null;
+        } else if (state) {
+          state.creatorAttributionToken = state.creatorAttributionToken.trim() || null;
+        }
+
+        if (state && typeof state.creatorAttributionUpdatedAt !== 'number') {
+          state.creatorAttributionUpdatedAt = null;
         }
 
         if (state && typeof state.a1111Enabled !== 'boolean') {

--- a/types.ts
+++ b/types.ts
@@ -700,6 +700,14 @@ export interface ImageLineage {
   resizeMode?: string | null;
 }
 
+export interface MetaHubAttribution {
+  schema_version?: number;
+  token: string;
+  source?: string;
+  node_version?: string;
+  [key: string]: unknown;
+}
+
 export interface BaseMetadata extends SharedBaseMetadata {
   clip_skip?: number;
   media_type?: 'image' | 'video' | 'audio';
@@ -710,6 +718,7 @@ export interface BaseMetadata extends SharedBaseMetadata {
   lineage?: ImageLineage | null;
   tags?: string[];
   notes?: string;
+  imh_attribution?: MetaHubAttribution | null;
   analytics?: {
     vram_peak_mb?: number | null;
     gpu_device?: string | null;

--- a/utils/creatorAttribution.ts
+++ b/utils/creatorAttribution.ts
@@ -1,0 +1,49 @@
+import type { BaseMetadata, IndexedImage, MetaHubAttribution } from '../types';
+
+export const PRO_LICENSE_URL = 'https://imagemetahub.com/getpro.html';
+
+const normalizeToken = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const token = value.trim();
+  return token.length > 0 ? token : null;
+};
+
+export const extractCreatorAttributionToken = (metadata?: BaseMetadata | null): string | null => {
+  const attribution = metadata?.imh_attribution as MetaHubAttribution | null | undefined;
+  return normalizeToken(attribution?.token);
+};
+
+export const extractImageCreatorAttributionToken = (image?: IndexedImage | null): string | null =>
+  extractCreatorAttributionToken(image?.metadata?.normalizedMetadata ?? null);
+
+export const findLatestCreatorAttributionToken = (images: IndexedImage[]): string | null => {
+  let latestToken: string | null = null;
+  let latestTimestamp = Number.NEGATIVE_INFINITY;
+
+  for (const image of images) {
+    const token = extractImageCreatorAttributionToken(image);
+    if (!token) {
+      continue;
+    }
+
+    const timestamp = Number.isFinite(image.lastModified) ? image.lastModified : 0;
+    if (!latestToken || timestamp >= latestTimestamp) {
+      latestToken = token;
+      latestTimestamp = timestamp;
+    }
+  }
+
+  return latestToken;
+};
+
+export const buildProLicenseUrl = (token?: string | null): string => {
+  const url = new URL(PRO_LICENSE_URL);
+  const normalizedToken = normalizeToken(token);
+  if (normalizedToken) {
+    url.searchParams.set('imh_ref', normalizedToken);
+  }
+  return url.toString();
+};


### PR DESCRIPTION
## Summary
- Preserve `imh_attribution` in normalized metadata for images and videos.
- Persist the latest valid creator attribution token locally.
- Route Get/Buy Pro links through `getpro.html?imh_ref=...` when attribution is present, with a clean fallback when absent.
- Add focused tests for attribution persistence and parser preservation.

## Tests
- `npm test -- --run __tests__/creatorAttribution.test.ts __tests__/video-metahub-parser.test.ts __tests__/comfyui-parser.test.ts`