### PR TITLE
Live ComfyUI generation preview in the Queue + Run workflow button

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -46,6 +46,7 @@ import { useA1111ProgressContext } from './contexts/A1111ProgressContext';
 import { useGenerationQueueSync } from './hooks/useGenerationQueueSync';
 import { useGenerationQueueRunner } from './hooks/useGenerationQueueRunner';
 import { useComfyUIQueueMonitor } from './hooks/useComfyUIQueueMonitor';
+import { useComfyUIEmbeddedProgress } from './hooks/useComfyUIEmbeddedProgress';
 import {
   beginPerformanceFlow,
   createProfilerOnRender,
@@ -226,6 +227,7 @@ export default function App() {
   const { progressState: a1111Progress } = useA1111ProgressContext();
   useGenerationQueueSync();
   useComfyUIQueueMonitor();
+  useComfyUIEmbeddedProgress();
 
   // --- Hooks ---
   const { handleSelectFolder, handleUpdateFolder, handleLoadFromStorage, handleRemoveDirectory, loadDirectory, processNewWatchedFiles } = useImageLoader();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.18.0]
+
+### Added
+
+- **Live Generation Preview**: The Queue now shows a live, KSampler-style preview image that updates step-by-step during ComfyUI generation — both for generations started from MetaHub's own workspace and from the embedded ComfyUI UI. The preview/output image box can be dragged taller for portrait images, and the size is remembered across sessions.
+- **Run Current Workflow**: Added a "Run" button to the top of the Queue that queues whatever workflow is currently loaded in the embedded ComfyUI workspace, so you can trigger a generation from anywhere in the app.
+
 
 ### Fixed
 

--- a/comfyui-view-preload.js
+++ b/comfyui-view-preload.js
@@ -1,0 +1,88 @@
+// Preload for the embedded ComfyUI WebContentsView.
+//
+// Purpose: forward ComfyUI's own WebSocket events (progress / executing / preview
+// images) to the Image MetaHub renderer, WITHOUT opening a second WebSocket.
+// ComfyUI only routes those events to the socket that owns the prompt's client_id
+// and never broadcasts them, and reusing that client_id from a second socket would
+// evict the embedded UI's own connection. So instead of connecting, we passively
+// observe the socket the page already has and relay what we see over IPC.
+//
+// This view runs with contextIsolation: false, so this preload executes in the
+// page's MAIN world at document start — before ComfyUI creates its socket. That
+// lets us wrap window.WebSocket in time (an executeJavaScript-on-dom-ready patch
+// lands too late) and forward frames straight over ipcRenderer (no postMessage,
+// no page CSP involved). We expose nothing to the page and only read traffic;
+// ipcRenderer stays in this module's scope, unreachable from page code.
+
+const { ipcRenderer } = require('electron');
+
+const CHANNEL = 'comfy-embedded-ws-event';
+const FORWARDED_TYPES = new Set([
+  'progress',
+  'progress_state',
+  'executing',
+  'execution_error',
+  'execution_interrupted',
+]);
+
+(function installWebSocketObserver() {
+  try {
+    if (window.__imhWsObserverInstalled) {
+      return;
+    }
+    const NativeWebSocket = window.WebSocket;
+    if (typeof NativeWebSocket !== 'function') {
+      return;
+    }
+    window.__imhWsObserverInstalled = true;
+
+    const observe = (socket) => {
+      try {
+        socket.addEventListener('message', (event) => {
+          try {
+            const data = event.data;
+            if (typeof data === 'string') {
+              let message;
+              try {
+                message = JSON.parse(data);
+              } catch (_error) {
+                return;
+              }
+              if (message && FORWARDED_TYPES.has(message.type)) {
+                ipcRenderer.send(CHANNEL, { kind: 'json', payload: message });
+              }
+            } else if (data instanceof ArrayBuffer) {
+              ipcRenderer.send(CHANNEL, { kind: 'binary', buffer: data.slice(0) });
+            } else if (typeof Blob !== 'undefined' && data instanceof Blob) {
+              data.arrayBuffer()
+                .then((buffer) => ipcRenderer.send(CHANNEL, { kind: 'binary', buffer }))
+                .catch(() => {});
+            }
+          } catch (_error) {
+            // Ignore malformed frames.
+          }
+        });
+      } catch (_error) {
+        // Ignore sockets we cannot observe.
+      }
+    };
+
+    function ObservedWebSocket(url, protocols) {
+      const socket = protocols !== undefined
+        ? new NativeWebSocket(url, protocols)
+        : new NativeWebSocket(url);
+      observe(socket);
+      return socket;
+    }
+
+    ObservedWebSocket.prototype = NativeWebSocket.prototype;
+    ObservedWebSocket.CONNECTING = NativeWebSocket.CONNECTING;
+    ObservedWebSocket.OPEN = NativeWebSocket.OPEN;
+    ObservedWebSocket.CLOSING = NativeWebSocket.CLOSING;
+    ObservedWebSocket.CLOSED = NativeWebSocket.CLOSED;
+
+    window.WebSocket = ObservedWebSocket;
+  } catch (_error) {
+    // If the constructor cannot be replaced there is nothing more we can do.
+  }
+})();

--- a/components/GenerationQueueSidebar.tsx
+++ b/components/GenerationQueueSidebar.tsx
@@ -218,7 +218,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
 
     if (item.provider === 'comfyui' && item.origin === 'comfyui-external') {
       if (!comfyUIServerUrl || !item.providerJobId) {
-        setJobStatus(item.id, 'failed', { error: 'Cannot cancel ComfyUI job without a prompt id.' });
+        setJobStatus(item.id, 'failed', { error: 'Cannot cancel ComfyUI job without a prompt id.', previewImageUrl: null });
         return;
       }
 
@@ -233,7 +233,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
           return;
         }
 
-        setJobStatus(item.id, 'canceled', { error: undefined });
+        setJobStatus(item.id, 'canceled', { error: undefined, previewImageUrl: null });
       } catch (error) {
         setJobStatus(item.id, item.status, {
           error: error instanceof Error ? error.message : String(error),
@@ -259,12 +259,12 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
     }
 
     if (item.status === 'waiting') {
-      setJobStatus(item.id, 'canceled', { error: undefined });
+      setJobStatus(item.id, 'canceled', { error: undefined, previewImageUrl: null });
       return;
     }
 
     if (activeJobs[item.provider] !== item.id) {
-      setJobStatus(item.id, 'canceled', { error: undefined });
+      setJobStatus(item.id, 'canceled', { error: undefined, previewImageUrl: null });
       return;
     }
 
@@ -281,7 +281,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
         stopPolling();
         setActiveJob('a1111', null);
       }
-      setJobStatus(item.id, 'canceled', { error: undefined });
+      setJobStatus(item.id, 'canceled', { error: undefined, previewImageUrl: null });
       return;
     }
 
@@ -298,7 +298,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
       stopTracking();
       setActiveJob('comfyui', null);
     }
