### PR TITLE
Fix macOS audio playback mitigation

### DIFF
--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -37,6 +37,7 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
     fileName: diagnostics?.fileName ?? title,
     surface: diagnostics?.surface ?? 'audio-player',
     src,
+    hasAudioTrack: true,
     onAudioRendererError: handleAudioRendererError,
   });
 
@@ -68,7 +69,7 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
             Audio playback failed in Electron
           </p>
           <p className="mt-1 max-w-md text-xs text-gray-400">
-            The macOS audio service reported an audio renderer error.
+            The macOS audio service failed while initializing playback.
           </p>
         </div>
         <button

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -613,7 +613,8 @@ const VideoPlayer: React.FC<{
   onEnded?: React.ReactEventHandler<HTMLVideoElement>;
   externalPath?: string | null;
   diagnostics?: Omit<MediaDiagnosticsContext, 'mediaKind' | 'src'>;
-}> = ({ src, poster, onContextMenu, onLoadedMetadata, onCanPlay, onPlaying, onEnded, externalPath, diagnostics }) => {
+  hasAudioTrack?: boolean;
+}> = ({ src, poster, onContextMenu, onLoadedMetadata, onCanPlay, onPlaying, onEnded, externalPath, diagnostics, hasAudioTrack = false }) => {
   const videoRef = React.useRef<HTMLVideoElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [audioRendererFailed, setAudioRendererFailed] = useState(false);
@@ -631,6 +632,7 @@ const VideoPlayer: React.FC<{
     fileName: diagnostics?.fileName ?? '',
     surface: diagnostics?.surface ?? 'image-modal',
     src,
+    hasAudioTrack,
     onAudioRendererError: handleAudioRendererError,
   });
   
