### PR TITLE
Standardize icon button tactile feedback and accessibility

### DIFF
--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -3309,51 +3309,56 @@ const ImageModal: React.FC<ImageModalProps> = ({
             </div>
 
             <div className="flex items-center gap-2">
-              <button
+              <motion.button
                 onClick={handleDelete}
                 onPointerDown={(event) => event.stopPropagation()}
+                whileTap={{ scale: 0.85 }}
                 disabled={isIndexing}
-                className="rounded-lg border border-red-500/30 bg-red-500/10 p-1.5 text-red-400 transition-colors hover:border-red-500/50 hover:bg-red-500/15 hover:text-red-300 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
+                className="rounded-lg border border-red-500/30 bg-red-500/10 p-1.5 text-red-400 transition-colors hover:border-red-500/50 hover:bg-red-500/15 hover:text-red-300 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                 title={isIndexing ? 'Cannot delete during indexing' : 'Delete image'}
                 aria-label={isIndexing ? 'Cannot delete during indexing' : 'Delete image'}
               >
                 <Trash2 className="w-3.5 h-3.5" />
-              </button>
-              <button
+              </motion.button>
+              <motion.button
                 onClick={() => setIsRenaming(true)}
                 onPointerDown={(event) => event.stopPropagation()}
+                whileTap={{ scale: 0.85 }}
                 disabled={isIndexing}
-                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-orange-300 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
+                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-orange-300 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                 title={isIndexing ? 'Cannot rename during indexing' : 'Rename image'}
                 aria-label={isIndexing ? 'Cannot rename during indexing' : 'Rename image'}
               >
                 <Pencil className="w-3.5 h-3.5" />
-              </button>
-              <button
+              </motion.button>
+              <motion.button
                 onClick={() => void handleMinimizeWithAnimation()}
                 onPointerDown={(event) => event.stopPropagation()}
-                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white"
+                whileTap={{ scale: 0.85 }}
+                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                 title="Minimize window"
               >
                 <Minus className="w-3.5 h-3.5" />
-              </button>
-              <button
+              </motion.button>
+              <motion.button
                 onClick={toggleWindowMaximize}
                 onPointerDown={(event) => event.stopPropagation()}
-                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white"
+                whileTap={{ scale: 0.85 }}
+                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                 title={isWindowMaximized ? 'Restore window' : 'Maximize window'}
               >
                 {isWindowMaximized ? <Minimize2 className="w-3.5 h-3.5" /> : <Maximize2 className="w-3.5 h-3.5" />}
-              </button>
-              <button
+              </motion.button>
+              <motion.button
                 onClick={onClose}
                 onPointerDown={(event) => event.stopPropagation()}
-                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white"
+                whileTap={{ scale: 0.85 }}
+                className="rounded-lg border border-gray-700 bg-gray-800 p-1.5 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-700 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                 aria-label="Close image"
                 title="Close (Esc)"
               >
                 <X className="w-3.5 h-3.5" />
-              </button>
+              </motion.button>
             </div>
           </div>
         )}
@@ -3810,7 +3815,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
               <div className="flex w-fit items-center gap-2 rounded-lg border border-gray-700/60 bg-gray-950/30 px-2 py-1.5">
                 <motion.button
                   onClick={handleToggleFavorite}
