### PR TITLE
🎨 Palette: Add keyboard accessibility to ComfyUI metadata toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 
 **Learning:** Keyboard shortcut hints for global actions (like `/` for search) are highly beneficial for power users but should be hidden on mobile viewports (`hidden sm:inline-flex`) where hardware shortcuts are typically unavailable.
 **Action:** Always include responsive visibility constraints for desktop-specific shortcut indicators.
+
+## 2026-06-23 - Keyboard Accessibility for Custom Buttons
+**Learning:** Custom interactive elements with `role="button"` and `tabIndex={0}` are reachable by keyboard navigation, but they do not automatically handle `Enter` or `Space` keystrokes like native `<button>` elements do.
+**Action:** When creating custom buttons using `<div>` or `<span>`, always remember to attach an `onKeyDown` listener that checks for `event.key === 'Enter' || event.key === ' '`, calls `event.preventDefault()` to stop page scrolling, and triggers the same click handler.

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -510,6 +510,9 @@ const WorkspaceImagePreviewModal: React.FC<{
         onMouseDown={(event) => event.stopPropagation()}
         onClick={handleMetadataPanelClick}
         onKeyDown={(event) => {
+          if (event.target !== event.currentTarget) {
+            return;
+          }
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
             handleMetadataPanelClick();

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -509,6 +509,12 @@ const WorkspaceImagePreviewModal: React.FC<{
         }`}
         onMouseDown={(event) => event.stopPropagation()}
         onClick={handleMetadataPanelClick}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            handleMetadataPanelClick();
+          }
+        }}
         tabIndex={0}
         role="button"
         aria-label="Toggle metadata"

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -515,6 +515,7 @@ const WorkspaceImagePreviewModal: React.FC<{
           }
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
+            event.stopPropagation();
             handleMetadataPanelClick();
           }
         }}


### PR DESCRIPTION
**💡 What:** Added `onKeyDown` support (`Enter` and `Space`) to the ComfyUI workspace metadata panel toggle, making it fully accessible via keyboard.
**🎯 Why:** While the panel `div` correctly used `role="button"` and `tabIndex={0}` to allow keyboard focus, it did not respond to standard keyboard interactions, leaving keyboard-only users unable to toggle the metadata view without a mouse.
**♿ Accessibility:** Custom components acting as buttons must explicitly handle keyboard events. This change maps `Enter` and `Space` to the existing `handleMetadataPanelClick` and calls `preventDefault()` on `Space` to stop the browser from scrolling the page down.

---
*PR created automatically by Jules for task [15392496031152838690](https://jules.google.com/task/15392496031152838690) started by @LuqP2*