### PR TITLE
Add visual feedback to metadata copy buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2025-06-23 - Smooth Filter Bar Transitions
 **Learning:** Unifying list-based UI elements (like filter chips) under a single AnimatePresence with the 'popLayout' mode and 'layout' prop ensures that additions, removals, and reordering feel fluid rather than jarring. This pattern is particularly effective for highly interactive bars where multiple filter types are mixed.
 **Action:** Use a shared motion configuration and stable unique keys for all dynamic list items to maintain consistent animation behavior across the application.
+
+## 2025-06-24 - Async Clipboard Feedback
+**Learning:** Asynchronous UI feedback for operations like `navigator.clipboard.writeText` must await the Promise resolution. Providing immediate visual confirmation (like a "Copied!" checkmark) without checking for success can mislead users if the operation fails due to permissions or browser restrictions.
+**Action:** Always await clipboard operations and use their success/failure to drive visual feedback states.

--- a/components/ComparisonMetadataPanel.tsx
+++ b/components/ComparisonMetadataPanel.tsx
@@ -7,7 +7,7 @@ import { compareField, formatFieldValue, diffText, DiffToken } from '../utils/me
 const MetadataField: FC<{
   label: string;
   value: unknown;
-  onCopy?: () => void;
+  onCopy?: () => void | Promise<void | boolean>;
   multiline?: boolean;
   otherValue?: unknown;
   isDiffMode?: boolean;
@@ -83,11 +83,13 @@ const MetadataField: FC<{
     );
   };
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (onCopy) {
-      onCopy();
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      const result = await onCopy();
+      if (result !== false) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
     }
   };
 
@@ -124,9 +126,10 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
   const metadata = image.metadata?.normalizedMetadata;
   const isDiffMode = viewMode === 'diff';
 
-  const copyToClipboard = (value: string, label: string) => {
+  const copyToClipboard = async (value: string, label: string) => {
     if (navigator.clipboard && window.isSecureContext) {
-      navigator.clipboard.writeText(value).then(() => {
+      try {
+        await navigator.clipboard.writeText(value);
         // Show notification
         const notification = document.createElement('div');
         notification.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-50';
@@ -137,9 +140,11 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
             document.body.removeChild(notification);
           }
         }, 2000);
-      }).catch(err => {
+        return true;
+      } catch (err) {
         console.error('Failed to copy to clipboard:', err);
-      });
+        return false;
+      }
     } else {
       // Fallback for older browsers
       const textArea = document.createElement('textarea');
@@ -151,12 +156,17 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
       textArea.focus();
       textArea.select();
       try {
-        document.execCommand('copy');
+        const success = document.execCommand('copy');
         textArea.remove();
-        alert(`${label} copied to clipboard!`);
+        if (success) {
+          alert(`${label} copied to clipboard!`);
+          return true;
+        }
+        return false;
       } catch (err) {
         console.error('Failed to copy:', err);
         textArea.remove();
+        return false;
       }
     }
   };

--- a/components/ComparisonMetadataPanel.tsx
+++ b/components/ComparisonMetadataPanel.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useMemo } from 'react';
-import { ChevronDown, ChevronRight, Copy, AlertTriangle } from 'lucide-react';
+import React, { FC, useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, Copy, AlertTriangle, CheckCircle } from 'lucide-react';
 import { ComparisonMetadataPanelProps, BaseMetadata } from '../types';
 import { compareField, formatFieldValue, diffText, DiffToken } from '../utils/metadataComparison';
 
@@ -13,6 +13,7 @@ const MetadataField: FC<{
   isDiffMode?: boolean;
   field?: string;
 }> = ({ label, value, onCopy, multiline, otherValue, isDiffMode, field }) => {
+  const [copied, setCopied] = useState(false);
   // Check if value exists
   const hasValue = value !== undefined && value !== null && value !== '';
   const hasOtherValue = otherValue !== undefined && otherValue !== null && otherValue !== '';
@@ -82,17 +83,26 @@ const MetadataField: FC<{
     );
   };
 