@@ -735,7 +737,7 @@ const VideoPlayer: React.FC<{
         <div>
           <p className="text-lg font-medium text-gray-100">Audio playback failed in Electron</p>
           <p className="mt-1 max-w-md text-sm text-gray-400">
-            The macOS audio service reported an audio renderer error.
+            The macOS audio service failed while initializing playback.
           </p>
         </div>
         <button
@@ -3375,6 +3377,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   poster={preferredThumbnailUrl ?? undefined}
                   externalPath={externalMediaPath}
                   diagnostics={{ fileName: image.name, surface: isSlideshowMode ? 'slideshow' : 'image-modal' }}
+                  hasAudioTrack={Boolean((image.metadata?.normalizedMetadata as any)?.audio)}
                   onContextMenu={handleContextMenu}
                   onLoadedMetadata={(event) => {
                     const duration = event.currentTarget.duration;

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -208,6 +208,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     fileName: activeImage?.name ?? '',
     surface: 'preview-sidebar',
     src: imageUrl,
+    hasAudioTrack: Boolean((activeImage?.metadata?.normalizedMetadata as any)?.audio),
     onAudioRendererError: () => setMediaRendererFailed(true),
   });
   const tagSuggestionLimit = useSettingsStore((state) => state.tagSuggestionLimit);
@@ -539,7 +540,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 </div>
                 <div>
                   <p className="text-sm font-medium text-gray-100">Audio playback failed in Electron</p>
-                  <p className="mt-1 max-w-md text-xs text-gray-400">The macOS audio service reported an audio renderer error.</p>
+                  <p className="mt-1 max-w-md text-xs text-gray-400">The macOS audio service failed while initializing playback.</p>
                 </div>
                 <button
                   type="button"

--- a/electron.mjs
+++ b/electron.mjs
@@ -38,6 +38,11 @@ const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 const gpuMitigationEnabled = process.env.IMH_DISABLE_GPU === '1' || process.env.IMH_DISABLE_GPU === 'true';
 const mediaSafeModeEnabled = process.platform === 'darwin' && (process.env.IMH_MEDIA_SAFE_MODE === '1' || process.env.IMH_MEDIA_SAFE_MODE === 'true');
 const audioDiagnosticModeEnabled = process.platform === 'darwin' && (process.env.IMH_AUDIO_DIAGNOSTIC_MODE === '1' || process.env.IMH_AUDIO_DIAGNOSTIC_MODE === 'true');
+const macOSAudioMitigationOptOut = process.env.IMH_DISABLE_MACOS_AUDIO_MITIGATION === '1'
+  || process.env.IMH_DISABLE_MACOS_AUDIO_MITIGATION === 'true'
+  || process.env.IMH_ENABLE_OUT_OF_PROCESS_AUDIO === '1'
+  || process.env.IMH_ENABLE_OUT_OF_PROCESS_AUDIO === 'true';
+const macOSAudioMitigationEnabled = process.platform === 'darwin' && app.isPackaged && !macOSAudioMitigationOptOut;
 const enabledMediaCommandLineSwitches = [];
 const disabledChromiumFeatures = new Set();
 
@@ -61,6 +66,16 @@ if (audioDiagnosticModeEnabled) {
   console.warn('[Media] macOS audio diagnostic mode enabled via IMH_AUDIO_DIAGNOSTIC_MODE.');
 }
 
+if (macOSAudioMitigationEnabled) {
+  // macOS/Electron AudioServiceOutOfProcess appears to crash or fail after a
+  // cold system start for at least one user. Silent videos work, while MP3 and
+  // MP4 files with audio fail; disabling this path via diagnostics confirmed
+  // audio-bearing media playback works.
+  disabledChromiumFeatures.add('AudioServiceSandbox');
+  disabledChromiumFeatures.add('AudioServiceOutOfProcess');
+  console.warn('[Media] macOS packaged audio mitigation enabled. Set IMH_DISABLE_MACOS_AUDIO_MITIGATION=1 to opt out for debugging.');
+}
+
 if (disabledChromiumFeatures.size > 0) {
   const disableFeaturesValue = Array.from(disabledChromiumFeatures).join(',');
   app.commandLine.appendSwitch('disable-features', disableFeaturesValue);
@@ -71,7 +86,7 @@ app.commandLine.appendSwitch('js-flags', '--max-old-space-size=4096');
 
 // Parser version - increment when parser logic changes
 // This ensures cache is invalidated when parsing rules change
-const PARSER_VERSION = 8; // v8: Add Image MetaHub creator attribution metadata
+const PARSER_VERSION = 9; // v9: Preserve probed audio stream metadata on normalized video records
 
 const logMainPerf = (event, details = {}) => {
   console.log('[main:perf]', { event, ...details });
@@ -1016,6 +1031,7 @@ function registerProcessDiagnostics() {
     kind: 'app-startup',
     logs: getDiagnosticsLogPaths(),
     gpuMitigationEnabled,
+    macOSAudioMitigationEnabled,
     mediaSafeModeEnabled,
     audioDiagnosticModeEnabled,
     mediaCommandLineSwitches: enabledMediaCommandLineSwitches,

--- a/hooks/useMediaDiagnostics.ts
+++ b/hooks/useMediaDiagnostics.ts
@@ -20,6 +20,7 @@ export interface MediaDiagnosticsContext {
   fileName: string;
   surface: string;
   src?: string | null;
+  hasAudioTrack?: boolean;
   onAudioRendererError?: () => void;
 }
 
@@ -37,6 +38,14 @@ const getMediaErrorMessage = (error: MediaError | null): string | null => {
 
 export const isAudioRendererErrorMessage = (message?: string | null): boolean =>
   typeof message === 'string' && message.includes('AUDIO_RENDERER_ERROR');
+
+const isMacElectronRenderer = (): boolean => {
+  if (typeof window === 'undefined' || !window.electronAPI || typeof navigator === 'undefined') {
+    return false;
+  }
+
+  return /mac/i.test(navigator.platform || '') || /Mac OS X/i.test(navigator.userAgent || '');
+};
 
 export function useMediaDiagnostics(context: MediaDiagnosticsContext) {
   const logMediaEvent = useCallback(
@@ -58,11 +67,15 @@ export function useMediaDiagnostics(context: MediaDiagnosticsContext) {
         errorMessage,
       });
 
-      if (event.type === 'error' && isAudioRendererErrorMessage(errorMessage)) {
+      const shouldOfferMacAudioFallback = event.type === 'error'
+        && isMacElectronRenderer()
+        && (context.mediaKind === 'audio' || context.hasAudioTrack === true);
+
+      if (event.type === 'error' && (isAudioRendererErrorMessage(errorMessage) || shouldOfferMacAudioFallback)) {
         context.onAudioRendererError?.();
       }
     },
-    [context.fileName, context.mediaKind, context.onAudioRendererError, context.src, context.surface],
+    [context.fileName, context.hasAudioTrack, context.mediaKind, context.onAudioRendererError, context.src, context.surface],
   );
 
   return useMemo(

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -10,7 +10,7 @@ import {
  * Parser version - increment when parser logic changes significantly
  * This ensures cache is invalidated when parsing rules change
  */
-export const PARSER_VERSION = 8; // v8: Add Image MetaHub creator attribution metadata
+export const PARSER_VERSION = 9; // v9: Preserve probed audio stream metadata on normalized video records
 
 // Simplified metadata structure for the JSON cache
 export interface CacheImageMetadata {

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -1695,6 +1695,13 @@ if (normalizedMetadata && isAudio) {
   normalizedMetadata.media_type = 'audio';
   normalizedMetadata.audio = normalizedMetadata.audio ?? audioInfo;
 }
+if (normalizedMetadata && isVideo) {
+  normalizedMetadata.width = normalizedMetadata.width || (videoInfo?.width ?? 0);
+  normalizedMetadata.height = normalizedMetadata.height || (videoInfo?.height ?? 0);
+  normalizedMetadata.media_type = 'video';
+  normalizedMetadata.video = normalizedMetadata.video ?? videoInfo;
+  normalizedMetadata.audio = normalizedMetadata.audio ?? audioInfo;
+}
 
 // ==============================================================================
 // FIM DA SUBSTITUIÇÃO - O código seguinte (Read actual image dimensions) 

--- a/services/metadataEngine.ts
+++ b/services/metadataEngine.ts
@@ -593,7 +593,9 @@ export async function parseImageFile(filePath: string): Promise<MetadataEngineRe
   if (metadata && isVideo && videoInfo) {
     metadata.width = metadata.width || (videoInfo.width ?? 0);
     metadata.height = metadata.height || (videoInfo.height ?? 0);
+    metadata.media_type = 'video';
     metadata.video = metadata.video ?? videoInfo;
+    metadata.audio = metadata.audio ?? audioInfo;
   }
   if (metadata && isAudio) {
     metadata.width = metadata.width || 0;
@@ -611,6 +613,7 @@ export async function parseImageFile(filePath: string): Promise<MetadataEngineRe
       scheduler: '',
       media_type: 'video',
       video: videoInfo,
+      audio: audioInfo,
     };
   }
   if (!metadata && isAudio) {


### PR DESCRIPTION
## Summary

Promotes the successful macOS audio diagnostic workaround into the default packaged macOS runtime path. Packaged macOS builds now disable `AudioServiceSandbox` and `AudioServiceOutOfProcess`, with opt-out environment variables for debugging.

The renderer fallback also handles generic macOS/Electron media errors for audio files and videos with indexed audio streams, while leaving silent video playback alone.

Refers to #406 

## Why

User reports showed MP3 and MP4-with-audio failures on macOS, especially after cold system startup, while silent MP4 files continued to play. `IMH_MEDIA_SAFE_MODE` did not help, but `IMH_AUDIO_DIAGNOSTIC_MODE=1` made the same audio-bearing media play correctly, pointing to Electron's AudioService path rather than the `imh-media://` protocol or a file-specific decode issue.

## Validation

- `npm run build` passed
- Package version left unchanged at `0.17.3`