### PR TITLE
fix: restore native external file drag on macOS grid cards (#466)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ packages/license-server/data/test-sqlite-relative.db-journal
 packages/license-server/data/test-sqlite.db
 packages/license-server/data/test-sqlite.db-journal
 image-metahub.code-workspace
+.claude/settings.json

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -53,6 +53,12 @@ import {
 } from '../utils/performanceDiagnostics';
 import { clearInternalImageDragData, setInternalImageDragData } from '../utils/internalImageDrag';
 
+// macOS ignores Electron's startDrag() unless it is invoked synchronously from the
+// dragstart handler, so native external drag has to be kicked off differently there
+// than on Windows (see handleDragStart / handleDrag).
+const IS_MAC_RENDERER = typeof navigator !== 'undefined' &&
+  (/mac/i.test(navigator.platform || '') || /Mac OS X/i.test(navigator.userAgent || ''));
+
 // Module-level variable to track internal image drag state (survives native file drag)
 let _activeDragImageIds: string[] = [];
 let _activeExternalDragPayload: { directoryPath: string; relativePath: string } | null = null;
@@ -370,6 +376,23 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
       _activeExternalDragPayload = { directoryPath: image.directoryId, relativePath };
     } else {
       _activeExternalDragPayload = null;
+    }
+
+    // macOS: Electron's startDrag() only takes effect when called synchronously from
+    // dragstart. The Windows path (handleDrag) defers it until the cursor leaves the
+    // window, but macOS ignores a mid-drag startDrag — which is why dropping a card onto
+    // ComfyUI/Finder stopped working (#466). Hand the drag off to the OS now so the real
+    // file is dragged. This makes the drag OS-level, so the internal move-to-folder DnD is
+    // unavailable on macOS (right-click → Move/Copy still works).
+    if (IS_MAC_RENDERER && _activeExternalDragPayload && window.electronAPI?.startFileDrag) {
+      _nativeDragStarted = true;
+      e.preventDefault();
+      window.electronAPI.startFileDrag(_activeExternalDragPayload);
+      // The drag is now an OS-level native file drag; the in-app dragend won't fire and
+      // internal move-to-folder DnD doesn't apply on macOS. Clear the internal drag
+      // markers so the sidebar/header don't render as in-app drop targets.
+      clearActiveDragImageIds();
+      clearInternalImageDragData();
     }
   };
 

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -52,12 +52,12 @@ import {
   recordPerformanceDuration,
 } from '../utils/performanceDiagnostics';
 import { clearInternalImageDragData, setInternalImageDragData } from '../utils/internalImageDrag';
+import { isMacPlatform } from '../utils/platform';
 
 // macOS ignores Electron's startDrag() unless it is invoked synchronously from the
 // dragstart handler, so native external drag has to be kicked off differently there
 // than on Windows (see handleDragStart / handleDrag).
-const IS_MAC_RENDERER = typeof navigator !== 'undefined' &&
-  (/mac/i.test(navigator.platform || '') || /Mac OS X/i.test(navigator.userAgent || ''));
+const IS_MAC_RENDERER = isMacPlatform();
 
 // Module-level variable to track internal image drag state (survives native file drag)
 let _activeDragImageIds: string[] = [];

--- a/hooks/useMediaDiagnostics.ts
+++ b/hooks/useMediaDiagnostics.ts
@@ -1,4 +1,5 @@
 import { type SyntheticEvent, useCallback, useMemo } from 'react';
+import { isMacPlatform } from '../utils/platform';
 
 export const MEDIA_DIAGNOSTIC_EVENTS = [
   'loadstart',
@@ -40,11 +41,11 @@ export const isAudioRendererErrorMessage = (message?: string | null): boolean =>
   typeof message === 'string' && message.includes('AUDIO_RENDERER_ERROR');
 
 const isMacElectronRenderer = (): boolean => {
-  if (typeof window === 'undefined' || !window.electronAPI || typeof navigator === 'undefined') {
+  if (typeof window === 'undefined' || !window.electronAPI) {
     return false;
   }
 
-  return /mac/i.test(navigator.platform || '') || /Mac OS X/i.test(navigator.userAgent || '');
+  return isMacPlatform();
 };
 
 export function useMediaDiagnostics(context: MediaDiagnosticsContext) {

--- a/utils/platform.ts
+++ b/utils/platform.ts
@@ -1,0 +1,3 @@
+export const isMacPlatform = (): boolean =>
+  typeof navigator !== 'undefined' &&
+  (/mac/i.test(navigator.platform || '') || /Mac OS X/i.test(navigator.userAgent || ''));


### PR DESCRIPTION
Addresses the drag-and-drop regression in #466 (macOS feedback): dragging a grid card onto ComfyUI (to open its workflow) or into a Finder folder no longer worked — the card only carried a text payload, so Finder created a `.textClipping` of the path instead of copying the real file.

## Root cause
The external-drag path calls Electron's `startFileDrag` **mid-drag**, once the cursor leaves the window (`handleDrag`). That works on Windows, but macOS ignores a `startDrag()` that isn't invoked **synchronously from the `dragstart` handler**, so the native OS drag never started on macOS.

## Fix (gated to macOS)
On macOS, kick off `startFileDrag` directly in `dragstart` (`preventDefault` + hand off to the OS) — the canonical Electron native-drag pattern already used in `ComfyUIWorkspace`. Windows keeps the existing leave-the-window hybrid unchanged.

Because the macOS drag becomes OS-level, the internal move-to-folder drag is unavailable on macOS (right-click → **Move/Copy** still works). Internal drag markers are cleared when the native drag starts so the sidebar/header don't render as in-app drop targets.

Platform detection mirrors the existing `navigator.platform`/`userAgent` check used elsewhere in the renderer.

## Manual verification (macOS)
- [ ] Drag a card onto a running ComfyUI window → the embedded workflow opens.
- [ ] Drag a card into a Finder folder → the real image file is copied (no `.textClipping`).
- [ ] Multi-select then drag → primary file drags out.
- [ ] Right-click → Move/Copy to folder still works (internal move alternative).

## Regression check (Windows)
- [x] External drag to ComfyUI/Explorer still works via the existing hybrid.
- [x] Internal drag-to-folder in the sidebar still works.

Part of #466 (drag-and-drop). The folder-tree sort item is in a separate PR.