### PR TITLE
🎨 Palette: Add option to skip delete confirmation

### DIFF
--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -1311,13 +1311,16 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
       return;
     }
 
-    const confirmed = window.confirm(
-      targetImages.length === 1
-        ? `Delete "${targetImages[0].name}"? This sends the file to the recycle bin.`
-        : `Delete ${targetImages.length} selected images? This sends the files to the recycle bin.`,
-    );
-    if (!confirmed) {
-      return;
+    const { skipDeleteConfirmation } = useSettingsStore.getState();
+    if (!skipDeleteConfirmation) {
+      const confirmed = window.confirm(
+        targetImages.length === 1
+          ? `Delete "${targetImages[0].name}"? This sends the file to the recycle bin.`
+          : `Delete ${targetImages.length} selected images? This sends the files to the recycle bin.`,
+      );
+      if (!confirmed) {
+        return;
+      }
     }
 
     const results = await Promise.all(targetImages.map((candidate) => FileOperations.deleteFile(candidate)));

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2796,7 +2796,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
       return;
     }
 
-    if (window.confirm('Are you sure you want to delete this image? This action cannot be undone.')) {
+    const { skipDeleteConfirmation } = useSettingsStore.getState();
+    if (skipDeleteConfirmation || window.confirm('Are you sure you want to delete this image? This action cannot be undone.')) {
       const idToDelete = image.id;
       const imageToDelete = image;
       const sourceDirectory = directories.find((directory) => directory.id === imageToDelete.directoryId);

--- a/components/settings/ViewerSettingsPanel.tsx
+++ b/components/settings/ViewerSettingsPanel.tsx
@@ -22,6 +22,8 @@ export const ViewerSettingsPanel: React.FC = () => {
   const setShowFullFilePath = useSettingsStore((state) => state.setShowFullFilePath);
   const doubleClickToOpen = useSettingsStore((state) => state.doubleClickToOpen);
   const setDoubleClickToOpen = useSettingsStore((state) => state.setDoubleClickToOpen);
+  const skipDeleteConfirmation = useSettingsStore((state) => state.skipDeleteConfirmation);
+  const setSkipDeleteConfirmation = useSettingsStore((state) => state.setSkipDeleteConfirmation);
   const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
   const setTagSuggestionLimit = useSettingsStore((state) => state.setTagSuggestionLimit);
   const recentTagChipLimit = useSettingsStore((state) => state.recentTagChipLimit);
@@ -48,6 +50,11 @@ export const ViewerSettingsPanel: React.FC = () => {
           label="Double-click to open"
           description="Keep single click for selection and open details on double click."
           control={<SettingSwitch checked={doubleClickToOpen} onChange={setDoubleClickToOpen} />}
+        />
+        <SettingRow
+          label="Skip delete confirmation"
+          description="Bypass the confirmation dialog when deleting files to the trash."
+          control={<SettingSwitch checked={skipDeleteConfirmation} onChange={setSkipDeleteConfirmation} />}
         />
       </SettingsSectionCard>
 

--- a/hooks/useImageSelection.ts
+++ b/hooks/useImageSelection.ts
@@ -77,14 +77,17 @@ export function useImageSelection() {
 
     const handleDeleteSelectedImages = useCallback(async () => {
         const { selectedImages, images, directories } = useImageStore.getState();
+        const { skipDeleteConfirmation } = useSettingsStore.getState();
         if (selectedImages.size === 0) return;
         if (isDeletingSelectedImages) return;
 
         isDeletingSelectedImages = true;
 
         try {
-            const confirmMessage = `Are you sure you want to delete ${selectedImages.size} image(s)?`;
-            if (!window.confirm(confirmMessage)) return;
+            if (!skipDeleteConfirmation) {
+                const confirmMessage = `Are you sure you want to delete ${selectedImages.size} image(s)?`;
+                if (!window.confirm(confirmMessage)) return;
+            }
 
             const imagesToDelete = Array.from(selectedImages);
             const deletedIdsHandledLocally: string[] = [];

--- a/hooks/useImageSelection.ts
+++ b/hooks/useImageSelection.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useImageStore } from '../store/useImageStore';
+import { useSettingsStore } from '../store/useSettingsStore';
 import { IndexedImage } from '../types';
 import { FileOperations } from '../services/fileOperations';
 

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -115,6 +115,7 @@ interface SettingsState {
   globalAutoWatch: boolean;
   startupVerificationMode: StartupVerificationMode;
   doubleClickToOpen: boolean;
+  skipDeleteConfirmation: boolean;
   tagSuggestionLimit: number;
   recentTagChipLimit: number;
   sensitiveTags: string[];
@@ -164,6 +165,7 @@ interface SettingsState {
   toggleGlobalAutoWatch: () => void;
   setStartupVerificationMode: (value: StartupVerificationMode) => void;
   setDoubleClickToOpen: (value: boolean) => void;
+  setSkipDeleteConfirmation: (value: boolean) => void;
   setTagSuggestionLimit: (value: number) => void;
   setRecentTagChipLimit: (value: number) => void;
   setSensitiveTags: (tags: string[]) => void;
@@ -217,6 +219,7 @@ export const useSettingsStore = create<SettingsState>()(
       globalAutoWatch: true,
       startupVerificationMode: 'off',
       doubleClickToOpen: false,
+      skipDeleteConfirmation: false,
       tagSuggestionLimit: DEFAULT_TAG_SUGGESTION_LIMIT,
       recentTagChipLimit: DEFAULT_RECENT_TAG_CHIP_LIMIT,
       sensitiveTags: ['nsfw', 'private', 'hidden'],
@@ -273,6 +276,7 @@ export const useSettingsStore = create<SettingsState>()(
       toggleGlobalAutoWatch: () => set((state) => ({ globalAutoWatch: !state.globalAutoWatch })),
       setStartupVerificationMode: (value) => set({ startupVerificationMode: value }),
       setDoubleClickToOpen: (value) => set({ doubleClickToOpen: !!value }),
+      setSkipDeleteConfirmation: (value) => set({ skipDeleteConfirmation: !!value }),
       setTagSuggestionLimit: (value) => set({ tagSuggestionLimit: sanitizeTagUiLimit(value, DEFAULT_TAG_SUGGESTION_LIMIT) }),
       setRecentTagChipLimit: (value) => set({ recentTagChipLimit: sanitizeTagUiLimit(value, DEFAULT_RECENT_TAG_CHIP_LIMIT) }),
       setSensitiveTags: (tags) => {
@@ -353,6 +357,7 @@ export const useSettingsStore = create<SettingsState>()(
         globalAutoWatch: true,
         startupVerificationMode: 'off',
         doubleClickToOpen: false,
+        skipDeleteConfirmation: false,
         tagSuggestionLimit: DEFAULT_TAG_SUGGESTION_LIMIT,
         recentTagChipLimit: DEFAULT_RECENT_TAG_CHIP_LIMIT,
         sensitiveTags: ['nsfw', 'private', 'hidden'],
@@ -420,6 +425,10 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.showFullFilePath !== 'boolean') {
           state.showFullFilePath = false;
+        }
+
+        if (state && typeof state.skipDeleteConfirmation !== 'boolean') {
+          state.skipDeleteConfirmation = false;
         }
 
         if (state) {


### PR DESCRIPTION
💡 What: Added a new "Skip delete confirmation" setting to the application.
🎯 Why: Native `window.confirm` dialogs in Electron can be disruptive and slow down the workflow for power users who frequently delete files to the trash.
📸 Before/After: A new toggle is now available in Settings > Viewer > Behavior.
♿ Accessibility: The setting is disabled by default to ensure safety for all users. Custom interactive elements follow existing focus-visible standards.

---
*PR created automatically by Jules for task [17257807429283134746](https://jules.google.com/task/17257807429283134746) started by @LuqP2*