### PR TITLE
Enhance ImageCard action buttons with tactile feedback and focus visibility

### DIFF
--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -3,6 +3,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
+import { motion } from 'framer-motion';
 import { type IndexedImage, type BaseMetadata, type Directory, ImageStack, SmartCollection } from '../types';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
@@ -493,12 +494,13 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
         draggable={canDragImage}
       >
         {/* box for selection - always visible on hover or when selected */}
-        <button
+        <motion.button
           onClick={handleboxClick}
-          className={`absolute top-2 left-2 z-20 p-1 rounded transition-all focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+          whileTap={{ scale: 0.85 }}
+          className={`absolute top-2 left-2 z-20 p-1 rounded transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
             isSelected
               ? 'bg-blue-500 text-white opacity-100'
-              : 'bg-black/50 text-white opacity-0 group-hover:opacity-100 hover:bg-blue-500/80'
+              : `bg-black/50 text-white opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-blue-500/80 ${isFocused ? 'opacity-100' : ''}`
           }`}
           title={isSelected ? 'Deselect image' : 'Select image'}
           aria-label={isSelected ? 'Deselect image' : 'Select image'}
@@ -508,7 +510,7 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
           ) : (
             <Square className="h-5 w-5" />
           )}
-        </button>
+        </motion.button>
 
         {/* Deduplication: Best badge */}
         {isMarkedBest && (
@@ -531,40 +533,43 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
             Compare #1
           </div>
         )}
-        <button
+        <motion.button
           onClick={handlePreviewClick}
-          className="absolute top-11 left-2 z-10 p-1.5 bg-black/50 rounded-full text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:opacity-100"
+          whileTap={{ scale: 0.85 }}
+          className={`absolute top-11 left-2 z-10 p-1.5 bg-black/50 rounded-full text-white transition-opacity hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:opacity-100 opacity-0 group-hover:opacity-100 ${isFocused ? 'opacity-100' : ''}`}
           title="Show details"
           aria-label="Show details"
         >
           <Info className="h-4 w-4" />
-        </button>
+        </motion.button>
 
-        <button
+        <motion.button
           onClick={handleFavoriteClick}
-          className={`absolute top-2 right-2 z-10 p-1.5 rounded-full transition-all focus:outline-none focus:ring-2 focus:ring-rose-500 focus:opacity-100 ${
+          whileTap={{ scale: 0.85 }}
+          className={`absolute top-2 right-2 z-10 p-1.5 rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:opacity-100 ${
             image.isFavorite
               ? 'bg-rose-500/85 text-white opacity-100 hover:bg-rose-600'
-              : 'bg-black/50 text-white opacity-0 group-hover:opacity-100 hover:bg-rose-500'
+              : `bg-black/50 text-white opacity-0 group-hover:opacity-100 hover:bg-rose-500 ${isFocused ? 'opacity-100' : ''}`
           }`}
           title={image.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
           aria-label={image.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
         >
           <Heart className={`h-4 w-4 ${image.isFavorite ? 'fill-current' : ''}`} />
-        </button>
-        <button
+        </motion.button>
+        <motion.button
           onClick={handleCopyClick}
-          className={`absolute top-2 right-11 z-10 p-1.5 rounded-full transition-all focus:outline-none focus:ring-2 focus:ring-green-500 focus:opacity-100 ${
+          whileTap={{ scale: 0.85 }}
+          className={`absolute top-2 right-11 z-10 p-1.5 rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:opacity-100 ${
             copied
               ? 'bg-green-600 text-white opacity-100'
-              : 'bg-black/50 text-white opacity-0 group-hover:opacity-100 hover:bg-green-500'
+              : `bg-black/50 text-white opacity-0 group-hover:opacity-100 hover:bg-green-500 ${isFocused ? 'opacity-100' : ''}`
           }`}
           title={copied ? 'Copied!' : 'Copy Prompt'}
           aria-label={copied ? 'Copied!' : 'Copy Prompt'}
           disabled={!image.prompt}
         >
           {copied ? <CheckCircle className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-        </button>
+        </motion.button>
 
         {hasThumbnailError ? (
           <div className="w-full h-full flex items-center justify-center bg-gray-900">


### PR DESCRIPTION
What: Added tactile feedback and improved keyboard accessibility to ImageCard action buttons. Specifically, converted buttons to `motion.button` with `whileTap={{ scale: 0.85 }}`, added standard `focus-visible:ring-2` focus rings, and ensured buttons are visible when the parent card is focused via keyboard.

Why: The previous implementation relied solely on hover for button visibility, making these actions inaccessible to keyboard-only users. Additionally, the buttons lacked visual feedback on interaction, making the interface feel less responsive.

Before/After: Buttons were invisible to keyboard users and static on click. Now, they appear automatically during tab navigation and provide a subtle 'squish' effect when clicked or tapped. Verified with screenshots showing the focus rings and visibility in the focused state.

Accessibility: Added `focus-visible:opacity-100` and JS-driven focus visibility to ensure all action buttons are discoverable and usable without a mouse. Standardized focus ring colors for each action (Blue for Selection/Info, Rose for Favorite, Green for Copy) to provide clear visual cues.

---
*PR created automatically by Jules for task [5257693601898130882](https://jules.google.com/task/5257693601898130882) started by @LuqP2*