### PR TITLE
feat: Create New Folder in the Move/Copy To panel (#463)

### DIFF
--- a/__tests__/TransferImagesModal.createFolder.test.tsx
+++ b/__tests__/TransferImagesModal.createFolder.test.tsx
@@ -71,6 +71,34 @@ describe('TransferImagesModal — Create New Folder', () => {
     expect(createSubfolder).not.toHaveBeenCalled();
   });
 
+  it('keeps a created folder when a slow subfolder scan resolves afterwards', async () => {
+    let resolveList: (value: unknown) => void = () => {};
+    const listPromise = new Promise((resolve) => { resolveList = resolve; });
+    (window as any).electronAPI = {
+      listSubfolders: vi.fn().mockReturnValue(listPromise),
+      createSubfolder: vi.fn().mockResolvedValue({
+        success: true,
+        folder: { name: 'Keepers', path: '/root/Renders/Keepers', realPath: '/root/Renders/Keepers' },
+      }),
+    };
+
+    render(<TransferImagesModal {...baseProps} />);
+    // Root option is available immediately, before the (still pending) scan.
+    await screen.findByText('Renders');
+
+    fireEvent.click(screen.getByText('New folder'));
+    fireEvent.change(screen.getByPlaceholderText('Folder name'), { target: { value: 'Keepers' } });
+    fireEvent.click(screen.getByText('Create'));
+    await screen.findByText('Keepers');
+
+    // The slow scan now finishes with an older set that does not include the new folder.
+    resolveList({ success: true, subfolders: [{ name: 'Old', path: '/root/Renders/Old', realPath: '/root/Renders/Old' }] });
+    await screen.findByText('Old');
+
+    // The just-created folder must survive the scan replacing subfolderOptions.
+    expect(screen.getByText('Keepers')).toBeTruthy();
+  });
+
   it('surfaces a backend error (e.g. duplicate folder)', async () => {
     createSubfolder.mockResolvedValueOnce({ success: false, error: 'A folder with that name already exists.' });
     render(<TransferImagesModal {...baseProps} />);

--- a/__tests__/TransferImagesModal.createFolder.test.tsx
+++ b/__tests__/TransferImagesModal.createFolder.test.tsx
@@ -99,6 +99,27 @@ describe('TransferImagesModal — Create New Folder', () => {
     expect(screen.getByText('Keepers')).toBeTruthy();
   });
 
+  it('derives the relative path from the selected parent even if the backend returns a resolved (symlink) path', async () => {
+    // Simulate the IPC resolving the parent's realpath: the returned folder.path
+    // is NOT a textual child of the root directory. The new option must still get
+    // a correct, non-empty relative path derived from the selected parent.
+    createSubfolder.mockResolvedValueOnce({
+      success: true,
+      folder: { name: 'Keepers', path: '/mnt/real-target/Keepers', realPath: '/mnt/real-target/Keepers' },
+    });
+
+    render(<TransferImagesModal {...baseProps} />);
+    await screen.findByText('Renders');
+
+    fireEvent.click(screen.getByText('New folder'));
+    fireEvent.change(screen.getByPlaceholderText('Folder name'), { target: { value: 'Keepers' } });
+    fireEvent.click(screen.getByText('Create'));
+
+    // The row renders its relativePath as the label; it must be 'Keepers', not empty.
+    const label = await screen.findByText('Keepers');
+    expect(label).toBeTruthy();
+  });
+
   it('surfaces a backend error (e.g. duplicate folder)', async () => {
     createSubfolder.mockResolvedValueOnce({ success: false, error: 'A folder with that name already exists.' });
     render(<TransferImagesModal {...baseProps} />);

--- a/__tests__/TransferImagesModal.createFolder.test.tsx
+++ b/__tests__/TransferImagesModal.createFolder.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import TransferImagesModal from '../components/TransferImagesModal';
+import type { Directory } from '../types';
+
+const directory = {
+  id: 'dir-1',
+  name: 'Renders',
+  path: '/root/Renders',
+} as unknown as Directory;
+
+const baseProps = {
+  isOpen: true,
+  images: [],
+  directories: [directory],
+  mode: 'move' as const,
+  isSubmitting: false,
+  onClose: () => {},
+  onConfirm: () => {},
+};
+
+describe('TransferImagesModal — Create New Folder', () => {
+  let createSubfolder: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createSubfolder = vi.fn().mockResolvedValue({
+      success: true,
+      folder: { name: 'Keepers', path: '/root/Renders/Keepers', realPath: '/root/Renders/Keepers' },
+    });
+    (window as any).electronAPI = {
+      listSubfolders: vi.fn().mockResolvedValue({ success: true, subfolders: [] }),
+      createSubfolder,
+    };
+  });
+
+  afterEach(() => {
+    delete (window as any).electronAPI;
+  });
+
+  it('creates a subfolder under the selected destination and selects it', async () => {
+    render(<TransferImagesModal {...baseProps} />);
+
+    // Wait for the root option to be present and selected.
+    await screen.findByText('Renders');
+
+    fireEvent.click(screen.getByText('New folder'));
+
+    const input = screen.getByPlaceholderText('Folder name') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Keepers' } });
+    fireEvent.click(screen.getByText('Create'));
+
+    await waitFor(() => {
+      expect(createSubfolder).toHaveBeenCalledWith('/root/Renders', 'Keepers');
+    });
+
+    // The new folder shows up as a destination option.
+    await screen.findByText('Keepers');
+  });
+
+  it('shows a validation error for an invalid name without calling the API', async () => {
+    render(<TransferImagesModal {...baseProps} />);
+    await screen.findByText('Renders');
+
+    fireEvent.click(screen.getByText('New folder'));
+    const input = screen.getByPlaceholderText('Folder name');
+    fireEvent.change(input, { target: { value: 'bad/name' } });
+    fireEvent.click(screen.getByText('Create'));
+
+    await screen.findByText('Folder name contains invalid characters.');
+    expect(createSubfolder).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a backend error (e.g. duplicate folder)', async () => {
+    createSubfolder.mockResolvedValueOnce({ success: false, error: 'A folder with that name already exists.' });
+    render(<TransferImagesModal {...baseProps} />);
+    await screen.findByText('Renders');
+
+    fireEvent.click(screen.getByText('New folder'));
+    fireEvent.change(screen.getByPlaceholderText('Folder name'), { target: { value: 'Keepers' } });
+    fireEvent.click(screen.getByText('Create'));
+
+    await screen.findByText('A folder with that name already exists.');
+  });
+});

--- a/__tests__/folderName.test.ts
+++ b/__tests__/folderName.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { validateFolderName } from '../utils/folderName';
+
+describe('validateFolderName', () => {
+  it('accepts ordinary names, including spaces and hyphens', () => {
+    for (const name of ['renders', 'My Folder', 'text-to-image', 'v2_final', 'SDXL 1.0']) {
+      const result = validateFolderName(name);
+      expect(result.ok, name).toBe(true);
+      expect(result.value).toBe(name);
+    }
+  });
+
+  it('trims surrounding whitespace', () => {
+    const result = validateFolderName('  keepers  ');
+    expect(result.ok).toBe(true);
+    expect(result.value).toBe('keepers');
+  });
+
+  it('rejects empty or whitespace-only names', () => {
+    expect(validateFolderName('').ok).toBe(false);
+    expect(validateFolderName('   ').ok).toBe(false);
+  });
+
+  it('rejects path separators and traversal', () => {
+    for (const name of ['a/b', 'a\\b', '..', '.', '../escape', 'nested/deep']) {
+      expect(validateFolderName(name).ok, name).toBe(false);
+    }
+  });
+
+  it('rejects Windows-illegal punctuation and control chars', () => {
+    for (const name of ['a<b', 'a>b', 'a:b', 'a"b', 'a|b', 'a?b', 'a*b', 'tab\there']) {
+      expect(validateFolderName(name).ok, name).toBe(false);
+    }
+  });
+
+  it('rejects a trailing dot (silently stripped by Windows)', () => {
+    expect(validateFolderName('folder.').ok).toBe(false);
+    expect(validateFolderName('a.b.c.').ok).toBe(false);
+    // A trailing space is removed by the leading trim, so it is not itself a failure.
+    expect(validateFolderName('folder ').value).toBe('folder');
+  });
+
+  it('rejects reserved device names case-insensitively', () => {
+    for (const name of ['CON', 'con', 'PRN', 'nul', 'COM1', 'lpt9']) {
+      expect(validateFolderName(name).ok, name).toBe(false);
+    }
+  });
+
+  it('allows reserved-like names with extra characters', () => {
+    expect(validateFolderName('console').ok).toBe(true);
+    expect(validateFolderName('com10').ok).toBe(true);
+  });
+});

--- a/components/TransferImagesModal.tsx
+++ b/components/TransferImagesModal.tsx
@@ -244,11 +244,19 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
         return;
       }
 
-      const relativePath = getRelativePath(parentOption.rootDirectory.path, result.folder.path);
+      // Derive the relative path textually from the selected parent rather than
+      // from the backend's returned path. The IPC resolves the parent's realpath
+      // before creating, so result.folder.path may be a different (symlink target
+      // or case-normalized) string that is not a textual child of the root — which
+      // would make getRelativePath return '' and mis-record the move under the root.
+      const createdName = result.folder.name;
+      const relativePath = parentOption.relativePath
+        ? `${parentOption.relativePath}/${createdName}`
+        : createdName;
       const newOption: DestinationOption = {
         id: `${parentOption.rootDirectory.id}::${relativePath}`,
         rootDirectory: parentOption.rootDirectory,
-        name: result.folder.name,
+        name: createdName,
         path: result.folder.path,
         realPath: result.folder.realPath,
         relativePath,

--- a/components/TransferImagesModal.tsx
+++ b/components/TransferImagesModal.tsx
@@ -58,6 +58,10 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
 }) => {
   const [selectedDirectoryId, setSelectedDirectoryId] = useState<string>('');
   const [subfolderOptions, setSubfolderOptions] = useState<DestinationOption[]>([]);
+  // Folders created via "New folder" during this session. Kept separate from the
+  // scanned subfolderOptions so an in-flight loadSubfolders() cannot overwrite
+  // and lose a just-created destination.
+  const [createdFolderOptions, setCreatedFolderOptions] = useState<DestinationOption[]>([]);
   const [isLoadingSubfolders, setIsLoadingSubfolders] = useState(false);
   const [subfolderLoadError, setSubfolderLoadError] = useState<string | null>(null);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
@@ -84,12 +88,20 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
       depth: 0,
     }));
 
