### PR TITLE
feat: link model/LoRA to Civitai on demand from the image modal

### DIFF
--- a/components/CivitaiResourceLink.tsx
+++ b/components/CivitaiResourceLink.tsx
@@ -1,0 +1,122 @@
+import React, { FC, ReactNode, useEffect, useState } from 'react';
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { useSettingsStore } from '../store/useSettingsStore';
+import { lookupRef, peekCachedRef, type LookupResult } from '../services/civitai/civitaiLookup';
+import { type ResourceRef } from '../services/civitai/resourceExtraction';
+
+interface CivitaiResourceLinkProps {
+  resource: ResourceRef;
+  children: ReactNode;
+}
+
+type ViewState = 'idle' | 'loading' | LookupResult['status'];
+
+const TOOLTIP_IDLE = 'Open on Civitai — makes a one-time request; the result is cached locally.';
+
+/**
+ * Wraps a model/LoRA label so it links to Civitai on demand. On mount it only
+ * reads the local cache (no network). Clicking resolves the reference through
+ * the Electron main process and opens the page in the browser; results are
+ * cached so a reference is fetched at most once. When the Civitai lookup setting
+ * is off, the label renders as plain text with no network affordance.
+ */
+export const CivitaiResourceLink: FC<CivitaiResourceLinkProps> = ({ resource, children }) => {
+  const enabled = useSettingsStore((state) => state.civitaiLookupEnabled);
+  const [state, setState] = useState<ViewState>('idle');
+  const [url, setUrl] = useState<string | null>(null);
+
+  const refIdentity = resource.hash ?? resource.modelVersionId;
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('idle');
+    setUrl(null);
+    peekCachedRef(resource).then((cached) => {
+      if (cancelled || !cached) return;
+      if (cached.status === 'found') {
+        setUrl(cached.hit.url);
+        setState('found');
+      } else if (cached.status === 'notFound') {
+        setState('notFound');
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refIdentity]);
+
+  const open = (target: string) => {
+    window.electronAPI?.openExternalUrl?.(target);
+  };
+
+  const handleClick = async () => {
+    if (url) {
+      open(url);
+      return;
+    }
+    if (state === 'loading') return;
+    setState('loading');
+    const result = await lookupRef(resource);
+    if (result.status === 'found') {
+      setUrl(result.hit.url);
+      setState('found');
+      open(result.hit.url);
+    } else {
+      setState(result.status);
+    }
+  };
+
+  // Setting disabled: plain text, no affordance.
+  if (!enabled) {
+    return <>{children}</>;
+  }
+
+  // Confirmed absent from Civitai: plain text with a quiet hint.
+  if (state === 'notFound') {
+    return (
+      <span title="Not found on Civitai" className="text-gray-200">
+        {children}
+      </span>
+    );
+  }
+
+  const title =
+    state === 'unavailable'
+      ? 'Civitai is unavailable right now. Click to try again.'
+      : state === 'found'
+        ? 'Open on Civitai'
+        : TOOLTIP_IDLE;
+
+  const colorClass =
+    state === 'unavailable'
+      ? 'text-amber-400 hover:text-amber-300 decoration-amber-400/40'
+      : 'text-blue-400 hover:text-blue-300 decoration-blue-400/40';
+
+  // `inline` (not inline-flex) so long, space-less model names wrap/break inside
+  // the box instead of overflowing; the icon trails inline.
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          handleClick();
+        }
+      }}
+      title={title}
+      className={`cursor-pointer break-all underline decoration-dotted underline-offset-2 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded-sm ${colorClass}`}
+    >
+      {children}
+      {state === 'loading' ? (
+        <Loader2 className="inline-block w-3 h-3 ml-0.5 align-[-2px] animate-spin" />
+      ) : (
+        <ExternalLink className="inline-block w-3 h-3 ml-0.5 align-[-2px]" />
+      )}
+    </span>
+  );
+};
+
+export default CivitaiResourceLink;

--- a/components/CivitaiResourceLink.tsx
+++ b/components/CivitaiResourceLink.tsx
@@ -43,7 +43,6 @@ export const CivitaiResourceLink: FC<CivitaiResourceLinkProps> = ({ resource, ch
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refIdentity]);
 
   const open = (target: string) => {

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -17,6 +17,8 @@ import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } fr
 import { type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGenerateModal';
 import ComfyUIWorkflowWorkspace from './ComfyUIWorkflowWorkspace';
 import ProBadge from './ProBadge';
+import { CivitaiResourceLink } from './CivitaiResourceLink';
+import { extractResourceRefs, normalizeResourceName, type ResourceRef } from '../services/civitai/resourceExtraction';
 import hotkeyManager from '../services/hotkeyManager';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -571,7 +573,7 @@ const SUPPORTED_MEDIA_EXTENSION_REGEX = new RegExp(
   'i'
 );
 
-const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void | Promise<void | boolean> }> = ({ label, value, isPrompt = false, onCopy }) => {
+const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPrompt?: boolean; onCopy?: (value: string) => void | Promise<void | boolean>; renderValue?: (displayValue: string) => React.ReactNode }> = ({ label, value, isPrompt = false, onCopy, renderValue }) => {
   const [copied, setCopied] = useState(false);
 
   if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
@@ -609,7 +611,7 @@ const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPromp
       {isPrompt ? (
         <pre className="text-gray-200 whitespace-pre-wrap break-words font-mono text-sm mt-1">{displayValue}</pre>
       ) : (
-        <p className="text-gray-200 break-words font-mono text-sm mt-1">{displayValue}</p>
+        <p className="text-gray-200 break-words font-mono text-sm mt-1">{renderValue ? renderValue(displayValue) : displayValue}</p>
       )}
     </div>
   );
