### PR TITLE
fix: re-read budget-skipped and WebP files when head-read truncates metadata (#448)

### DIFF
--- a/__tests__/fileIndexer.webp-truncation.test.ts
+++ b/__tests__/fileIndexer.webp-truncation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { parseWebPMetadata } from '../services/fileIndexer';
+
+/** Little-endian uint32, the byte order WebP/RIFF uses for sizes. */
+function le32(n: number): number[] {
+  return [n & 0xff, (n >>> 8) & 0xff, (n >>> 16) & 0xff, (n >>> 24) & 0xff];
+}
+
+/**
+ * Builds a RIFF chunk: type(4) + size(4, LE) + data + optional pad byte to an even
+ * boundary. `declaredSize` overrides the size field so a fixture can claim a chunk is
+ * larger than the bytes actually present (i.e. cut off by a head-read).
+ */
+function buildChunk(type: string, data: number[], declaredSize?: number): number[] {
+  const typeBytes = Array.from(Buffer.from(type, 'latin1')); // must be exactly 4 chars
+  const size = declaredSize ?? data.length;
+  const padded = data.length % 2 !== 0 ? [...data, 0] : data;
+  return [...typeBytes, ...le32(size), ...padded];
+}
+
+/** Wraps chunks in a RIFF/WEBP container with a correct RIFF size field. */
+function buildWebp(chunks: number[][]): ArrayBuffer {
+  const body = [...Array.from(Buffer.from('WEBP', 'latin1')), ...chunks.flat()];
+  const bytes = [...Array.from(Buffer.from('RIFF', 'latin1')), ...le32(body.length), ...body];
+  return new Uint8Array(bytes).buffer;
+}
+
+/** A tiny stand-in for the VP8 image-data chunk (contents are irrelevant to metadata). */
+function buildImageChunk(size: number): number[] {
+  return buildChunk('VP8 ', new Array(Math.max(0, size)).fill(0x7a));
+}
+
+const METAHUB_EXIF_JSON = '{"imagemetahub_data":{"generator":"ComfyUI","seed":12345}}';
+
+describe('parseWebPMetadata head-read truncation handling (issue #448)', () => {
+  it('flags truncated=true when the EXIF chunk is cut off mid-file', async () => {
+    // A realistic large EXIF payload (e.g. an embedded ComfyUI workflow) whose declared
+    // size runs well past what a 64KB head-read would have captured.
+    const exifData = new Array(40 * 1024).fill(0x00);
+    const fullBuffer = buildWebp([buildImageChunk(8), buildChunk('EXIF', exifData)]);
+
+    // Simulate the head-read: keep the RIFF header, the VP8 chunk, the EXIF chunk *header*
+    // (so the parser sees the chunk and its declared size) but cut into the EXIF data.
+    const truncatedBuffer = fullBuffer.slice(0, 12 + 16 + 8 + 100);
+    expect(truncatedBuffer.byteLength).toBeLessThan(fullBuffer.byteLength);
+
+    const truncationInfo = { truncated: false };
+    await parseWebPMetadata(truncatedBuffer, truncationInfo);
+
+    // Core of the fix: the parser reports that the metadata chunk was cut off, so Phase B
+    // forces a full-file re-read instead of caching a partial/garbled parse.
+    expect(truncationInfo.truncated).toBe(true);
+  });
+
+  it('does not flag truncated when the full EXIF chunk is present', async () => {
+    const exifData = Array.from(Buffer.from(METAHUB_EXIF_JSON, 'utf-8'));
+    const fullBuffer = buildWebp([buildImageChunk(8), buildChunk('EXIF', exifData)]);
+
+    const truncationInfo = { truncated: false };
+    const result = await parseWebPMetadata(fullBuffer, truncationInfo);
+
+    expect(truncationInfo.truncated).toBe(false);
+    expect(result && 'imagemetahub_data' in result).toBe(true);
+  });
+
+  it('does not flag truncated for a WebP cut off in non-metadata (image) data', async () => {
+    // No EXIF chunk at all — just image data that overruns the head-read buffer. The
+    // truncation flag must stay false; the "no metadata + file bigger than buffer"
+    // heuristic in Phase B is what triggers the re-read for this shape, not this flag.
+    const fullBuffer = buildWebp([buildImageChunk(80 * 1024)]);
+    const truncatedBuffer = fullBuffer.slice(0, 64 * 1024);
+    expect(truncatedBuffer.byteLength).toBeLessThan(fullBuffer.byteLength);
+
+    const truncationInfo = { truncated: false };
+    await parseWebPMetadata(truncatedBuffer, truncationInfo);
+
+    expect(truncationInfo.truncated).toBe(false);
+  });
+});

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -894,7 +894,10 @@ async function parseJPEGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | n
   }
 }
 