-                  whileTap={{ scale: 0.9 }}
+                  whileTap={{ scale: 0.85 }}
                   className={`p-1 rounded transition-all focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
                     currentIsFavorite
                       ? 'text-rose-400 hover:text-rose-300'
@@ -4416,7 +4421,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   <>
                     <motion.button
                       onClick={() => setShowOriginal(!showOriginal)}
-                      whileTap={{ scale: 0.95 }}
+                      whileTap={{ scale: 0.85 }}
                       className={`p-1.5 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${showOriginal ? 'bg-blue-900/50 text-blue-300' : 'bg-gray-800 text-gray-400 hover:text-white'}`}
                       title={showOriginal ? "Back to Edited" : "See Original"}
                       aria-label={showOriginal ? "Back to Edited" : "See Original"}
@@ -4429,7 +4434,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                           deleteShadowMetadata();
                         }
                       }}
-                      whileTap={{ scale: 0.95 }}
+                      whileTap={{ scale: 0.85 }}
                       className="p-1.5 bg-gray-800 hover:bg-red-900/50 rounded-md transition-colors text-gray-400 hover:text-red-400 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                       title="Revert to Original (Delete Edits)"
                       aria-label="Revert to Original (Delete Edits)"
@@ -4440,7 +4445,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 )}
                 <motion.button
                   onClick={() => setIsMetadataEditorOpen(true)}
-                  whileTap={{ scale: 0.95 }}
+                  whileTap={{ scale: 0.85 }}
                   className="p-1.5 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors text-gray-400 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                   title="Edit Metadata (Shadow)"
                   aria-label="Edit Metadata (Shadow)"
@@ -4449,7 +4454,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 </motion.button>
                 <motion.button
                   onClick={openBatchExport}
-                  whileTap={{ scale: 0.95 }}
+                  whileTap={{ scale: 0.85 }}
                   className="p-1.5 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors text-gray-400 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                   title={exportSelectionIds.size > 1 && !canUseBatchExport && initialized ? 'Pro feature - start trial' : 'Open export flow'}
                   aria-label={exportSelectionIds.size > 1 && !canUseBatchExport && initialized ? 'Pro feature - start trial' : 'Open export flow'}

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -616,7 +616,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
             <div className="flex w-fit items-center gap-2 rounded-lg border border-gray-200 bg-white/70 px-2 py-1.5 dark:border-gray-700/60 dark:bg-gray-950/30">
               <motion.button
                 onClick={handleToggleFavorite}
-                whileTap={{ scale: 0.9 }}
+                whileTap={{ scale: 0.85 }}
                 className={`p-1 rounded transition-all focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
                   activeImage.isFavorite
                     ? 'text-rose-400 hover:text-rose-300'
@@ -735,7 +735,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 {shadowMetadata && (
                   <motion.button
                     onClick={() => setShowOriginal((current) => !current)}
-                    whileTap={{ scale: 0.95 }}
+                    whileTap={{ scale: 0.85 }}
                     className={`p-1.5 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${showOriginal ? 'bg-blue-900/50 text-blue-300' : 'bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-900 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white'}`}
                     title={showOriginal ? 'Show edited metadata' : 'Show original metadata'}
                     aria-label={showOriginal ? 'Show edited metadata' : 'Show original metadata'}
@@ -745,7 +745,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 )}
                 <motion.button
                   onClick={() => setIsMetadataEditorOpen(true)}
-                  whileTap={{ scale: 0.95 }}
+                  whileTap={{ scale: 0.85 }}
                   className="p-1.5 rounded-md transition-colors bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-900 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                   title="Edit metadata overrides"
                   aria-label="Edit metadata overrides"
@@ -754,7 +754,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 </motion.button>
                 <motion.button
                   onClick={openBatchExport}
-                  whileTap={{ scale: 0.95 }}
+                  whileTap={{ scale: 0.85 }}
                   className="p-1.5 rounded-md transition-colors bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-900 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                   title={exportSelectionIds.size > 1 && !canUseBatchExport && initialized ? 'Pro feature - start trial' : 'Open export flow'}
                   aria-label={exportSelectionIds.size > 1 && !canUseBatchExport && initialized ? 'Pro feature - start trial' : 'Open export flow'}

--- a/components/RatingStars.tsx
+++ b/components/RatingStars.tsx
@@ -101,7 +101,7 @@ const RatingStars: React.FC<RatingStarsProps> = ({
             type="button"
             disabled={!isInteractive}
             whileHover={isInteractive ? { scale: 1.1 } : {}}
-            whileTap={isInteractive ? { scale: 0.95 } : {}}
+            whileTap={isInteractive ? { scale: 0.85 } : {}}
             onMouseEnter={() => {
               if (isInteractive) {
                 setHoverRating(value);


### PR DESCRIPTION
This change improves the overall tactile consistency and accessibility of the interface by standardizing micro-interactions for icon-only buttons.

What:
- Standardized whileTap scale to 0.85 for icon-only buttons in ImageModal, ImagePreviewSidebar, and RatingStars.
- Added focus-visible:ring-2 focus-visible:ring-blue-500 to Title Bar buttons in ImageModal.
- Converted Title Bar buttons to motion.button.

Why:
- The UI had inconsistent tap feedback scales (ranging from 0.9 to 0.95), making the physical feel of the interface disjointed.
- Title Bar buttons were missing clear visual focus indicators, hindering keyboard navigation.

Impact:
- A more predictable and satisfying tactile experience when interacting with small controls.
- Improved accessibility for users navigating with a keyboard.

Accessibility:
- Title Bar controls are now easily identifiable when focused via keyboard.
- Maintained existing ARIA labels and roles.

---
*PR created automatically by Jules for task [12185316660379406678](https://jules.google.com/task/12185316660379406678) started by @LuqP2*