@@ -1276,6 +1278,30 @@ const ImageModal: React.FC<ImageModalProps> = ({
     }
   }, [directoryPath, hydratedRawMetadataImage, liveImage]);
 
+  // Checkpoint/LoRA references for on-demand Civitai links. Extraction is
+  // local-only (reads the raw metadata); the network lookup happens on click.
+  // Runtime metadata is compacted for large payloads (the params string, where
+  // hashes live, is stripped), so hydrate on demand before extracting.
+  const [resourceRefs, setResourceRefs] = useState<ResourceRef[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    const immediate = extractResourceRefs(rawMetadataImage?.metadata);
+    if (immediate.length > 0) {
+      setResourceRefs(immediate);
+      return;
+    }
+    if (hasCompactedRuntimeMetadata(liveImage)) {
+      ensureFullRawMetadata().then((full) => {
+        if (!cancelled) setResourceRefs(extractResourceRefs(full.metadata));
+      });
+    } else {
+      setResourceRefs([]);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [liveImage.id, rawMetadataImage, ensureFullRawMetadata]);
+
   useEffect(() => {
     setImageEditRecipe(DEFAULT_IMAGE_EDIT_RECIPE);
     setImageEditorTab('adjust');
@@ -1712,6 +1738,22 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const nMeta: BaseMetadata | undefined = getUsableNormalizedMetadata(liveImage);
   const canFindSimilar = Boolean(nMeta?.prompt) && Boolean(onFindSimilar);
   const effectiveMetadata = buildEffectiveMetadata(nMeta, shadowMetadata, showOriginal);
+
+  // The single checkpoint reference (if any) links the "Model" value.
+  const checkpointRef = useMemo(
+    () => resourceRefs.find((ref) => ref.type === 'checkpoint'),
+    [resourceRefs],
+  );
+  // LoRA refs keyed by normalized name so a displayed LoRA can be matched to its
+  // reference; unmatched LoRAs simply render as plain text.
+  const loraRefByName = useMemo(() => {
+    const map = new Map<string, ResourceRef>();
+    for (const ref of resourceRefs) {
+      if (ref.type === 'lora') map.set(normalizeResourceName(ref.name), ref);
+    }
+    return map;
+  }, [resourceRefs]);
+
   const generationImage = useMemo<IndexedImage>(() => (
     effectiveMetadata
       ? {
@@ -3996,7 +4038,14 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
                 <div className="grid grid-cols-2 gap-3">
                   <MetadataItem label="Seed" value={effectiveMetadata?.seed} onCopy={() => copyToClipboard(String(effectiveMetadata?.seed || ''), 'Seed', true)} />
-                  <MetadataItem label="Model" value={effectiveMetadata?.model} onCopy={() => copyToClipboard(effectiveMetadata?.model || '', 'Model', true)} />
+                  <MetadataItem
+                    label="Model"
+                    value={effectiveMetadata?.model}
+                    onCopy={() => copyToClipboard(effectiveMetadata?.model || '', 'Model', true)}
+                    renderValue={checkpointRef
+                      ? (value) => <CivitaiResourceLink resource={checkpointRef}>{value}</CivitaiResourceLink>
+                      : undefined}
+                  />
                 </div>
               </div>
 
@@ -4015,7 +4064,14 @@ const ImageModal: React.FC<ImageModalProps> = ({
                     {nMeta.generationType && (
                       <MetadataItem label="Generation Type" value={getGenerationTypeLabel(nMeta.generationType)} />
                     )}
-                    <MetadataItem label="Model" value={nMeta.model} onCopy={(v) => copyToClipboard(v, "Model", true)} />
+                    <MetadataItem
+                      label="Model"
+                      value={nMeta.model}
+                      onCopy={(v) => copyToClipboard(v, "Model", true)}
+                      renderValue={checkpointRef
+                        ? (value) => <CivitaiResourceLink resource={checkpointRef}>{value}</CivitaiResourceLink>
+                        : undefined}
+                    />
                     {nMeta.generator && (
                       <MetadataItem label="Generator" value={nMeta.generator} />
                     )}
@@ -4023,7 +4079,23 @@ const ImageModal: React.FC<ImageModalProps> = ({
                       <MetadataItem label="VAE" value={(nMeta as any).vae || (nMeta as any).vaes?.[0]?.name} />
                     )}
                     {effectiveMetadata?.loras && effectiveMetadata.loras.length > 0 && (
-                      <MetadataItem label="LoRAs" value={effectiveMetadata.loras.map(formatLoRA).join(', ')} />
+                      <MetadataItem
+                        label="LoRAs"
+                        value={effectiveMetadata.loras.map(formatLoRA).join(', ')}
+                        renderValue={loraRefByName.size > 0
+                          ? () => effectiveMetadata.loras.map((lora, index) => {
+                              const display = formatLoRA(lora);
+                              const rawName = typeof lora === 'string' ? lora : (lora.name || lora.model_name || display);
+                              const ref = loraRefByName.get(normalizeResourceName(rawName));
+                              return (
+                                <React.Fragment key={index}>
+                                  {index > 0 && ', '}
+                                  {ref ? <CivitaiResourceLink resource={ref}>{display}</CivitaiResourceLink> : display}
+                                </React.Fragment>
+                              );
+                            })
+                          : undefined}
+                      />
                     )}
                     <div className="grid grid-cols-2 gap-2">
                       <MetadataItem label="Steps" value={effectiveMetadata?.steps} onCopy={(v) => copyToClipboard(v, "Steps", true)} />

--- a/components/settings/PrivacySettingsPanel.tsx
+++ b/components/settings/PrivacySettingsPanel.tsx
@@ -10,6 +10,8 @@ export const PrivacySettingsPanel: React.FC = () => {
   const setSensitiveTags = useSettingsStore((state) => state.setSensitiveTags);
   const blurSensitiveImages = useSettingsStore((state) => state.blurSensitiveImages);
   const setBlurSensitiveImages = useSettingsStore((state) => state.setBlurSensitiveImages);
+  const civitaiLookupEnabled = useSettingsStore((state) => state.civitaiLookupEnabled);
+  const setCivitaiLookupEnabled = useSettingsStore((state) => state.setCivitaiLookupEnabled);
   const [sensitiveTagsInput, setSensitiveTagsInput] = useState('');
 
   useEffect(() => {
@@ -47,6 +49,14 @@ export const PrivacySettingsPanel: React.FC = () => {
           label="Blur instead of hide"
           description="Keep matches visible with blur, instead of removing them from the grid."
           control={<SettingSwitch checked={blurSensitiveImages} onChange={setBlurSensitiveImages} />}
+        />
+      </SettingsSectionCard>
+
+      <SettingsSectionCard title="Online lookups">
+        <SettingRow
+          label="Civitai links"
+          description="Let the model and LoRA names link to Civitai. The lookup only runs when you click one — it makes a single request to civitai.com and caches the result locally. Nothing is sent during indexing."
+          control={<SettingSwitch checked={civitaiLookupEnabled} onChange={setCivitaiLookupEnabled} />}
         />
       </SettingsSectionCard>
     </SettingsPanel>

--- a/electron.mjs
+++ b/electron.mjs
@@ -3192,6 +3192,55 @@ function setupFileOperationHandlers() {
     }
   });
 
+  // On-demand Civitai lookup for a model/LoRA reference, keyed by hash or by
+  // Civitai model version id. This is the ONLY outbound network request the app
+  // makes for this feature, and it fires only when the user clicks a model/LoRA
+  // in the image modal — never during indexing. Routing it through the main
+  // process avoids CORS and keeps it auditable/local-first.
+  ipcMain.handle('civitai-lookup', async (event, query) => {
+    try {
+      const hash = typeof query?.hash === 'string' ? query.hash.trim() : '';
+      const versionId = typeof query?.versionId === 'number' ? query.versionId : null;
+
+      let endpoint;
+      if (hash && /^[0-9a-f]{8,64}$/i.test(hash)) {
+        endpoint = `https://civitai.com/api/v1/model-versions/by-hash/${encodeURIComponent(hash)}`;
+      } else if (versionId && Number.isFinite(versionId)) {
+        endpoint = `https://civitai.com/api/v1/model-versions/${encodeURIComponent(String(versionId))}`;
+      } else {
+        return { status: 'notFound' };
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 15000);
+      let response;
+      try {
+        response = await fetch(endpoint, { signal: controller.signal, headers: { Accept: 'application/json' } });
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      if (response.status === 404) {
+        return { status: 'notFound' };
+      }
+      // Rate limit / server hiccups / anything non-OK: transient, do not cache.
+      if (!response.ok) {
+        return { status: 'unavailable' };
+      }
+
+      const data = await response.json();
+      const modelId = data?.modelId;
+      const resolvedVersionId = data?.id;
+      if (typeof modelId !== 'number' || typeof resolvedVersionId !== 'number') {
+        return { status: 'notFound' };
+      }
+      return { status: 'found', modelId, versionId: resolvedVersionId };
+    } catch (error) {
+      // Network failure / abort — transient, let the renderer offer a retry.
+      return { status: 'unavailable' };
+    }
+  });
+
   ipcMain.handle('open-path', async (event, filePath) => {
     try {
       if (!filePath) {

--- a/packages/metadata-engine/src/core/types.ts
+++ b/packages/metadata-engine/src/core/types.ts
@@ -23,6 +23,11 @@ export interface ElectronAPI {
   skipUpdateVersion: (version: string) => Promise<{ success: boolean; error?: string }>;
   launchGenerator: (payload: { command: string; workingDirectory?: string }) => Promise<{ success: boolean; error?: string; scriptPath?: string }>;
   openExternalUrl: (url: string) => Promise<{ success: boolean; error?: string }>;
+  civitaiLookup: (query: { hash?: string; versionId?: number }) => Promise<
+    | { status: 'found'; modelId: number; versionId: number }
+    | { status: 'notFound' }
+    | { status: 'unavailable' }
+  >;
   getDefaultCachePath: () => Promise<{ success: boolean; path?: string; error?: string }>;
   getAppVersion: () => Promise<string>;
   joinPaths: (...paths: string[]) => Promise<{ success: boolean; path?: string; error?: string }>;

--- a/preload.js
+++ b/preload.js
@@ -217,6 +217,7 @@ const electronAPI = {
   skipUpdateVersion: (version) => ipcRenderer.invoke('skip-version', version),
   launchGenerator: (payload) => ipcRenderer.invoke('launch-generator', payload),
   openExternalUrl: (url) => ipcRenderer.invoke('open-external-url', url),
+  civitaiLookup: (query) => ipcRenderer.invoke('civitai-lookup', query),
   openPath: (filePath) => ipcRenderer.invoke('open-path', filePath),
   comfyUIViewOpen: (payload) => ipcRenderer.invoke('comfy-view-open', payload),
   comfyUIViewShow: (payload) => ipcRenderer.invoke('comfy-view-show', payload),

--- a/services/civitai/civitaiLookup.ts
+++ b/services/civitai/civitaiLookup.ts
@@ -1,0 +1,147 @@
+/**
+ * On-demand Civitai resolution for resource references, with a persistent local
+ * cache. A reference resolves either by hash or by Civitai model version id.
+ *
+ * Local-first guarantees:
+ * - No request is ever made except from an explicit user action (clicking a
+ *   model/LoRA in the image modal). Nothing here runs during indexing.
+ * - The request is performed in the Electron main process (a single, auditable
+ *   egress point) — see the `civitai-lookup` IPC handler.
+ * - Results are cached locally so a given ref is fetched at most once. Negative
+ *   ("not on Civitai") results are cached with a TTL; transient failures (rate
+ *   limit, 5xx, network errors) are NOT cached.
+ */
+
+import { refKey, type ResourceRef } from './resourceExtraction';
+
+const CACHE_ID = 'civitai-hash-lookups';
+/** Re-check "not found" refs after this long — a model may appear later. */
+const NOT_FOUND_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export interface CivitaiHit {
+  url: string;
+  modelId: number;
+  versionId: number;
+}
+
+export type LookupResult =
+  | { status: 'found'; hit: CivitaiHit }
+  | { status: 'notFound' }
+  | { status: 'unavailable' };
+
+type CacheEntry = CivitaiHit | { notFound: true; fetchedAt: number };
+type CacheMap = Record<string, CacheEntry>;
+
+let memoryCache: CacheMap | null = null;
+const inFlight = new Map<string, Promise<LookupResult>>();
+
+const canUseElectron = (): boolean =>
+  typeof window !== 'undefined' && !!window.electronAPI?.civitaiLookup;
+
+const canUseJsonCache = (): boolean =>
+  typeof window !== 'undefined' &&
+  !!window.electronAPI?.getJsonCacheData &&
+  !!window.electronAPI?.writeJsonCacheData;
+
+const buildUrl = (modelId: number, versionId: number): string =>
+  `https://civitai.com/models/${modelId}?modelVersionId=${versionId}`;
+
+async function loadCache(): Promise<CacheMap> {
+  if (memoryCache) return memoryCache;
+  if (!canUseJsonCache()) {
+    memoryCache = {};
+    return memoryCache;
+  }
+  try {
+    const result = await window.electronAPI!.getJsonCacheData(CACHE_ID);
+    memoryCache = result.success && result.data && typeof result.data === 'object' ? (result.data as CacheMap) : {};
+  } catch {
+    memoryCache = {};
+  }
+  return memoryCache;
+}
+
+async function persistCache(): Promise<void> {
+  if (!canUseJsonCache() || !memoryCache) return;
+  try {
+    await window.electronAPI!.writeJsonCacheData({ cacheId: CACHE_ID, data: memoryCache });
+  } catch {
+    // Best-effort; a failure just means we re-fetch later.
+  }
+}
+
+function entryToResult(entry: CacheEntry): LookupResult | null {
+  if ('notFound' in entry) {
+    if (Date.now() - entry.fetchedAt < NOT_FOUND_TTL_MS) {
+      return { status: 'notFound' };
+    }
+    return null; // expired — treat as cache miss
+  }
+  return { status: 'found', hit: entry };
+}
+
+/**
+ * Read-only cache probe. Used when the modal mounts so a resolved ref shows as a
+ * ready link without any network request. Never triggers a lookup.
+ */
+export async function peekCachedRef(ref: ResourceRef): Promise<LookupResult | null> {
+  const cache = await loadCache();
+  const entry = cache[refKey(ref)];
+  return entry ? entryToResult(entry) : null;
+}
+
+/**
+ * Resolve a ref to a Civitai link, using the cache first and only hitting the
+ * network on a miss. Safe to call concurrently for the same ref.
+ */
+export async function lookupRef(ref: ResourceRef): Promise<LookupResult> {
+  const key = refKey(ref);
+
+  const cached = await peekCachedRef(ref);
+  if (cached) return cached;
+
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+
+  const promise = performLookup(ref, key).finally(() => inFlight.delete(key));
+  inFlight.set(key, promise);
+  return promise;
+}
+
+async function performLookup(ref: ResourceRef, key: string): Promise<LookupResult> {
+  if (!canUseElectron()) {
+    // Strictly Electron app; without the bridge we cannot reach Civitai.
+    return { status: 'unavailable' };
+  }
+
+  let response;
+  try {
+    response = await window.electronAPI!.civitaiLookup(
+      ref.hash ? { hash: ref.hash } : { versionId: ref.modelVersionId }
+    );
+  } catch {
+    return { status: 'unavailable' };
+  }
+
+  const cache = await loadCache();
+
+  if (response.status === 'found') {
+    const hit: CivitaiHit = {
+      url: buildUrl(response.modelId, response.versionId),
+      modelId: response.modelId,
+      versionId: response.versionId,
+    };
+    cache[key] = hit;
+    await persistCache();
+    return { status: 'found', hit };
+  }
+
+  if (response.status === 'notFound') {
+    cache[key] = { notFound: true, fetchedAt: Date.now() };
+    await persistCache();
+    return { status: 'notFound' };
+  }
+
+  // 'unavailable' — transient. Do NOT cache, so a retry re-fetches.
+  return { status: 'unavailable' };
+}

--- a/services/civitai/resourceExtraction.test.ts
+++ b/services/civitai/resourceExtraction.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { extractResourceRefs, normalizeResourceName } from './resourceExtraction';
+
+describe('extractResourceRefs', () => {
+  it('extracts checkpoint + LoRA hashes from an A1111 parameters string', () => {
+    const params =
+      'a prompt, <lora:- SDXL - AI-Breaker_V3.5:.5>\n' +
+      'Negative prompt: 3d\n' +
+      'Steps: 15, Seed: 980493476, Size: 816x1232, ' +
+      'Model hash: 36fab8f31a, Model: SDXL - T - haveallsdxl_v10, ' +
+      'Lora hashes: "- SDXL - AI-Breaker_V3.5: 62064ee0c3ba, CBS_novuschroma38 style: 29179d2a6166", ' +
+      'Hashes: {"lora:- SDXL - AI-Breaker_V3.5": "458cc11561", "lora:CBS_novuschroma38 style": "a1c6e6cad2", "model": "36fab8f31a"}';
+
+    const refs = extractResourceRefs({ parameters: params });
+    const checkpoints = refs.filter((r) => r.type === 'checkpoint');
+    expect(checkpoints).toHaveLength(1);
+    expect(checkpoints[0].hash).toBe('36fab8f31a');
+
+    const loras = refs.filter((r) => r.type === 'lora');
+    expect(loras).toHaveLength(2);
+    expect(loras.every((l) => !!l.hash)).toBe(true);
+  });
+
+  it('extracts model version ids from a `Civitai resources:` block', () => {
+    const params =
+      'a prompt\nSteps: 30, Seed: 1, Size: 832x1216, ' +
+      'Civitai resources: [' +
+      '{"type":"checkpoint","modelVersionId":691639,"modelName":"FLUX","modelVersionName":"Dev"},' +
+      '{"type":"lora","weight":0.3,"modelVersionId":1527024,"modelName":"FLUX.1-dev-LoRA-Cinematic"}' +
+      '], Civitai metadata: {}';
+
+    const refs = extractResourceRefs({ parameters: params });
+    expect(refs).toEqual([
+      { type: 'checkpoint', name: 'FLUX', modelVersionId: 691639 },
+      { type: 'lora', name: 'FLUX.1-dev-LoRA-Cinematic', modelVersionId: 1527024 },
+    ]);
+  });
+
+  it('extracts InvokeAI blake3 model + lora hashes, stripping the prefix', () => {
+    const raw = {
+      model: {
+        key: 'd1aac6dc',
+        hash: 'blake3:473a76d0adb6d3a1f63398f1dbe6b902cc6e09ee635c0655d1976a4bf6b6ad39',
+        name: 'Architecture (RealVisXL5)',
+      },
+      loras: [{ model: { hash: 'blake3:1234abcd5678ef90', name: 'MyLora' }, weight: 0.7 }],
+    };
+
+    const refs = extractResourceRefs(raw);
+    expect(refs).toEqual([
+      { type: 'checkpoint', name: 'Architecture (RealVisXL5)', hash: '473a76d0adb6d3a1f63398f1dbe6b902cc6e09ee635c0655d1976a4bf6b6ad39' },
+      { type: 'lora', name: 'MyLora', hash: '1234abcd5678ef90' },
+    ]);
+  });
+
+  it('falls back to `Model hash:` when there is no richer source', () => {
+    const params = 'a prompt\nSteps: 20, Model hash: ABCDEF1234, Model: myCheckpoint';
+    expect(extractResourceRefs({ parameters: params })).toEqual([
+      { type: 'checkpoint', name: 'myCheckpoint', hash: 'abcdef1234' },
+    ]);
+  });
+
+  it('returns [] when nothing is linkable', () => {
+    expect(extractResourceRefs({ parameters: 'just a prompt, Steps: 20' })).toEqual([]);
+    expect(extractResourceRefs({ workflow: '{}' })).toEqual([]);
+    expect(extractResourceRefs(null)).toEqual([]);
+  });
+});
+
+describe('normalizeResourceName', () => {
+  it('lowercases and strips path + extension', () => {
+    expect(normalizeResourceName('subdir\\My-LoRA.safetensors')).toBe('my-lora');
+    expect(normalizeResourceName('folder/Other.ckpt')).toBe('other');
+  });
+});

--- a/services/civitai/resourceExtraction.ts
+++ b/services/civitai/resourceExtraction.ts
@@ -1,0 +1,217 @@
+/**
+ * Extracts model/checkpoint and LoRA references from raw image metadata so they
+ * can be linked to Civitai on demand. A reference is resolvable either by hash
+ * (A1111 `Model hash:`/`Hashes:`, InvokeAI blake3) or directly by Civitai model
+ * version id (A1111 `Civitai resources:` JSON, written by Civitai/MetaHub).
+ *
+ * Extraction only reads already-parsed raw metadata (no network). The actual
+ * Civitai lookup happens on click — see services/civitai/civitaiLookup.ts.
+ */
+
+export type ResourceType = 'checkpoint' | 'lora';
+
+export interface ResourceRef {
+  type: ResourceType;
+  /** Best-effort label. The hash/versionId is the value that matters. */
+  name: string;
+  /** Normalized (lowercase) hash for a by-hash lookup. */
+  hash?: string;
+  /** Civitai model version id, when known directly (no lookup needed to key). */
+  modelVersionId?: number;
+}
+
+/** A stable key identifying what a ref resolves to (hash or version id). */
+export function refKey(ref: ResourceRef): string {
+  return ref.hash ? `h:${ref.hash}` : `v:${ref.modelVersionId}`;
+}
+
+/** Civitai-indexed hashes are hex; accept truncated AUTOSHA up to full blake3. */
+const HEX_HASH = /^[0-9a-f]{8,64}$/;
+
+function normalizeHash(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  // Strip InvokeAI/Civitai algorithm prefixes like "blake3:" / "sha256:".
+  const hash = raw.trim().toLowerCase().replace(/^(blake3|sha256|autov\d+):/, '');
+  return HEX_HASH.test(hash) ? hash : null;
+}
+
+function getParametersString(rawMetadata: unknown): string {
+  if (typeof rawMetadata === 'string') return rawMetadata;
+  if (rawMetadata && typeof rawMetadata === 'object') {
+    const params = (rawMetadata as Record<string, unknown>).parameters;
+    if (typeof params === 'string') return params;
+  }
+  return '';
+}
+
+interface ExtractionState {
+  out: ResourceRef[];
+  /** Ref keys already emitted, to avoid exact duplicates. */
+  seenKeys: Set<string>;
+  /** Normalized LoRA names already emitted, so a LoRA links once even when
+   *  multiple sources (Civitai resources, Hashes, Lora hashes) record it. */
+  seenLoraNames: Set<string>;
+}
+
+function hasCheckpoint(state: ExtractionState): boolean {
+  return state.out.some((r) => r.type === 'checkpoint');
+}
+
+function addCheckpoint(state: ExtractionState, ref: Omit<ResourceRef, 'type'>): void {
+  if (hasCheckpoint(state)) return;
+  const full: ResourceRef = { type: 'checkpoint', ...ref };
+  const key = refKey(full);
+  if (state.seenKeys.has(key)) return;
+  state.out.push(full);
+  state.seenKeys.add(key);
+}
+
+function addLora(state: ExtractionState, name: string, ref: Omit<ResourceRef, 'type' | 'name'>): void {
+  const full: ResourceRef = { type: 'lora', name, ...ref };
+  const key = refKey(full);
+  const nameKey = normalizeResourceName(name);
+  if (state.seenKeys.has(key) || state.seenLoraNames.has(nameKey)) return;
+  state.out.push(full);
+  state.seenKeys.add(key);
+  state.seenLoraNames.add(nameKey);
+}
+
+/**
+ * A1111 `Civitai resources: [{type, modelVersionId, modelName, ...}]` — written
+ * by Civitai/MetaHub. Carries the model version id directly (highest priority).
+ */
+function extractCivitaiResources(params: string, state: ExtractionState): void {
+  const match = params.match(/Civitai resources:\s*(\[[\s\S]*?\])/);
+  if (!match) return;
+
+  let resources: unknown;
+  try {
+    resources = JSON.parse(match[1]);
+  } catch {
+    return;
+  }
+  if (!Array.isArray(resources)) return;
+
+  for (const resource of resources) {
+    const versionId = resource?.modelVersionId;
+    if (typeof versionId !== 'number') continue;
+    const name = typeof resource?.modelName === 'string' ? resource.modelName : undefined;
+
+    if (resource?.type === 'checkpoint') {
+      addCheckpoint(state, { name: name || 'Model', modelVersionId: versionId });
+    } else if (resource?.type === 'lora') {
+      addLora(state, name || 'LoRA', { modelVersionId: versionId });
+    }
+  }
+}
+
+/** A1111 `Hashes: {"model": "...", "lora:Name": "..."}` block. */
+function extractFromHashesBlock(params: string, state: ExtractionState): void {
+  const match = params.match(/Hashes:\s*(\{[\s\S]*?\})/i);
+  if (!match) return;
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch {
+    return;
+  }
+  if (!parsed || typeof parsed !== 'object') return;
+
+  for (const [key, value] of Object.entries(parsed)) {
+    const hash = normalizeHash(value);
+    if (!hash) continue;
+    const lower = key.toLowerCase();
+    if (lower === 'model') {
+      addCheckpoint(state, { name: 'Model', hash });
+    } else if (lower.startsWith('lora:')) {
+      addLora(state, key.slice('lora:'.length) || key, { hash });
+    }
+  }
+}
+
+/** A1111 `Lora hashes: "name: hash, name2: hash2"` block. */
+function extractFromLoraHashesBlock(params: string, state: ExtractionState): void {
+  const block = params.match(/Lora hashes:\s*"([^"]+)"/i)?.[1];
+  if (!block) return;
+
+  for (const pair of block.split(',')) {
+    const idx = pair.lastIndexOf(':');
+    if (idx === -1) continue;
+    const name = pair.slice(0, idx).trim();
+    const hash = normalizeHash(pair.slice(idx + 1));
+    if (!name || !hash) continue;
+    addLora(state, name, { hash });
+  }
+}
+
+/** Standalone `Model hash: xxxx` (A1111/Forge/SDNext) checkpoint fallback. */
+function extractCheckpointHashFallback(params: string, state: ExtractionState): void {
+  if (hasCheckpoint(state)) return;
+  const hash = normalizeHash(params.match(/Model hash:\s*([0-9a-f]+)/i)?.[1]);
+  if (!hash) return;
+  const name = params.match(/Model:\s*([^,\n]+)/i)?.[1]?.trim() || 'Model';
+  addCheckpoint(state, { name, hash });
+}
+
+/**
+ * InvokeAI native JSON: `model: { name, hash: "blake3:..." }` and
+ * `loras: [{ model: { name, hash }, weight }]`.
+ */
+function extractInvokeAI(rawMetadata: unknown, state: ExtractionState): void {
+  if (!rawMetadata || typeof rawMetadata !== 'object') return;
+  const raw = rawMetadata as Record<string, unknown>;
+
+  const model = raw.model;
+  if (model && typeof model === 'object') {
+    const m = model as Record<string, unknown>;
+    const hash = normalizeHash(m.hash);
+    if (hash) addCheckpoint(state, { name: typeof m.name === 'string' ? m.name : 'Model', hash });
+  }
+
+  if (Array.isArray(raw.loras)) {
+    for (const entry of raw.loras) {
+      const lm = (entry?.model ?? entry) as Record<string, unknown> | undefined;
+      const hash = normalizeHash(lm?.hash);
+      if (hash) addLora(state, typeof lm?.name === 'string' ? lm.name : 'LoRA', { hash });
+    }
+  }
+}
+
+/**
+ * Extract all checkpoint + LoRA references from raw metadata, deduped.
+ * Returns [] when the format carries nothing linkable.
+ */
+export function extractResourceRefs(rawMetadata: unknown): ResourceRef[] {
+  const state: ExtractionState = {
+    out: [],
+    seenKeys: new Set<string>(),
+    seenLoraNames: new Set<string>(),
+  };
+
+  const params = getParametersString(rawMetadata);
+  if (params) {
+    // Civitai resources first: it gives the version id directly.
+    extractCivitaiResources(params, state);
+    extractFromHashesBlock(params, state);
+    extractFromLoraHashesBlock(params, state);
+    extractCheckpointHashFallback(params, state);
+  }
+  extractInvokeAI(rawMetadata, state);
+
+  return state.out;
+}
+
+/**
+ * Normalize a resource name for matching a displayed label against an extracted
+ * ref: lowercase, strip directory prefix and file extension.
+ */
+export function normalizeResourceName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/\\/g, '/')
+    .split('/')
+    .pop()!
+    .replace(/\.(safetensors|ckpt|pt|pth|bin)$/i, '');
+}

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -121,6 +121,7 @@ interface SettingsState {
   sensitiveTags: string[];
   blurSensitiveImages: boolean;
   enableSafeMode: boolean;
+  civitaiLookupEnabled: boolean;
   enableAnimations: boolean;
   performanceDiagnosticsEnabled: boolean;
   slideshowIntervalSeconds: number;
@@ -171,6 +172,7 @@ interface SettingsState {
   setSensitiveTags: (tags: string[]) => void;
   setBlurSensitiveImages: (value: boolean) => void;
   setEnableSafeMode: (value: boolean) => void;
+  setCivitaiLookupEnabled: (value: boolean) => void;
   setEnableAnimations: (value: boolean) => void;
   setPerformanceDiagnosticsEnabled: (value: boolean) => void;
   setSlideshowIntervalSeconds: (value: number) => void;
@@ -225,6 +227,7 @@ export const useSettingsStore = create<SettingsState>()(
       sensitiveTags: ['nsfw', 'private', 'hidden'],
       blurSensitiveImages: true,
       enableSafeMode: true,
+      civitaiLookupEnabled: true,
       enableAnimations: true,
       performanceDiagnosticsEnabled: false,
       slideshowIntervalSeconds: DEFAULT_SLIDESHOW_INTERVAL_SECONDS,
@@ -287,6 +290,7 @@ export const useSettingsStore = create<SettingsState>()(
       },
       setBlurSensitiveImages: (value) => set({ blurSensitiveImages: !!value }),
       setEnableSafeMode: (value) => set({ enableSafeMode: !!value }),
+      setCivitaiLookupEnabled: (value) => set({ civitaiLookupEnabled: !!value }),
       setEnableAnimations: (value) => set({ enableAnimations: !!value }),
       setPerformanceDiagnosticsEnabled: (value) => set({ performanceDiagnosticsEnabled: !!value }),
       setSlideshowIntervalSeconds: (value) =>
@@ -363,6 +367,7 @@ export const useSettingsStore = create<SettingsState>()(
         sensitiveTags: ['nsfw', 'private', 'hidden'],
         blurSensitiveImages: true,
         enableSafeMode: true,
+        civitaiLookupEnabled: true,
         enableAnimations: true,
         performanceDiagnosticsEnabled: false,
         slideshowIntervalSeconds: DEFAULT_SLIDESHOW_INTERVAL_SECONDS,
@@ -455,6 +460,10 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && typeof state.enableSafeMode !== 'boolean') {
           state.enableSafeMode = true;
+        }
+
+        if (state && typeof state.civitaiLookupEnabled !== 'boolean') {
+          state.civitaiLookupEnabled = true;
         }
 
         if (state && typeof state.enableAnimations !== 'boolean') {

--- a/types.ts
+++ b/types.ts
@@ -379,6 +379,16 @@ export interface ThumbnailGenerateToCacheRequest extends ThumbnailCacheCandidate
   quality?: number;
 }
 
+export type CivitaiLookupResult =
+  | { status: 'found'; modelId: number; versionId: number }
+  | { status: 'notFound' }
+  | { status: 'unavailable' };
+
+export interface CivitaiLookupQuery {
+  hash?: string;
+  versionId?: number;
+}
+
 export interface ElectronAPI {
   trashFile: (filename: string) => Promise<{ success: boolean; error?: string }>;
   renameFile: (oldName: string, newName: string) => Promise<{ success: boolean; error?: string }>;
@@ -426,6 +436,7 @@ export interface ElectronAPI {
   skipUpdateVersion: (version: string) => Promise<{ success: boolean; error?: string }>;
   launchGenerator: (payload: { command: string; workingDirectory?: string }) => Promise<{ success: boolean; error?: string; scriptPath?: string }>;
   openExternalUrl: (url: string) => Promise<{ success: boolean; error?: string }>;
+  civitaiLookup: (query: CivitaiLookupQuery) => Promise<CivitaiLookupResult>;
   openPath: (filePath: string) => Promise<{ success: boolean; error?: string; errorType?: string }>;
   comfyUIViewOpen: (payload: { url: string; bounds?: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;
   comfyUIViewShow: (payload?: { bounds?: ComfyUIViewBounds }) => Promise<ComfyUIViewResult>;


### PR DESCRIPTION
## What

Makes the **Model** and **LoRA** values in the image modal clickable, opening the corresponding Civitai page. Nothing changes for images with no linkable reference.

## How it works

- **Local extraction (no network):** references are pulled from raw metadata at display time — A1111 `Civitai resources:` model version ids, A1111/Forge/SDNext/Fooocus hashes (`Model hash:` / `Hashes:` / `Lora hashes:`), and InvokeAI blake3 hashes (`model.hash`, `loras[].model.hash`). Compacted runtime metadata is hydrated on demand before extracting.
- **On-demand lookup:** the Civitai request runs only when you click a model/LoRA. It goes through a single main-process egress point (`civitai-lookup`, keyed by hash or model version id) to avoid CORS and keep the network surface auditable. The result opens in the browser.
- **Local-first cache:** results are cached locally (hash/version → URL), so a reference is fetched at most once. "Not found" is cached with a 7-day TTL; transient failures (429/5xx/network) are not cached. **No requests are made during indexing.**
- **Opt-out:** a "Civitai links" toggle under Settings › Privacy (on by default) turns the feature off, rendering names as plain text.

## Notes

- Long, space-less model names now wrap inside the metadata box instead of overflowing.
- InvokeAI uses full blake3 hashes; Civitai's by-hash coverage for blake3 may be partial, in which case the model shows as plain text ("not found on Civitai").

## Tests

`services/civitai/resourceExtraction.test.ts` covers A1111 hashes, `Civitai resources:` version ids, and InvokeAI blake3 extraction (6 cases). UI states (found / not found / unavailable / toggle off / no request during indexing) verified manually.