### PR TITLE
feat: add drag and drop into the ComfyUI workspace

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3274,6 +3274,12 @@ export default function App() {
           onGeneratorSetupNeeded={handleGeneratorSetupNeeded}
           libraryView={libraryView}
           onLibraryViewChange={setLibraryView}
+          onOpenDroppedImageInComfyUI={(imageId) => {
+            const image = imageLookup.get(imageId);
+            if (image) {
+              openComfyUIWorkflowInWorkspace(image, displayImages);
+            }
+          }}
         />
 
         <CollectionFormModal

--- a/__tests__/Header.launch-generator.test.tsx
+++ b/__tests__/Header.launch-generator.test.tsx
@@ -24,6 +24,8 @@ vi.mock('../services/a1111ApiClient', () => ({
 vi.mock('../hooks/useFeatureAccess', () => ({
   useFeatureAccess: () => ({
     canUseAnalytics: true,
+    canUseComfyUI: true,
+    canUseImageEditor: true,
     showProModal: vi.fn(),
     isTrialActive: false,
     trialDaysRemaining: 0,
@@ -119,5 +121,38 @@ describe('Header launch generator', () => {
     fireEvent.click(screen.getByRole('button', { name: /collections/i }));
 
     expect(onLibraryViewChange).toHaveBeenCalledWith('collections');
+  });
+
+  it('opens a dragged grid or table image in the ComfyUI workspace', () => {
+    const onOpenDroppedImageInComfyUI = vi.fn();
+    const payload = JSON.stringify({
+      primaryImageId: 'directory::image.png',
+      imageIds: ['directory::image.png'],
+    });
+    const dataTransfer = {
+      types: ['application/x-image-metahub-drag'],
+      getData: vi.fn(() => payload),
+      dropEffect: 'none',
+    };
+
+    render(
+      <Header
+        onOpenSettings={() => {}}
+        onOpenAnalytics={() => {}}
+        onOpenLicense={() => {}}
+        libraryView="library"
+        onLibraryViewChange={() => {}}
+        onOpenDroppedImageInComfyUI={onOpenDroppedImageInComfyUI}
+      />
+    );
+
+    const comfyUIButton = screen.getByRole('button', { name: /^comfyui$/i });
+    fireEvent.dragEnter(comfyUIButton, { dataTransfer });
+    expect(comfyUIButton.className).toContain('ring-cyan-400');
+
+    fireEvent.drop(comfyUIButton, { dataTransfer });
+
+    expect(onOpenDroppedImageInComfyUI).toHaveBeenCalledWith('directory::image.png');
+    expect(comfyUIButton.className).not.toContain('ring-cyan-400');
   });
 });

--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -5,6 +5,7 @@ import { useImageStore } from '../store/useImageStore';
 import { transferIndexedImages } from '../services/fileTransferService';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { getActiveDragImageIds, clearActiveDragImageIds } from './ImageGrid';
+import { INTERNAL_IMAGE_DRAG_TYPE } from '../utils/internalImageDrag';
 
 interface DirectoryListProps {
   directories: Directory[];
@@ -483,7 +484,7 @@ export default function DirectoryList({
 
     if (imageIds.length === 0) {
       try {
-        const data = e.dataTransfer.getData('application/x-image-metahub-drag');
+        const data = e.dataTransfer.getData(INTERNAL_IMAGE_DRAG_TYPE);
         if (data) {
           const payload = JSON.parse(data);
           imageIds = payload.imageIds || [];

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,6 +7,7 @@ import { A1111ApiClient } from '../services/a1111ApiClient';
 import { ComfyUIApiClient } from '../services/comfyUIApiClient';
 import { detectGeneratorFromLaunchCommand } from '../utils/detectGeneratorLaunch';
 import { buildProLicenseUrl } from '../utils/creatorAttribution';
+import { clearInternalImageDragData, getInternalImageDragId, hasInternalImageDragType } from '../utils/internalImageDrag';
 
 type LibraryView = 'library' | 'smart' | 'model' | 'node' | 'collections' | 'comfyui' | 'editor';
 
@@ -17,6 +18,7 @@ interface HeaderProps {
     onGeneratorSetupNeeded?: () => void;
     libraryView?: LibraryView;
     onLibraryViewChange?: (view: LibraryView) => void;
+    onOpenDroppedImageInComfyUI?: (imageId: string) => void;
 }
 
 const Header: React.FC<HeaderProps> = ({ 
@@ -25,7 +27,8 @@ const Header: React.FC<HeaderProps> = ({
     onOpenLicense, 
     onGeneratorSetupNeeded,
     libraryView,
-    onLibraryViewChange
+    onLibraryViewChange,
+    onOpenDroppedImageInComfyUI,
 }) => {
   const {
     canUseAnalytics,
@@ -79,6 +82,7 @@ const Header: React.FC<HeaderProps> = ({
     [generatorLaunchCommand]
   );
   const [isLaunchingGenerator, setIsLaunchingGenerator] = useState(false);
+  const [isComfyUIDragTarget, setIsComfyUIDragTarget] = useState(false);
   const launchPollingDeadlineRef = useRef<number | null>(null);
   const relevantServerUrl =
     detectedGenerator.runtimeFamily === 'comfyui'
@@ -369,11 +373,52 @@ const Header: React.FC<HeaderProps> = ({
                 {viewTabs.map((tab) => {
                   const Icon = 'icon' in tab ? tab.icon : null;
                   const count = 'count' in tab ? tab.count : null;
+                  const isComfyUITab = tab.id === 'comfyui';
                   return (
                     <button
                       key={tab.id}
                       onClick={() => handleViewTabClick(tab.id)}
-                      className={`app-top-segment whitespace-nowrap ${libraryView === tab.id ? 'app-top-segment-active' : ''}`}
+                      onDragEnter={isComfyUITab ? (event) => {
+                        if (hasInternalImageDragType(event.dataTransfer)) {
+                          event.preventDefault();
+                          setIsComfyUIDragTarget(true);
+                        }
+                      } : undefined}
+                      onDragOver={isComfyUITab ? (event) => {
+                        if (hasInternalImageDragType(event.dataTransfer)) {
+                          event.preventDefault();
+                          event.dataTransfer.dropEffect = 'copy';
+                        }
+                      } : undefined}
+                      onDragLeave={isComfyUITab ? (event) => {
+                        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+                          setIsComfyUIDragTarget(false);
+                        }
+                      } : undefined}
+                      onDrop={isComfyUITab ? (event) => {
+                        event.preventDefault();
+                        setIsComfyUIDragTarget(false);
+                        const imageId = getInternalImageDragId(event.dataTransfer);
+                        if (!imageId) {
+                          clearInternalImageDragData();
+                          return;
+                        }
+                        if (!canUseComfyUI) {
+                          showProModal('comfyui');
+                          clearInternalImageDragData();
+                          return;
+                        }
+                        onOpenDroppedImageInComfyUI?.(imageId);
+                        clearInternalImageDragData();
+                      } : undefined}
+                      className={`app-top-segment whitespace-nowrap ${
+                        libraryView === tab.id ? 'app-top-segment-active' : ''
+                      } ${
+                        isComfyUITab && isComfyUIDragTarget
+                          ? 'ring-2 ring-cyan-400 bg-cyan-500/25 text-cyan-100'
+                          : ''
+                      }`}
+                      title={isComfyUITab ? 'Open ComfyUI, or drop an image here to load its workflow' : undefined}
                     >
                       {Icon && <Icon size={14} />}
                       <span>{tab.label}</span>

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -51,6 +51,7 @@ import {
   recordPerformanceCounter,
   recordPerformanceDuration,
 } from '../utils/performanceDiagnostics';
+import { clearInternalImageDragData, setInternalImageDragData } from '../utils/internalImageDrag';
 
 // Module-level variable to track internal image drag state (survives native file drag)
 let _activeDragImageIds: string[] = [];
@@ -189,6 +190,7 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
   const [showToast, setShowToast] = useState(false);
   const toggleImageSelection = useImageStore((state) => state.toggleImageSelection);
   const canDragExternally = typeof window !== 'undefined' && !!window.electronAPI?.startFileDrag;
+  const canDragImage = typeof window !== 'undefined';
   const isVideo = isVideoFileName(image.name, image.fileType);
   const isAudio = isAudioFileName(image.name, image.fileType);
   const audioDuration = formatAudioDuration((image.metadata as any)?.normalizedMetadata?.audio?.duration_seconds);
@@ -349,36 +351,21 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
   };
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
-    if (!canDragExternally) {
-      return;
-    }
-
-    const directoryPath = image.directoryId;
-    if (!directoryPath) {
-      return;
-    }
-
-    const [, relativeFromId] = image.id.split('::');
-    const relativePath = relativeFromId || image.name;
-
     suppressNextClickRef.current = true;
-    // Do NOT call e.preventDefault() — that kills HTML5 dragover/drop on page elements.
-    // Suppress the browser ghost image with a transparent pixel so the OS cursor
-    // from startFileDrag is the only visible indicator.
-    const transparentPixel = document.createElement('canvas');
-    transparentPixel.width = 1;
-    transparentPixel.height = 1;
-    e.dataTransfer.setDragImage(transparentPixel, 0, 0);
     const currentSelectedImages = useImageStore.getState().selectedImages;
     const imageIds = currentSelectedImages.has(image.id) ? Array.from(currentSelectedImages) : [image.id];
-    // Store in module-level variables so DirectoryList can consume internal drops.
     _activeDragImageIds = imageIds;
-    _activeExternalDragPayload = { directoryPath, relativePath };
+    setInternalImageDragData(e.dataTransfer, image.id, imageIds);
     _nativeDragStarted = false;
     e.dataTransfer.effectAllowed = 'copyMove';
-    try {
-      e.dataTransfer.setData('application/x-image-metahub-drag', JSON.stringify({ imageIds }));
-    } catch (_) { /* ignore in Electron native drag context */ }
+
+    if (canDragExternally && image.directoryId) {
+      const [, relativeFromId] = image.id.split('::');
+      const relativePath = relativeFromId || image.name;
+      _activeExternalDragPayload = { directoryPath: image.directoryId, relativePath };
+    } else {
+      _activeExternalDragPayload = null;
+    }
   };
 
   const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
@@ -408,6 +395,7 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
       dragResetTimeoutRef.current = null;
       // Clear drag IDs if not consumed by a drop handler
       clearActiveDragImageIds();
+      clearInternalImageDragData();
       _activeExternalDragPayload = null;
       _nativeDragStarted = false;
     }, 100);
@@ -499,7 +487,7 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
         onDragStart={handleDragStart}
         onDrag={handleDrag}
         onDragEnd={handleDragEnd}
-        draggable={canDragExternally}
+        draggable={canDragImage}
       >
         {/* Checkbox for selection - always visible on hover or when selected */}
         <button

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -20,6 +20,7 @@ import CollectionFormModal, { CollectionFormValues } from './CollectionFormModal
 import RenameImageModal from './RenameImageModal';
 import { getFileExtension, isAudioFileName, isVideoFileName } from '../utils/mediaTypes.js';
 import { groupImages, type ImageGroupByMode, type ImageGroupingSortOrder, type ImageGroupRenderItem } from '../utils/imageGrouping';
+import { clearInternalImageDragData, setInternalImageDragData } from '../utils/internalImageDrag';
 
 interface ImageTableProps {
   images: IndexedImage[];
@@ -1020,6 +1021,12 @@ const ImageTableRow: React.FC<ImageTableRowProps> = React.memo(({ image, onImage
         }
       }}
       onContextMenu={(e) => onContextMenu && onContextMenu(image, e)}
+      onDragStart={(e) => {
+        setInternalImageDragData(e.dataTransfer, image.id);
+        e.dataTransfer.effectAllowed = 'copy';
+      }}
+      onDragEnd={clearInternalImageDragData}
+      draggable
       style={{ height: '64px', gridTemplateColumns }}
     >
       <div className="px-3 py-2">

--- a/utils/internalImageDrag.ts
+++ b/utils/internalImageDrag.ts
@@ -1,0 +1,54 @@
+export const INTERNAL_IMAGE_DRAG_TYPE = 'application/x-image-metahub-drag';
+
+interface InternalImageDragPayload {
+  imageIds: string[];
+  primaryImageId?: string;
+}
+
+let activeInternalImageDrag: InternalImageDragPayload | null = null;
+
+export const setInternalImageDragData = (
+  dataTransfer: DataTransfer,
+  primaryImageId: string,
+  imageIds: string[] = [primaryImageId],
+): void => {
+  const uniqueImageIds = Array.from(new Set([primaryImageId, ...imageIds]));
+  activeInternalImageDrag = { imageIds: uniqueImageIds, primaryImageId };
+
+  try {
+    dataTransfer.setData(
+      INTERNAL_IMAGE_DRAG_TYPE,
+      JSON.stringify({ imageIds: uniqueImageIds, primaryImageId } satisfies InternalImageDragPayload),
+    );
+    dataTransfer.setData('text/plain', primaryImageId);
+  } catch {
+    // Electron's native file drag can reject custom MIME data; external dragging still works.
+  }
+};
+
+export const getInternalImageDragId = (dataTransfer: DataTransfer): string | null => {
+  try {
+    const rawPayload = dataTransfer.getData(INTERNAL_IMAGE_DRAG_TYPE);
+    if (!rawPayload) {
+      return activeInternalImageDrag?.primaryImageId ?? activeInternalImageDrag?.imageIds[0] ?? null;
+    }
+
+    const payload = JSON.parse(rawPayload) as Partial<InternalImageDragPayload>;
+    if (typeof payload.primaryImageId === 'string' && payload.primaryImageId) {
+      return payload.primaryImageId;
+    }
+
+    return Array.isArray(payload.imageIds) && typeof payload.imageIds[0] === 'string'
+      ? payload.imageIds[0]
+      : null;
+  } catch {
+    return activeInternalImageDrag?.primaryImageId ?? activeInternalImageDrag?.imageIds[0] ?? null;
+  }
+};
+
+export const hasInternalImageDragType = (dataTransfer: DataTransfer): boolean =>
+  activeInternalImageDrag !== null || Array.from(dataTransfer.types).includes(INTERNAL_IMAGE_DRAG_TYPE);
+
+export const clearInternalImageDragData = (): void => {
+  activeInternalImageDrag = null;
+};


### PR DESCRIPTION
## Summary
- allow dragging images from the library grid and table into the ComfyUI tab
- load the dropped image workflow directly in the embedded ComfyUI workspace
- preserve existing external drag behavior while restoring the normal drag preview

## Testing
- build and typecheck already run locally by the user
