### PR TITLE
fix: link Civitai for MetaHub Save Node images

### DIFF
--- a/services/civitai/resourceExtraction.test.ts
+++ b/services/civitai/resourceExtraction.test.ts
@@ -53,6 +53,34 @@ describe('extractResourceRefs', () => {
     ]);
   });
 
+  it('extracts the checkpoint hash from a MetaHub Save Node chunk', () => {
+    // MetaHub-saved images keep only `imagemetahub_data`; the `parameters`
+    // chunk (with the LoRA hash) is dropped by the indexer.
+    const raw = {
+      imagemetahub_data: {
+        generator: 'ComfyUI',
+        model: 'intorealism_zitV70.safetensors',
+        model_hash: '62ef7640ab',
+        loras: [{ name: 'Z-Detail-Slider.safetensors', weight: 0.5325 }],
+      },
+    };
+    expect(extractResourceRefs(raw)).toEqual([
+      { type: 'checkpoint', name: 'intorealism_zitV70.safetensors', hash: '62ef7640ab' },
+    ]);
+  });
+
+  it('extracts MetaHub LoRA hashes when present on the lora entry', () => {
+    const raw = {
+      imagemetahub_data: {
+        model: 'ckpt',
+        model_hash: 'aaaa1111bbbb',
+        loras: [{ name: 'MyLora', hash: 'cccc2222dddd' }],
+      },
+    };
+    const refs = extractResourceRefs(raw);
+    expect(refs).toContainEqual({ type: 'lora', name: 'MyLora', hash: 'cccc2222dddd' });
+  });
+
   it('falls back to `Model hash:` when there is no richer source', () => {
     const params = 'a prompt\nSteps: 20, Model hash: ABCDEF1234, Model: myCheckpoint';
     expect(extractResourceRefs({ parameters: params })).toEqual([

--- a/services/civitai/resourceExtraction.ts
+++ b/services/civitai/resourceExtraction.ts
@@ -179,6 +179,29 @@ function extractInvokeAI(rawMetadata: unknown, state: ExtractionState): void {
 }
 
 /**
+ * MetaHub Save Node JSON (`imagemetahub_data`). For MetaHub-saved images the
+ * indexer keeps only this chunk and drops the A1111 `parameters` string, so the
+ * checkpoint hash must come from here: `{ model, model_hash, loras: [...] }`.
+ */
+function extractMetaHubData(rawMetadata: unknown, state: ExtractionState): void {
+  if (!rawMetadata || typeof rawMetadata !== 'object') return;
+  const data = (rawMetadata as Record<string, unknown>).imagemetahub_data;
+  if (!data || typeof data !== 'object') return;
+  const d = data as Record<string, unknown>;
+
+  const modelHash = normalizeHash(d.model_hash);
+  if (modelHash) addCheckpoint(state, { name: typeof d.model === 'string' ? d.model : 'Model', hash: modelHash });
+
+  if (Array.isArray(d.loras)) {
+    for (const entry of d.loras) {
+      const lora = entry as Record<string, unknown> | undefined;
+      const hash = normalizeHash(lora?.hash ?? lora?.model_hash);
+      if (hash) addLora(state, typeof lora?.name === 'string' ? lora.name : 'LoRA', { hash });
+    }
+  }
+}
+
+/**
  * Extract all checkpoint + LoRA references from raw metadata, deduped.
  * Returns [] when the format carries nothing linkable.
  */
@@ -198,6 +221,7 @@ export function extractResourceRefs(rawMetadata: unknown): ResourceRef[] {
     extractCheckpointHashFallback(params, state);
   }
   extractInvokeAI(rawMetadata, state);
+  extractMetaHubData(rawMetadata, state);
 
   return state.out;
 }


### PR DESCRIPTION
## Problem

For images saved with the **MetaHub Save Node** (e.g. ComfyUI), the model/LoRA values stayed plain text — the Civitai link never appeared.

Cause: the indexer keeps only the `imagemetahub_data` chunk for these images and drops the A1111 `parameters` string (`fileIndexer` PNG parser, PRIORITY 0). The resource extractor only read `parameters`, so it found no hashes.

## Fix

Extract from `imagemetahub_data` as well:
- checkpoint hash from `imagemetahub_data.model_hash` (label from `model`);
- LoRA hashes from `loras[].hash` / `loras[].model_hash` when the node records them.

Runtime compaction strips these fields for large payloads (big ComfyUI workflows), but the modal already hydrates the full raw metadata on demand before extracting, so the link resolves after hydration.

## Notes

- If a checkpoint hash isn't indexed on Civitai (niche/local models), it correctly shows as plain "not found" — that's expected, not a regression.
- In the sample image, the LoRA hash lived only in the dropped `parameters` chunk, so LoRAs there stay unlinked; checkpoints now link.

## Tests

Two cases added to `services/civitai/resourceExtraction.test.ts` (MetaHub checkpoint hash; MetaHub LoRA hash when present). 8/8 passing.