### PR TITLE
🛡️ Sentinel: [security improvement] Harden file system IPC handlers

### DIFF
--- a/electron.mjs
+++ b/electron.mjs
@@ -4221,10 +4221,13 @@ function setupFileOperationHandlers() {
   // Handle show item in folder
   ipcMain.handle('show-item-in-folder', async (event, filePath) => {
     try {
-      // Allow opening any folder/file that the user has access to via the OS dialogs
-      // We removed the isPathAllowed check here because export destinations can be anywhere
-      
       const normalizedFilePath = path.normalize(filePath);
+
+      if (!isAllowedOrInternal(normalizedFilePath) && !isApprovedWritePath(normalizedFilePath)) {
+        console.error('SECURITY VIOLATION: Attempted to show item in folder outside approved directories.');
+        return { success: false, error: 'Access denied', errorType: 'PERMISSION_DENIED' };
+      }
+
       console.log('📂 Attempting to show item in folder:', normalizedFilePath);
 
       // Verify the path exists before trying to open or show it
@@ -4258,10 +4261,16 @@ function setupFileOperationHandlers() {
     }
   });
 
-  // Handle open cache location (without security restrictions since it's app's internal cache)
+  // Handle open cache location
   ipcMain.handle('open-cache-location', async (event, cachePath) => {
     try {
       const normalizedCachePath = path.normalize(cachePath);
+
+      if (!isInternalPath(normalizedCachePath)) {
+        console.error('SECURITY VIOLATION: Attempted to open cache location outside internal paths.');
+        return { success: false, error: 'Access denied' };
+      }
+
       const parentPath = path.dirname(normalizedCachePath);
       console.log('📂 Opening cache parent directory:', parentPath);
 
@@ -4428,6 +4437,11 @@ function setupFileOperationHandlers() {
     try {
       if (!dirPath) {
         return { success: false, error: 'No directory path provided' };
+      }
+
+      if (!isPathAllowed(dirPath)) {
+        console.error('SECURITY VIOLATION: Attempted to list files outside of allowed directories.');
+        return { success: false, error: 'Access denied', errorType: 'PERMISSION_DENIED' };
       }
 
       let imageFiles = [];


### PR DESCRIPTION
Harden file system IPC handlers in `electron.mjs` to prevent path traversal and unauthorized filesystem access.

### 🛡️ Sentinel Security Report

*   🚨 **Severity:** MEDIUM
*   💡 **Vulnerability:** Potential path traversal in multiple Electron IPC handlers (`show-item-in-folder`, `open-cache-location`, `list-directory-files`).
*   🎯 **Impact:** If the renderer process were compromised, it could have been used to list or reveal arbitrary files on the user's filesystem by bypassing intended directory restrictions.
*   🔧 **Fix:** Re-introduced and strengthened path validation in the affected IPC handlers. Specifically:
    *   `show-item-in-folder` now uses `isAllowedOrInternal` and `isApprovedWritePath`.
    *   `open-cache-location` now enforces `isInternalPath`.
    *   `list-directory-files` now enforces `isPathAllowed`.
*   ✅ **Verification:** Verified that the security checks are correctly applied in `electron.mjs`. Ran the full test suite (`pnpm test`), and all 456 tests passed, ensuring no functional regressions.

---
*PR created automatically by Jules for task [3571099094687711641](https://jules.google.com/task/3571099094687711641) started by @LuqP2*