### PR TITLE
Improve facet filter row keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,3 +26,7 @@
 ## 2026-06-27 - Enhancing Hidden Interactive Elements
 **Learning:** Buttons that only appear on hover (e.g., metadata copy buttons) are inaccessible to keyboard users. Using `group-focus-within:opacity-100` or `focus-visible` is critical to reveal these elements during navigation.
 **Action:** Always pair `group-hover` visibility with `focus-within` or `focus-visible` states and provide a clear focus ring for keyboard users.
+
+## 2026-07-24 - Keyboard Accessibility for Complex Interactive Rows
+**Learning:** When making complex interactive rows (like facets) accessible, adding `role="button"` and `tabIndex={0}` is only the first step. To prevent nested action buttons from double-triggering the parent's toggle logic when activated via keyboard, a target guard (`if (e.target !== e.currentTarget) return;`) is essential in the parent's `onKeyDown` handler.
+**Action:** Always implement event target validation in keyboard handlers for interactive containers that house independent sub-actions.

--- a/components/FacetFilterSection.tsx
+++ b/components/FacetFilterSection.tsx
@@ -161,8 +161,18 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                 return (
                   <div
                     key={item}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={isIncluded || isExcluded}
                     onClick={handleRowClick}
-                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors cursor-pointer ${
+                    onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRowClick();
+                      }
+                    }}
+                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 outline-none ${
                       isIncluded
                         ? 'bg-emerald-500/10'
                         : isExcluded
@@ -191,7 +201,7 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                           e.stopPropagation();
                           onIncludeToggle(item);
                         }}
-                        className={`flex items-center justify-center p-1 rounded transition-colors ${
+                        className={`flex items-center justify-center p-1 rounded transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 outline-none ${
                           isIncluded
                             ? 'bg-emerald-500/20 text-emerald-400'
                             : 'text-gray-500 hover:bg-emerald-500/15 hover:text-emerald-400'
@@ -207,7 +217,7 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                           e.stopPropagation();
                           onExcludeToggle(item);
                         }}
-                        className={`flex items-center justify-center p-1 rounded transition-colors ${
+                        className={`flex items-center justify-center p-1 rounded transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 outline-none ${
                           isExcluded
                             ? 'bg-rose-500/20 text-rose-400'
                             : 'text-gray-500 hover:bg-rose-500/15 hover:text-rose-400'


### PR DESCRIPTION
### What
Implemented keyboard accessibility and ARIA support for facet filter rows in the sidebar.

### Why
The facet filter rows were only interactive via mouse clicks on a `div`, making them inaccessible to keyboard users and screen readers.

### Impact
Users can now navigate the sidebar filters using the 'Tab' key and toggle them using 'Enter' or 'Space'. Screen reader users will receive correct feedback about the element's role and its active/pressed state.

### Measurement
- Verified that `role="button"`, `tabindex="0"`, and `aria-pressed` are present in the DOM.
- Verified that focus rings appear only during keyboard navigation.
- Verified that 'Enter' key successfully toggles filters in a Playwright test.
- Verified that nested buttons do not trigger the parent row's toggle logic when activated via keyboard.

---
*PR created automatically by Jules for task [2750617127746311327](https://jules.google.com/task/2750617127746311327) started by @LuqP2*