### PR TITLE
fix: sort folder tree subfolders case-insensitively (#466)

### DIFF
--- a/components/DirectoryList.tsx
+++ b/components/DirectoryList.tsx
@@ -42,6 +42,11 @@ interface VisibleDirectoryNode {
   rootDirectory: Directory;
 }
 
+// Case-insensitive, natural ("2" before "10") ordering for folder names, matching how
+// Finder / Windows Explorer sort. Fixes the macOS folder tree listing raw APFS order,
+// where "A" sorted before "a" (#466).
+const folderNameCollator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
+
 const normalizePath = (path: string) => path.replace(/\\/g, '/').replace(/\/+$/, '');
 const toForwardSlashes = (path: string) => normalizePath(path);
 const makeNodeKey = (rootId: string, relativePath: string) => `${rootId}::${relativePath === '' ? '.' : relativePath}`;
@@ -315,11 +320,13 @@ export default function DirectoryList({
         const result = await (window as any).electronAPI.listSubfolders(nodePath);
 
         if (result.success) {
-          const subfolders: SubfolderNode[] = (result.subfolders || []).map((subfolder: { name: string; path: string }) => ({
-            name: subfolder.name,
-            path: subfolder.path,
-            relativePath: getRelativePath(rootDirectory.path, subfolder.path)
-          }));
+          const subfolders: SubfolderNode[] = (result.subfolders || [])
+            .map((subfolder: { name: string; path: string }) => ({
+              name: subfolder.name,
+              path: subfolder.path,
+              relativePath: getRelativePath(rootDirectory.path, subfolder.path)
+            }))
+            .sort((a: SubfolderNode, b: SubfolderNode) => folderNameCollator.compare(a.name, b.name));
 
           setSubfolderCache(prev => {
             const next = new Map(prev);


### PR DESCRIPTION
Addresses the folder-tree sort-order observation in #466 (macOS feedback).

## Problem
The folder tree rendered subfolders in the raw `fs.readdir` order returned by the `list-subfolders` IPC. On macOS/APFS that order is case-sensitive, so a folder starting with `A` sorted before one starting with `a`. Windows/NTFS returns entries pre-sorted, which is why this only showed up on macOS.

## Fix
`DirectoryList` now sorts the loaded subfolders with a case-insensitive, natural `Intl.Collator` (`sensitivity: 'base'`, `numeric: true`) before caching them — matching how Finder and Windows Explorer order names (also gives `2` before `10`).

Scoped to the folder tree in `DirectoryList` (the component the report is about). The Move/Copy modal already applies its own `localeCompare` sort.

## Manual verification
- [ ] macOS: expand a root with mixed-case subfolders (e.g. `Apple`, `apricot`, `Banana`) → sorted case-insensitively, not `A`…`Z` before `a`…`z`.
- [ ] Numbered folders (`2`, `10`, `100`) sort naturally rather than lexically.
- [ ] Windows: ordering unchanged / still correct.

Part of #466 (folder tree sort). The drag-and-drop item from that issue is tracked separately.