### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal in IPC Handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - IPC Path Traversal in Filesystem Handlers
+**Vulnerability:** Several IPC handlers (`list-directory-files`, `show-item-in-folder`, `open-cache-location`) lacked robust path validation, allowing the renderer process to potentially access or expose files outside of user-approved directories.
+**Learning:** Security checks were previously removed from `show-item-in-folder` to allow opening export destinations anywhere, but this created a gap for arbitrary path traversal. Using `isApprovedWritePath` allows specific user-selected paths without compromising general security.
+**Prevention:** All IPC handlers exposing filesystem functionality must use appropriate validation helpers (`isPathAllowed`, `isInternalPath`, or `isApprovedWritePath`) before performing any I/O or shell operations.

--- a/electron.mjs
+++ b/electron.mjs
@@ -4221,9 +4221,11 @@ function setupFileOperationHandlers() {
   // Handle show item in folder
   ipcMain.handle('show-item-in-folder', async (event, filePath) => {
     try {
-      // Allow opening any folder/file that the user has access to via the OS dialogs
-      // We removed the isPathAllowed check here because export destinations can be anywhere
-      
+      if (!isAllowedOrInternal(filePath) && !isApprovedWritePath(filePath)) {
+        console.error('SECURITY VIOLATION: Attempted to show item in folder outside allowed or approved paths.');
+        return { success: false, error: 'Access denied', errorType: 'PERMISSION_DENIED' };
+      }
+
       const normalizedFilePath = path.normalize(filePath);
       console.log('📂 Attempting to show item in folder:', normalizedFilePath);
 
@@ -4258,9 +4260,14 @@ function setupFileOperationHandlers() {
     }
   });
 
-  // Handle open cache location (without security restrictions since it's app's internal cache)
+  // Handle open cache location
   ipcMain.handle('open-cache-location', async (event, cachePath) => {
     try {
+      if (!isInternalPath(cachePath)) {
+        console.error('SECURITY VIOLATION: Attempted to open cache location outside internal paths.');
+        return { success: false, error: 'Access denied', errorType: 'PERMISSION_DENIED' };
+      }
+
       const normalizedCachePath = path.normalize(cachePath);
       const parentPath = path.dirname(normalizedCachePath);
       console.log('📂 Opening cache parent directory:', parentPath);
@@ -4428,6 +4435,11 @@ function setupFileOperationHandlers() {
     try {
       if (!dirPath) {
         return { success: false, error: 'No directory path provided' };
+      }
+
+      if (!isPathAllowed(dirPath)) {
+        console.error('SECURITY VIOLATION: Attempted to list directory outside allowed paths.');
+        return { success: false, error: 'Access denied', errorType: 'PERMISSION_DENIED' };
       }
 
       let imageFiles = [];


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Several IPC handlers in `electron.mjs` lacked robust path validation. Specifically, `list-directory-files` had no check, `show-item-in-folder` had its check removed to support arbitrary export locations, and `open-cache-location` was unrestricted.
🎯 Impact: A compromised or malicious renderer process could use these IPC calls to explore the local filesystem, leak directory structures, or open files outside of user-approved indexed folders.
🔧 Fix: Added appropriate security validation using `isPathAllowed`, `isInternalPath`, and `isApprovedWritePath`. The `isApprovedWritePath` check restores security for `show-item-in-folder` while still allowing the user to open folders they have explicitly interacted with via native save/open dialogs.
✅ Verification: Verified code changes manually and ran the full test suite (`pnpm test`), which passed all 472 tests.

---
*PR created automatically by Jules for task [14947570882360519414](https://jules.google.com/task/14947570882360519414) started by @LuqP2*