### PR TITLE
Improve metadata panel UX with synchronized scrolling and unified expansion

### DIFF
--- a/__tests__/ComparisonModal.interaction.test.tsx
+++ b/__tests__/ComparisonModal.interaction.test.tsx
@@ -53,17 +53,25 @@ vi.mock('../components/ComparisonMetadataPanel', () => ({
     image,
     isExpanded,
     isHighlighted,
+    viewMode,
+    onToggleExpanded,
   }: {
     image: IndexedImage;
     isExpanded: boolean;
     isHighlighted?: boolean;
+    viewMode?: 'standard' | 'diff';
+    onToggleExpanded?: () => void;
   }) => (
     <div
       data-testid={`metadata-${image.id}`}
       data-expanded={isExpanded ? 'true' : 'false'}
       data-highlighted={isHighlighted ? 'true' : 'false'}
+      data-view-mode={viewMode}
     >
       {image.name}
+      <button type="button" aria-label={`Toggle ${image.id}`} onClick={() => onToggleExpanded?.()}>
+        Toggle
+      </button>
     </div>
   ),
 }));
@@ -111,6 +119,49 @@ describe('ComparisonModal interactions', () => {
 
     fireEvent.mouseLeave(screen.getByTestId('pane-img-2'));
     expect(screen.getByTestId('metadata-img-2').getAttribute('data-highlighted')).toBe('false');
+  });
+
+  it('expands every metadata panel together from a single toggle click', () => {
+    const first = createImage('img-1', 'first prompt');
+    const second = createImage('img-2', 'second prompt');
+
+    useImageStore.setState({
+      comparisonImages: [first, second],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+    } as any);
+
+    render(<ComparisonModal isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByTestId('metadata-img-1').getAttribute('data-expanded')).toBe('false');
+    expect(screen.getByTestId('metadata-img-2').getAttribute('data-expanded')).toBe('false');
+
+    // Clicking a single panel's toggle should reveal all panels at once.
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle img-1' }));
+
+    expect(screen.getByTestId('metadata-img-1').getAttribute('data-expanded')).toBe('true');
+    expect(screen.getByTestId('metadata-img-2').getAttribute('data-expanded')).toBe('true');
+  });
+
+  it('defaults the metadata view to diff and toggles back to standard', () => {
+    const first = createImage('img-1', 'first prompt');
+    const second = createImage('img-2', 'second prompt');
+
+    useImageStore.setState({
+      comparisonImages: [first, second],
+      directories: [{ id: 'dir-1', path: 'D:/library' }],
+    } as any);
+
+    render(<ComparisonModal isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByTestId('metadata-img-1').getAttribute('data-view-mode')).toBe('diff');
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByTestId('metadata-img-1').getAttribute('data-view-mode')).toBe('standard');
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
   });
 
   it('enables advanced two-image modes and shows visual delta controls', () => {

--- a/components/ComparisonMetadataPanel.tsx
+++ b/components/ComparisonMetadataPanel.tsx
@@ -122,6 +122,8 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
   className,
   compareLabel,
   isHighlighted = false,
+  registerScrollRef,
+  onContentScroll,
 }) => {
   const metadata = image.metadata?.normalizedMetadata;
   const isDiffMode = viewMode === 'diff';
@@ -209,7 +211,10 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
 
       {/* Metadata Content */}
       {isExpanded && (
-        <div className="p-3 space-y-3 max-h-[300px] overflow-y-auto border-t border-gray-700/50">
+        <div
+          ref={registerScrollRef}
+          onScroll={onContentScroll ? (event) => onContentScroll(event.currentTarget.scrollTop) : undefined}
+          className="p-3 space-y-3 max-h-[300px] overflow-y-auto border-t border-gray-700/50">
           {/* Prompt */}
           {(metadata.prompt || (isDiffMode && otherImageMetadata?.prompt)) && (
             <MetadataField

--- a/components/ComparisonModal.tsx
+++ b/components/ComparisonModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, FC, useMemo } from 'react';
+import React, { useState, useEffect, FC, useMemo, useRef } from 'react';
 import { X, Repeat, ArrowLeft } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { BaseMetadata, ComparisonAdvancedSettings, ComparisonLayoutMode, ComparisonModalProps, IndexedImage, ZoomState, ComparisonViewMode } from '../types';
@@ -30,10 +30,10 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
 
   const [syncEnabled, setSyncEnabled] = useState(true);
   const [sharedZoom, setSharedZoom] = useState<ZoomState>({ zoom: 1, x: 0, y: 0 });
-  const [expandedMetadataIndexes, setExpandedMetadataIndexes] = useState<Set<number>>(() => new Set());
+  const [isMetadataExpanded, setIsMetadataExpanded] = useState(false);
   const [viewMode, setViewMode] = useState<ComparisonViewMode>('side-by-side');
   const [layoutMode, setLayoutMode] = useState<ComparisonLayoutMode>('strip');
-  const [metadataViewMode, setMetadataViewMode] = useState<'standard' | 'diff'>('standard');
+  const [metadataViewMode, setMetadataViewMode] = useState<'standard' | 'diff'>('diff');
   const [activeMetadataIndex, setActiveMetadataIndex] = useState<number | null>(null);
   const [visualMetrics, setVisualMetrics] = useState<VisualComparisonMetrics | null>(null);
   const [highlightDeltaRegion, setHighlightDeltaRegion] = useState(false);
@@ -46,6 +46,9 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
     loupeZoom: 2,
     showLabels: true,
   });
+
+  const metadataScrollRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  const isSyncingMetadataScroll = useRef(false);
 
   const imageCount = comparisonImages.length;
   const supportsOverlayModes = imageCount === 2;
@@ -98,20 +101,34 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
     }
   };
 
