### PR TITLE
🛡️ Sentinel: [HIGH] Fix directory traversal in IPC handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-20 - Path Traversal in IPC Handlers
+**Vulnerability:** The `list-directory-files` IPC handler was missing path validation, allowing the renderer process to list any directory on the host system. Additionally, `show-item-in-folder` and `open-cache-location` had insufficient or missing checks.
+**Learning:** IPC handlers that accept filesystem paths from the renderer are high-risk entry points. In an Electron app, these must always be validated against a whitelist of allowed directories to maintain the security sandbox.
+**Prevention:** Always use `isPathAllowed`, `isInternalPath`, or `isApprovedWritePath` (or the combined `isAllowedOrInternal`) to validate every path received via IPC before performing filesystem operations or opening paths in the OS shell.

--- a/electron.mjs
+++ b/electron.mjs
@@ -4221,10 +4221,13 @@ function setupFileOperationHandlers() {
   // Handle show item in folder
   ipcMain.handle('show-item-in-folder', async (event, filePath) => {
     try {
-      // Allow opening any folder/file that the user has access to via the OS dialogs
-      // We removed the isPathAllowed check here because export destinations can be anywhere
-      
       const normalizedFilePath = path.normalize(filePath);
+
+      if (!isAllowedOrInternal(normalizedFilePath) && !isApprovedWritePath(normalizedFilePath)) {
+        console.error('SECURITY VIOLATION: Attempted to show item outside of allowed directories.');
+        return { success: false, error: 'Access denied: Cannot show items outside of the allowed directories.' };
+      }
+
       console.log('📂 Attempting to show item in folder:', normalizedFilePath);
 
       // Verify the path exists before trying to open or show it
@@ -4262,6 +4265,12 @@ function setupFileOperationHandlers() {
   ipcMain.handle('open-cache-location', async (event, cachePath) => {
     try {
       const normalizedCachePath = path.normalize(cachePath);
+
+      if (!isInternalPath(normalizedCachePath)) {
+        console.error('SECURITY VIOLATION: Attempted to open cache location outside of internal paths.');
+        return { success: false, error: 'Access denied: Cannot open cache location outside of the application internal paths.' };
+      }
+
       const parentPath = path.dirname(normalizedCachePath);
       console.log('📂 Opening cache parent directory:', parentPath);
 
@@ -4428,6 +4437,11 @@ function setupFileOperationHandlers() {
     try {
       if (!dirPath) {
         return { success: false, error: 'No directory path provided' };
+      }
+
+      if (!isPathAllowed(dirPath)) {
+        console.error('SECURITY VIOLATION: Attempted to list directory files outside of allowed directories.');
+        return { success: false, error: 'Access denied: Cannot list files outside of the allowed directories.' };
       }
 
       let imageFiles = [];


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix directory traversal in IPC handlers

I have identified and fixed a directory traversal vulnerability in the Electron main process.

### Vulnerabilities Addressed
1.  **`list-directory-files`**: Was missing path validation, allowing listing of any directory on the system. Added `isPathAllowed(dirPath)` check.
2.  **`show-item-in-folder`**: Previously allowed opening any path. Added `isAllowedOrInternal(normalizedFilePath) || isApprovedWritePath(normalizedFilePath)` validation.
3.  **`open-cache-location`**: Was intended for internal cache but lacked enforcement. Added `isInternalPath(normalizedCachePath)` check.

### Verification Results
- **Tests**: Ran the full Vitest suite (`pnpm test`), and all 472 tests passed.
- **Linting**: No new lint errors introduced (`pnpm lint`).
- **Journal**: Logged critical learnings in `.jules/sentinel.md`.

These changes ensure that the renderer process is strictly confined to user-approved or application-internal directories when interacting with the host filesystem via IPC.

---
*PR created automatically by Jules for task [10981122129469461350](https://jules.google.com/task/10981122129469461350) started by @LuqP2*