+  const handleCopy = () => {
+    if (onCopy) {
+      onCopy();
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
   return (
     <div className={`p-2 rounded border ${highlightClass}`}>
       <div className="flex justify-between items-start">
         <p className="text-gray-400 text-xs uppercase tracking-wider">{label}</p>
         {onCopy && (
           <button
-            onClick={onCopy}
-            className="text-gray-400 hover:text-white transition-colors"
-            title={`Copy ${label}`}
+            onClick={handleCopy}
+            className={`transition-all duration-200 ${copied ? 'text-green-400' : 'text-gray-400 hover:text-white'}`}
+            title={copied ? 'Copied!' : `Copy ${label}`}
+            aria-label={copied ? 'Copied!' : `Copy ${label}`}
           >
-            <Copy className="w-3 h-3" />
+            {copied ? <CheckCircle className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
           </button>
         )}
       </div>

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -570,7 +570,7 @@ const SUPPORTED_MEDIA_EXTENSION_REGEX = new RegExp(
   'i'
 );
 
-const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void }> = ({ label, value, isPrompt = false, onCopy }) => {
+const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void | Promise<void | boolean> }> = ({ label, value, isPrompt = false, onCopy }) => {
   const [copied, setCopied] = useState(false);
 
   if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
@@ -579,11 +579,13 @@ const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPromp
 
   const displayValue = Array.isArray(value) ? value.join(', ') : String(value);
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (onCopy) {
-      onCopy(displayValue);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      const result = await onCopy(displayValue);
+      if (result !== false) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
     }
   };
 
@@ -1825,27 +1827,34 @@ const ImageModal: React.FC<ImageModalProps> = ({
     setModalWindow(createMaximizedModalWindow());
   }, [isWindowMaximized]);
 
-  const copyToClipboard = (text: string, type: string) => {
+  const copyToClipboard = async (text: string, type: string) => {
     if(!text) {
         alert(`No ${type} to copy.`);
-        return;
+        return false;
     }
-    navigator.clipboard.writeText(text).then(() => {
+    try {
+      await navigator.clipboard.writeText(text);
       const notification = document.createElement('div');
       notification.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-50';
       notification.textContent = `${type} copied to clipboard!`;
       document.body.appendChild(notification);
-      setTimeout(() => document.body.removeChild(notification), 2000);
-    }).catch(err => {
+      setTimeout(() => {
+        if (document.body.contains(notification)) {
+          document.body.removeChild(notification);
+        }
+      }, 2000);
+      return true;
+    } catch (err) {
       console.error(`Failed to copy ${type}:`, err);
       alert(`Failed to copy ${type}.`);
-    });
+      return false;
+    }
   };
 
   const copyToClipboardElectron = async (text: string, type: string) => {
     if (!text) {
       alert(`No ${type} to copy.`);
-      return;
+      return false;
     }
 
     try {
@@ -1855,10 +1864,16 @@ const ImageModal: React.FC<ImageModalProps> = ({
       notification.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-50';
       notification.textContent = `${type} copied to clipboard!`;
       document.body.appendChild(notification);
-      setTimeout(() => document.body.removeChild(notification), 2000);
+      setTimeout(() => {
+        if (document.body.contains(notification)) {
+          document.body.removeChild(notification);
+        }
+      }, 2000);
+      return true;
     } catch (err) {
       console.error(`Failed to copy ${type}:`, err);
       alert(`Failed to copy ${type}.`);
+      return false;
     }
   };
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -571,19 +571,34 @@ const SUPPORTED_MEDIA_EXTENSION_REGEX = new RegExp(
 );
 
 const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void }> = ({ label, value, isPrompt = false, onCopy }) => {
+  const [copied, setCopied] = useState(false);
+
   if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
     return null;
   }
 
   const displayValue = Array.isArray(value) ? value.join(', ') : String(value);
 
+  const handleCopy = () => {
+    if (onCopy) {
+      onCopy(displayValue);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
   return (
     <div className="bg-gray-900/50 p-3 rounded-md border border-gray-700/50 relative group">
       <div className="flex justify-between items-start">
         <p className="font-semibold text-gray-400 text-xs uppercase tracking-wider">{label}</p>
         {onCopy && (
-            <button onClick={() => onCopy(displayValue)} className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-white" title={`Copy ${label}`} aria-label={`Copy ${label}`}>
-                <Copy className="w-4 h-4" />
+            <button
+              onClick={handleCopy}
+              className={`transition-all duration-200 ${copied ? 'opacity-100 text-green-400' : 'opacity-0 group-hover:opacity-100 text-gray-400 hover:text-white'}`}
+              title={copied ? 'Copied!' : `Copy ${label}`}
+              aria-label={copied ? 'Copied!' : `Copy ${label}`}
+            >
+                {copied ? <CheckCircle className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
             </button>
         )}
       </div>

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -89,7 +89,7 @@ const formatDurationSeconds = (seconds: number): string => {
   return `${minutes}m ${remainingSeconds}s`;
 };
 
-const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void }> = ({ label, value, isPrompt = false, onCopy }) => {
+const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void | Promise<void | boolean> }> = ({ label, value, isPrompt = false, onCopy }) => {
   const [copied, setCopied] = useState(false);
 
   if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
@@ -98,11 +98,13 @@ const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPromp
 
   const displayValue = Array.isArray(value) ? value.join(', ') : String(value);
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (onCopy) {
-      onCopy(displayValue);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      const result = await onCopy(displayValue);
+      if (result !== false) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
     }
   };
 
@@ -421,11 +423,15 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     setIsBatchExportModalOpen(true);
   };
 
-  const copyToClipboard = (text: string, type: string) => {
-    if(!text) return;
-    navigator.clipboard.writeText(text).catch(err => {
+  const copyToClipboard = async (text: string, type: string) => {
+    if(!text) return false;
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (err) {
       console.error(`Failed to copy ${type}:`, err);
-    });
+      return false;
+    }
   };
 
   const hideContextMenu = () => {

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -90,19 +90,34 @@ const formatDurationSeconds = (seconds: number): string => {
 };
 
 const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void }> = ({ label, value, isPrompt = false, onCopy }) => {
+  const [copied, setCopied] = useState(false);
+
   if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
     return null;
   }
 
   const displayValue = Array.isArray(value) ? value.join(', ') : String(value);
 
+  const handleCopy = () => {
+    if (onCopy) {
+      onCopy(displayValue);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
   return (
     <div className="bg-gray-50 dark:bg-gray-900/50 p-3 rounded-md border border-gray-200 dark:border-gray-700/50 relative group">
       <div className="flex justify-between items-start">
         <p className="font-semibold text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">{label}</p>
         {onCopy && (
-            <button onClick={() => onCopy(displayValue)} className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-gray-50" title={`Copy ${label}`} aria-label={`Copy ${label}`}>
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path d="M7 3a1 1 0 011-1h6a1 1 0 110 2H8a1 1 0 01-1-1zM5 5a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2H5z"></path></svg>
+            <button
+              onClick={handleCopy}
+              className={`transition-all duration-200 ${copied ? 'opacity-100 text-green-500 dark:text-green-400' : 'opacity-0 group-hover:opacity-100 text-gray-400 hover:text-gray-900 dark:hover:text-gray-50'}`}
+              title={copied ? 'Copied!' : `Copy ${label}`}
+              aria-label={copied ? 'Copied!' : `Copy ${label}`}
+            >
+                {copied ? <CheckCircle className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
             </button>
         )}
       </div>


### PR DESCRIPTION
What: Added visual "Copied!" feedback to metadata copy buttons in ImageModal, ImagePreviewSidebar, and ComparisonMetadataPanel.
Why: Users need clear confirmation when they successfully copy metadata to the clipboard.
Accessibility: Updated ARIA labels to reflect the "Copied!" state when active.

---
*PR created automatically by Jules for task [14820473410598257665](https://jules.google.com/task/14820473410598257665) started by @LuqP2*