### PR TITLE
Optimize unique period count in analytics

### DIFF
--- a/__tests__/analytics-utils.test.ts
+++ b/__tests__/analytics-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildAnalyticsExplorerData, calculateTopItems, truncateName } from '../utils/analyticsUtils';
+import { buildAnalyticsExplorerData, calculateTopItems, getUniquePeriodCount, truncateName } from '../utils/analyticsUtils';
 import { type IndexedImage } from '../types';
 
 const createImage = (overrides: Partial<IndexedImage>): IndexedImage => ({
@@ -99,5 +99,29 @@ describe('analyticsUtils', () => {
     // Ensure 2 and 3 star ratings are NOT in distribution (count 0)
     expect(dist.find(d => d.key === '2')).toBeUndefined();
     expect(dist.find(d => d.key === '3')).toBeUndefined();
+  });
+
+  describe('getUniquePeriodCount', () => {
+    it('correctly counts unique models in a period', () => {
+      const now = Date.now();
+      const images: IndexedImage[] = [
+        createImage({ id: '1', models: ['Model A', 'Model B'], lastModified: now }),
+        createImage({ id: '2', models: ['Model A'], lastModified: now }),
+        createImage({ id: '3', models: ['Model C'], lastModified: now - 60 * 24 * 60 * 60 * 1000 }), // Outside 30 days
+      ];
+
+      expect(getUniquePeriodCount(images, 'models', 30)).toBe(2); // Model A, Model B
+    });
+
+    it('correctly counts unique loras in a period', () => {
+      const now = Date.now();
+      const images: IndexedImage[] = [
+        createImage({ id: '1', loras: ['Lora A', 'Lora B'], lastModified: now }),
+        createImage({ id: '2', loras: [{ name: 'Lora A' } as any], lastModified: now }),
+        createImage({ id: '3', loras: ['Lora C'], lastModified: now }),
+      ];
+
+      expect(getUniquePeriodCount(images, 'loras', 30)).toBe(3); // Lora A, Lora B, Lora C
+    });
   });
 });

--- a/utils/analyticsUtils.ts
+++ b/utils/analyticsUtils.ts
@@ -167,15 +167,24 @@ export function getUniquePeriodCount(
   const periodStart = now - daysBack * 24 * 60 * 60 * 1000;
 
   const uniqueItems = new Set<string>();
-  images
-    .filter((img) => img.lastModified >= periodStart)
-    .forEach((img) => {
-      const items = Array.isArray(img[field]) ? img[field] : [img[field]];
-      items.forEach((item) => {
-        const normalizedItem = normalizeItemName(item);
+
+  // Optimization: Single-pass O(N) loop to avoid intermediate array allocations and GC pressure.
+  // Impact: Improves performance for large libraries by eliminating .filter() and .forEach() overhead.
+  for (let i = 0; i < images.length; i++) {
+    const img = images[i];
+    if (img.lastModified >= periodStart) {
+      const items = img[field];
+      if (Array.isArray(items)) {
+        for (let j = 0; j < items.length; j++) {
+          const normalizedItem = normalizeItemName(items[j]);
+          if (normalizedItem) uniqueItems.add(normalizedItem);
+        }
+      } else {
+        const normalizedItem = normalizeItemName(items);
         if (normalizedItem) uniqueItems.add(normalizedItem);
-      });
-    });
+      }
+    }
+  }
 
   return uniqueItems.size;
 }


### PR DESCRIPTION
What: Optimized the getUniquePeriodCount function in utils/analyticsUtils.ts by replacing a .filter().forEach() chain with a single O(N) for loop.

Why: The previous implementation created intermediate arrays during filtering and wrapping values, which increased memory churn and garbage collection pressure in analytics hot paths.

Impact: Improves performance and reduces memory allocations when generating analytics insights, particularly beneficial for users with large datasets.

Measurement: Verified with existing and new unit tests in __tests__/analytics-utils.test.ts. All tests passed.

---
*PR created automatically by Jules for task [9220919189585439012](https://jules.google.com/task/9220919189585439012) started by @LuqP2*