### PR TITLE
fix: parse A1111 Sampler and Schedule type into separate fields

### DIFF
--- a/packages/metadata-engine/src/parsers/automatic1111Parser.test.ts
+++ b/packages/metadata-engine/src/parsers/automatic1111Parser.test.ts
@@ -21,9 +21,17 @@ describe('parseA1111Metadata', () => {
     const params = 'A beautiful landscape\nNegative prompt: ugly, blurry\nSteps: 20, Sampler: Euler a, CFG scale: 7, Seed: 12345';
     const result = parseA1111Metadata(params);
     expect(result?.steps).toBe(20);
-    expect(result?.scheduler).toBe('Euler a');
+    expect(result?.sampler).toBe('Euler a');
+    expect(result?.scheduler).toBeUndefined();
     expect(result?.cfg_scale).toBe(7);
     expect(result?.seed).toBe(12345);
+  });
+
+  it('should parse Sampler and Schedule type into separate fields', () => {
+    const params = 'A beautiful landscape\nSteps: 25, Sampler: Euler a, Schedule type: Simple, CFG scale: 5, Seed: 3036648173';
+    const result = parseA1111Metadata(params);
+    expect(result?.sampler).toBe('Euler a');
+    expect(result?.scheduler).toBe('Simple');
   });
 
   it('should handle missing negative prompt', () => {

--- a/packages/metadata-engine/src/parsers/automatic1111Parser.ts
+++ b/packages/metadata-engine/src/parsers/automatic1111Parser.ts
@@ -131,11 +131,11 @@ export function parseA1111Metadata(parameters: string): BaseMetadata {
   if (stepsMatch) result.steps = parseInt(stepsMatch[1], 10);
 
   const samplerMatch = parameters.match(/Sampler: ([^,]+)/);
-  if (samplerMatch) result.scheduler = samplerMatch[1].trim();
+  if (samplerMatch) result.sampler = samplerMatch[1].trim();
 
   // Suporte para "Schedule type:" (usado em builds modernas)
   const scheduleTypeMatch = parameters.match(/Schedule type: ([^,]+)/);
-  if (scheduleTypeMatch && !result.scheduler) {
+  if (scheduleTypeMatch) {
     result.scheduler = scheduleTypeMatch[1].trim();
   }
 

--- a/services/parsers/automatic1111Parser.test.ts
+++ b/services/parsers/automatic1111Parser.test.ts
@@ -21,9 +21,17 @@ describe('parseA1111Metadata', () => {
     const params = 'A beautiful landscape\nNegative prompt: ugly, blurry\nSteps: 20, Sampler: Euler a, CFG scale: 7, Seed: 12345';
     const result = parseA1111Metadata(params);
     expect(result?.steps).toBe(20);
-    expect(result?.scheduler).toBe('Euler a');
+    expect(result?.sampler).toBe('Euler a');
+    expect(result?.scheduler).toBeUndefined();
     expect(result?.cfg_scale).toBe(7);
     expect(result?.seed).toBe(12345);
+  });
+
+  it('should parse Sampler and Schedule type into separate fields', () => {
+    const params = 'A beautiful landscape\nSteps: 25, Sampler: Euler a, Schedule type: Simple, CFG scale: 5, Seed: 3036648173';
+    const result = parseA1111Metadata(params);
+    expect(result?.sampler).toBe('Euler a');
+    expect(result?.scheduler).toBe('Simple');
   });
 
   it('should handle missing negative prompt', () => {

--- a/services/parsers/automatic1111Parser.ts
+++ b/services/parsers/automatic1111Parser.ts
@@ -147,11 +147,11 @@ export function parseA1111Metadata(parameters: string): BaseMetadata {
   if (stepsMatch) result.steps = parseInt(stepsMatch[1], 10);
 
   const samplerMatch = parameters.match(/Sampler: ([^,]+)/);
-  if (samplerMatch) result.scheduler = samplerMatch[1].trim();
+  if (samplerMatch) result.sampler = samplerMatch[1].trim();
 
   // Suporte para "Schedule type:" (usado em builds modernas)
   const scheduleTypeMatch = parameters.match(/Schedule type: ([^,]+)/);
-  if (scheduleTypeMatch && !result.scheduler) {
+  if (scheduleTypeMatch) {
     result.scheduler = scheduleTypeMatch[1].trim();
   }
 


### PR DESCRIPTION
## Summary
- Fixes #474: the `Sampler` value from A1111-style metadata (e.g. `Sampler: Euler a`) was being written to `result.scheduler` instead of `result.sampler`, so the Generation Details pane showed the sampler name under the **SCHEDULER** heading while **SAMPLER** was left blank.
- `Schedule type:` (used by modern A1111/Forge builds) now always populates `scheduler` independently of `sampler`, so both fields are preserved when present (e.g. `Sampler: Euler a, Schedule type: Simple`).
- Applied the same fix to the duplicated parser in `packages/metadata-engine` (published npm package), which had the identical bug.

## Test plan
- [x] Updated `automatic1111Parser.test.ts` (both `services/parsers` and `packages/metadata-engine`) to assert `sampler`/`scheduler` are populated correctly, including a new test covering `Sampler` + `Schedule type` together (matching the ForgeNeo sample from the issue).
- [x] Full test suite passes: `npx vitest run` — 103 files / 517 tests passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A3swLmrLFK7ThSWWUkpVSR)_