### PR TITLE
🛡️ Sentinel: [security improvement] Hardening filesystem IPC handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Hardening Filesystem IPC Handlers
+**Vulnerability:** Multiple IPC handlers (`list-directory-files`, `open-cache-location`, `show-item-in-folder`, `export-images-batch`, `export-images-zip`) lacked path validation, allowing a compromised renderer process to access or write to arbitrary filesystem locations.
+**Learning:** Security checks were previously removed or omitted for "convenience" (e.g., to allow exports anywhere), but this broke the "Trust Nothing, Verify Everything" principle.
+**Prevention:** Always enforce path validation in IPC handlers that interact with the filesystem. Use `isPathAllowed` for read-only indexed paths, `isInternalPath` for app data, and `isApprovedWritePath` for paths explicitly chosen by the user via native dialogs.

--- a/electron.mjs
+++ b/electron.mjs
@@ -4221,10 +4221,15 @@ function setupFileOperationHandlers() {
   // Handle show item in folder
   ipcMain.handle('show-item-in-folder', async (event, filePath) => {
     try {
-      // Allow opening any folder/file that the user has access to via the OS dialogs
-      // We removed the isPathAllowed check here because export destinations can be anywhere
-      
       const normalizedFilePath = path.normalize(filePath);
+
+      // --- SECURITY CHECK ---
+      if (!isAllowedOrInternal(normalizedFilePath) && !isApprovedWritePath(normalizedFilePath)) {
+        console.error('SECURITY VIOLATION: Attempted to show item outside of allowed directories.');
+        return { success: false, error: 'Access denied: Cannot show items outside of the allowed directories.' };
+      }
+      // --- END SECURITY CHECK ---
+
       console.log('📂 Attempting to show item in folder:', normalizedFilePath);
 
       // Verify the path exists before trying to open or show it
@@ -4262,6 +4267,12 @@ function setupFileOperationHandlers() {
   ipcMain.handle('open-cache-location', async (event, cachePath) => {
     try {
       const normalizedCachePath = path.normalize(cachePath);
+
+      if (!isInternalPath(normalizedCachePath)) {
+        console.error('SECURITY VIOLATION: Attempted to open cache location outside userData.');
+        return { success: false, error: 'Access denied: Cannot open cache location outside userData.' };
+      }
+
       const parentPath = path.dirname(normalizedCachePath);
       console.log('📂 Opening cache parent directory:', parentPath);
 
@@ -4429,6 +4440,13 @@ function setupFileOperationHandlers() {
       if (!dirPath) {
         return { success: false, error: 'No directory path provided' };
       }
+
+      // --- SECURITY CHECK ---
+      if (!isPathAllowed(dirPath)) {
+        console.error('SECURITY VIOLATION: Attempted to list files outside of allowed directories.');
+        return { success: false, error: 'Access denied: Cannot list files outside of the allowed directories.' };
+      }
+      // --- END SECURITY CHECK ---
 
       let imageFiles = [];
 
@@ -5120,7 +5138,15 @@ function setupFileOperationHandlers() {
         return { success: false, error: 'No destination directory provided.', exportedCount: 0, failedCount: 0 };
       }
 
-      await fs.mkdir(destDir, { recursive: true });
+      // --- SECURITY CHECK ---
+      const normalizedDestDir = path.normalize(destDir);
+      if (!isAllowedOrInternal(normalizedDestDir) && !isApprovedWritePath(normalizedDestDir)) {
+        console.error('SECURITY VIOLATION: Attempted to export to unapproved directory.');
+        return { success: false, error: 'Access denied: Cannot export to unapproved directories.', exportedCount: 0, failedCount: 0 };
+      }
+      // --- END SECURITY CHECK ---
+
+      await fs.mkdir(normalizedDestDir, { recursive: true });
       const usedNames = new Set();
       let exportedCount = 0;
       let failedCount = 0;
@@ -5179,7 +5205,7 @@ function setupFileOperationHandlers() {
             effectiveMetadata: file.effectiveMetadata,
           });
           const uniqueName = getUniqueName(artifact.fileName, usedNames);
-          const destPath = path.resolve(destDir, uniqueName);
+          const destPath = path.resolve(normalizedDestDir, uniqueName);
           await fs.writeFile(destPath, artifact.buffer);
           exportedCount += 1;
         } catch (error) {
@@ -5238,7 +5264,15 @@ function setupFileOperationHandlers() {
         return { success: false, error: 'No ZIP destination provided.', exportedCount: 0, failedCount: 0 };
       }
 
-      await fs.mkdir(path.dirname(destZipPath), { recursive: true });
+      // --- SECURITY CHECK ---
+      const normalizedDestZipPath = path.normalize(destZipPath);
+      if (!isAllowedOrInternal(normalizedDestZipPath) && !isApprovedWritePath(normalizedDestZipPath)) {
+        console.error('SECURITY VIOLATION: Attempted to export ZIP to unapproved directory.');
+        return { success: false, error: 'Access denied: Cannot export to unapproved directories.', exportedCount: 0, failedCount: 0 };
+      }
+      // --- END SECURITY CHECK ---
+
+      await fs.mkdir(path.dirname(normalizedDestZipPath), { recursive: true });
       const usedNames = new Set();
       let exportedCount = 0;
       let failedCount = 0;
@@ -5273,7 +5307,7 @@ function setupFileOperationHandlers() {
       };
       const isCanceled = () => progressId ? activeCanceledExportIds.has(progressId) : false;
 
-      const output = fsSync.createWriteStream(destZipPath);
+      const output = fsSync.createWriteStream(normalizedDestZipPath);
       const archive = archiver('zip', { zlib: { level: 9 } });
 
       const finalizePromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
### 🛡️ Sentinel: [security improvement] Hardening filesystem IPC handlers

🚨 **Severity**: HIGH

💡 **Vulnerability**: Unvalidated file path access via IPC (Inter-Process Communication) handlers. Several handlers in `electron.mjs` were interacting with the filesystem without verifying if the requested paths were within allowed or user-approved directories.

🎯 **Impact**: A compromised renderer process or a malicious script could exploit these handlers to read, list, or write arbitrary files on the user's filesystem, bypassing the application's directory indexing and privacy protections.

🔧 **Fix**: Introduced robust path validation in five key IPC handlers:
1.  `list-directory-files`: Now enforces `isPathAllowed` to restrict listing to indexed folders.
2.  `open-cache-location`: Now enforces `isInternalPath` to ensure only app-specific data directories can be opened.
3.  `show-item-in-folder`: Added `isAllowedOrInternal` and `isApprovedWritePath` checks to prevent opening arbitrary system locations.
4.  `export-images-batch`: Hardened with path normalization and `isApprovedWritePath` validation for destination folders.
5.  `export-images-zip`: Hardened with path normalization and `isApprovedWritePath` validation for the output ZIP file.

✅ **Verification**:
- Successfully ran `pnpm lint`.
- Successfully ran the full test suite (`pnpm test`) with 473/473 tests passing.
- Manually verified the security logic and path normalization in `electron.mjs`.
- Confirmed that legitimate workflows (like exporting to a folder selected via a dialog) continue to work via the `isApprovedWritePath` helper.

---
*PR created automatically by Jules for task [16097630491055365432](https://jules.google.com/task/16097630491055365432) started by @LuqP2*