### PR TITLE
Sentinel: security improvement for IPC handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Hardening IPC Path Validation
+**Vulnerability:** Path Traversal and unauthorized file disclosure through IPC handlers. The handlers `show-item-in-folder`, `open-cache-location`, and `list-directory-files` lacked sufficient path validation, potentially allowing a compromised renderer to access files outside of the user's indexed folders.
+**Learning:** Security checks were previously relaxed or omitted in certain handlers to simplify feature implementation (e.g., revealing exported files in their destination folders). This created gaps in the application's "local-first" security model.
+**Prevention:** Ensure all IPC handlers that take file paths as input strictly validate those paths using the established security helper functions (`isAllowedOrInternal`, `isPathAllowed`, `isApprovedWritePath`). Never assume a path is safe just because it might originate from a "trusted" UI flow like a file dialog, as the renderer can be compromised.

--- a/electron.mjs
+++ b/electron.mjs
@@ -4221,10 +4221,12 @@ function setupFileOperationHandlers() {
   // Handle show item in folder
   ipcMain.handle('show-item-in-folder', async (event, filePath) => {
     try {
-      // Allow opening any folder/file that the user has access to via the OS dialogs
-      // We removed the isPathAllowed check here because export destinations can be anywhere
-      
       const normalizedFilePath = path.normalize(filePath);
+
+      if (!isAllowedOrInternal(normalizedFilePath) && !isApprovedWritePath(normalizedFilePath)) {
+        console.error('SECURITY VIOLATION: Attempted to show item in folder outside of approved directories.');
+        return { success: false, error: 'Access denied: Cannot show items outside of approved directories.' };
+      }
       console.log('📂 Attempting to show item in folder:', normalizedFilePath);
 
       // Verify the path exists before trying to open or show it
@@ -4258,10 +4260,20 @@ function setupFileOperationHandlers() {
     }
   });
 
-  // Handle open cache location (without security restrictions since it's app's internal cache)
+  // Handle open cache location
   ipcMain.handle('open-cache-location', async (event, cachePath) => {
     try {
       const normalizedCachePath = path.normalize(cachePath);
+
+      if (!isInternalPath(normalizedCachePath)) {
+        const rootPath = await getCacheRootPath();
+        const normalizedRootPath = path.normalize(rootPath);
+        if (!normalizedCachePath.startsWith(normalizedRootPath)) {
+          console.error('SECURITY VIOLATION: Attempted to open cache location outside of cache root.');
+          return { success: false, error: 'Access denied: Cannot open cache locations outside of the cache root.' };
+        }
+      }
+
       const parentPath = path.dirname(normalizedCachePath);
       console.log('📂 Opening cache parent directory:', parentPath);
 
@@ -4428,6 +4440,11 @@ function setupFileOperationHandlers() {
     try {
       if (!dirPath) {
         return { success: false, error: 'No directory path provided' };
+      }
+
+      if (!isPathAllowed(dirPath)) {
+        console.error('SECURITY VIOLATION: Attempted to list directory files outside of allowed paths.');
+        return { success: false, error: 'Access denied: Cannot list files outside of allowed paths.' };
       }
 
       let imageFiles = [];

--- a/electron.mjs
+++ b/electron.mjs
@@ -4267,8 +4267,7 @@ function setupFileOperationHandlers() {
 
       if (!isInternalPath(normalizedCachePath)) {
         const rootPath = await getCacheRootPath();
-        const normalizedRootPath = path.normalize(rootPath);
-        if (!normalizedCachePath.startsWith(normalizedRootPath)) {
+        if (!isSameOrChildPath(normalizeAllowedPath(normalizedCachePath), normalizeAllowedPath(rootPath))) {
           console.error('SECURITY VIOLATION: Attempted to open cache location outside of cache root.');
           return { success: false, error: 'Access denied: Cannot open cache locations outside of the cache root.' };
         }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing or incomplete path validation in several IPC handlers (`list-directory-files`, `show-item-in-folder`, `open-cache-location`) could allow a compromised renderer process to access or disclose files outside of the user's indexed folders.
🎯 Impact: Unauthorized directory listing and file location disclosure on the local file system.
🔧 Fix: Implemented strict path validation using existing security helpers (`isPathAllowed`, `isAllowedOrInternal`, `isApprovedWritePath`).
✅ Verification: Implementation verified manually; all Electron main process tests passed.

---
*PR created automatically by Jules for task [761883995491868763](https://jules.google.com/task/761883995491868763) started by @LuqP2*