### PR TITLE
⚡ Bolt: optimize curation metrics calculation in analytics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -72,3 +72,7 @@
 ## $(date +%Y-%m-%d) - Eliminate Object.entries().forEach and chained .map().filter() allocations during payload processing
 **Learning:** Using `Object.entries(payload.obj || {}).forEach(...)` along with chained array methods like `.map().filter()` inside a payload processing loop (e.g., when receiving auto-tags from a worker) creates significant memory allocation overhead. This generates a temporary array of keys/values and multiple intermediate arrays per processed item, leading to increased garbage collection (GC) pressure.
 **Action:** Replace `Object.entries()` with a direct `for...in` loop. Replace chained `.map().filter()` operations with a single `for` loop pushing valid items into a pre-instantiated array. Also, prefer `Map.size` over `Object.keys().length` for logging sizes to avoid allocating an array of keys solely for counting.
+
+## 2026-06-17 - Consolidate Multiple O(N) Passes in Analytics Derivation
+**Learning:** The analytics dashboard was performing ~14 full array traversals (filter/map) to compute rating distribution and favorite metrics. This creates significant CPU overhead and garbage collection pressure for users with large libraries.
+**Action:** Replace multiple .filter() calls with a single O(N) for loop that tallies all required metrics into a Map or local counters. This reduces the time complexity constant factor significantly.

--- a/__tests__/analytics-utils.test.ts
+++ b/__tests__/analytics-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { calculateTopItems, truncateName } from '../utils/analyticsUtils';
+import { buildAnalyticsExplorerData, calculateTopItems, truncateName } from '../utils/analyticsUtils';
 import { type IndexedImage } from '../types';
 
 const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
@@ -44,5 +44,60 @@ describe('analyticsUtils', () => {
     expect(truncateName(12345, 4)).toBe('1...');
     expect(truncateName({ foo: 'bar' } as any, 6)).toBe('[ob...');
     expect(truncateName(null as any, 10)).toBe('');
+  });
+
+  it('buildAnalyticsExplorerData correctly calculates curation metrics in a single pass', () => {
+    const images: IndexedImage[] = [
+      createImage({ id: '1', rating: 5, isFavorite: true }),
+      createImage({ id: '2', rating: 5, isFavorite: false }),
+      createImage({ id: '3', rating: 4, isFavorite: true }),
+      createImage({ id: '4', rating: undefined, isFavorite: true }), // Unrated favorite
+      createImage({ id: '5', rating: undefined, isFavorite: false }), // Unrated non-favorite
+      createImage({ id: '6', rating: 1, isFavorite: false }),
+    ];
+
+    const data = buildAnalyticsExplorerData({
+      scopeImages: images,
+      allImages: images,
+      scopeMode: 'library',
+    });
+
+    expect(data.curation.favoritesCount).toBe(3);
+    expect(data.curation.unratedCount).toBe(2);
+    expect(data.curation.favoriteRate).toBe(3 / 6);
+
+    const dist = data.curation.ratingDistribution;
+
+    // Check 5 star rating
+    const r5 = dist.find(d => d.key === '5');
+    expect(r5).toBeDefined();
+    expect(r5?.count).toBe(2);
+    expect(r5?.favorites).toBe(1);
+    expect(r5?.keeperRate).toBe(0.5);
+
+    // Check 4 star rating
+    const r4 = dist.find(d => d.key === '4');
+    expect(r4).toBeDefined();
+    expect(r4?.count).toBe(1);
+    expect(r4?.favorites).toBe(1);
+    expect(r4?.keeperRate).toBe(1);
+
+    // Check 1 star rating
+    const r1 = dist.find(d => d.key === '1');
+    expect(r1).toBeDefined();
+    expect(r1?.count).toBe(1);
+    expect(r1?.favorites).toBe(0);
+    expect(r1?.keeperRate).toBe(0);
+
+    // Check Unrated
+    const unrated = dist.find(d => d.key === 'unrated');
+    expect(unrated).toBeDefined();
+    expect(unrated?.count).toBe(2);
+    expect(unrated?.favorites).toBe(1);
+    expect(unrated?.keeperRate).toBe(0.5);
+
+    // Ensure 2 and 3 star ratings are NOT in distribution (count 0)
+    expect(dist.find(d => d.key === '2')).toBeUndefined();
+    expect(dist.find(d => d.key === '3')).toBeUndefined();
   });
 });

