### PR TITLE
Bolt: optimize creation habits analytics and avoid redundant traversals

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2024-05-26 - Reusing Derived Facets in Analytics
 **Learning:** In the analytics dashboard, the same datasets (models, loras) are often displayed in multiple places (e.g., top resources list and curation summary). Calculating these facets multiple times via (N)$ scans of the entire image library is wasteful.
 **Action:** Pre-calculate facets once at the beginning of the analytics generation process and pass or reuse the results for subsequent summary or curation sections. This reduces the number of full-library traversals from  + N$ to just $, where $ is the number of summary sections requiring those same facets.
+
+## 2025-01-24 - Efficient Temporal Analytics via Date Reuse and TypedArrays
+**Learning:** Performing temporal analysis on large datasets often involves thousands of ephemeral `Date` object allocations and `Map` lookups for fixed-range keys (e.g., hours of day, days of week).
+**Action:** Use a single `Date` object and update it via `.setTime(timestamp)` inside the loop to avoid GC pressure. For fixed-range categorical counts, replace `Map` with `Uint32Array` for faster lookups and reduced memory footprint. Additionally, ensure expensive analytics functions are called once and their results cached when needed multiple times in the same derivation block.

--- a/utils/analyticsUtils.ts
+++ b/utils/analyticsUtils.ts
@@ -326,27 +326,33 @@ export function calculateTopItems(
  */
 export function analyzeCreationHabits(images: IndexedImage[]): CreationHabits {
   const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-  const weekdayCounts = new Map<number, number>();
-  const hourlyCounts = new Map<number, number>();
+  const weekdayCounts = new Uint32Array(7);
+  const hourlyCounts = new Uint32Array(24);
+  const date = new Date();
 
-  images.forEach((img) => {
-    const date = new Date(img.lastModified);
-    const weekday = date.getDay();
-    const hour = date.getHours();
+  // Optimization: Standard for loop and Date reuse to minimize allocations.
+  // Impact: Reduces GC pressure by avoiding N Date object creations and Map lookups.
+  for (let i = 0; i < images.length; i++) {
+    date.setTime(images[i].lastModified);
+    weekdayCounts[date.getDay()]++;
+    hourlyCounts[date.getHours()]++;
+  }
 
-    weekdayCounts.set(weekday, (weekdayCounts.get(weekday) || 0) + 1);
-    hourlyCounts.set(hour, (hourlyCounts.get(hour) || 0) + 1);
-  });
+  const weekdayDistribution = new Array(7);
+  for (let i = 0; i < 7; i++) {
+    weekdayDistribution[i] = {
+      day: weekdays[i],
+      count: weekdayCounts[i],
+    };
+  }
 
-  const weekdayDistribution = weekdays.map((day, index) => ({
-    day,
-    count: weekdayCounts.get(index) || 0,
-  }));
-
-  const hourlyDistribution = Array.from({ length: 24 }, (_, hour) => ({
-    hour,
-    count: hourlyCounts.get(hour) || 0,
-  }));
+  const hourlyDistribution = new Array(24);
+  for (let i = 0; i < 24; i++) {
+    hourlyDistribution[i] = {
+      hour: i,
+      count: hourlyCounts[i],
+    };
+  }
 
   return { weekdayDistribution, hourlyDistribution };
 }
@@ -1257,6 +1263,8 @@ export const buildAnalyticsExplorerData = ({
     });
   }
 
+  const habits = analyzeCreationHabits(scopeImages);
+
   const explorerData: AnalyticsExplorerData = {
     scopeMode,
     totalImages,
@@ -1290,8 +1298,8 @@ export const buildAnalyticsExplorerData = ({
     },
     time: {
       timeline: buildTimelinePoints(scopeImages),
-      weekday: analyzeCreationHabits(scopeImages).weekdayDistribution.map((entry) => ({ key: entry.day, label: entry.day, count: entry.count })),
-      hourly: analyzeCreationHabits(scopeImages).hourlyDistribution.map((entry) => ({ key: String(entry.hour), label: `${entry.hour}:00`, count: entry.count })),
+      weekday: habits.weekdayDistribution.map((entry) => ({ key: entry.day, label: entry.day, count: entry.count })),
+      hourly: habits.hourlyDistribution.map((entry) => ({ key: String(entry.hour), label: `${entry.hour}:00`, count: entry.count })),
       sessions: buildSessions(scopeImages),
     },
     performance: {


### PR DESCRIPTION
What: Optimized the `analyzeCreationHabits` utility and its usage in `buildAnalyticsExplorerData`.
Why: The previous implementation allocated a new `Date` object for every image and used `Map` objects for fixed-size counters, leading to high GC pressure and slower lookups. Additionally, the analytics data builder was calling the function twice, causing redundant library traversals.
Impact: Reduces memory allocations during analytics generation by $O(N)$ and reduces complexity of the relevant section in `buildAnalyticsExplorerData` from $2 \times O(N)$ to $1 \times O(N)$.
Measurement: Correctness verified with `pnpm test analytics-utils`. Performance gain is observable via reduced GC activity for large datasets (>10k images).

---
*PR created automatically by Jules for task [16902243280004486407](https://jules.google.com/task/16902243280004486407) started by @LuqP2*