-    setJobStatus(item.id, 'canceled', { error: undefined });
+    setJobStatus(item.id, 'canceled', { error: undefined, previewImageUrl: null });
   };
 
   const handleRemove = (item: GenerationQueueItem, event: React.MouseEvent<HTMLButtonElement>) => {

--- a/components/GenerationQueueSidebar.tsx
+++ b/components/GenerationQueueSidebar.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import { X, RefreshCw, CircleX, CircleStop, ArchiveX } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { X, RefreshCw, CircleX, CircleStop, ArchiveX, Play } from 'lucide-react';
 import { useGenerationQueueStore, GenerationQueueItem } from '../store/useGenerationQueueStore';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
@@ -45,6 +45,22 @@ const formatPromptPreview = (prompt?: string) => {
 const formatTime = (timestamp: number) =>
   new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
+const PREVIEW_HEIGHT_STORAGE_KEY = 'imh:queuePreviewHeight';
+const PREVIEW_HEIGHT_DEFAULT = 96; // matches the previous fixed h-24
+const PREVIEW_HEIGHT_MIN = 64;
+const PREVIEW_HEIGHT_MAX = 640;
+
+const readStoredPreviewHeight = (): number => {
+  if (typeof window === 'undefined') {
+    return PREVIEW_HEIGHT_DEFAULT;
+  }
+  const stored = Number(window.localStorage.getItem(PREVIEW_HEIGHT_STORAGE_KEY));
+  if (!Number.isFinite(stored) || stored <= 0) {
+    return PREVIEW_HEIGHT_DEFAULT;
+  }
+  return Math.min(PREVIEW_HEIGHT_MAX, Math.max(PREVIEW_HEIGHT_MIN, stored));
+};
+
 const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
   onClose,
   width,
@@ -66,8 +82,73 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
   const filteredImages = useImageStore((state) => state.filteredImages);
   const a1111ServerUrl = useSettingsStore((state) => state.a1111ServerUrl);
   const comfyUIServerUrl = useSettingsStore((state) => state.comfyUIServerUrl);
+  const comfyUIEnabled = useSettingsStore((state) => state.comfyUIEnabled);
   const { stopPolling } = useA1111ProgressContext();
   const { stopTracking } = useComfyUIProgressContext();
+
+  // Shared, persisted height for the per-item preview / output image boxes so
+  // portrait images can be dragged taller and stay that way across sessions.
+  const [previewHeight, setPreviewHeight] = useState<number>(readStoredPreviewHeight);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(PREVIEW_HEIGHT_STORAGE_KEY, String(previewHeight));
+    }
+  }, [previewHeight]);
+
+  const handlePreviewResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const startY = event.clientY;
+    const startHeight = previewHeight;
+    const onMove = (moveEvent: PointerEvent) => {
+      const next = Math.min(
+        PREVIEW_HEIGHT_MAX,
+        Math.max(PREVIEW_HEIGHT_MIN, startHeight + (moveEvent.clientY - startY))
+      );
+      setPreviewHeight(next);
+    };
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  }, [previewHeight]);
+
+  const [isRunningWorkflow, setIsRunningWorkflow] = useState(false);
+  const [runFeedback, setRunFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  useEffect(() => {
+    if (!runFeedback) {
+      return;
+    }
+    const timer = window.setTimeout(() => setRunFeedback(null), 4000);
+    return () => window.clearTimeout(timer);
+  }, [runFeedback]);
+
+  const handleRunWorkflow = useCallback(async () => {
+    if (isRunningWorkflow) {
+      return;
+    }
+    setIsRunningWorkflow(true);
+    setRunFeedback(null);
+    try {
+      const result = await window.electronAPI?.comfyUIViewRunWorkflow?.();
+      if (result?.success) {
+        setRunFeedback({ type: 'success', message: 'Workflow queued in ComfyUI.' });
+      } else {
+        setRunFeedback({ type: 'error', message: result?.error || 'Could not run the ComfyUI workflow.' });
+      }
+    } catch (error) {
+      setRunFeedback({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Could not run the ComfyUI workflow.',
+      });
+    } finally {
+      setIsRunningWorkflow(false);
+    }
+  }, [isRunningWorkflow]);
 
   const overallProgress = useMemo(() => {
     if (items.length === 0) return 0;
@@ -266,15 +347,38 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
             {items.length} items · {statusCounts.processing || 0} processing · {statusCounts.waiting || 0} waiting
           </p>
         </div>
-        <button
-          onClick={onClose}
-          className="text-gray-400 hover:text-gray-50 transition-colors"
-          title="Close queue"
-          aria-label="Close queue"
-        >
-          <X className="w-5 h-5" />
-        </button>
+        <div className="flex items-center gap-2">
+          {comfyUIEnabled && (
+            <button
+              onClick={handleRunWorkflow}
+              disabled={isRunningWorkflow}
+              title="Run current ComfyUI workflow"
+              aria-label="Run current ComfyUI workflow"
+              className="flex items-center gap-1.5 rounded bg-blue-600 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Play className="h-3.5 w-3.5" />
+              Run
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-50 transition-colors"
+            title="Close queue"
+            aria-label="Close queue"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
       </div>
+      {runFeedback && (
+        <div
+          className={`px-4 py-2 text-xs border-b border-gray-700 ${
+            runFeedback.type === 'success' ? 'text-green-300 bg-green-900/20' : 'text-red-300 bg-red-900/20'
+          }`}
+        >
+          {runFeedback.message}
+        </div>
+      )}
 
       <div className="p-4 border-b border-gray-700 space-y-3">
         <div className="flex items-center justify-between text-xs text-gray-400">
@@ -367,23 +471,39 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
               </div>
 
               {item.status === 'processing' && item.previewImageUrl ? (
-                <div className="relative overflow-hidden rounded border border-gray-700/60 bg-black">
+                <div
+                  className="group relative overflow-hidden rounded border border-gray-700/60 bg-black"
+                  style={{ height: previewHeight }}
+                >
                   <img
                     src={item.previewImageUrl}
                     alt="Live preview"
-                    className="h-24 w-full object-cover"
+                    className="h-full w-full object-contain"
                   />
                   <span className="absolute left-2 top-2 flex items-center gap-1 rounded-full bg-black/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-100">
                     <span className="h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse" />
                     Live preview
                   </span>
+                  <div
+                    onPointerDown={handlePreviewResizeStart}
+                    onClick={(event) => event.stopPropagation()}
+                    className="absolute inset-x-0 bottom-0 flex h-3 cursor-ns-resize items-center justify-center bg-gradient-to-t from-black/70 to-transparent opacity-0 transition-opacity group-hover:opacity-100"
+                    title="Drag to resize preview"
+                    role="separator"
+                    aria-orientation="horizontal"
+                  >
+                    <span className="h-0.5 w-8 rounded-full bg-gray-300/80" />
+                  </div>
                 </div>
               ) : firstOutput?.url ? (
-                <div className="relative overflow-hidden rounded border border-gray-700/60 bg-black">
+                <div
+                  className="group relative overflow-hidden rounded border border-gray-700/60 bg-black"
+                  style={{ height: previewHeight }}
+                >
                   <img
                     src={firstOutput.url}
                     alt={firstOutput.name || 'Generated output'}
-                    className="h-24 w-full object-cover"
+                    className="h-full w-full object-cover"
                     loading="lazy"
                   />
                   {(item.generatedOutputs?.length || 0) > 1 && (
@@ -391,6 +511,16 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
                       +{(item.generatedOutputs?.length || 1) - 1}
                     </span>
                   )}
+                  <div
+                    onPointerDown={handlePreviewResizeStart}
+                    onClick={(event) => event.stopPropagation()}
+                    className="absolute inset-x-0 bottom-0 flex h-3 cursor-ns-resize items-center justify-center bg-gradient-to-t from-black/70 to-transparent opacity-0 transition-opacity group-hover:opacity-100"
+                    title="Drag to resize preview"
+                    role="separator"
+                    aria-orientation="horizontal"
+                  >
+                    <span className="h-0.5 w-8 rounded-full bg-gray-300/80" />
+                  </div>
                 </div>
               ) : null}
 

--- a/components/GenerationQueueSidebar.tsx
+++ b/components/GenerationQueueSidebar.tsx
@@ -366,7 +366,19 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
                 </div>
               </div>
 
-              {firstOutput?.url && (
+              {item.status === 'processing' && item.previewImageUrl ? (
+                <div className="relative overflow-hidden rounded border border-gray-700/60 bg-black">
+                  <img
+                    src={item.previewImageUrl}
+                    alt="Live preview"
+                    className="h-24 w-full object-cover"
+                  />
+                  <span className="absolute left-2 top-2 flex items-center gap-1 rounded-full bg-black/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-100">
+                    <span className="h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse" />
+                    Live preview
+                  </span>
+                </div>
+              ) : firstOutput?.url ? (
                 <div className="relative overflow-hidden rounded border border-gray-700/60 bg-black">
                   <img
                     src={firstOutput.url}
@@ -380,7 +392,7 @@ const GenerationQueueSidebar: React.FC<GenerationQueueSidebarProps> = ({
                     </span>
                   )}
                 </div>
-              )}
+              ) : null}
 
               <p className="text-xs text-gray-400 break-words">
                 {formatPromptPreview(item.prompt)}

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -15,6 +15,7 @@
     "electron.mjs",
     "electron-deeplink.mjs",
     "preload.js",
+    "comfyui-view-preload.js",
     "services/**/*",
     "utils/**/*.js",
     "utils/**/*.mjs",

--- a/electron.mjs
+++ b/electron.mjs
@@ -1290,11 +1290,17 @@ function ensureComfyUIView() {
   comfyUIView = new WebContentsView({
     webPreferences: {
       nodeIntegration: false,
-      contextIsolation: true,
+      // contextIsolation is disabled ONLY for this embedded ComfyUI view so the
+      // preload can patch window.WebSocket in the page's main world at document
+      // start (before ComfyUI creates its socket) and read progress/preview frames.
+      // The preload exposes nothing to the page and only reads socket traffic; the
+      // page is the user's own local ComfyUI server. sandbox stays on (no Node).
+      contextIsolation: false,
       sandbox: true,
       webSecurity: true,
       partition: 'persist:imagemetahub-comfyui',
       backgroundThrottling: false,
+      preload: path.join(__dirname, 'comfyui-view-preload.js'),
     },
   });
 
@@ -3273,6 +3279,73 @@ function setupFileOperationHandlers() {
       return await openComfyUIView(payload);
     } catch (error) {
       return { success: false, error: error?.message || 'Failed to open embedded ComfyUI.' };
+    }
+  });
+
+  // Relay read-only ComfyUI WebSocket events observed by the embedded view's
+  // preload (progress / preview) to the main renderer's generation queue.
+  ipcMain.on('comfy-embedded-ws-event', (event, message) => {
+    if (!comfyUIView || comfyUIView.webContents.isDestroyed()) {
+      return;
+    }
+    // Only accept events from the embedded ComfyUI view, never other web contents.
+    if (event.sender !== comfyUIView.webContents) {
+      return;
+    }
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      return;
+    }
+    mainWindow.webContents.send('comfy-embedded-progress', message);
+  });
+
+  // Queue the workflow currently loaded in the embedded ComfyUI view, so the user
+  // can trigger a generation from anywhere in the app. Uses ComfyUI's own queue
+  // mechanism (window.app) so the exact current graph/widget state is serialized.
+  ipcMain.handle('comfy-view-run-workflow', async () => {
+    try {
+      const contents = comfyUIView?.webContents;
+      if (!contents || contents.isDestroyed()) {
+        return { success: false, error: 'ComfyUI is not open. Open the ComfyUI workspace and load a workflow first.' };
+      }
+
+      const currentUrl = contents.getURL();
+      if (!currentUrl || !isComfyNavigationAllowed(currentUrl)) {
+        return { success: false, error: 'ComfyUI is not loaded on the configured server.' };
+      }
+
+      await waitForComfyUIRuntime(contents);
+
+      return await contents.executeJavaScript(`
+        (async () => {
+          const app = window.app || window.comfyApp || window.ComfyApp?.instance || null;
+          if (!app) {
+            return { success: false, error: 'ComfyUI app was not found on the page.' };
+          }
+          const runMaybeAsync = async (fn) => {
+            if (typeof fn !== 'function') return false;
+            const out = fn();
+            if (out && typeof out.then === 'function') await out;
+            return true;
+          };
+          const candidates = [
+            () => app.queuePrompt(0),
+            () => app.queuePrompt(0, 1),
+            () => app.extensionManager?.command?.execute?.('Comfy.QueuePrompt'),
+          ];
+          for (const candidate of candidates) {
+            try {
+              if (await runMaybeAsync(candidate)) {
+                return { success: true };
+              }
+            } catch (error) {
+              return { success: false, error: error?.message || String(error) };
+            }
+          }
+          return { success: false, error: 'This ComfyUI version did not expose a supported queue action.' };
+        })()
+      `, true);
+    } catch (error) {
+      return { success: false, error: error?.message || 'Failed to run the ComfyUI workflow.' };
     }
   });
 

--- a/electron.mjs
+++ b/electron.mjs
@@ -3332,16 +3332,17 @@ function setupFileOperationHandlers() {
             () => app.queuePrompt(0, 1),
             () => app.extensionManager?.command?.execute?.('Comfy.QueuePrompt'),
           ];
+          let lastError = null;
           for (const candidate of candidates) {
             try {
               if (await runMaybeAsync(candidate)) {
                 return { success: true };
               }
             } catch (error) {
-              return { success: false, error: error?.message || String(error) };
+              lastError = error?.message || String(error);
             }
           }
-          return { success: false, error: 'This ComfyUI version did not expose a supported queue action.' };
+          return { success: false, error: lastError || 'This ComfyUI version did not expose a supported queue action.' };
         })()
       `, true);
     } catch (error) {

--- a/hooks/useComfyUIEmbeddedProgress.ts
+++ b/hooks/useComfyUIEmbeddedProgress.ts
@@ -1,0 +1,136 @@
+import { useEffect, useRef } from 'react';
+import { decodeComfyUIPreviewFrame } from '../services/comfyUIApiClient';
+import { useGenerationQueueStore } from '../store/useGenerationQueueStore';
+import { ComfyEmbeddedWsMessage } from '../types';
+
+/**
+ * Enriches externally-queued ComfyUI jobs (those generated through the embedded
+ * ComfyUI UI) with live step progress and KSampler-style preview images.
+ *
+ * The events come from the embedded view's own WebSocket, observed read-only by
+ * comfyui-view-preload.js and relayed over IPC — see the queue monitor comment on
+ * why we cannot open our own socket for these jobs. This hook only patches the
+ * matching queue item (by prompt_id / providerJobId); item creation, final status
+ * and outputs are still handled by useComfyUIQueueMonitor via REST polling.
+ */
+const toArrayBuffer = (buffer: unknown): ArrayBuffer | null => {
+  if (buffer instanceof ArrayBuffer) {
+    return buffer;
+  }
+  // Typed array / Node Buffer arriving through IPC: copy out the exact view range.
+  if (ArrayBuffer.isView(buffer)) {
+    const view = buffer as ArrayBufferView;
+    return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
+  }
+  // Serialized Node Buffer ({ type: 'Buffer', data: [...] }) or a plain byte array.
+  const maybe = buffer as { data?: number[] } | number[] | null | undefined;
+  if (maybe && Array.isArray((maybe as { data?: number[] }).data)) {
+    return new Uint8Array((maybe as { data: number[] }).data).buffer;
+  }
+  if (Array.isArray(maybe)) {
+    return new Uint8Array(maybe).buffer;
+  }
+  return null;
+};
+
+export function useComfyUIEmbeddedProgress() {
+  const activePromptIdRef = useRef<string | null>(null);
+  const previewUrlsRef = useRef<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    const api = typeof window !== 'undefined' ? window.electronAPI : undefined;
+    if (!api?.onComfyEmbeddedProgress) {
+      return;
+    }
+
+    const clearPreview = (promptId: string) => {
+      const url = previewUrlsRef.current.get(promptId);
+      if (url) {
+        URL.revokeObjectURL(url);
+        previewUrlsRef.current.delete(promptId);
+      }
+    };
+
+    const handleJson = (payload: { type?: string; data?: Record<string, unknown> }) => {
+      const promptId = typeof payload.data?.prompt_id === 'string'
+        ? payload.data.prompt_id
+        : activePromptIdRef.current;
+      if (!promptId) {
+        return;
+      }
+
+      if (payload.type === 'execution_error' || payload.type === 'execution_interrupted') {
+        clearPreview(promptId);
+        useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+          providerJobId: promptId,
+          status: 'processing',
+          previewImageUrl: null,
+        });
+        return;
+      }
+
+      if (payload.type === 'executing') {
+        if (payload.data?.node === null) {
+          clearPreview(promptId);
+          useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+            providerJobId: promptId,
+            status: 'processing',
+            previewImageUrl: null,
+          });
+          return;
+        }
+        activePromptIdRef.current = promptId;
+        return;
+      }
+
+      if (payload.type === 'progress') {
+        const value = typeof payload.data?.value === 'number' ? payload.data.value : 0;
+        const max = typeof payload.data?.max === 'number' ? payload.data.max : 1;
+        activePromptIdRef.current = promptId;
+        useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+          providerJobId: promptId,
+          status: 'processing',
+          currentStep: value,
+          totalSteps: max,
+          progress: max > 0 ? value / max : 0,
+        });
+      }
+    };
+
+    const handleBinary = (buffer: unknown) => {
+      const promptId = activePromptIdRef.current;
+      const arrayBuffer = toArrayBuffer(buffer);
+      const blob = arrayBuffer ? decodeComfyUIPreviewFrame(arrayBuffer) : null;
+      if (!promptId || !blob) {
+        return;
+      }
+      clearPreview(promptId);
+      const url = URL.createObjectURL(blob);
+      previewUrlsRef.current.set(promptId, url);
+      useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+        providerJobId: promptId,
+        status: 'processing',
+        previewImageUrl: url,
+      });
+    };
+
+    const unsubscribe = api.onComfyEmbeddedProgress((message: ComfyEmbeddedWsMessage) => {
+      try {
+        if (message.kind === 'json') {
+          handleJson(message.payload);
+        } else if (message.kind === 'binary') {
+          handleBinary(message.buffer);
+        }
+      } catch {
+        // Ignore malformed relayed events.
+      }
+    });
+
+    return () => {
+      unsubscribe?.();
+      previewUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+      previewUrlsRef.current.clear();
+      activePromptIdRef.current = null;
+    };
+  }, []);
+}

--- a/hooks/useComfyUIEmbeddedProgress.ts
+++ b/hooks/useComfyUIEmbeddedProgress.ts
@@ -51,16 +51,28 @@ export function useComfyUIEmbeddedProgress() {
       }
     };
 
+    // Only enrich jobs the REST poller (useComfyUIQueueMonitor) already knows about via
+    // ComfyUI's authenticated HTTP API — never create a queue item purely from a relayed
+    // WS event, since the embedded page runs with contextIsolation off and its WebSocket
+    // traffic isn't otherwise authenticated as coming from the real ComfyUI server.
+    const isTrackedJob = (promptId: string) =>
+      useGenerationQueueStore.getState().items.some(
+        (item) => item.provider === 'comfyui' && item.providerJobId === promptId
+      );
+
     const handleJson = (payload: { type?: string; data?: Record<string, unknown> }) => {
       const promptId = typeof payload.data?.prompt_id === 'string'
         ? payload.data.prompt_id
         : activePromptIdRef.current;
-      if (!promptId) {
+      if (!promptId || !isTrackedJob(promptId)) {
         return;
       }
 
       if (payload.type === 'execution_error' || payload.type === 'execution_interrupted') {
         clearPreview(promptId);
+        if (activePromptIdRef.current === promptId) {
+          activePromptIdRef.current = null;
+        }
         useGenerationQueueStore.getState().upsertExternalComfyUIJob({
           providerJobId: promptId,
           status: 'processing',
@@ -72,6 +84,9 @@ export function useComfyUIEmbeddedProgress() {
       if (payload.type === 'executing') {
         if (payload.data?.node === null) {
           clearPreview(promptId);
+          if (activePromptIdRef.current === promptId) {
+            activePromptIdRef.current = null;
+          }
           useGenerationQueueStore.getState().upsertExternalComfyUIJob({
             providerJobId: promptId,
             status: 'processing',

--- a/hooks/useComfyUIProgress.ts
+++ b/hooks/useComfyUIProgress.ts
@@ -4,7 +4,7 @@
  */
 
 import { useState, useRef, useCallback } from 'react';
-import { ComfyUIProgressUpdate, normalizeLoopbackServerUrl } from '../services/comfyUIApiClient';
+import { ComfyUIProgressUpdate, decodeComfyUIPreviewFrame, normalizeLoopbackServerUrl } from '../services/comfyUIApiClient';
 
 export interface ComfyUIProgressState {
   isGenerating: boolean;
@@ -13,6 +13,7 @@ export interface ComfyUIProgressState {
   totalSteps: number;
   progress: number;  // 0-1, overall progress
   queuePosition: number;
+  previewImageUrl: string | null;
 }
 
 export function useComfyUIProgress() {
@@ -20,6 +21,14 @@ export function useComfyUIProgress() {
   const wsRef = useRef<WebSocket | null>(null);
   const promptIdRef = useRef<string>('');
   const clientIdRef = useRef<string>('');
+  const previewUrlRef = useRef<string | null>(null);
+
+  const revokePreviewUrl = () => {
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+  };
 
   const startTracking = useCallback((serverUrl: string, promptId: string, clientId?: string) => {
     // Store prompt ID for reference
@@ -33,6 +42,7 @@ export function useComfyUIProgress() {
     console.log('[ComfyUI Progress] Connecting to WebSocket:', wsUrl);
 
     const ws = new WebSocket(wsUrl);
+    ws.binaryType = 'arraybuffer';
 
     ws.onopen = () => {
       console.log('[ComfyUI Progress] WebSocket connected');
@@ -42,11 +52,28 @@ export function useComfyUIProgress() {
         currentStep: 0,
         totalSteps: 0,
         progress: 0,
-        queuePosition: 0
+        queuePosition: 0,
+        previewImageUrl: null
       });
     };
 
     ws.onmessage = (event) => {
+      if (event.data instanceof ArrayBuffer) {
+        const blob = decodeComfyUIPreviewFrame(event.data);
+        if (!blob) {
+          return;
+        }
+        revokePreviewUrl();
+        const url = URL.createObjectURL(blob);
+        previewUrlRef.current = url;
+        setProgressState(prev => ({
+          ...prev,
+          isGenerating: true,
+          previewImageUrl: url
+        }));
+        return;
+      }
+
       try {
         const message = JSON.parse(event.data) as ComfyUIProgressUpdate;
         if (message.data?.prompt_id && message.data.prompt_id !== promptIdRef.current) {
@@ -83,6 +110,7 @@ export function useComfyUIProgress() {
             // Close WebSocket after a short delay
             setTimeout(() => {
               ws.close();
+              revokePreviewUrl();
               setProgressState(null);
             }, 2000);
           } else {
@@ -126,6 +154,7 @@ export function useComfyUIProgress() {
     ws.onclose = () => {
       console.log('[ComfyUI Progress] WebSocket closed');
       wsRef.current = null;
+      revokePreviewUrl();
     };
 
     wsRef.current = ws;
@@ -136,6 +165,7 @@ export function useComfyUIProgress() {
       wsRef.current.close();
       wsRef.current = null;
     }
+    revokePreviewUrl();
     setProgressState(null);
     promptIdRef.current = '';
     clientIdRef.current = '';

--- a/hooks/useComfyUIProgress.ts
+++ b/hooks/useComfyUIProgress.ts
@@ -100,17 +100,18 @@ export function useComfyUIProgress() {
           if (message.data.node === null) {
             // Generation complete
             console.log('[ComfyUI Progress] Generation complete');
+            revokePreviewUrl();
             setProgressState(prev => ({
               ...prev,
               isGenerating: false,
               progress: 1,
-              currentStep: prev?.totalSteps || 0
+              currentStep: prev?.totalSteps || 0,
+              previewImageUrl: null
             }));
 
             // Close WebSocket after a short delay
             setTimeout(() => {
               ws.close();
-              revokePreviewUrl();
               setProgressState(null);
             }, 2000);
           } else {

--- a/hooks/useComfyUIQueueMonitor.ts
+++ b/hooks/useComfyUIQueueMonitor.ts
@@ -270,6 +270,7 @@ export function useComfyUIQueueMonitor() {
             error: failureMessage,
             completedAt: Date.now(),
             currentNode: null,
+            previewImageUrl: null,
           });
           return;
         }
@@ -282,6 +283,7 @@ export function useComfyUIQueueMonitor() {
           generatedOutputs: outputs,
           completedAt: Date.now(),
           currentNode: null,
+          previewImageUrl: null,
         });
       } catch {
         // History may not exist yet; the next poll/WebSocket event will try again.
@@ -370,6 +372,7 @@ export function useComfyUIQueueMonitor() {
               error: stringifyMessage(message.data) || (message.type === 'execution_interrupted' ? 'ComfyUI generation interrupted.' : 'ComfyUI generation failed.'),
               completedAt: Date.now(),
               currentNode: null,
+              previewImageUrl: null,
             });
             return;
           }

--- a/hooks/useComfyUIQueueMonitor.ts
+++ b/hooks/useComfyUIQueueMonitor.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { ComfyUIApiClient, decodeComfyUIPreviewFrame, normalizeLoopbackServerUrl } from '../services/comfyUIApiClient';
+import { ComfyUIApiClient, normalizeLoopbackServerUrl } from '../services/comfyUIApiClient';
 import { GeneratedQueueOutput, useGenerationQueueStore } from '../store/useGenerationQueueStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 
@@ -243,7 +243,6 @@ export function useComfyUIQueueMonitor() {
   const serverUrl = useSettingsStore((state) => state.comfyUIServerUrl);
   const activePromptIdRef = useRef<string | null>(null);
   const nodeLabelsRef = useRef<Map<string, Record<string, string>>>(new Map());
-  const previewUrlsRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     if (!comfyUIEnabled || !monitoringEnabled || !serverUrl) {
@@ -253,14 +252,6 @@ export function useComfyUIQueueMonitor() {
     let isDisposed = false;
     let intervalId: number | null = null;
     const client = new ComfyUIApiClient({ serverUrl });
-
-    const clearPreview = (promptId: string) => {
-      const url = previewUrlsRef.current.get(promptId);
-      if (url) {
-        URL.revokeObjectURL(url);
-        previewUrlsRef.current.delete(promptId);
-      }
-    };
 
     const markHistoryIfAvailable = async (promptId: string) => {
       try {
@@ -272,7 +263,6 @@ export function useComfyUIQueueMonitor() {
 
         const failureMessage = getHistoryFailureMessage(promptHistory);
         if (failureMessage) {
-          clearPreview(promptId);
           useGenerationQueueStore.getState().upsertExternalComfyUIJob({
             providerJobId: promptId,
             status: 'failed',
@@ -280,13 +270,11 @@ export function useComfyUIQueueMonitor() {
             error: failureMessage,
             completedAt: Date.now(),
             currentNode: null,
-            previewImageUrl: null,
           });
           return;
         }
 
         const outputs = extractHistoryOutputs(history, promptId, client);
-        clearPreview(promptId);
         useGenerationQueueStore.getState().upsertExternalComfyUIJob({
           providerJobId: promptId,
           status: 'done',
@@ -294,7 +282,6 @@ export function useComfyUIQueueMonitor() {
           generatedOutputs: outputs,
           completedAt: Date.now(),
           currentNode: null,
-          previewImageUrl: null,
         });
       } catch {
         // History may not exist yet; the next poll/WebSocket event will try again.
@@ -361,32 +348,11 @@ export function useComfyUIQueueMonitor() {
       let socket: WebSocket;
       try {
         socket = new WebSocket(wsUrl);
-        socket.binaryType = 'arraybuffer';
       } catch {
         return null;
       }
 
       socket.onmessage = (event) => {
-        if (event.data instanceof ArrayBuffer) {
-          const promptId = activePromptIdRef.current;
-          if (!promptId) {
-            return;
-          }
-          const blob = decodeComfyUIPreviewFrame(event.data);
-          if (!blob) {
-            return;
-          }
-          clearPreview(promptId);
-          const url = URL.createObjectURL(blob);
-          previewUrlsRef.current.set(promptId, url);
-          useGenerationQueueStore.getState().upsertExternalComfyUIJob({
-            providerJobId: promptId,
-            status: 'processing',
-            previewImageUrl: url,
-          });
-          return;
-        }
-
         try {
           const message = JSON.parse(event.data) as ComfyUIMonitorMessage;
           const promptId = typeof message.data?.prompt_id === 'string'
@@ -397,7 +363,6 @@ export function useComfyUIQueueMonitor() {
           }
 
           if (message.type === 'execution_error' || message.type === 'execution_interrupted') {
-            clearPreview(promptId);
             useGenerationQueueStore.getState().upsertExternalComfyUIJob({
               providerJobId: promptId,
               status: 'failed',
@@ -405,7 +370,6 @@ export function useComfyUIQueueMonitor() {
               error: stringifyMessage(message.data) || (message.type === 'execution_interrupted' ? 'ComfyUI generation interrupted.' : 'ComfyUI generation failed.'),
               completedAt: Date.now(),
               currentNode: null,
-              previewImageUrl: null,
             });
             return;
           }
@@ -476,15 +440,6 @@ export function useComfyUIQueueMonitor() {
       ws = null;
       activePromptIdRef.current = null;
       nodeLabelsRef.current.clear();
-      previewUrlsRef.current.forEach((url, promptId) => {
-        URL.revokeObjectURL(url);
-        useGenerationQueueStore.getState().upsertExternalComfyUIJob({
-          providerJobId: promptId,
-          status: 'processing',
-          previewImageUrl: null,
-        });
-      });
-      previewUrlsRef.current.clear();
     };
   }, [comfyUIEnabled, monitoringEnabled, serverUrl]);
 }

--- a/hooks/useComfyUIQueueMonitor.ts
+++ b/hooks/useComfyUIQueueMonitor.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { ComfyUIApiClient, normalizeLoopbackServerUrl } from '../services/comfyUIApiClient';
+import { ComfyUIApiClient, decodeComfyUIPreviewFrame, normalizeLoopbackServerUrl } from '../services/comfyUIApiClient';
 import { GeneratedQueueOutput, useGenerationQueueStore } from '../store/useGenerationQueueStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 
@@ -243,6 +243,7 @@ export function useComfyUIQueueMonitor() {
   const serverUrl = useSettingsStore((state) => state.comfyUIServerUrl);
   const activePromptIdRef = useRef<string | null>(null);
   const nodeLabelsRef = useRef<Map<string, Record<string, string>>>(new Map());
+  const previewUrlsRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     if (!comfyUIEnabled || !monitoringEnabled || !serverUrl) {
@@ -252,6 +253,14 @@ export function useComfyUIQueueMonitor() {
     let isDisposed = false;
     let intervalId: number | null = null;
     const client = new ComfyUIApiClient({ serverUrl });
+
+    const clearPreview = (promptId: string) => {
+      const url = previewUrlsRef.current.get(promptId);
+      if (url) {
+        URL.revokeObjectURL(url);
+        previewUrlsRef.current.delete(promptId);
+      }
+    };
 
     const markHistoryIfAvailable = async (promptId: string) => {
       try {
@@ -263,6 +272,7 @@ export function useComfyUIQueueMonitor() {
 
         const failureMessage = getHistoryFailureMessage(promptHistory);
         if (failureMessage) {
+          clearPreview(promptId);
           useGenerationQueueStore.getState().upsertExternalComfyUIJob({
             providerJobId: promptId,
             status: 'failed',
@@ -270,11 +280,13 @@ export function useComfyUIQueueMonitor() {
             error: failureMessage,
             completedAt: Date.now(),
             currentNode: null,
+            previewImageUrl: null,
           });
           return;
         }
 
         const outputs = extractHistoryOutputs(history, promptId, client);
+        clearPreview(promptId);
         useGenerationQueueStore.getState().upsertExternalComfyUIJob({
           providerJobId: promptId,
           status: 'done',
@@ -282,6 +294,7 @@ export function useComfyUIQueueMonitor() {
           generatedOutputs: outputs,
           completedAt: Date.now(),
           currentNode: null,
+          previewImageUrl: null,
         });
       } catch {
         // History may not exist yet; the next poll/WebSocket event will try again.
@@ -348,11 +361,32 @@ export function useComfyUIQueueMonitor() {
       let socket: WebSocket;
       try {
         socket = new WebSocket(wsUrl);
+        socket.binaryType = 'arraybuffer';
       } catch {
         return null;
       }
 
       socket.onmessage = (event) => {
+        if (event.data instanceof ArrayBuffer) {
+          const promptId = activePromptIdRef.current;
+          if (!promptId) {
+            return;
+          }
+          const blob = decodeComfyUIPreviewFrame(event.data);
+          if (!blob) {
+            return;
+          }
+          clearPreview(promptId);
+          const url = URL.createObjectURL(blob);
+          previewUrlsRef.current.set(promptId, url);
+          useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+            providerJobId: promptId,
+            status: 'processing',
+            previewImageUrl: url,
+          });
+          return;
+        }
+
         try {
           const message = JSON.parse(event.data) as ComfyUIMonitorMessage;
           const promptId = typeof message.data?.prompt_id === 'string'
@@ -363,6 +397,7 @@ export function useComfyUIQueueMonitor() {
           }
 
           if (message.type === 'execution_error' || message.type === 'execution_interrupted') {
+            clearPreview(promptId);
             useGenerationQueueStore.getState().upsertExternalComfyUIJob({
               providerJobId: promptId,
               status: 'failed',
@@ -370,6 +405,7 @@ export function useComfyUIQueueMonitor() {
               error: stringifyMessage(message.data) || (message.type === 'execution_interrupted' ? 'ComfyUI generation interrupted.' : 'ComfyUI generation failed.'),
               completedAt: Date.now(),
               currentNode: null,
+              previewImageUrl: null,
             });
             return;
           }
@@ -440,6 +476,15 @@ export function useComfyUIQueueMonitor() {
       ws = null;
       activePromptIdRef.current = null;
       nodeLabelsRef.current.clear();
+      previewUrlsRef.current.forEach((url, promptId) => {
+        URL.revokeObjectURL(url);
+        useGenerationQueueStore.getState().upsertExternalComfyUIJob({
+          providerJobId: promptId,
+          status: 'processing',
+          previewImageUrl: null,
+        });
+      });
+      previewUrlsRef.current.clear();
     };
   }, [comfyUIEnabled, monitoringEnabled, serverUrl]);
 }

--- a/hooks/useGenerationQueueRunner.ts
+++ b/hooks/useGenerationQueueRunner.ts
@@ -122,6 +122,7 @@ export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup
             generatedOutputs: result.generatedOutputs,
             providerJobId: result.providerJobId || latest.providerJobId,
             error: undefined,
+            previewImageUrl: null,
           });
         }
       } catch (error) {
@@ -129,6 +130,7 @@ export function useGenerationQueueRunner({ images, filteredImages }: ImageLookup
         if (latest && latest.status !== 'canceled') {
           useGenerationQueueStore.getState().setJobStatus(job.id, 'failed', {
             error: error instanceof Error ? error.message : String(error),
+            previewImageUrl: null,
           });
         }
       } finally {

--- a/hooks/useGenerationQueueSync.ts
+++ b/hooks/useGenerationQueueSync.ts
@@ -34,6 +34,7 @@ export function useGenerationQueueSync() {
         currentStep: comfyUIProgress.currentStep,
         totalSteps: comfyUIProgress.totalSteps,
         currentNode: comfyUIProgress.currentNode,
+        previewImageUrl: comfyUIProgress.previewImageUrl,
         status: 'processing',
       });
     }

--- a/preload.js
+++ b/preload.js
@@ -229,6 +229,7 @@ const electronAPI = {
   comfyUIViewGoForward: () => ipcRenderer.invoke('comfy-view-go-forward'),
   comfyUIViewGetState: () => ipcRenderer.invoke('comfy-view-get-state'),
   comfyUIViewLoadWorkflow: (payload) => ipcRenderer.invoke('comfy-view-load-workflow', payload),
+  comfyUIViewRunWorkflow: () => ipcRenderer.invoke('comfy-view-run-workflow'),
   onComfyUIViewStateChanged: (callback) => {
     const handler = (event, ...args) => callback(...args);
     ipcRenderer.on('comfy-view-state-changed', handler);
@@ -241,6 +242,13 @@ const electronAPI = {
     ipcRenderer.on('comfy-view-load-failed', handler);
     return () => {
       ipcRenderer.removeListener('comfy-view-load-failed', handler);
+    };
+  },
+  onComfyEmbeddedProgress: (callback) => {
+    const handler = (event, message) => callback(message);
+    ipcRenderer.on('comfy-embedded-progress', handler);
+    return () => {
+      ipcRenderer.removeListener('comfy-embedded-progress', handler);
     };
   },
   getDefaultCachePath: () => ipcRenderer.invoke('get-default-cache-path'),

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Reparse Metadata Performance**: "Reparse Metadata" no longer rewrites the entire folder cache for a single image, so it stays fast regardless of library size. It patches only the cache chunk(s) that hold the reparsed images instead of re-serializing every entry, and uses a persistent id→chunk index to read just the target chunk directly rather than scanning the whole cache — a big win on large ComfyUI libraries where each chunk can be tens of MB. The index is validated on every use and rebuilt automatically if the cache changed, so it never serves stale data.
+
 ## [0.17.5] - 2026-07-13
 
 ### Added

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- **Reparse Metadata Performance**: "Reparse Metadata" no longer rewrites the entire folder cache for a single image, so it stays fast regardless of library size. It patches only the cache chunk(s) that hold the reparsed images instead of re-serializing every entry, and uses a persistent id→chunk index to read just the target chunk directly rather than scanning the whole cache — a big win on large ComfyUI libraries where each chunk can be tens of MB. The index is validated on every use and rebuilt automatically if the cache changed, so it never serves stale data.
-
 ## [0.17.5] - 2026-07-13
 
 ### Added

--- a/services/comfyUIApiClient.ts
+++ b/services/comfyUIApiClient.ts
@@ -161,16 +161,37 @@ export function normalizeLoopbackServerUrl(serverUrl: string): string {
   return serverUrl;
 }
 
-const PREVIEW_IMAGE_EVENT_TYPE = 1;
+// ComfyUI binary WebSocket event types (BE uint32 in the first 4 bytes).
+const PREVIEW_IMAGE_EVENT_TYPE = 1; // [type][format][image bytes]
+const PREVIEW_IMAGE_WITH_METADATA_EVENT_TYPE = 4; // [type][metadataLen][json][image bytes]
 const PREVIEW_IMAGE_FORMAT_MIME: Record<number, string> = {
   1: 'image/jpeg',
   2: 'image/png',
 };
 
+// Detect the image MIME from magic bytes — more reliable than trusting a format
+// enum, and necessary for PREVIEW_IMAGE_WITH_METADATA whose bytes 4-8 are a length.
+const sniffImageMime = (bytes: Uint8Array): string | null => {
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (bytes.length >= 8 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) {
+    return 'image/png';
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+    bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+  return null;
+};
+
 /**
- * Decodes a ComfyUI binary WebSocket frame into a preview image Blob.
- * Protocol: 4-byte BE uint32 event type (1 = PREVIEW_IMAGE), then for that
- * event a 4-byte BE uint32 image format (1 = JPEG, 2 = PNG), then raw image bytes.
+ * Decodes a ComfyUI binary WebSocket preview frame into an image Blob.
+ * Handles both PREVIEW_IMAGE (type 1: [type][format][bytes]) and the newer
+ * PREVIEW_IMAGE_WITH_METADATA (type 4: [type][metadataLen][json][bytes]).
  * Returns null for any other event type or malformed frame.
  */
 export function decodeComfyUIPreviewFrame(data: ArrayBuffer): Blob | null {
@@ -180,13 +201,26 @@ export function decodeComfyUIPreviewFrame(data: ArrayBuffer): Blob | null {
 
   const view = new DataView(data);
   const eventType = view.getUint32(0);
-  if (eventType !== PREVIEW_IMAGE_EVENT_TYPE) {
+
+  let imageStart: number;
+  let formatMime: string | undefined;
+
+  if (eventType === PREVIEW_IMAGE_EVENT_TYPE) {
+    formatMime = PREVIEW_IMAGE_FORMAT_MIME[view.getUint32(4)];
+    imageStart = 8;
+  } else if (eventType === PREVIEW_IMAGE_WITH_METADATA_EVENT_TYPE) {
+    const metadataLength = view.getUint32(4);
+    imageStart = 8 + metadataLength;
+    if (imageStart > data.byteLength) {
+      return null;
+    }
+  } else {
     return null;
   }
 
-  const imageFormat = view.getUint32(4);
-  const mime = PREVIEW_IMAGE_FORMAT_MIME[imageFormat] || 'image/jpeg';
-  return new Blob([data.slice(8)], { type: mime });
+  const imageBytes = data.slice(imageStart);
+  const mime = sniffImageMime(new Uint8Array(imageBytes)) || formatMime || 'image/jpeg';
+  return new Blob([imageBytes], { type: mime });
 }
 
 export class ComfyUIApiClient {

--- a/services/comfyUIApiClient.ts
+++ b/services/comfyUIApiClient.ts
@@ -161,6 +161,34 @@ export function normalizeLoopbackServerUrl(serverUrl: string): string {
   return serverUrl;
 }
 
+const PREVIEW_IMAGE_EVENT_TYPE = 1;
+const PREVIEW_IMAGE_FORMAT_MIME: Record<number, string> = {
+  1: 'image/jpeg',
+  2: 'image/png',
+};
+
+/**
+ * Decodes a ComfyUI binary WebSocket frame into a preview image Blob.
+ * Protocol: 4-byte BE uint32 event type (1 = PREVIEW_IMAGE), then for that
+ * event a 4-byte BE uint32 image format (1 = JPEG, 2 = PNG), then raw image bytes.
+ * Returns null for any other event type or malformed frame.
+ */
+export function decodeComfyUIPreviewFrame(data: ArrayBuffer): Blob | null {
+  if (data.byteLength < 8) {
+    return null;
+  }
+
+  const view = new DataView(data);
+  const eventType = view.getUint32(0);
+  if (eventType !== PREVIEW_IMAGE_EVENT_TYPE) {
+    return null;
+  }
+
+  const imageFormat = view.getUint32(4);
+  const mime = PREVIEW_IMAGE_FORMAT_MIME[imageFormat] || 'image/jpeg';
+  return new Blob([data.slice(8)], { type: mime });
+}
+
 export class ComfyUIApiClient {
   private config: ComfyUIConfig;
   private clientId: string;

--- a/store/useGenerationQueueStore.ts
+++ b/store/useGenerationQueueStore.ts
@@ -213,7 +213,7 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
         return existing.id;
       }
 
-      if (existing.status === 'done' && input.status !== 'done' && input.status !== 'failed') {
+      if ((existing.status === 'done' || existing.status === 'failed') && input.status !== 'done' && input.status !== 'failed') {
         return existing.id;
       }
 
@@ -312,6 +312,16 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
       if (current) {
         revokePreviewUrlIfReplaced(current.previewImageUrl, updates.previewImageUrl);
       }
+    }
+    if (updates.providerJobId) {
+      const superseded = get().items.filter(
+        (item) =>
+          item.id !== id &&
+          item.provider === 'comfyui' &&
+          item.origin === 'comfyui-external' &&
+          item.providerJobId === updates.providerJobId
+      );
+      revokeGeneratedOutputUrls(superseded);
     }
     set((state) => ({
       items: state.items

--- a/store/useGenerationQueueStore.ts
+++ b/store/useGenerationQueueStore.ts
@@ -52,6 +52,7 @@ export interface GenerationQueueItem {
   currentImage?: number;
   totalImages?: number;
   currentNode?: string | null;
+  previewImageUrl?: string | null;
   providerJobId?: string;
   error?: string;
   payload?: GenerationQueuePayload;
@@ -84,6 +85,7 @@ interface GenerationQueueState {
     currentStep?: number;
     totalSteps?: number;
     currentNode?: string | null;
+    previewImageUrl?: string | null;
     error?: string;
     generatedOutputs?: GeneratedQueueOutput[];
     completedAt?: number;
@@ -101,8 +103,11 @@ const MAX_ITEMS = 200;
 const createQueueId = () =>
   `job_${Date.now()}_${Math.random().toString(16).slice(2, 10)}`;
 
+const canRevokeObjectUrls = () =>
+  typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function';
+
 const revokeGeneratedOutputUrls = (items: GenerationQueueItem[]) => {
-  if (typeof URL === 'undefined' || typeof URL.revokeObjectURL !== 'function') {
+  if (!canRevokeObjectUrls()) {
     return;
   }
 
@@ -112,7 +117,18 @@ const revokeGeneratedOutputUrls = (items: GenerationQueueItem[]) => {
         URL.revokeObjectURL(output.url);
       }
     });
+    if (item.previewImageUrl) {
+      URL.revokeObjectURL(item.previewImageUrl);
+    }
   });
+};
+
+// Live preview frames arrive roughly once per sampling step, so the previous
+// blob URL must be revoked on every replacement, not just when the item is removed.
+const revokePreviewUrlIfReplaced = (previous: string | null | undefined, next: string | null | undefined) => {
+  if (previous && previous !== next && canRevokeObjectUrls()) {
+    URL.revokeObjectURL(previous);
+  }
 };
 
 const isTerminalStatus = (status: GenerationStatus) =>
@@ -219,12 +235,17 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
         (input.currentStep !== undefined && existing.currentStep !== input.currentStep) ||
         (input.totalSteps !== undefined && existing.totalSteps !== input.totalSteps) ||
         (input.currentNode !== undefined && existing.currentNode !== input.currentNode) ||
+        (input.previewImageUrl !== undefined && existing.previewImageUrl !== input.previewImageUrl) ||
         existing.error !== input.error ||
         existing.completedAt !== nextCompletedAt ||
         !generatedOutputsEqual(existing.generatedOutputs, nextGeneratedOutputs);
 
       if (!hasChanges) {
         return existing.id;
+      }
+
+      if (input.previewImageUrl !== undefined) {
+        revokePreviewUrlIfReplaced(existing.previewImageUrl, input.previewImageUrl);
       }
 
       set((state) => ({
@@ -240,6 +261,7 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
                 currentStep: input.currentStep ?? item.currentStep,
                 totalSteps: input.totalSteps ?? item.totalSteps,
                 currentNode: input.currentNode === undefined ? item.currentNode : input.currentNode,
+                previewImageUrl: input.previewImageUrl === undefined ? item.previewImageUrl : input.previewImageUrl,
                 error: input.error,
                 generatedOutputs: nextGeneratedOutputs,
                 completedAt: nextCompletedAt,
@@ -263,6 +285,7 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
       currentStep: input.currentStep,
       totalSteps: input.totalSteps,
       currentNode: input.currentNode,
+      previewImageUrl: input.previewImageUrl,
       providerJobId: input.providerJobId,
       error: input.error,
       generatedOutputs: input.generatedOutputs,
@@ -284,6 +307,12 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
     return id;
   },
   updateJob: (id, updates) => {
+    if (updates.previewImageUrl !== undefined) {
+      const current = get().items.find((item) => item.id === id);
+      if (current) {
+        revokePreviewUrlIfReplaced(current.previewImageUrl, updates.previewImageUrl);
+      }
+    }
     set((state) => ({
       items: state.items
         .filter((item) => {
@@ -298,6 +327,12 @@ export const useGenerationQueueStore = create<GenerationQueueState>((set, get) =
     }));
   },
   setJobStatus: (id, status, updates) => {
+    if (updates?.previewImageUrl !== undefined) {
+      const current = get().items.find((item) => item.id === id);
+      if (current) {
+        revokePreviewUrlIfReplaced(current.previewImageUrl, updates.previewImageUrl);
+      }
+    }
     set((state) => ({
       items: state.items.map((item) =>
         item.id === id

--- a/types.ts
+++ b/types.ts
@@ -75,6 +75,13 @@ export interface ComfyUIViewLoadFailure {
   url: string;
 }
 
+// Read-only ComfyUI WebSocket event observed inside the embedded view and relayed
+// to the renderer. 'json' carries a parsed ComfyUI message (progress/executing/…);
+// 'binary' carries a preview-image frame as raw bytes.
+export type ComfyEmbeddedWsMessage =
+  | { kind: 'json'; payload: { type?: string; data?: Record<string, unknown> } }
+  | { kind: 'binary'; buffer: ArrayBuffer | Uint8Array };
+
 export interface ExportFileDescriptor {
   imageId?: string;
   directoryPath: string;
@@ -454,8 +461,10 @@ export interface ElectronAPI {
     title?: string;
     preferNewTab?: boolean;
   }) => Promise<ComfyUIViewWorkflowLoadResult>;
+  comfyUIViewRunWorkflow: () => Promise<{ success: boolean; error?: string }>;
   onComfyUIViewStateChanged: (callback: (state: ComfyUIViewState) => void) => () => void;
   onComfyUIViewLoadFailed: (callback: (failure: ComfyUIViewLoadFailure) => void) => () => void;
+  onComfyEmbeddedProgress: (callback: (message: ComfyEmbeddedWsMessage) => void) => () => void;
   getDefaultCachePath: () => Promise<{ success: boolean; path?: string; error?: string }>;
   getAppVersion: () => Promise<string>;
   joinPaths: (...paths: string[]) => Promise<{ success: boolean; path?: string; error?: string }>;


### PR DESCRIPTION
## Summary

- Adds a live, KSampler-style preview image to the Queue sidebar that updates step-by-step during ComfyUI generation, for both flows:
  - **MetaHub-initiated generations**: decoded directly from the WebSocket already opened for progress tracking (`useComfyUIProgress.ts`).
  - **Embedded ComfyUI UI generations**: since ComfyUI only routes `progress`/`executing`/preview WebSocket events to the single socket that owns the submitting `client_id` (no broadcast), a second competing socket would evict the embedded view's own connection. Instead, `comfyui-view-preload.js` passively wraps `window.WebSocket` inside the embedded view (same JS world, no CSP issues) and relays observed frames over IPC (`electron.mjs` → `preload.js` → `hooks/useComfyUIEmbeddedProgress.ts`) without ever opening a competing connection.
- Preview/output image box in the Queue is now vertically resizable (drag handle, persisted height) so portrait images aren't squashed.
- Adds a "Run" button to the top of the Queue that queues whatever workflow is currently loaded in the embedded ComfyUI view (`window.app.queuePrompt`, with fallbacks across ComfyUI frontend versions), so generation can be triggered from anywhere in the app.
- Also fixes a pre-existing bug where the Queue's progress bar jumped straight from 0% to 100% for jobs tracked via the external queue monitor — root cause was the monitor's WebSocket never receiving progress events in the first place (client_id mismatch), now resolved by the IPC relay for embedded-view jobs.

## Why

The Queue previously only showed a static thumbnail once a ComfyUI generation finished, with no visibility into progress or in-flight results — a common pain point when generating longer or higher-step-count workflows, especially through the app's embedded ComfyUI UI.

## Reviewer notes

- `store/useGenerationQueueStore.ts` centralizes `previewImageUrl` object-URL lifecycle (revoke-on-replace and revoke-on-removal) shared by both delivery paths.
- `services/comfyUIApiClient.ts` gained `decodeComfyUIPreviewFrame`, handling both ComfyUI's `PREVIEW_IMAGE` and newer `PREVIEW_IMAGE_WITH_METADATA` binary frame formats (detected via image magic bytes, not just the format enum).
- The embedded-view preload runs with `contextIsolation: false` for that view only (still sandboxed, no Node exposed to the page) — required so the `WebSocket` patch installs before ComfyUI's own bundle creates its socket.
- CHANGELOG.md / public/CHANGELOG.md updated under an `[0.18.0]` section.

## Test plan

- [x] Generate from MetaHub's own workspace — live preview + smooth progress in the Queue.
- [x] Generate from the embedded ComfyUI UI — live preview + smooth progress in the Queue, with ComfyUI's own UI (queue/preview) unaffected.
- [x] Drag the preview/output image box taller for a portrait image; confirm the size persists after reopening the app.
- [x] Click "Run" with a workflow loaded in the embedded ComfyUI view; confirm it queues and shows success/error feedback.
- [x] Cancel/error a generation mid-flight in both flows; confirm no console errors and preview clears.