### PR TITLE
Standardize tactile feedback and accessibility for modal controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,7 @@
 ## 2025-06-28 - Keyboard Parity for Interactive List Items
 **Learning:** Facet filters and list items often use `div` elements for layout flexibility, but they must implement `role="button"`, `tabIndex={0}`, and `onKeyDown` handlers to be accessible. Adding `framer-motion`'s `whileTap` provides the tactile feedback users expect from native interactive elements.
 **Action:** When converting static list items to interactive ones, ensure full keyboard parity and use micro-interactions (like subtle scaling) to signal interactivity.
+
+## 2026-07-02 - Refined Tactile Feedback for Desktop Controls
+**Learning:** While 0.85 scale is suitable for very small/nested icons, a more conservative 0.9 scale is better for prominent header and window controls on desktop. It provides clear physical feedback without feeling overly "squishy." Additionally, always pair these interactions with clear focus indicators (e.g., `focus-visible:ring-2`) to maintain accessibility standards when modifying custom interactive elements.
+**Action:** Use 0.9 scale for primary modal/window controls and ensure focus-visible rings are present.

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -3309,51 +3309,56 @@ const ImageModal: React.FC<ImageModalProps> = ({
             </div>
 
             <div className="flex items-center gap-2">
-              <button
+              <motion.button
                 onClick={handleDelete}
+                whileTap={{ scale: 0.9 }}
                 onPointerDown={(event) => event.stopPropagation()}
                 disabled={isIndexing}
-                className="rounded-lg border border-red-500/30 bg-red-500/10 p-1.5 text-red-400 transition-colors hover:border-red-500/50 hover:bg-red-500/15 hover:text-red-300 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
+                className="rounded-lg border border-red-500/30 bg-red-500/10 p-1.5 text-red-400 transition-colors hover:border-red-500/50 hover:bg-red-500/15 hover:text-red-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
                 title={isIndexing ? 'Cannot delete during indexing' : 'Delete image'}
                 aria-label={isIndexing ? 'Cannot delete during indexing' : 'Delete image'}
               >
                 <Trash2 className="w-3.5 h-3.5" />
-              </button>
-              <button
+              </motion.button>
+              <motion.button
                 onClick={() => setIsRenaming(true)}
+                whileTap={{ scale: 0.9 }}
                 onPointerDown={(event) => event.stopPropagation()}
                 disabled={isIndexing}
-                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-orange-300 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
+                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-orange-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
                 title={isIndexing ? 'Cannot rename during indexing' : 'Rename image'}
                 aria-label={isIndexing ? 'Cannot rename during indexing' : 'Rename image'}
               >
                 <Pencil className="w-3.5 h-3.5" />
-              </button>
-              <button
+              </motion.button>
+              <motion.button
                 onClick={() => void handleMinimizeWithAnimation()}
+                whileTap={{ scale: 0.9 }}
                 onPointerDown={(event) => event.stopPropagation()}
-                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white"
+                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 title="Minimize window"
               >
                 <Minus className="w-3.5 h-3.5" />
-              </button>
-              <button
+              </motion.button>
+              <motion.button
                 onClick={toggleWindowMaximize}
+                whileTap={{ scale: 0.9 }}
                 onPointerDown={(event) => event.stopPropagation()}
-                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white"
+                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 title={isWindowMaximized ? 'Restore window' : 'Maximize window'}
               >
                 {isWindowMaximized ? <Minimize2 className="w-3.5 h-3.5" /> : <Maximize2 className="w-3.5 h-3.5" />}
-              </button>
-              <button
+              </motion.button>
+              <motion.button
                 onClick={onClose}
+                whileTap={{ scale: 0.9 }}
                 onPointerDown={(event) => event.stopPropagation()}
-                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white"
+                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 aria-label="Close image"
                 title="Close (Esc)"
               >
                 <X className="w-3.5 h-3.5" />
-              </button>
+              </motion.button>
             </div>
           </div>
         )}


### PR DESCRIPTION
What: Replaced standard buttons in the ImageModal header with motion.button elements. Added tactile feedback using whileTap scale of 0.9 and improved keyboard accessibility by adding focus-visible rings.

Why: The header controls (Delete, Rename, Minimize, Maximize, Close) lacked physical feedback upon interaction, making the UI feel static. They also lacked clear focus indicators for keyboard navigation.

Accessibility: Added focus-visible:ring-2 focus-visible:ring-blue-500 to ensure keyboard users can clearly identify the focused control.

---
*PR created automatically by Jules for task [15022424823958895061](https://jules.google.com/task/15022424823958895061) started by @LuqP2*