### PR TITLE
🎨 Palette: add keyboard shortcut hint to SearchBar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,6 @@
+## 2025-05-14 - Visual Keyboard Shortcut Hints
+**Learning:** Using Tailwind's `peer` and `peer-focus` utilities provides a clean, CSS-only mechanism for toggling keyboard shortcut hints (`<kbd>`) based on input focus, avoiding redundant React state and keeping components lightweight.
+**Action:** Favor peer utilities for simple focus-dependent UI elements in future UX enhancements.
+
+**Learning:** Keyboard shortcut hints for global actions (like `/` for search) are highly beneficial for power users but should be hidden on mobile viewports (`hidden sm:inline-flex`) where hardware shortcuts are typically unavailable.
+**Action:** Always include responsive visibility constraints for desktop-specific shortcut indicators.

--- a/__tests__/SearchBarHint.test.tsx
+++ b/__tests__/SearchBarHint.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SearchBar from '../components/SearchBar';
+import React from 'react';
+
+describe('SearchBar Shortcut Hint', () => {
+  it('renders the keyboard shortcut hint when input is empty', () => {
+    render(<SearchBar value="" onChange={() => {}} />);
+    const hint = screen.getByText('/');
+    expect(hint).toBeDefined();
+    // It should have the kbd tag
+    expect(hint.tagName).toBe('KBD');
+  });
+
+  it('hides the keyboard shortcut hint when input has value', () => {
+    render(<SearchBar value="test" onChange={() => {}} />);
+    const hint = screen.queryByText('/');
+    expect(hint).toBeNull();
+  });
+
+  it('calls onChange with empty string when clear button is clicked', () => {
+    const onChange = vi.fn();
+    render(<SearchBar value="some query" onChange={onChange} />);
+
+    const clearButton = screen.getByLabelText('Clear search');
+    fireEvent.click(clearButton);
+
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+});

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -34,7 +34,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         onChange={(e) => onChange(e.target.value)}
         placeholder="Search by prompt, model, etc..."
         aria-label="Search"
-        className="w-full bg-gray-800/50 backdrop-blur-sm text-gray-200 placeholder-gray-400 py-3 pl-10 pr-10 rounded-xl border border-gray-700/50 focus:outline-none focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 transition-all duration-300 shadow-sm hover:bg-gray-800/70"
+        className="peer w-full bg-gray-800/50 backdrop-blur-sm text-gray-200 placeholder-gray-400 py-3 pl-10 pr-10 rounded-xl border border-gray-700/50 focus:outline-none focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 transition-all duration-300 shadow-sm hover:bg-gray-800/70"
         data-testid="search-input"
       />
       <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors duration-300 group-focus-within:text-blue-500">
@@ -42,6 +42,14 @@ const SearchBar: React.FC<SearchBarProps> = ({
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
       </div>
+
+      {!value && (
+        <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 transition-opacity duration-200 peer-focus:opacity-0">
+          <kbd className="hidden h-5 items-center rounded border border-gray-700/50 bg-gray-900/50 px-1.5 font-sans text-[10px] font-medium text-gray-500 sm:inline-flex">
+            /
+          </kbd>
+        </div>
+      )}
       
       {value && (
         <button


### PR DESCRIPTION
Added a visual keyboard shortcut hint (`/`) to the SearchBar component to improve discoverability of the search functionality. The hint is implemented using Tailwind's peer utilities for zero-state overhead and is responsive to focus and input value. It is hidden on mobile viewports where the shortcut is inapplicable. Verified that the actual hotkey logic already exists in `useHotkeys.ts` and correctly targets the search input via `data-testid`. Added unit tests and recorded UX learnings.

---
*PR created automatically by Jules for task [11128194667943375971](https://jules.google.com/task/11128194667943375971) started by @LuqP2*