-  const toggleMetadataPanel = (index: number) => {
-    setExpandedMetadataIndexes((current) => {
-      const next = new Set(current);
-      if (next.has(index)) {
-        next.delete(index);
-      } else {
-        next.add(index);
+  const toggleMetadataPanel = () => {
+    setIsMetadataExpanded((current) => !current);
+  };
+
+  const registerMetadataScrollRef = (index: number) => (element: HTMLDivElement | null) => {
+    if (element) {
+      metadataScrollRefs.current.set(index, element);
+    } else {
+      metadataScrollRefs.current.delete(index);
+    }
+  };
+
+  const handleMetadataScroll = (index: number, scrollTop: number) => {
+    if (isSyncingMetadataScroll.current) return;
+    isSyncingMetadataScroll.current = true;
+    metadataScrollRefs.current.forEach((element, refIndex) => {
+      if (refIndex !== index && element.scrollTop !== scrollTop) {
+        element.scrollTop = scrollTop;
       }
-      return next;
+    });
+    // Release the lock after the synced scrolls have dispatched their events.
+    window.requestAnimationFrame(() => {
+      isSyncingMetadataScroll.current = false;
     });
   };
 
   useEffect(() => {
-    setExpandedMetadataIndexes(new Set());
+    setIsMetadataExpanded(false);
     setActiveMetadataIndex(null);
     setVisualMetrics(null);
     setHighlightDeltaRegion(false);
@@ -523,30 +540,27 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
             )}
           </div>
 
-          <div className="inline-flex bg-gray-900/60 border border-gray-700/70 rounded-lg overflow-hidden">
-            <button
-              onClick={() => setMetadataViewMode('standard')}
-              className={`px-3 py-1.5 text-sm font-medium transition-colors border-r border-gray-700/40 ${
-                metadataViewMode === 'standard'
-                  ? 'bg-blue-600 text-white border-blue-500/60'
-                  : 'text-gray-300 hover:text-white hover:bg-gray-700/60'
+          <button
+            type="button"
+            role="switch"
+            aria-checked={metadataViewMode === 'diff'}
+            onClick={() => setMetadataViewMode((current) => (current === 'diff' ? 'standard' : 'diff'))}
+            className="group inline-flex items-center gap-2 text-xs font-medium text-gray-400 hover:text-gray-200 transition-colors"
+            title={metadataViewMode === 'diff' ? 'Highlighting differences — click to show standard view' : 'Showing standard view — click to highlight differences'}
+          >
+            <span className={metadataViewMode === 'diff' ? 'text-gray-200' : ''}>Diff</span>
+            <span
+              className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${
+                metadataViewMode === 'diff' ? 'bg-blue-600' : 'bg-gray-600/70'
               }`}
-              title="Show all metadata in standard format"
             >
-              Standard View
-            </button>
-            <button
-              onClick={() => setMetadataViewMode('diff')}
-              className={`px-3 py-1.5 text-sm font-medium transition-colors ${
-                metadataViewMode === 'diff'
-                  ? 'bg-blue-600 text-white border-blue-500/60'
-                  : 'text-gray-300 hover:text-white hover:bg-gray-700/60'
-              }`}
-              title="Highlight differences between metadata"
-            >
-              Diff View
-            </button>
-          </div>
+              <span
+                className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${
+                  metadataViewMode === 'diff' ? 'translate-x-3.5' : 'translate-x-0.5'
+                }`}
+              />
+            </span>
+          </button>
         </div>
 
         <div className={`grid gap-4 max-w-7xl mx-auto ${imageCount > 2 ? 'grid-cols-1 md:grid-cols-2' : 'grid-cols-1 md:grid-cols-2'}`}>
@@ -558,13 +572,15 @@ const ComparisonModal: FC<ComparisonModalProps> = ({ isOpen, onClose }) => {
               <ComparisonMetadataPanel
                 key={image.id}
                 image={image}
-                isExpanded={expandedMetadataIndexes.has(index)}
-                onToggleExpanded={() => toggleMetadataPanel(index)}
+                isExpanded={isMetadataExpanded}
+                onToggleExpanded={toggleMetadataPanel}
                 viewMode={metadataViewMode}
                 otherImageMetadata={otherImageMetadata}
                 className={isOddLastGridItem ? 'md:col-span-2' : ''}
                 compareLabel={index === 0 ? 'Reference' : metadataViewMode === 'diff' ? 'vs Image 1' : undefined}
                 isHighlighted={activeMetadataIndex === index}
+                registerScrollRef={registerMetadataScrollRef(index)}
+                onContentScroll={(scrollTop) => handleMetadataScroll(index, scrollTop)}
               />
             );
           })}

--- a/components/ComparisonOverlayView.tsx
+++ b/components/ComparisonOverlayView.tsx
@@ -73,6 +73,10 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDraggingHandle, setIsDraggingHandle] = useState(false);
   const isAdvancedMode = ADVANCED_MODES.has(mode);
+  // Flicker renders its own single-image layer (see renderAdvancedLayer) rather than
+  // stacking both base images, but it must not trigger the heavy visual analysis that
+  // the ADVANCED_MODES pipeline performs.
+  const usesCustomLayer = isAdvancedMode || mode === 'flicker';
 
   useEffect(() => {
     if (!transformRef.current || !transformRef.current.state) return;
@@ -480,7 +484,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                   </div>
                 )}
 
-                {!isAdvancedMode && rightUrl && (
+                {!usesCustomLayer && rightUrl && (
                   <img
                     src={rightUrl}
                     alt={rightImage.name}
@@ -489,7 +493,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                   />
                 )}
 
-                {!isAdvancedMode && leftUrl && (
+                {!usesCustomLayer && leftUrl && (
                   <img
                     src={leftUrl}
                     alt={leftImage.name}
@@ -498,7 +502,7 @@ const ComparisonOverlayView: FC<ComparisonOverlayViewProps> = ({
                   />
                 )}
 
-                {isAdvancedMode && renderAdvancedLayer()}
+                {usesCustomLayer && renderAdvancedLayer()}
 
                 {ready && mode === 'slider' && (
                   <>

--- a/packages/metadata-engine/src/core/types.ts
+++ b/packages/metadata-engine/src/core/types.ts
@@ -650,4 +650,6 @@ export interface ComparisonMetadataPanelProps {
   otherImageMetadata?: BaseMetadata | null;
   className?: string;
   compareLabel?: string;
+  registerScrollRef?: (element: HTMLDivElement | null) => void;
+  onContentScroll?: (scrollTop: number) => void;
 }

--- a/types.ts
+++ b/types.ts
@@ -1109,6 +1109,8 @@ export interface ComparisonMetadataPanelProps {
   className?: string;
   compareLabel?: string;
   isHighlighted?: boolean;
+  registerScrollRef?: (element: HTMLDivElement | null) => void;
+  onContentScroll?: (scrollTop: number) => void;
 }
 
 // ===== Smart Clustering & Auto-Tagging Types =====


### PR DESCRIPTION
## Summary
This PR enhances the metadata comparison experience by implementing synchronized scrolling across metadata panels and simplifying the expansion behavior to toggle all panels together rather than individually.

## Key Changes

- **Unified Metadata Panel Expansion**: Changed from per-image expansion tracking to a single boolean state (`isMetadataExpanded`). Now clicking the toggle on any metadata panel expands/collapses all panels simultaneously, providing a more cohesive UX.

- **Synchronized Metadata Scrolling**: Implemented scroll synchronization across metadata panels using `useRef` to track scroll positions. When one panel is scrolled, others automatically scroll to the same position, keeping content aligned across comparisons.

- **Default to Diff View**: Changed the default metadata view mode from 'standard' to 'diff', making it easier for users to immediately spot differences between images.

- **Improved Metadata View Toggle**: Replaced the two-button toggle UI with a modern switch component that better communicates the current state and provides clearer affordance for toggling between standard and diff views.

- **Fixed Flicker Mode Rendering**: Corrected the overlay view logic to properly handle the 'flicker' mode, which uses a custom layer like advanced modes but shouldn't trigger the heavy visual analysis pipeline. Introduced `usesCustomLayer` variable for clarity.

## Implementation Details

- Added `metadataScrollRefs` and `isSyncingMetadataScroll` refs to manage scroll synchronization with debouncing via `requestAnimationFrame` to prevent infinite scroll loops.
- Updated `ComparisonMetadataPanel` to accept `registerScrollRef` and `onContentScroll` callbacks for scroll event handling.
- Simplified the `toggleMetadataPanel` function to toggle a single boolean instead of managing a Set of expanded indexes.
- Updated test cases to verify the new unified expansion behavior and default diff view mode.

https://claude.ai/code/session_01WfuDWh5ubLPKpdDe5beULB