### PR TITLE
Improve keyboard accessibility and tactile feedback for facet filter items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,3 +26,7 @@
 ## 2026-06-27 - Enhancing Hidden Interactive Elements
 **Learning:** Buttons that only appear on hover (e.g., metadata copy buttons) are inaccessible to keyboard users. Using `group-focus-within:opacity-100` or `focus-visible` is critical to reveal these elements during navigation.
 **Action:** Always pair `group-hover` visibility with `focus-within` or `focus-visible` states and provide a clear focus ring for keyboard users.
+
+## 2025-06-28 - Keyboard Parity for Interactive List Items
+**Learning:** Facet filters and list items often use `div` elements for layout flexibility, but they must implement `role="button"`, `tabIndex={0}`, and `onKeyDown` handlers to be accessible. Adding `framer-motion`'s `whileTap` provides the tactile feedback users expect from native interactive elements.
+**Action:** When converting static list items to interactive ones, ensure full keyboard parity and use micro-interactions (like subtle scaling) to signal interactivity.

--- a/components/FacetFilterSection.tsx
+++ b/components/FacetFilterSection.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { ChevronDown, Minus, Plus, Search, X } from 'lucide-react';
+import { motion } from 'framer-motion';
 
 interface FacetFilterSectionProps {
   title: string;
@@ -159,10 +160,22 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                 };
 
                 return (
-                  <div
+                  <motion.div
                     key={item}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={isIncluded}
+                    aria-label={`${isIncluded ? 'Remove' : 'Include'} ${item} (${counts?.get(item) ?? 0} items)`}
+                    whileTap={{ scale: 0.98 }}
                     onClick={handleRowClick}
-                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors cursor-pointer ${
+                    onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRowClick();
+                      }
+                    }}
+                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 ${
                       isIncluded
                         ? 'bg-emerald-500/10'
                         : isExcluded
@@ -218,7 +231,7 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                         <Minus className="h-3.5 w-3.5" />
                       </button>
                     </div>
-                  </div>
+                  </motion.div>
                 );
               })
             )}

--- a/components/FacetFilterSection.tsx
+++ b/components/FacetFilterSection.tsx
@@ -160,22 +160,9 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                 };
 
                 return (
-                  <motion.div
+                  <div
                     key={item}
-                    role="button"
-                    tabIndex={0}
-                    aria-pressed={isIncluded}
-                    aria-label={`${isIncluded ? 'Remove' : 'Include'} ${item} (${counts?.get(item) ?? 0} items)`}
-                    whileTap={{ scale: 0.98 }}
-                    onClick={handleRowClick}
-                    onKeyDown={(e) => {
-                      if (e.target !== e.currentTarget) return;
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        handleRowClick();
-                      }
-                    }}
-                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 ${
+                    className={`group flex items-center justify-between gap-2 rounded-md px-2 py-1 transition-colors ${
                       isIncluded
                         ? 'bg-emerald-500/10'
                         : isExcluded
@@ -183,7 +170,19 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                           : 'hover:bg-gray-800/40'
                     }`}
                   >
-                    <div className="flex items-center gap-2 min-w-0 flex-1">
+                    <motion.button
+                      type="button"
+                      aria-pressed={isIncluded}
+                      aria-label={`${isIncluded ? 'Remove' : 'Include'} ${item} (${counts?.get(item) ?? 0} items)`}
+                      whileTap={{ scale: 0.98 }}
+                      onClick={handleRowClick}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.stopPropagation();
+                        }
+                      }}
+                      className="flex min-w-0 flex-1 items-center gap-2 rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
+                    >
                       <div
                         className={`text-sm leading-tight truncate ${
                           isIncluded ? 'text-emerald-300' : isExcluded ? 'text-rose-300 line-through opacity-70' : 'text-gray-300'
@@ -195,7 +194,7 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                       <div className="text-[10px] text-gray-500 whitespace-nowrap">
                         {counts?.get(item) ?? 0}
                       </div>
-                    </div>
+                    </motion.button>
 
                     <div className={`flex items-center gap-0.5 ${isIncluded || isExcluded ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus-within:opacity-100'} transition-opacity`}>
                       <button
@@ -203,6 +202,11 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                         onClick={(e) => {
                           e.stopPropagation();
                           onIncludeToggle(item);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.stopPropagation();
+                          }
                         }}
                         className={`flex items-center justify-center p-1 rounded transition-colors ${
                           isIncluded
@@ -220,6 +224,11 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                           e.stopPropagation();
                           onExcludeToggle(item);
                         }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.stopPropagation();
+                          }
+                        }}
                         className={`flex items-center justify-center p-1 rounded transition-colors ${
                           isExcluded
                             ? 'bg-rose-500/20 text-rose-400'
@@ -231,7 +240,7 @@ const FacetFilterSection: React.FC<FacetFilterSectionProps> = ({
                         <Minus className="h-3.5 w-3.5" />
                       </button>
                     </div>
-                  </motion.div>
+                  </div>
                 );
               })
             )}


### PR DESCRIPTION
### What
Converted facet filter items in the sidebar to accessible interactive components.

### Why
The facet filter items (Checkpoints, Samplers, etc.) were implemented as static `div` elements with click handlers. This meant they were invisible to keyboard users (not focusable) and lacked the standard interaction feedback users expect from buttons.

### Impact
- **Accessibility:** Users can now navigate through all facet items using the `Tab` key and toggle them using `Enter` or `Space`.
- **Micro-interaction:** Added a subtle scale animation on tap/click using `framer-motion` to provide immediate tactile feedback.
- **Visual Clarity:** Added a clear focus ring to indicate which filter item is currently targeted by the keyboard.
- **Robustness:** Added event bubbling protection to ensure that clicking the "Include/Exclude" buttons inside a facet doesn't double-trigger the main facet toggle.

### Measurement
- Verified keyboard navigation flow (Tab -> Focus Ring -> Enter/Space to toggle) via Playwright.
- Confirmed that `pnpm lint` and `pnpm test` pass.
- Inspected visual feedback via screenshots.

---
*PR created automatically by Jules for task [5631856727230992427](https://jules.google.com/task/5631856727230992427) started by @LuqP2*