### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,11 @@
 ## 2025-01-24 - Optimized Jaccard Similarity via Direct Set Interrogation
 **Learning:** Calculating set-based metrics like Jaccard similarity using array spreads and filters (`new Set([...a].filter(x => b.has(x)))`) creates significant garbage collection pressure due to multiple intermediate array and set allocations per call. This is particularly impactful in hot loops like image clustering or similarity search.
 **Action:** Use direct `for...of` loops to count intersections and apply the inclusion-exclusion principle (|A| + |B| - |A \cap B|) to determine the union size. This approach avoids all intermediate allocations while maintaining O(N) complexity, resulting in a ~75% performance boost in micro-benchmarks.
+
+## 2025-01-24 - Optimized Jaccard Similarity via Direct Set Interrogation
+**Learning:** Calculating set-based metrics like Jaccard similarity using array spreads and filters (`new Set([...a].filter(x => b.has(x)))`) creates significant garbage collection pressure due to multiple intermediate array and set allocations per call. This is particularly impactful in hot loops like image clustering or similarity search.
+**Action:** Use direct `for...of` loops to count intersections and apply the inclusion-exclusion principle (|A| + |B| - |A \cap B|) to determine the union size. This approach avoids all intermediate allocations while maintaining O(N) complexity, resulting in a ~75% performance boost in micro-benchmarks.
+
+## 2025-01-24 - Optimized `shareKeywords` via Direct Loop and Early Return
+**Learning:** Checking for set intersections using spread operators and array filters (e.g., `[...setA].filter(x => setB.has(x)).length`) allocates unnecessary intermediate arrays, straining garbage collection in performance-critical areas like similarity calculations.
+**Action:** Replace these patterns with direct `for...of` loops and implement early returns when a required threshold is met. This avoids intermediate array allocations and short-circuits execution, minimizing performance overhead in hot paths.

--- a/utils/similarityMetrics.ts
+++ b/utils/similarityMetrics.ts
@@ -288,7 +288,17 @@ export function shareKeywords(
   const keywords1 = new Set(extractKeywords(prompt1, 10));
   const keywords2 = new Set(extractKeywords(prompt2, 10));
 
-  const sharedCount = [...keywords1].filter((kw) => keywords2.has(kw)).length;
+  // Optimization: Direct loop avoids intermediate array spread and filter allocations
+  let sharedCount = 0;
+  for (const kw of keywords1) {
+    if (keywords2.has(kw)) {
+      sharedCount++;
+      // Early return optimization: if we reach minShared, no need to keep checking
+      if (sharedCount >= minShared) {
+        return true;
+      }
+    }
+  }
 
   return sharedCount >= minShared;
 }


### PR DESCRIPTION
What: Optimized the `shareKeywords` function in `utils/similarityMetrics.ts` by replacing intermediate array allocations and chained `.filter()` methods with a direct `for...of` loop and an early return.

Why: The previous implementation used `[...keywords1].filter(kw => keywords2.has(kw)).length`, which allocated an intermediate array via the spread syntax and then another via `.filter()`. In hot paths like image clustering or similar image searches, this created significant, unnecessary garbage collection pressure. Additionally, it lacked an early return once `minShared` was met.

Impact: This eliminates two intermediate array allocations per call and allows for early exits when the required `minShared` threshold is met, reducing execution time and garbage collection overhead in similarity analysis loops.

Measurement: Memory profiling and execution traces of clustering large image sets will show a decrease in temporary array allocations and slightly faster end-to-end clustering times.

---
*PR created automatically by Jules for task [17535830304770301982](https://jules.google.com/task/17535830304770301982) started by @LuqP2*