-async function parseWebPMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | null> {
+export async function parseWebPMetadata(
+  buffer: ArrayBuffer,
+  truncationInfo?: { truncated: boolean }
+): Promise<ImageMetadata | null> {
   try {
     // WebP stores EXIF in an 'EXIF' chunk within the RIFF container
     // We need to extract the EXIF chunk first, then parse it with exifr
@@ -961,6 +964,12 @@ async function parseWebPMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | n
       if (chunkType === 'EXIF') {
         // Found EXIF chunk!
         const exifStart = offset + 8; // Skip chunk header (type + size)
+        // If the declared chunk runs past the (possibly head-read) buffer, the metadata
+        // was cut off mid-file. Signal truncation so Phase B forces a full-file re-read
+        // instead of caching a partial/garbled parse of a large workflow (#448).
+        if (truncationInfo && exifStart + chunkSize > view.byteLength) {
+          truncationInfo.truncated = true;
+        }
         const rawExifData = buffer.slice(exifStart, exifStart + chunkSize);
         const rawBytes = new Uint8Array(rawExifData);
         const tiffHeaderOffset = findExifTiffHeaderOffset(rawBytes);
@@ -1419,7 +1428,7 @@ async function processSingleFileOptimized(
     // IndexedImage (`_metadataTruncated`) so the Phase B enrichment loop can tell
     // "genuinely no metadata" apart from "metadata chunk was cut off mid-file" and
     // decide whether a full-file re-read is needed.
-    const pngTruncationInfo = { truncated: false };
+    const metadataTruncationInfo = { truncated: false };
     const inferredType = fileEntry.type ?? inferMimeTypeFromName(fileEntry.handle.name);
     const isVideo = isVideoFileName(fileEntry.handle.name) || inferredType.startsWith('video/');
     const isAudio = isAudioFileName(fileEntry.handle.name) || inferredType.startsWith('audio/');
@@ -1436,11 +1445,11 @@ async function processSingleFileOptimized(
       const view = new DataView(fileData);
       const detectedType = detectImageType(view);
       if (detectedType === 'png') {
-        rawMetadata = await parsePNGMetadata(fileData, pngTruncationInfo);
+        rawMetadata = await parsePNGMetadata(fileData, metadataTruncationInfo);
       } else if (detectedType === 'jpeg') {
         rawMetadata = await parseJPEGMetadata(fileData);
       } else if (detectedType === 'webp') {
-        rawMetadata = await parseWebPMetadata(fileData);
+        rawMetadata = await parseWebPMetadata(fileData, metadataTruncationInfo);
       } else {
         rawMetadata = null;
       }
@@ -1466,11 +1475,11 @@ async function processSingleFileOptimized(
       const view = new DataView(fileData);
       const detectedType = detectImageType(view);
       if (detectedType === 'png') {
-        rawMetadata = await parsePNGMetadata(fileData, pngTruncationInfo);
+        rawMetadata = await parsePNGMetadata(fileData, metadataTruncationInfo);
       } else if (detectedType === 'jpeg') {
         rawMetadata = await parseJPEGMetadata(fileData);
       } else if (detectedType === 'webp') {
-        rawMetadata = await parseWebPMetadata(fileData);
+        rawMetadata = await parseWebPMetadata(fileData, metadataTruncationInfo);
       } else {
         rawMetadata = null;
       }
@@ -1801,7 +1810,7 @@ if (normalizedMetadata && isVideo) {
       workflowNodes,
       fileSize: normalizedFileSize,
       fileType: normalizedFileType,
-      _metadataTruncated: pngTruncationInfo.truncated,
+      _metadataTruncated: metadataTruncationInfo.truncated,
     } as IndexedImage;
   } catch (error) {
     console.error(`Skipping file ${fileEntry.handle.name} due to an error:`, error);
@@ -2977,7 +2986,9 @@ export async function processFiles(
         return false;
       }
       const fileType = entry.source.type ?? inferMimeTypeFromName(entry.source.handle.name);
-      if (fileType !== 'image/png') {
+      // PNG and WebP both store metadata in container chunks that a 64 KB head-read can
+      // cut off mid-file (WebP EXIF/XMP lives in RIFF chunks). Both need the full re-read.
+      if (fileType !== 'image/png' && fileType !== 'image/webp') {
         return false;
       }
       // Explicit signal: the head-read buffer cut a chunk off mid-file (e.g. a large
@@ -3236,7 +3247,15 @@ export async function processFiles(
             if (fullReadResult.success && Array.isArray(fullReadResult.files)) {
               for (const file of fullReadResult.files) {
                 if (!file.success || !file.data) {
-                  if (file.errorType === 'FILE_TOO_LARGE' || file.errorType === 'BATCH_BYTE_LIMIT') {
+                  // FILE_TOO_LARGE is a hard per-file cap: the file cannot be read via
+                  // the batch IPC at all, so block it and keep the partial head floor.
+                  // BATCH_BYTE_LIMIT is different — it only means this file didn't fit the
+                  // batch's rolling byte budget. The file is individually under the cap,
+                  // and which files overflow the budget is non-deterministic across scans
+                  // (fallback order comes from the concurrent head-parse). Leaving it
+                  // blocked cached a truncated parse for large ComfyUI workflows (#448).
+                  // Keep it unblocked so the per-file full-read fallback below re-reads it.
+                  if (file.errorType === 'FILE_TOO_LARGE') {
                     const imageId = fallbackPathToImageId.get(file.path);
                     if (imageId) {
                       blockedFromGenericFallback.add(imageId);


### PR DESCRIPTION
Follow-up to #464, addressing the two remaining problems reported by @himurayuji in #448 after the initial PNG head-read truncation fix.

## 1. Inconsistent parsing on large libraries (point 2)
Files parse correctly on one scan and incorrectly on the next, even after clearing the cache — identical files behaving differently.

**Root cause:** the full-read fallback uses a rolling `FULL_READ_FALLBACK_MAX_BATCH_BYTES` (96 MB) budget per read-batch. When truncated files in a batch collectively exceed it, the server returns `BATCH_BYTE_LIMIT` for the overflow, and those were treated the same as the hard `FILE_TOO_LARGE` cap — so they kept their **truncated** head-parse instead of being re-read. Because the fallback order comes from the concurrent head-parse completion order, *which* files overflow the budget changes between scans → non-deterministic results.

**Fix:** `BATCH_BYTE_LIMIT` files are individually under the 32 MB cap; they just didn't fit that batch's budget. They are no longer blocked, so the existing per-file full-read fallback re-reads them → deterministic and correct.

## 2. WebP not covered (point 3)
The original issue persists for WebP files (MetaHub Save Node / ComfyUI-Image-Saver), fixable only via a manual reparse.

**Root cause:** truncation detection (`_metadataTruncated`) and `shouldFallbackToFullRead` were PNG-only. WebP EXIF/XMP lives in RIFF chunks that a 64 KB head-read can cut off, but no fallback ever fired.

**Fix:** `parseWebPMetadata` now flags truncation when an EXIF chunk's declared size runs past the buffer, and `shouldFallbackToFullRead` accepts `image/webp` (so both the explicit truncation signal and the "no metadata + file larger than buffer" heuristic apply).

## Tests
- New `__tests__/fileIndexer.webp-truncation.test.ts` (cut-off EXIF flags truncation; full EXIF does not; non-metadata image-data cut-off does not false-positive).
- Existing PNG truncation tests still pass.

## Manual verification checklist
- [x] Large library (~5k, PNGs 1.5–7.6 MB, workflow ~180 KB): clear cache + re-scan several times → affected files parse consistently correct, no manual reparse.
- [x] WebP from MetaHub Save Node and ComfyUI-Image-Saver: clear cache + re-scan → parses correctly on first pass.
- [x] Regression: normal small PNG/WebP indexing unaffected; head-read optimization still used for files with metadata up front.

Closes #448