--- a/utils/analyticsUtils.ts
+++ b/utils/analyticsUtils.ts
@@ -1117,37 +1117,70 @@ export const buildAnalyticsExplorerData = ({
   const dominantGenerator = generators[0]?.label;
   const periodStats = calculatePeriodStats(allImages, 30);
 
-  const favoritesCount = scopeImages.filter((image) => image.isFavorite).length;
-  const unratedCount = scopeImages.filter((image) => typeof image.rating !== 'number').length;
-  const ratingDistribution = [
-    ...RATING_VALUES.map((rating) => {
-      const count = scopeImages.filter((image) => image.rating === rating).length;
-      const matchingImages = scopeImages.filter((image) => image.rating === rating);
-      const favorites = matchingImages.filter((image) => image.isFavorite).length;
-      return {
+  // Optimization: Consolidate curation metrics calculation into a single pass.
+  // Impact: Reduces O(N) array traversals from ~13 passes to 1, minimizing heap allocations and GC pressure.
+  let favoritesCount = 0;
+  let unratedCount = 0;
+  let unratedFavoritesCount = 0;
+  const ratingStats = new Map<number, { count: number; favorites: number }>();
+
+  for (let i = 0; i < RATING_VALUES.length; i++) {
+    ratingStats.set(RATING_VALUES[i], { count: 0, favorites: 0 });
+  }
+
+  for (let i = 0; i < scopeImages.length; i++) {
+    const image = scopeImages[i];
+    const isFavorite = image.isFavorite === true;
+    const rating = image.rating;
+
+    if (isFavorite) {
+      favoritesCount++;
+    }
+
+    if (typeof rating === 'number' && ratingStats.has(rating)) {
+      const stats = ratingStats.get(rating)!;
+      stats.count++;
+      if (isFavorite) {
+        stats.favorites++;
+      }
+    } else {
+      unratedCount++;
+      if (isFavorite) {
+        unratedFavoritesCount++;
+      }
+    }
+  }
+
+  const ratingDistribution: AnalyticsFacetItem[] = [];
+  for (let i = 0; i < RATING_VALUES.length; i++) {
+    const rating = RATING_VALUES[i];
+    const stats = ratingStats.get(rating)!;
+    if (stats.count > 0) {
+      ratingDistribution.push({
         key: String(rating),
         label: `${rating}★`,
-        count,
-        share: totalImages > 0 ? count / totalImages : 0,
-        favorites,
-        keeperRate: count > 0 ? favorites / count : 0,
-        averageRating: count > 0 ? rating : 0,
-        ratingCount: count,
-      };
-    }),
-    {
+        count: stats.count,
+        share: totalImages > 0 ? stats.count / totalImages : 0,
+        favorites: stats.favorites,
+        keeperRate: stats.count > 0 ? stats.favorites / stats.count : 0,
+        averageRating: rating,
+        ratingCount: stats.count,
+      });
+    }
+  }
+
+  if (unratedCount > 0) {
+    ratingDistribution.push({
       key: 'unrated',
       label: 'Unrated',
       count: unratedCount,
       share: totalImages > 0 ? unratedCount / totalImages : 0,
-      favorites: scopeImages.filter((image) => typeof image.rating !== 'number' && image.isFavorite).length,
-      keeperRate: unratedCount > 0
-        ? scopeImages.filter((image) => typeof image.rating !== 'number' && image.isFavorite).length / unratedCount
-        : 0,
+      favorites: unratedFavoritesCount,
+      keeperRate: unratedCount > 0 ? unratedFavoritesCount / unratedCount : 0,
       averageRating: 0,
       ratingCount: 0,
-    },
-  ].filter((item) => item.count > 0);
+    });
+  }
 
   const explorerData: AnalyticsExplorerData = {
     scopeMode,


### PR DESCRIPTION
💡 What: Consolidate curation metrics calculation in `utils/analyticsUtils.ts`.
🎯 Why: The previous implementation performed ~14 full array traversals using `.filter()` and `.map()` to build the rating distribution and count favorites, which is inefficient for large datasets.
📊 Impact: Reduces time complexity constant factor by ~14x and eliminates multiple intermediate array allocations, leading to faster analytics dashboard loads and reduced GC pressure.
🔬 Measurement: Verified with new and existing tests in `__tests__/analytics-utils.test.ts`. Passes both logic and baseline regression tests.

---
*PR created automatically by Jules for task [6511844380492451597](https://jules.google.com/task/6511844380492451597) started by @LuqP2*