### PR TITLE
fix: video controls intercepted by next/prev hover zones

### DIFF
--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -825,7 +825,7 @@ const VideoPlayer: React.FC<{
 
       {/* Center Play Button Overlay (only when paused and not hovering controls) */}
       {!isPlaying && (
-        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <div className="absolute inset-0 z-30 flex items-center justify-center pointer-events-none">
           <button
             type="button"
             aria-label="Play video"
@@ -839,8 +839,8 @@ const VideoPlayer: React.FC<{
       )}
 
       {/* Controls Overlay */}
-      <div 
-        className={`absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/90 via-black/60 to-transparent transition-opacity duration-300 ${isHovering || !isPlaying ? 'opacity-100' : 'opacity-0'}`}
+      <div
+        className={`absolute bottom-0 left-0 right-0 z-30 p-4 bg-gradient-to-t from-black/90 via-black/60 to-transparent transition-opacity duration-300 ${isHovering || !isPlaying ? 'opacity-100' : 'opacity-0'}`}
         onClick={(e) => e.stopPropagation()} // Prevent clicking controls from toggling play
       >
         {/* Progress Bar */}


### PR DESCRIPTION
## Summary
- Video player's center play button and bottom controls bar (play/pause, mute/volume, loop, seek) had no explicit z-index, so the next/prev navigation buttons (z-20, spanning full container height) painted on top and intercepted clicks near the edges of the controls.
- Added `z-30` to both overlays in `VideoPlayer` (components/ImageModal.tsx), matching the z-30 already used elsewhere in this file for overlays that need to sit above the nav strips.

Fixes #487

## Test plan
- [x] Open a video in the Media Viewer, let it autoplay
- [x] Click play/pause in the bottom-left controls — toggles playback, doesn't navigate to previous item
- [x] Click mute icon / drag volume slider — mutes/adjusts volume, doesn't navigate
- [x] Click loop toggle (bottom-right) — toggles loop, doesn't navigate to next item
- [x] Hover mid-height near left/right edges (outside controls bar) — next/prev nav still works
- [x] Pause video, click centered play button at a narrow window width — resumes playback, doesn't navigate