### PR TITLE
fix: re-read full file when PNG head-read truncates metadata (#448)

### DIFF
--- a/__tests__/fileIndexer.png-truncation.test.ts
+++ b/__tests__/fileIndexer.png-truncation.test.ts
@@ -54,6 +54,20 @@ function buildLargeComfyWorkflowJson(approxBytes: number): string {
   });
 }
 
+/** A large IDAT (image pixel data) chunk — not metadata, just bulk bytes. */
+function buildIdatChunk(approxBytes: number): number[] {
+  const size = Math.max(0, approxBytes);
+  const lengthBytes = [
+    (size >>> 24) & 0xff,
+    (size >>> 16) & 0xff,
+    (size >>> 8) & 0xff,
+    size & 0xff,
+  ];
+  const typeBytes = Array.from(Buffer.from('IDAT', 'latin1'));
+  const data = new Array(size).fill(0x7a);
+  return [...lengthBytes, ...typeBytes, ...data, 0, 0, 0, 0];
+}
+
 function buildPng(chunks: number[][]): ArrayBuffer {
   const bytes = [...PNG_SIGNATURE, ...buildIhdrChunk(), ...chunks.flat(), ...buildIendChunk()];
   return new Uint8Array(bytes).buffer;
@@ -112,5 +126,27 @@ describe('parsePNGMetadata head-read truncation handling (issue #448)', () => {
 
     expect(truncationInfo.truncated).toBe(false);
     expect(result == null).toBe(true);
+  });
+
+  it('does NOT flag truncated when only a trailing IDAT (image data) is cut off', async () => {
+    // Metadata chunk parses fully; a large IDAT chunk follows and overruns the
+    // head-read buffer. Since IDAT carries no metadata, truncation must stay false
+    // so the head-read optimization is not defeated (regression guard for the
+    // Codex review on #464).
+    const promptChunk = buildTextChunk('prompt', buildComfyPromptJson());
+    const idatChunk = buildIdatChunk(80 * 1024);
+    const fullBuffer = buildPng([promptChunk, idatChunk]);
+
+    const HEAD_READ_MAX_BYTES = 64 * 1024;
+    const truncatedBuffer = fullBuffer.slice(0, Math.min(HEAD_READ_MAX_BYTES, fullBuffer.byteLength));
+    expect(truncatedBuffer.byteLength).toBeLessThan(fullBuffer.byteLength);
+
+    const truncationInfo = { truncated: false };
+    const result = await parsePNGMetadata(truncatedBuffer, truncationInfo);
+
+    // The prompt metadata was found; the cut-off IDAT must not be treated as
+    // metadata truncation.
+    expect(truncationInfo.truncated).toBe(false);
+    expect(result && 'prompt' in result).toBe(true);
   });
 });