-    return [...rootOptions, ...subfolderOptions].sort((a, b) => {
+    // Dedupe by id so a created folder that a later scan also returns appears once.
+    const byId = new Map<string, DestinationOption>();
+    for (const option of [...rootOptions, ...subfolderOptions, ...createdFolderOptions]) {
+      if (!byId.has(option.id)) {
+        byId.set(option.id, option);
+      }
+    }
+
+    return [...byId.values()].sort((a, b) => {
       const rootCompare = a.rootDirectory.name.localeCompare(b.rootDirectory.name);
       if (rootCompare !== 0) return rootCompare;
       return a.relativePath.localeCompare(b.relativePath);
     });
-  }, [sortedDirectories, subfolderOptions]);
+  }, [sortedDirectories, subfolderOptions, createdFolderOptions]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -105,6 +117,7 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
   useEffect(() => {
     if (!isOpen) {
       setSubfolderOptions([]);
+      setCreatedFolderOptions([]);
       setIsLoadingSubfolders(false);
       setSubfolderLoadError(null);
       setIsCreatingFolder(false);
@@ -242,7 +255,7 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
         depth: parentOption.depth + 1,
       };
 
-      setSubfolderOptions((prev) => (
+      setCreatedFolderOptions((prev) => (
         prev.some((option) => option.id === newOption.id) ? prev : [...prev, newOption]
       ));
       setSelectedDirectoryId(newOption.id);

--- a/components/TransferImagesModal.tsx
+++ b/components/TransferImagesModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { ArrowRightLeft, Copy, Folder, MoveRight, X } from 'lucide-react';
+import { ArrowRightLeft, Copy, Folder, FolderPlus, MoveRight, X } from 'lucide-react';
 import type { Directory, IndexedImage, IndexedImageTransferMode, IndexedImageTransferProgress } from '../types';
+import { validateFolderName } from '../utils/folderName';
 
 export type TransferDestination = Directory & {
   rootDirectoryPath: string;
@@ -59,6 +60,10 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
   const [subfolderOptions, setSubfolderOptions] = useState<DestinationOption[]>([]);
   const [isLoadingSubfolders, setIsLoadingSubfolders] = useState(false);
   const [subfolderLoadError, setSubfolderLoadError] = useState<string | null>(null);
+  const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState('');
+  const [createFolderError, setCreateFolderError] = useState<string | null>(null);
+  const [isSubmittingNewFolder, setIsSubmittingNewFolder] = useState(false);
 
   const imageCount = images.length;
   const firstImage = images[0];
@@ -102,6 +107,10 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
       setSubfolderOptions([]);
       setIsLoadingSubfolders(false);
       setSubfolderLoadError(null);
+      setIsCreatingFolder(false);
+      setNewFolderName('');
+      setCreateFolderError(null);
+      setIsSubmittingNewFolder(false);
       return;
     }
 
@@ -193,6 +202,57 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
           : selectedOption.rootDirectory.name,
       }
     : null;
+  const canCreateFolder = Boolean(selectedOption) && typeof window !== 'undefined' && Boolean(window.electronAPI?.createSubfolder);
+
+  const handleCreateFolder = async () => {
+    const parentOption = selectedOption;
+    if (!parentOption) {
+      return;
+    }
+
+    const validation = validateFolderName(newFolderName);
+    if (!validation.ok || !validation.value) {
+      setCreateFolderError(validation.error ?? 'Invalid folder name.');
+      return;
+    }
+
+    const api = typeof window !== 'undefined' ? window.electronAPI : undefined;
+    if (!api?.createSubfolder) {
+      setCreateFolderError('Creating folders is not supported in this environment.');
+      return;
+    }
+
+    setIsSubmittingNewFolder(true);
+    setCreateFolderError(null);
+    try {
+      const result = await api.createSubfolder(parentOption.path, validation.value);
+      if (!result.success || !result.folder) {
+        setCreateFolderError(result.error ?? 'Could not create the folder.');
+        return;
+      }
+
+      const relativePath = getRelativePath(parentOption.rootDirectory.path, result.folder.path);
+      const newOption: DestinationOption = {
+        id: `${parentOption.rootDirectory.id}::${relativePath}`,
+        rootDirectory: parentOption.rootDirectory,
+        name: result.folder.name,
+        path: result.folder.path,
+        realPath: result.folder.realPath,
+        relativePath,
+        depth: parentOption.depth + 1,
+      };
+
+      setSubfolderOptions((prev) => (
+        prev.some((option) => option.id === newOption.id) ? prev : [...prev, newOption]
+      ));
+      setSelectedDirectoryId(newOption.id);
+      setNewFolderName('');
+      setIsCreatingFolder(false);
+    } finally {
+      setIsSubmittingNewFolder(false);
+    }
+  };
+
   const actionIcon = mode === 'move' ? <MoveRight className="w-5 h-5 text-amber-300" /> : <Copy className="w-5 h-5 text-blue-300" />;
 
   const progressPercent = progress && progress.total > 0
@@ -254,7 +314,63 @@ const TransferImagesModal: React.FC<TransferImagesModalProps> = ({
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm text-gray-300">Destination folder</label>
+            <div className="flex items-center justify-between">
+              <label className="text-sm text-gray-300">Destination folder</label>
+              {canCreateFolder && !isCreatingFolder && (
+                <button
+                  type="button"
+                  onClick={() => { setIsCreatingFolder(true); setCreateFolderError(null); }}
+                  disabled={isSubmitting}
+                  className="flex items-center gap-1.5 text-xs text-blue-300 hover:text-blue-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  <FolderPlus className="w-4 h-4" />
+                  New folder
+                </button>
+              )}
+            </div>
+
+            {isCreatingFolder && (
+              <div className="rounded-lg border border-gray-700 bg-gray-800/40 p-3 space-y-2">
+                <p className="text-xs text-gray-400 truncate">
+                  New folder inside: <span className="text-gray-300">{selectedOption ? (selectedOption.relativePath ? `${selectedOption.rootDirectory.name}/${selectedOption.relativePath}` : selectedOption.rootDirectory.name) : ''}</span>
+                </p>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    autoFocus
+                    value={newFolderName}
+                    onChange={(e) => { setNewFolderName(e.target.value); if (createFolderError) setCreateFolderError(null); }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); void handleCreateFolder(); }
+                      if (e.key === 'Escape') { e.preventDefault(); setIsCreatingFolder(false); setNewFolderName(''); setCreateFolderError(null); }
+                    }}
+                    placeholder="Folder name"
+                    disabled={isSubmittingNewFolder}
+                    className="flex-1 rounded-md border border-gray-600 bg-gray-900 px-3 py-1.5 text-sm text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:outline-none disabled:opacity-60"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void handleCreateFolder()}
+                    disabled={isSubmittingNewFolder || newFolderName.trim().length === 0}
+                    className="px-3 py-1.5 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {isSubmittingNewFolder ? 'Creating...' : 'Create'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setIsCreatingFolder(false); setNewFolderName(''); setCreateFolderError(null); }}
+                    disabled={isSubmittingNewFolder}
+                    className="px-3 py-1.5 rounded-md border border-gray-600 bg-gray-800 text-gray-200 text-sm hover:bg-gray-700 disabled:opacity-60 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                {createFolderError && (
+                  <p className="text-xs text-red-300">{createFolderError}</p>
+                )}
+              </div>
+            )}
+
             <div className="space-y-2 max-h-72 overflow-y-auto pr-1">
               {destinationOptions.map((directory) => (
                 <button

--- a/electron.mjs
+++ b/electron.mjs
@@ -4376,6 +4376,7 @@ function setupFileOperationHandlers() {
         'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
         'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9',
       ]);
+      // eslint-disable-next-line no-control-regex
       const illegal = new RegExp('[<>:"/\\\\|?*\\x00-\\x1f]');
       if (
         !name ||

--- a/electron.mjs
+++ b/electron.mjs
@@ -4402,10 +4402,25 @@ function setupFileOperationHandlers() {
         return { success: false, error: 'Parent folder does not exist.' };
       }
 
-      const targetPath = path.join(normalizedParent, name);
+      // The parent may be a symlink/alias (list-subfolders surfaces those as
+      // selectable destinations). isPathAllowed only checks the textual path, so
+      // resolve the real parent and re-validate before writing — otherwise a
+      // symlink could redirect the new folder outside the allowed library.
+      let realParent = normalizedParent;
+      try {
+        realParent = await fs.realpath(normalizedParent);
+      } catch {
+        realParent = normalizedParent;
+      }
+      if (!isPathAllowed(realParent)) {
+        console.error('SECURITY VIOLATION: Resolved parent folder is outside allowed directories.');
+        return { success: false, error: 'Access denied: Cannot create folders outside of the allowed directories.' };
+      }
+
+      const targetPath = path.join(realParent, name);
 
       // Defense in depth: the resolved target must stay directly inside the parent.
-      const relative = path.relative(normalizedParent, targetPath);
+      const relative = path.relative(realParent, targetPath);
       if (relative !== name || relative.startsWith('..') || path.isAbsolute(relative)) {
         return { success: false, error: 'Invalid folder name.' };
       }

--- a/electron.mjs
+++ b/electron.mjs
@@ -2423,6 +2423,41 @@ const isPathAllowed = (filePath) => {
   return Array.from(allowedDirectoryPaths).some((allowedPath) => isSameOrChildPath(normalizedFilePath, allowedPath));
 };
 
+// Symlink-aware containment check for write operations (e.g. creating a folder).
+// isPathAllowed compares textual paths, which is correct for reads but has two
+// blind spots when writing: a symlinked subfolder inside the library can point
+// OUTSIDE it, and an indexed root can itself be a symlink/alias (common on macOS,
+// or when the library lives on an external disk) whose real target is not in the
+// textual allowlist. Resolving both sides and comparing the *real* paths handles
+// both: it permits a legitimately symlinked root while still rejecting a symlink
+// that escapes the library's real tree. Falls back to the textual check if a
+// realpath cannot be resolved.
+const isResolvedPathWithinAllowed = async (candidatePath) => {
+  if (allowedDirectoryPaths.size === 0 || !candidatePath) return false;
+
+  let realCandidate;
+  try {
+    realCandidate = await fs.realpath(candidatePath);
+  } catch {
+    return isPathAllowed(candidatePath);
+  }
+  const normalizedCandidate = normalizeAllowedPath(realCandidate);
+
+  for (const allowedPath of allowedDirectoryPaths) {
+    let realAllowed = allowedPath;
+    try {
+      realAllowed = await fs.realpath(allowedPath);
+    } catch {
+      // Allowed root no longer resolvable; skip it.
+      continue;
+    }
+    if (isSameOrChildPath(normalizedCandidate, normalizeAllowedPath(realAllowed))) {
+      return true;
+    }
+  }
+  return false;
+};
+
 // Helper function for recursive file search
 async function mapWithConcurrency(items, concurrency, mapper) {
   const results = [];
@@ -4403,24 +4438,22 @@ function setupFileOperationHandlers() {
       }
 
       // The parent may be a symlink/alias (list-subfolders surfaces those as
-      // selectable destinations). isPathAllowed only checks the textual path, so
-      // resolve the real parent and re-validate before writing — otherwise a
-      // symlink could redirect the new folder outside the allowed library.
-      let realParent = normalizedParent;
-      try {
-        realParent = await fs.realpath(normalizedParent);
-      } catch {
-        realParent = normalizedParent;
-      }
-      if (!isPathAllowed(realParent)) {
+      // selectable destinations, and an indexed root can itself be a symlink).
+      // Validate by comparing the resolved parent against the resolved allowed
+      // roots: this rejects a symlink that escapes the library's real tree while
+      // still permitting a legitimately symlinked root whose target is not in the
+      // textual allowlist.
+      if (!(await isResolvedPathWithinAllowed(normalizedParent))) {
         console.error('SECURITY VIOLATION: Resolved parent folder is outside allowed directories.');
         return { success: false, error: 'Access denied: Cannot create folders outside of the allowed directories.' };
       }
 
-      const targetPath = path.join(realParent, name);
+      // Create under the parent as the user selected it (symlink-preserving, like
+      // list-subfolders); the OS follows the link to the real target.
+      const targetPath = path.join(normalizedParent, name);
 
-      // Defense in depth: the resolved target must stay directly inside the parent.
-      const relative = path.relative(realParent, targetPath);
+      // Defense in depth: the target must stay directly inside the parent.
+      const relative = path.relative(normalizedParent, targetPath);
       if (relative !== name || relative.startsWith('..') || path.isAbsolute(relative)) {
         return { success: false, error: 'Invalid folder name.' };
       }

--- a/electron.mjs
+++ b/electron.mjs
@@ -4355,6 +4355,85 @@ function setupFileOperationHandlers() {
     }
   });
 
+  // Create a new subfolder under an already-indexed root/subfolder. Used by the
+  // "Create New Folder" action in the Move/Copy To panel. Validation mirrors
+  // utils/folderName.ts; kept inline here because the main process cannot import
+  // the renderer TS helper.
+  ipcMain.handle('create-subfolder', async (event, { parentPath, folderName } = {}) => {
+    try {
+      if (typeof parentPath !== 'string' || typeof folderName !== 'string') {
+        return { success: false, error: 'Invalid arguments.' };
+      }
+
+      if (!isPathAllowed(parentPath)) {
+        console.error('SECURITY VIOLATION: Attempted to create a folder outside of allowed directories.');
+        return { success: false, error: 'Access denied: Cannot create folders outside of the allowed directories.' };
+      }
+
+      const name = folderName.trim();
+      const RESERVED = new Set([
+        'con', 'prn', 'aux', 'nul',
+        'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
+        'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9',
+      ]);
+      const illegal = new RegExp('[<>:"/\\\\|?*\\x00-\\x1f]');
+      if (
+        !name ||
+        name === '.' ||
+        name === '..' ||
+        illegal.test(name) ||
+        /[. ]$/.test(name) ||
+        RESERVED.has(name.toLowerCase()) ||
+        name.length > 255
+      ) {
+        return { success: false, error: 'Invalid folder name.' };
+      }
+
+      const normalizedParent = path.normalize(parentPath);
+
+      // Verify the parent exists and is a directory.
+      try {
+        const stats = await fs.stat(normalizedParent);
+        if (!stats.isDirectory()) {
+          return { success: false, error: 'Parent path is not a directory.' };
+        }
+      } catch {
+        return { success: false, error: 'Parent folder does not exist.' };
+      }
+
+      const targetPath = path.join(normalizedParent, name);
+
+      // Defense in depth: the resolved target must stay directly inside the parent.
+      const relative = path.relative(normalizedParent, targetPath);
+      if (relative !== name || relative.startsWith('..') || path.isAbsolute(relative)) {
+        return { success: false, error: 'Invalid folder name.' };
+      }
+
+      // Refuse to reuse an existing folder so the user gets clear feedback.
+      try {
+        await fs.access(targetPath);
+        return { success: false, error: 'A folder with that name already exists.' };
+      } catch {
+        // Does not exist — good, proceed.
+      }
+
+      await fs.mkdir(targetPath);
+
+      let realPath = targetPath;
+      try {
+        realPath = await fs.realpath(targetPath);
+      } catch {
+        realPath = targetPath;
+      }
+
+      console.log('📁 Created subfolder:', targetPath);
+      return { success: true, folder: { name, path: targetPath, realPath } };
+    } catch (error) {
+      console.error('❌ Error creating subfolder:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
   // Handle manual update check
   ipcMain.handle('check-for-updates', async () => {
     if (!autoUpdater) {

--- a/preload.js
+++ b/preload.js
@@ -191,6 +191,7 @@ const electronAPI = {
   showItemInFolder: (filePath) => ipcRenderer.invoke('show-item-in-folder', filePath),
   openCacheLocation: (cachePath) => ipcRenderer.invoke('open-cache-location', cachePath),
   listSubfolders: (folderPath) => ipcRenderer.invoke('list-subfolders', folderPath),
+  createSubfolder: (parentPath, folderName) => ipcRenderer.invoke('create-subfolder', { parentPath, folderName }),
   listDirectoryFiles: (args) => ipcRenderer.invoke('list-directory-files', args),
   resolveMediaUrl: (filePath) => ipcRenderer.invoke('resolve-media-url', filePath),
   readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),

--- a/types.ts
+++ b/types.ts
@@ -389,6 +389,7 @@ export interface ElectronAPI {
   showItemInFolder: (filePath: string) => Promise<{ success: boolean; error?: string }>;
   openCacheLocation: (cachePath: string) => Promise<{ success: boolean; error?: string }>;
   listSubfolders: (folderPath: string) => Promise<{ success: boolean; subfolders?: { name: string; path: string; realPath?: string }[]; error?: string }>;
+  createSubfolder: (parentPath: string, folderName: string) => Promise<{ success: boolean; folder?: { name: string; path: string; realPath?: string }; error?: string }>;
   listDirectoryFiles: (args: { dirPath: string; recursive?: boolean }) => Promise<{
     success: boolean;
     files?: { name: string; lastModified: number; size: number; type: string; birthtimeMs?: number; contentModifiedMs?: number }[];

--- a/utils/folderName.ts
+++ b/utils/folderName.ts
@@ -1,0 +1,64 @@
+// Shared validation for user-supplied folder names (e.g. "Create New Folder" in
+// the Move/Copy To panel). Kept as a pure helper so it can be unit-tested and
+// reused by both the renderer (pre-flight UX) and mirrored by the main process
+// (defense in depth before touching the filesystem).
+
+// Windows reserved device names (case-insensitive), which cannot be used as
+// file/folder names even with an extension.
+const RESERVED_NAMES = new Set([
+  'con', 'prn', 'aux', 'nul',
+  'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
+  'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9',
+]);
+
+// Characters that are illegal in a single path segment on Windows (a superset of
+// what POSIX forbids, so validating against it keeps names portable). Spaces and
+// hyphens are allowed; control characters, path separators, and Windows-reserved
+// punctuation are not.
+// eslint-disable-next-line no-control-regex
+const ILLEGAL_CHARS = new RegExp('[<>:"/\\\\|?*\\x00-\\x1f]');
+
+export interface FolderNameValidationResult {
+  ok: boolean;
+  /** Trimmed, filesystem-safe name. Only present when ok is true. */
+  value?: string;
+  error?: string;
+}
+
+/**
+ * Validate a single folder-name segment supplied by the user. Rejects empty
+ * names, path separators, traversal (`..`), illegal characters, trailing dots/
+ * spaces (which Windows silently strips, causing surprises), and reserved
+ * device names. Returns the trimmed name on success.
+ */
+export function validateFolderName(rawName: string): FolderNameValidationResult {
+  const name = (rawName ?? '').trim();
+
+  if (!name) {
+    return { ok: false, error: 'Folder name cannot be empty.' };
+  }
+
+  if (name === '.' || name === '..') {
+    return { ok: false, error: 'Folder name is not valid.' };
+  }
+
+  if (ILLEGAL_CHARS.test(name)) {
+    return { ok: false, error: 'Folder name contains invalid characters.' };
+  }
+
+  // Windows strips trailing dots and spaces, so "foo." would become "foo" —
+  // reject to avoid a mismatch between what the user typed and what is created.
+  if (/[. ]$/.test(name)) {
+    return { ok: false, error: 'Folder name cannot end with a space or period.' };
+  }
+
+  if (RESERVED_NAMES.has(name.toLowerCase())) {
+    return { ok: false, error: 'That folder name is reserved by the system.' };
+  }
+
+  if (name.length > 255) {
+    return { ok: false, error: 'Folder name is too long.' };
+  }
+
+  return { ok: true, value: name };
+}


### PR DESCRIPTION
## What
Adds a **Create New Folder** control to the Move/Copy To panel (`TransferImagesModal`), so users can create a destination subfolder inline instead of leaving the app. Addresses the "Create New Folder option in the Move To panel" request in #463.

The folder is created under the currently selected destination, then added to the list and auto-selected.

## How
- New `create-subfolder` IPC (`electron.mjs`) with path-containment + name validation, mirroring the `list-subfolders` security check (`isPathAllowed`, refuses traversal / existing folders).
- Exposed via preload as `createSubfolder(parentPath, folderName)`.
- Shared `utils/folderName.ts` `validateFolderName` helper (rejects separators, traversal, illegal/control chars, trailing dot, reserved device names) — used by the renderer for pre-flight UX and mirrored in main for defense in depth.

## Tests
- `__tests__/folderName.test.ts` — validator (accepts spaces/hyphens, rejects separators/reserved/etc.).
- `__tests__/TransferImagesModal.createFolder.test.tsx` — create+select, validation error (no API call), and backend-error surfacing.

Full suite (499 tests) + typecheck + lint pass.

## Note
This is a scoped bugfix-release item for v0.17.4. Items (d) Input-folder auto-detect and (c) the first-select thumbnail jump from #463 are **not** included — they're macOS-specific and need on-device testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)