### PR TITLE
Improve keyboard accessibility for sidebar facet filters

### DIFF
--- a/components/FacetFilterSection.tsx
+++ b/components/FacetFilterSection.tsx
@@ -161,8 +161,18 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                 return (
                   <div
                     key={item}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={isIncluded}
+                    aria-label={`Toggle ${item} filter`}
                     onClick={handleRowClick}
-                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors cursor-pointer ${
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRowClick();
+                      }
+                    }}
+                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 ${
                       isIncluded
                         ? 'bg-emerald-500/10'
                         : isExcluded


### PR DESCRIPTION
What: Enhanced the keyboard accessibility of the sidebar facet filters (Checkpoints, LoRAs, Samplers, Schedulers).

Why: Previously, these items were clickable divs that were unreachable via keyboard navigation and lacked proper semantics for screen readers.

Accessibility: Added role="button", tabIndex={0}, and ARIA attributes (aria-pressed, aria-label). Implemented standard keyboard interaction handling for Enter and Space keys, including focus-visible ring styles.

---
*PR created automatically by Jules for task [3118073221635756414](https://jules.google.com/task/3118073221635756414) started by @LuqP2*