### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal in list-directory-files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Path Traversal in list-directory-files]
+ **Vulnerability:** The `list-directory-files` IPC handler lacked path validation, allowing the renderer process to list files in any directory the OS process has access to.
+ **Learning:** In complex Electron applications with many IPC handlers, filesystem-exposing methods can easily be overlooked during security audits if they don't explicitly read or write file content, even though listing files is a form of unauthorized information disclosure.
+ **Prevention:** Use a 'deny-by-default' approach for all IPC handlers that accept paths. Maintain a centralized `isPathAllowed` helper and ensure it is called as the first step in every filesystem-related IPC handler.

--- a/electron.mjs
+++ b/electron.mjs
@@ -4430,6 +4430,11 @@ function setupFileOperationHandlers() {
         return { success: false, error: 'No directory path provided' };
       }
 
+      if (!isPathAllowed(dirPath)) {
+        console.error('SECURITY VIOLATION: Attempted to list directory outside of allowed directories.');
+        return { success: false, error: 'Access denied: Cannot list directory outside of the allowed directories.' };
+      }
+
       let imageFiles = [];
 
       if (recursive) {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `list-directory-files` IPC handler was missing path validation, allowing the renderer process to list any directory the application had permissions to access.
🎯 **Impact**: Path traversal/Information disclosure of local filesystem structure.
🔧 **Fix**: Integrated the existing `isPathAllowed` security helper into the `list-directory-files` handler to enforce the application's directory allowlist.
✅ **Verification**: Verified via manual inspection and by running the full test suite (`pnpm test -- electron-dev`), which confirmed no regressions in directory listing functionality for allowed paths.

---
*PR created automatically by Jules for task [12445617446057856183](https://jules.google.com/task/12445617446057856183) started by @LuqP2*