--- a/__tests__/fileIndexer.png-truncation.test.ts
+++ b/__tests__/fileIndexer.png-truncation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { parsePNGMetadata } from '../services/fileIndexer';
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/**
+ * Builds a raw tEXt chunk: length(4) + type('tEXt') + keyword + 0x00 + text + crc(4, dummy).
+ * parsePNGMetadata never validates the CRC, so any 4 bytes are fine there.
+ */
+function buildTextChunk(keyword: string, text: string): number[] {
+  const keywordBytes = Array.from(Buffer.from(keyword, 'latin1'));
+  const textBytes = Array.from(Buffer.from(text, 'utf-8'));
+  const data = [...keywordBytes, 0x00, ...textBytes];
+  const length = data.length;
+  const lengthBytes = [
+    (length >>> 24) & 0xff,
+    (length >>> 16) & 0xff,
+    (length >>> 8) & 0xff,
+    length & 0xff,
+  ];
+  const typeBytes = Array.from(Buffer.from('tEXt', 'latin1'));
+  const crcBytes = [0, 0, 0, 0]; // never checked by parsePNGMetadata
+  return [...lengthBytes, ...typeBytes, ...data, ...crcBytes];
+}
+
+function buildIendChunk(): number[] {
+  return [0, 0, 0, 0, ...Array.from(Buffer.from('IEND', 'latin1')), 0, 0, 0, 0];
+}
+
+/**
+ * Builds a minimal (fake, not spec-perfect, but good enough for this parser) IHDR chunk
+ * so the buffer starts like a real PNG. parsePNGMetadata starts walking chunks at byte 8
+ * and doesn't validate IHDR contents.
+ */
+function buildIhdrChunk(): number[] {
+  const data = new Array(13).fill(0);
+  return [0, 0, 0, 13, ...Array.from(Buffer.from('IHDR', 'latin1')), ...data, 0, 0, 0, 0];
+}
+
+/** A ComfyUI-style API prompt graph: small, and contains the class_type/inputs markers. */
+function buildComfyPromptJson(): string {
+  return JSON.stringify({
+    '1': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: 'model.safetensors' } },
+    '2': { class_type: 'KSampler', inputs: { seed: 12345, steps: 20 } },
+  });
+}
+
+/** A large ComfyUI-style UI workflow graph (no class_type keys — that's the 'prompt' chunk's job). */
+function buildLargeComfyWorkflowJson(approxBytes: number): string {
+  const filler = 'x'.repeat(Math.max(0, approxBytes));
+  return JSON.stringify({
+    last_node_id: 2,
+    nodes: [{ id: 1, type: 'CheckpointLoaderSimple', pos: [0, 0], widgets_values: [filler] }],
+  });
+}
+
+function buildPng(chunks: number[][]): ArrayBuffer {
+  const bytes = [...PNG_SIGNATURE, ...buildIhdrChunk(), ...chunks.flat(), ...buildIendChunk()];
+  return new Uint8Array(bytes).buffer;
+}
+
+describe('parsePNGMetadata head-read truncation handling (issue #448)', () => {
+  it('flags truncated=true and drops the workflow chunk when the buffer is cut off mid-file', async () => {
+    const promptJson = buildComfyPromptJson();
+    const workflowJson = buildLargeComfyWorkflowJson(80 * 1024); // ~80KB, like a complex real workflow
+
+    const promptChunk = buildTextChunk('prompt', promptJson);
+    const workflowChunk = buildTextChunk('workflow', workflowJson);
+
+    const fullBuffer = buildPng([promptChunk, workflowChunk]);
+
+    // Simulate the app's 64KB head-read optimization (HEAD_READ_MAX_BYTES in fileIndexer.ts).
+    const HEAD_READ_MAX_BYTES = 64 * 1024;
+    const truncatedBuffer = fullBuffer.slice(0, Math.min(HEAD_READ_MAX_BYTES, fullBuffer.byteLength));
+
+    // Sanity check for the test fixture itself: the workflow chunk must genuinely be cut off.
+    expect(truncatedBuffer.byteLength).toBeLessThan(fullBuffer.byteLength);
+
+    const truncationInfo = { truncated: false };
+    const partialResult = await parsePNGMetadata(truncatedBuffer, truncationInfo);
+
+    // This is the core of the fix: the parser must tell the caller it stopped early,
+    // rather than silently returning an incomplete-but-non-empty result.
+    expect(truncationInfo.truncated).toBe(true);
+
+    // The prompt chunk (small, appears first) survives; the workflow chunk (large,
+    // appears second) does not — this is exactly the shape that used to get
+    // permanently mis-cached instead of triggering a full re-read.
+    expect(partialResult).not.toBeNull();
+    expect(partialResult && 'workflow' in partialResult).toBe(false);
+  });
+
+  it('does not flag truncated when the full file is provided', async () => {
+    const promptJson = buildComfyPromptJson();
+    const workflowJson = buildLargeComfyWorkflowJson(80 * 1024);
+    const promptChunk = buildTextChunk('prompt', promptJson);
+    const workflowChunk = buildTextChunk('workflow', workflowJson);
+    const fullBuffer = buildPng([promptChunk, workflowChunk]);
+
+    const truncationInfo = { truncated: false };
+    const result = await parsePNGMetadata(fullBuffer, truncationInfo);
+
+    expect(truncationInfo.truncated).toBe(false);
+    expect(result && 'workflow' in result).toBe(true);
+  });
+
+  it('does not flag truncated for a small PNG that legitimately has no relevant metadata', async () => {
+    // No relevant tEXt chunks at all — just signature, IHDR, and IEND.
+    const buffer = buildPng([]);
+    const truncationInfo = { truncated: false };
+    const result = await parsePNGMetadata(buffer, truncationInfo);
+
+    expect(truncationInfo.truncated).toBe(false);
+    expect(result == null).toBe(true);
+  });
+});

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -487,9 +487,20 @@ export async function parsePNGMetadata(
     const length = view.getUint32(offset, false);
     const type = view.getUint32(offset + 4, false);
     if (offset + 12 + length > view.byteLength) {
-      // This chunk's declared length extends past the end of our buffer. Same
-      // reasoning as above: this chunk (and anything after it) was never inspected.
-      if (truncationInfo) truncationInfo.truncated = true;
+      // This chunk's declared length extends past the end of our buffer, so it
+      // was never inspected. Only treat this as *metadata* truncation when the
+      // chunk is one that can carry the metadata we extract (tEXt/iTXt/eXIf).
+      // A truncated IDAT (image pixel data) or other ancillary chunk does not
+      // mean we lost metadata, and flagging it would force a needless full-file
+      // re-read on nearly every PNG (IDAT is large and usually follows the text
+      // chunks), defeating the head-read optimization. If metadata genuinely
+      // lives beyond a huge truncated IDAT, no relevant chunk will have been
+      // found and the caller's "no metadata" fallback still triggers a re-read.
+      const isMetadataChunk =
+        type === PNG_CHUNK_TYPE_tEXt ||
+        type === PNG_CHUNK_TYPE_iTXt ||
+        type === PNG_CHUNK_TYPE_eXIf;
+      if (truncationInfo && isMetadataChunk) truncationInfo.truncated = true;
       break;
     }
     

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -3114,6 +3114,13 @@ export async function processFiles(
             : undefined;
           const enriched = await processSingleFileOptimized(entry.source, directoryId, buffer, profile);
           if (shouldFallbackToFullRead(entry, buffer, enriched)) {
+            // Keep the partial head-read result as a floor. The full-read fallback
+            // overwrites this on success, but when the full read is skipped —
+            // e.g. the file is over FULL_READ_FALLBACK_MAX_FILE_BYTES — we still
+            // apply whatever metadata the head parse recovered (such as a small
+            // `prompt`/`parameters` chunk before a truncated `workflow` chunk)
+            // instead of dropping the image to catalog-only.
+            resultsById.set(entry.image.id, { enriched, profile });
             fallbackEntries.push(entry);
             return null;
           }

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -3287,6 +3287,15 @@ export async function processFiles(
           if (missingEntries.has(entry.image.id)) {
             if (!blockedFromGenericFallback.has(entry.image.id)) {
               await iterator(entry);
+            } else {
+              // Blocked from the full-read fallback (server reported the file/batch
+              // too large). We can't re-read, but a partial head-read floor may have
+              // been recorded before the fallback was attempted — apply it instead of
+              // dropping the image to catalog-only.
+              const result = resultsById.get(entry.image.id);
+              if (result) {
+                await applyMergedEntry(entry, result.enriched, result.profile, queue.length);
+              }
             }
             continue;
           }

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -453,7 +453,19 @@ async function tryReadEasyDiffusionSidecarJson(imagePath: string, absolutePath?:
 }
 
 // Main parsing function for PNG files
-async function parsePNGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | null> {
+//
+// `truncationInfo`, when provided, is populated with `truncated: true` if the chunk
+// walk had to stop early because a chunk's declared length ran past the end of the
+// buffer we were given — i.e. `buffer` is a partial ("head read") slice of a larger
+// file, not the whole PNG. This is distinct from a clean stop at IEND or from hitting
+// the `maxChunks` early-exit optimization, both of which are NOT truncation and leave
+// `truncated` as `false`. Callers use this to decide whether it's safe to trust a
+// "no relevant metadata found" (or incomplete) result, or whether they need to re-read
+// the full file to get chunks (e.g. a large ComfyUI `workflow` chunk) that were cut off.
+export async function parsePNGMetadata(
+  buffer: ArrayBuffer,
+  truncationInfo?: { truncated: boolean }
+): Promise<ImageMetadata | null> {
   const view = new DataView(buffer);
   let offset = 8;
   const decoder = new TextDecoder();
@@ -466,11 +478,18 @@ async function parsePNGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | nu
 
   while (offset < view.byteLength && foundChunks < maxChunks) {
     if (offset + 8 > view.byteLength) {
+      // Not enough bytes left even for a chunk header. If this buffer is a partial
+      // head-read of a larger file, there could be more (unread) chunks beyond this
+      // point — flag it so the caller can decide to re-read the full file.
+      if (truncationInfo) truncationInfo.truncated = true;
       break;
     }
     const length = view.getUint32(offset, false);
     const type = view.getUint32(offset + 4, false);
     if (offset + 12 + length > view.byteLength) {
+      // This chunk's declared length extends past the end of our buffer. Same
+      // reasoning as above: this chunk (and anything after it) was never inspected.
+      if (truncationInfo) truncationInfo.truncated = true;
       break;
     }
     
@@ -1384,6 +1403,12 @@ async function processSingleFileOptimized(
     let sidecarJson: EasyDiffusionJson | null = null;
     let bufferForDimensions: ArrayBuffer | undefined;
     let fileSizeValue: number | undefined = fileEntry.size;
+    // Set to true if parsePNGMetadata had to stop scanning chunks early because a
+    // chunk overran the buffer we gave it. Threaded through to the returned
+    // IndexedImage (`_metadataTruncated`) so the Phase B enrichment loop can tell
+    // "genuinely no metadata" apart from "metadata chunk was cut off mid-file" and
+    // decide whether a full-file re-read is needed.
+    const pngTruncationInfo = { truncated: false };
     const inferredType = fileEntry.type ?? inferMimeTypeFromName(fileEntry.handle.name);
     const isVideo = isVideoFileName(fileEntry.handle.name) || inferredType.startsWith('video/');
     const isAudio = isAudioFileName(fileEntry.handle.name) || inferredType.startsWith('audio/');
@@ -1400,7 +1425,7 @@ async function processSingleFileOptimized(
       const view = new DataView(fileData);
       const detectedType = detectImageType(view);
       if (detectedType === 'png') {
-        rawMetadata = await parsePNGMetadata(fileData);
+        rawMetadata = await parsePNGMetadata(fileData, pngTruncationInfo);
       } else if (detectedType === 'jpeg') {
         rawMetadata = await parseJPEGMetadata(fileData);
       } else if (detectedType === 'webp') {
@@ -1430,7 +1455,7 @@ async function processSingleFileOptimized(
       const view = new DataView(fileData);
       const detectedType = detectImageType(view);
       if (detectedType === 'png') {
-        rawMetadata = await parsePNGMetadata(fileData);
+        rawMetadata = await parsePNGMetadata(fileData, pngTruncationInfo);
       } else if (detectedType === 'jpeg') {
         rawMetadata = await parseJPEGMetadata(fileData);
       } else if (detectedType === 'webp') {
@@ -1765,6 +1790,7 @@ if (normalizedMetadata && isVideo) {
       workflowNodes,
       fileSize: normalizedFileSize,
       fileType: normalizedFileType,
+      _metadataTruncated: pngTruncationInfo.truncated,
     } as IndexedImage;
   } catch (error) {
     console.error(`Skipping file ${fileEntry.handle.name} due to an error:`, error);
@@ -2939,13 +2965,24 @@ export async function processFiles(
       if (!fileSize || fileSize <= buffer.byteLength) {
         return false;
       }
+      const fileType = entry.source.type ?? inferMimeTypeFromName(entry.source.handle.name);
+      if (fileType !== 'image/png') {
+        return false;
+      }
+      // Explicit signal: the head-read buffer cut a chunk off mid-file (e.g. a large
+      // ComfyUI `workflow`/`prompt` chunk). Whatever `enriched` we got from the partial
+      // buffer may look non-empty (another, smaller chunk may have parsed fine) but is
+      // still incomplete/wrong, so we must always re-read the full file in that case —
+      // regardless of whether metadata happens to be present.
+      if (enriched?._metadataTruncated) {
+        return true;
+      }
       const hasMetadata = Boolean(enriched?.metadataString) ||
         (enriched?.metadata && Object.keys(enriched.metadata).length > 0);
       if (hasMetadata) {
         return false;
       }
-      const fileType = entry.source.type ?? inferMimeTypeFromName(entry.source.handle.name);
-      return fileType === 'image/png';
+      return true;
     };
 
     const shouldCheckTailForMetaHub = (

--- a/types.ts
+++ b/types.ts
@@ -967,6 +967,13 @@ export interface IndexedImage {
   clusterPosition?: number;      // Position within cluster (0 = cover image)
   autoTags?: string[];           // Auto-generated tags from TF-IDF
   autoTagsGeneratedAt?: number;  // Timestamp of tag generation
+
+  // Internal indexing-pipeline signal only. Set when the embedded metadata was parsed
+  // from a partial ("head read") buffer and the PNG chunk walk had to stop before
+  // reaching IEND because a chunk extended past the bytes we had in memory. Never
+  // persisted to the on-disk cache (see mapIndexedImageToCache) — used only to decide
+  // whether Phase B enrichment should fall back to reading the whole file.
+  _metadataTruncated?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What
Fixes #448 — ComfyUI workflows larger than ~50 KB were parsed incorrectly (wrong generator/sampler/analytics, missing `workflow` chunk), while "Reparse Metadata" always worked.

## Why
The indexing pipeline uses a 64 KB head-read optimization. Large PNG `workflow`/`prompt` tEXt chunks get cut off mid-file, so metadata is parsed from a partial buffer and then cached in that broken state. "Reparse Metadata" worked only because it reads the whole file.

## How
- `parsePNGMetadata` now reports (via an optional `truncationInfo`) when the chunk walk stops early because a chunk's declared length overran the buffer — distinct from a clean stop at IEND or the `maxChunks` early-exit.
- This is threaded through `processSingleFileOptimized` as an internal `_metadataTruncated` flag (never persisted to the on-disk cache) so Phase B enrichment forces a full-file re-read for truncated PNGs — regardless of whether a smaller chunk happened to parse.

## Tests
Adds `__tests__/fileIndexer.png-truncation.test.ts` covering truncated / full / no-metadata cases. Full suite (499 tests) + typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)