### PR TITLE
Improve facet filter accessibility and keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,3 +26,7 @@
 ## 2026-06-27 - Enhancing Hidden Interactive Elements
 **Learning:** Buttons that only appear on hover (e.g., metadata copy buttons) are inaccessible to keyboard users. Using `group-focus-within:opacity-100` or `focus-visible` is critical to reveal these elements during navigation.
 **Action:** Always pair `group-hover` visibility with `focus-within` or `focus-visible` states and provide a clear focus ring for keyboard users.
+
+## 2025-07-24 - Preventing Event Bubbling in Keyboard Handlers
+**Learning:** In custom interactive elements (like list rows) that contain nested native buttons, keyboard event handlers on the parent can double-trigger or conflict with child actions due to event bubbling. Using `if (e.target !== e.currentTarget) return;` in the parent's `onKeyDown` handler ensures that keyboard interactions only trigger when the parent itself is the specific target.
+**Action:** Always use target guards in keyboard handlers for parent elements that contain other interactive children.

--- a/components/FacetFilterSection.tsx
+++ b/components/FacetFilterSection.tsx
@@ -161,8 +161,18 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                 return (
                   <div
                     key={item}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={isIncluded}
                     onClick={handleRowClick}
-                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors cursor-pointer ${
+                    onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRowClick();
+                      }
+                    }}
+                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
                       isIncluded
                         ? 'bg-emerald-500/10'
                         : isExcluded


### PR DESCRIPTION
What: Added keyboard navigation support (Enter/Space), ARIA roles, and focus indicators to the interactive rows in the facet filter section.

Why: These rows were clickable but not accessible to keyboard users or screen readers, creating a barrier for accessibility and a less polished experience for power users.

Impact: Users can now navigate and toggle filters using only the keyboard.

Measurement: Verified with Playwright that Space key toggles the filter state and focus rings are correctly displayed. Semantic roles and attributes (role="button", tabIndex, aria-pressed) were confirmed via automated script.

---
*PR created automatically by Jules for task [2681725616881903799](https://jules.google.com/task/2681725616881903799) started by @LuqP2*