### PR TITLE
docs: instrumentar atribuição src=readme nos links do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Image MetaHub
 
 [![Join our Discord](https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/2MXWxjKyJ5)
-[![Buy License – $39](https://img.shields.io/badge/Buy%20License-%2439-4b8bbe)](https://imagemetahub.com/getpro.html)
+[![Buy License – $39](https://img.shields.io/badge/Buy%20License-%2439-4b8bbe)](https://www.imagemetahub.com/pro?src=readme)
 
 Local-first browser, search tool, and metadata hub for AI-generated images and videos.
 
@@ -324,8 +324,8 @@ Image MetaHub is built and maintained by **Lucas (LuqP2)** with community feedba
 
 ## Links
 
-* Website: [https://imagemetahub.com](https://imagemetahub.com)
+* Website: [https://www.imagemetahub.com?src=readme](https://www.imagemetahub.com?src=readme)
 * Discord: [https://discord.gg/2MXWxjKyJ5](https://discord.gg/2MXWxjKyJ5)
-* Pro license: [https://imagemetahub.com/getpro](https://imagemetahub.com/getpro)
+* Pro license: [https://www.imagemetahub.com/pro?src=readme](https://www.imagemetahub.com/pro?src=readme)
 * Ko-fi: [https://ko-fi.com/lucaspierri](https://ko-fi.com/lucaspierri)
 * ComfyUI Save Node: [https://github.com/LuqP2/ImageMetaHub-ComfyUI-Save](https://github.com/LuqP2/ImageMetaHub-ComfyUI-Save)


### PR DESCRIPTION
## Summary
- Adiciona `?src=readme` aos 3 links do README que apontam para imagemetahub.com, para alimentar a atribuição de tráfego em `js/analytics.js`/`js/checkout.js`
- Corrige o link de Pro license que apontava para `/getpro.html` (rota de redirect legada) para o caminho atual `/pro`
- Padroniza os hosts para `www.imagemetahub.com`, conforme os canonicals do site

Links fora de imagemetahub.com (Discord, Ko-fi, GitHub) não foram tocados — `?src=` só é lido pelo script rodando no próprio domínio.

## Test plan
- [ ] Clicar nos 3 links atualizados e confirmar que carregam corretamente com `www` e o parâmetro `src=readme` preservado