### PR TITLE
performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-01-24 - Keyword Memoization in Clustering Engine
 **Learning:** Performing keyword extraction (normalization + tokenization + filtering) multiple times for the same prompt during bucketing and pair comparisons is a significant performance bottleneck in large-scale clustering.
 **Action:** Pre-calculate and store expensive derived metadata (like keyword sets) in internal builder objects during initial O(N) passes. This reduces redundant regex-based processing from O(N * B) to O(N) where B is the average bucket size, significantly speeding up the bucketing phase.
+## 2024-05-25 - Optimizing Cohort Analytics
+**Learning:** Computing cohort aggregates using chained `.filter()` or `.reduce()` for each property (favorites, ratings, telemetry) creates multiple $O(N)$ passes and redundant intermediate arrays.
+**Action:** When calculating cohort statistics, consolidate all property aggregations into a single $O(N)$ `for` loop that updates local variables, significantly reducing array allocations and improving speed for large datasets.

--- a/utils/analyticsUtils.ts
+++ b/utils/analyticsUtils.ts
@@ -1094,19 +1094,35 @@ const buildCompareCohort = (
     }
   });
 
-  const favoriteCount = cohortImages.filter((image) => image.isFavorite).length;
-  const ratedImages = cohortImages.filter((image) => typeof image.rating === 'number');
+  // Optimization: Consolidate cohort metrics calculation into a single pass.
+  // Impact: Reduces O(N) array traversals from 3 passes down to 1, minimizing heap allocations.
+  let favoriteCount = 0;
+  let ratedCount = 0;
+  let ratingSum = 0;
+  let telemetryCount = 0;
+
+  for (let i = 0; i < cohortImages.length; i++) {
+    const image = cohortImages[i];
+    if (image.isFavorite) {
+      favoriteCount++;
+    }
+    if (typeof image.rating === 'number') {
+      ratedCount++;
+      ratingSum += image.rating;
+    }
+    if (hasTelemetryData(image)) {
+      telemetryCount++;
+    }
+  }
+
   const dominantModel = collectFacetItems(cohortImages, (image) => image.models || [], 1)[0]?.label;
-  const telemetryCount = cohortImages.filter((image) => hasTelemetryData(image)).length;
 
   return {
     key,
     label: key === 'present' ? 'Has telemetry' : key === 'missing' ? 'Missing telemetry' : key,
     count: cohortImages.length,
     favoriteRate: cohortImages.length > 0 ? favoriteCount / cohortImages.length : 0,
-    averageRating: ratedImages.length > 0
-      ? ratedImages.reduce((sum, image) => sum + (image.rating || 0), 0) / ratedImages.length
-      : 0,
+    averageRating: ratedCount > 0 ? ratingSum / ratedCount : 0,
     telemetryCoverage: cohortImages.length > 0 ? telemetryCount / cohortImages.length : 0,
     dominantModel,
   };


### PR DESCRIPTION
What: Refactored `buildCompareCohort` in `utils/analyticsUtils.ts` to compute array iterations in a single pass.
Why: The previous implementation iterated over the array 4 times for different attributes using `.filter()`, creating unnecessary heap allocations and garbage collection pressure when working with many images.
Impact: Reduces O(N) array traversals from 4 to 1, lowering memory consumption.
Measurement: Compare memory profiling for `buildCompareCohort` on large `IndexedImage` arrays in production. Tests pass correctly in `__tests__/analytics-utils.test.ts`.

---
*PR created automatically by Jules for task [9034705582865889098](https://jules.google.com/task/9034705582865889098) started by @LuqP2*