### PR TITLE
Reduce context menu noise and PRO badge clutter

### DIFF
--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -478,6 +478,7 @@ describe('ImageGrid context menu', () => {
 
     render(<Harness images={[image]} />);
 
+    fireEvent.click(screen.getByText('File'));
     fireEvent.click(screen.getByText('Rename...'));
 
     expect(screen.getByRole('textbox', { name: /rename alpha\.png/i })).toBeTruthy();

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -8,16 +8,14 @@ import { type IndexedImage, type BaseMetadata, type Directory, ImageStack, Smart
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
 import { useContextMenu } from '../hooks/useContextMenu';
-import { Heart, Info, Copy, CheckCircle, Folder, Download, Clipboard, Sparkles, GitCompare, Square, Search,
+import { Heart, Info, Copy, CheckCircle, Folder, Clipboard, Sparkles, GitCompare, Square, Search,
   ChevronRight,
   CheckSquare,
   EyeOff,
-  Package,
   Play,
   Music,
   Tag,
   RefreshCw,
-  Pencil,
   Image as ImageIcon,
   Workflow
 } from 'lucide-react';
@@ -32,7 +30,7 @@ import { RATING_VALUES, RatingValueIcons, getRatingChipClasses, getRatingLabel }
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useGenerationProviderAvailability } from '../hooks/useGenerationProviderAvailability';
 import ProBadge from './ProBadge';
-import { ContextMenuButton, ContextMenuSubmenu } from './contextMenu/ContextMenuPrimitives';
+import { ContextMenuButton, ContextMenuSubmenu, buildFileMenuItems } from './contextMenu/ContextMenuPrimitives';
 import { useImageStacking } from '../hooks/useImageStacking';
 import TagManagerModal from './TagManagerModal';
 import TransferImagesModal, { type TransferDestination } from './TransferImagesModal';
@@ -2407,52 +2405,17 @@ const ImageGrid: React.FC<ImageGridProps> = ({
           <div className="border-t border-gray-600 my-1"></div>
 
           {(() => {
-            const fileMenuItems = [
-              {
-                key: 'rename',
-                icon: <Pencil className="w-4 h-4" />,
-                label: 'Rename...',
-                onClick: () => openInlineRename(contextMenu.image),
-                isPro: false,
-              },
-              {
-                key: 'copy-to',
-                icon: <Folder className="w-4 h-4" />,
-                label: 'Copy To...',
-                onClick: () => openTransferModal('copy'),
-                isPro: !canUseFileManagement,
-              },
-              {
-                key: 'move-to',
-                icon: <Folder className="w-4 h-4" />,
-                label: 'Move To...',
-                onClick: () => openTransferModal('move'),
-                isPro: !canUseFileManagement,
-              },
-              {
-                key: 'show-in-folder',
-                icon: <Folder className="w-4 h-4" />,
-                label: 'Show in Folder',
-                onClick: showInFolder,
-                isPro: false,
-              },
-              {
-                key: 'export',
-                icon: <Download className="w-4 h-4" />,
-                label: 'Export Image',
-                onClick: exportImage,
-                isPro: false,
-              },
-              ...(selectedCount > 1
-                ? [{
-                    key: 'batch-export',
-                    icon: <Package className="w-4 h-4" />,
-                    label: `Batch Export Selected (${selectedCount})`,
-                    onClick: handleBatchExport,
-                    isPro: !canUseBatchExport,
-                  }]
-                : []),
-            ];
+            const fileMenuItems = buildFileMenuItems({
+              onRename: () => openInlineRename(contextMenu.image),
+              onCopyTo: () => openTransferModal('copy'),
+              onMoveTo: () => openTransferModal('move'),
+              onShowInFolder: showInFolder,
+              onExport: exportImage,
+              onBatchExport: handleBatchExport,
+              selectedCount,
+              canUseFileManagement,
+              canUseBatchExport,
+            });
             const fileHasProItem = fileMenuItems.some((item) => item.isPro);
 
             return (
@@ -2528,7 +2491,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                   label: 'Open in ComfyUI Workspace',
                   onClick: openComfyUIWorkspace,
                   isPro: !canUseComfyUI,
-                  title: canUseComfyUI ? 'Open this image workflow in the ComfyUI workspace' : undefined,
+                  title: 'Open this image workflow in the ComfyUI workspace',
                 });
               }
             }

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -30,7 +30,9 @@ import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } fr
 import { ComfyUIGenerateModal, type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGenerateModal';
 import { RATING_VALUES, RatingValueIcons, getRatingChipClasses, getRatingLabel } from './RatingStars';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
+import { useGenerationProviderAvailability } from '../hooks/useGenerationProviderAvailability';
 import ProBadge from './ProBadge';
+import { ContextMenuButton, ContextMenuSubmenu } from './contextMenu/ContextMenuPrimitives';
 import { useImageStacking } from '../hooks/useImageStacking';
 import TagManagerModal from './TagManagerModal';
 import TransferImagesModal, { type TransferDestination } from './TransferImagesModal';
@@ -1143,6 +1145,8 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const [isCopySubmenuOpen, setIsCopySubmenuOpen] = useState(false);
   const [isCollectionSubmenuOpen, setIsCollectionSubmenuOpen] = useState(false);
   const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
+  const [isGenerateSubmenuOpen, setIsGenerateSubmenuOpen] = useState(false);
+  const [isFileSubmenuOpen, setIsFileSubmenuOpen] = useState(false);
   const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
   const [renamingImageId, setRenamingImageId] = useState<string | null>(null);
   const [transferStatusText, setTransferStatusText] = useState<string>('');
@@ -1151,7 +1155,10 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
   const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
   const updateCollection = useImageStore((state) => state.updateCollection);
-  const { canUseComparison, showProModal, canUseA1111, canUseComfyUI, canUseBatchExport, canUseBulkTagging, canUseFileManagement, canUseImageEditor, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
+  const { canUseComparison, showProModal, canUseA1111, canUseComfyUI, canUseBatchExport, canUseBulkTagging, canUseFileManagement, canUseImageEditor, initialized } = useFeatureAccess();
+  const { visibleProviders, singleVisibleProvider } = useGenerationProviderAvailability();
+  const isA1111ProviderVisible = visibleProviders.some((provider) => provider.id === 'a1111');
+  const isComfyUIProviderVisible = visibleProviders.some((provider) => provider.id === 'comfyui');
   const selectedCount = selectedImages.size;
   const sensitiveTagSet = useMemo(() => {
     return new Set(
@@ -1347,7 +1354,13 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     if (!contextMenu.visible && isAddToCollectionSubmenuOpen) {
       setIsAddToCollectionSubmenuOpen(false);
     }
-  }, [contextMenu.visible, isAddToCollectionSubmenuOpen, isCollectionSubmenuOpen, isCopySubmenuOpen]);
+    if (!contextMenu.visible && isGenerateSubmenuOpen) {
+      setIsGenerateSubmenuOpen(false);
+    }
+    if (!contextMenu.visible && isFileSubmenuOpen) {
+      setIsFileSubmenuOpen(false);
+    }
+  }, [contextMenu.visible, isAddToCollectionSubmenuOpen, isCollectionSubmenuOpen, isCopySubmenuOpen, isFileSubmenuOpen, isGenerateSubmenuOpen]);
 
   const queuedComparisonFirstImageId = queuedComparisonImages[0]?.id;
   const imageGridProfilerOnRender = useMemo(() => createProfilerOnRender('ImageGrid'), []);
@@ -1593,15 +1606,10 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       hideContextMenu();
       return;
     }
-    if (!canUseFileManagement) {
-      showProModal('file_management');
-      hideContextMenu();
-      return;
-    }
 
     setRenamingImageId(image.id);
     hideContextMenu();
-  }, [canUseFileManagement, hideContextMenu, showProModal]);
+  }, [hideContextMenu]);
 
   const closeInlineRename = useCallback((result?: ImageRenameResult) => {
     if (result) {
@@ -2175,7 +2183,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
           >
             <Tag className="w-4 h-4" />
             <span className="flex-1">Add/Remove Tags</span>
-            {!canUseBulkTagging && selectedCount > 1 && initialized && !canUseDuringTrialOrPro && <ProBadge size="sm" />}
+            {!canUseBulkTagging && selectedCount > 1 && initialized && <ProBadge size="sm" variant="subtle" tooltip="Pro feature - start trial" />}
           </button>
 
           <div
@@ -2351,7 +2359,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             <span className="flex-1">
               Add to Compare {canUseComparison && comparisonCount > 0 ? `(${comparisonCount}/4)` : ''}
             </span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
+            {!canUseComparison && <ProBadge size="sm" variant="subtle" tooltip="Pro feature - start trial" />}
           </button>
 
           <button
@@ -2372,7 +2380,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             >
               <ImageIcon className="w-4 h-4" />
               <span className="flex-1">Open in Editor</span>
-              {!canUseDuringTrialOrPro && initialized && <ProBadge size="sm" />}
+              {!canUseImageEditor && initialized && <ProBadge size="sm" variant="subtle" tooltip="Image Editor (Pro Feature) - start trial" />}
             </button>
           )}
 
@@ -2398,110 +2406,179 @@ const ImageGrid: React.FC<ImageGridProps> = ({
 
           <div className="border-t border-gray-600 my-1"></div>
 
-          <button
-            onClick={showInFolder}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-          >
-            <Folder className="w-4 h-4" />
-            Show in Folder
-          </button>
+          {(() => {
+            const fileMenuItems = [
+              {
+                key: 'rename',
+                icon: <Pencil className="w-4 h-4" />,
+                label: 'Rename...',
+                onClick: () => openInlineRename(contextMenu.image),
+                isPro: false,
+              },
+              {
+                key: 'copy-to',
+                icon: <Folder className="w-4 h-4" />,
+                label: 'Copy To...',
+                onClick: () => openTransferModal('copy'),
+                isPro: !canUseFileManagement,
+              },
+              {
+                key: 'move-to',
+                icon: <Folder className="w-4 h-4" />,
+                label: 'Move To...',
+                onClick: () => openTransferModal('move'),
+                isPro: !canUseFileManagement,
+              },
+              {
+                key: 'show-in-folder',
+                icon: <Folder className="w-4 h-4" />,
+                label: 'Show in Folder',
+                onClick: showInFolder,
+                isPro: false,
+              },
+              {
+                key: 'export',
+                icon: <Download className="w-4 h-4" />,
+                label: 'Export Image',
+                onClick: exportImage,
+                isPro: false,
+              },
+              ...(selectedCount > 1
+                ? [{
+                    key: 'batch-export',
+                    icon: <Package className="w-4 h-4" />,
+                    label: `Batch Export Selected (${selectedCount})`,
+                    onClick: handleBatchExport,
+                    isPro: !canUseBatchExport,
+                  }]
+                : []),
+            ];
+            const fileHasProItem = fileMenuItems.some((item) => item.isPro);
 
-          <button
-            onClick={() => openInlineRename(contextMenu.image)}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            title={!canUseFileManagement && initialized ? 'Pro feature - start trial' : undefined}
-          >
-            <Pencil className="w-4 h-4" />
-            <span className="flex-1">Rename...</span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-          </button>
-
-          <button
-            onClick={() => openTransferModal('copy')}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            title={!canUseFileManagement && initialized ? 'Pro feature - start trial' : undefined}
-          >
-            <Folder className="w-4 h-4" />
-            <span className="flex-1">Copy To...</span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-          </button>
-
-          <button
-            onClick={() => openTransferModal('move')}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            title={!canUseFileManagement && initialized ? 'Pro feature - start trial' : undefined}
-          >
-            <Folder className="w-4 h-4" />
-            <span className="flex-1">Move To...</span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-          </button>
-
-            <button
-              onClick={exportImage}
-              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            >
-              <Download className="w-4 h-4" />
-              Export Image
-            </button>
-
-            {selectedCount > 1 && (
-              <button
-                onClick={handleBatchExport}
-                className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-                title={!canUseBatchExport && initialized ? 'Pro feature - start trial' : undefined}
+            return (
+              <ContextMenuSubmenu
+                label="File"
+                icon={<Folder className="w-4 h-4" />}
+                isOpen={isFileSubmenuOpen}
+                onOpenChange={setIsFileSubmenuOpen}
+                horizontalClass={submenuHorizontalClass}
+                showProBadge={fileHasProItem && initialized}
+                proBadgeTooltip="Pro feature - start trial"
               >
-                <Package className="w-4 h-4" />
-                <span className="flex-1">Batch Export Selected ({selectedCount})</span>
-                {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-              </button>
-            )}
+                {fileMenuItems.map((item) => (
+                  <ContextMenuButton
+                    key={item.key}
+                    onClick={item.onClick}
+                    icon={item.icon}
+                    label={item.label}
+                    title={item.isPro && initialized ? 'Pro feature - start trial' : undefined}
+                    showProBadge={item.isPro}
+                    proBadgeTooltip="Pro feature - start trial"
+                  />
+                ))}
+              </ContextMenuSubmenu>
+            );
+          })()}
 
-            <div className="border-t border-gray-600 my-1"></div>
+          {(() => {
+            const hasPromptMetadata = Boolean(contextMenu.image?.metadata?.normalizedMetadata?.prompt);
+            const generateMenuItems: Array<{
+              key: string;
+              icon: React.ReactNode;
+              label: string;
+              onClick: () => void;
+              disabled?: boolean;
+              isPro: boolean;
+              title?: string;
+            }> = [];
 
-          <button
-            onClick={copyMetadataToA1111}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            disabled={!contextMenu.image?.metadata?.normalizedMetadata?.prompt}
-            title={!canUseA1111 && initialized ? 'Pro feature - start trial' : undefined}
-          >
-            <Clipboard className="w-4 h-4" />
-            <span className="flex-1">Copy to A1111</span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-          </button>
+            if (isA1111ProviderVisible) {
+              generateMenuItems.push({
+                key: 'copy-a1111',
+                icon: <Clipboard className="w-4 h-4" />,
+                label: 'Copy to A1111',
+                onClick: copyMetadataToA1111,
+                disabled: !hasPromptMetadata,
+                isPro: !canUseA1111,
+              });
+              generateMenuItems.push({
+                key: 'generate-a1111',
+                icon: <Sparkles className="w-4 h-4" />,
+                label: singleVisibleProvider ? 'Generate' : 'Generate with A1111',
+                onClick: openGenerateModal,
+                disabled: !hasPromptMetadata,
+                isPro: !canUseA1111,
+              });
+            }
 
-          <button
-            onClick={openGenerateModal}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            disabled={!contextMenu.image?.metadata?.normalizedMetadata?.prompt}
-            title={!canUseA1111 && initialized ? 'Pro feature - start trial' : undefined}
-          >
-            <Sparkles className="w-4 h-4" />
-            <span className="flex-1">Generate with A1111</span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-          </button>
+            if (isComfyUIProviderVisible) {
+              generateMenuItems.push({
+                key: 'generate-comfyui',
+                icon: <Sparkles className="w-4 h-4" />,
+                label: singleVisibleProvider ? 'Generate' : 'Generate with ComfyUI',
+                onClick: openComfyUIGenerateModal,
+                disabled: !hasPromptMetadata,
+                isPro: !canUseComfyUI,
+              });
 
-          <button
-            onClick={openComfyUIGenerateModal}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            disabled={!contextMenu.image?.metadata?.normalizedMetadata?.prompt}
-            title={!canUseComfyUI && initialized ? 'Pro feature - start trial' : undefined}
-          >
-            <Sparkles className="w-4 h-4" />
-            <span className="flex-1">Generate with ComfyUI</span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-          </button>
+              if (onOpenComfyUIWorkspace) {
+                generateMenuItems.push({
+                  key: 'comfyui-workspace',
+                  icon: <Workflow className="w-4 h-4" />,
+                  label: 'Open in ComfyUI Workspace',
+                  onClick: openComfyUIWorkspace,
+                  isPro: !canUseComfyUI,
+                  title: canUseComfyUI ? 'Open this image workflow in the ComfyUI workspace' : undefined,
+                });
+              }
+            }
 
-          {onOpenComfyUIWorkspace && (
-            <button
-              onClick={openComfyUIWorkspace}
-              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-              title={!canUseComfyUI && initialized ? 'Pro feature - start trial' : 'Open this image workflow in the ComfyUI workspace'}
-            >
-              <Workflow className="w-4 h-4" />
-              <span className="flex-1">Open in ComfyUI Workspace</span>
-              {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-            </button>
-          )}
+            if (generateMenuItems.length === 0) {
+              return null;
+            }
+
+            const generateHasProItem = generateMenuItems.some((item) => item.isPro);
+
+            return (
+              <>
+                <div className="border-t border-gray-600 my-1"></div>
+                {generateMenuItems.length === 1 ? (
+                  <ContextMenuButton
+                    onClick={generateMenuItems[0].onClick}
+                    icon={generateMenuItems[0].icon}
+                    label={generateMenuItems[0].label}
+                    disabled={generateMenuItems[0].disabled}
+                    title={generateMenuItems[0].isPro && initialized ? 'Pro feature - start trial' : generateMenuItems[0].title}
+                    showProBadge={generateMenuItems[0].isPro}
+                    proBadgeTooltip="Pro feature - start trial"
+                  />
+                ) : (
+                  <ContextMenuSubmenu
+                    label="Generate"
+                    icon={<Sparkles className="w-4 h-4" />}
+                    isOpen={isGenerateSubmenuOpen}
+                    onOpenChange={setIsGenerateSubmenuOpen}
+                    horizontalClass={submenuHorizontalClass}
+                    showProBadge={generateHasProItem && initialized}
+                    proBadgeTooltip="Pro feature - start trial"
+                  >
+                    {generateMenuItems.map((item) => (
+                      <ContextMenuButton
+                        key={item.key}
+                        onClick={item.onClick}
+                        icon={item.icon}
+                        label={item.label}
+                        disabled={item.disabled}
+                        title={item.isPro && initialized ? 'Pro feature - start trial' : item.title}
+                        showProBadge={item.isPro}
+                        proBadgeTooltip="Pro feature - start trial"
+                      />
+                    ))}
+                  </ContextMenuSubmenu>
+                )}
+              </>
+            );
+          })()}
         </div>,
         document.body,
       )

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -5,14 +5,14 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { type IndexedImage, type Directory, SmartCollection } from '../types';
 import { useContextMenu } from '../hooks/useContextMenu';
 import { useImageStore } from '../store/useImageStore';
-import { Copy, Folder, Download, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Search, Star, Pencil, Workflow, Image as ImageIcon } from 'lucide-react';
+import { Copy, Folder, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Search, Star, Workflow, Image as ImageIcon } from 'lucide-react';
 import { useThumbnail } from '../hooks/useThumbnail';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useGenerationProviderAvailability } from '../hooks/useGenerationProviderAvailability';
 import ProBadge from './ProBadge';
-import { ContextMenuButton, ContextMenuSubmenu } from './contextMenu/ContextMenuPrimitives';
+import { ContextMenuButton, ContextMenuSubmenu, buildFileMenuItems } from './contextMenu/ContextMenuPrimitives';
 import TransferImagesModal, { type TransferDestination } from './TransferImagesModal';
 import { transferIndexedImages } from '../services/fileTransferService';
 import { RATING_VALUES, RatingValueIcons, getRatingBadgeClasses, getRatingChipClasses, getRatingLabel } from './RatingStars';
@@ -848,52 +848,17 @@ const ImageTable: React.FC<ImageTableProps> = ({
           <div className="border-t border-gray-600 my-1"></div>
 
           {(() => {
-            const fileMenuItems = [
-              {
-                key: 'rename',
-                icon: <Pencil className="w-4 h-4" />,
-                label: 'Rename...',
-                onClick: () => openRenameModal(contextMenu.image),
-                isPro: false,
-              },
-              {
-                key: 'copy-to',
-                icon: <Folder className="w-4 h-4" />,
-                label: 'Copy To...',
-                onClick: () => openTransferModal('copy'),
-                isPro: !canUseFileManagement,
-              },
-              {
-                key: 'move-to',
-                icon: <Folder className="w-4 h-4" />,
-                label: 'Move To...',
-                onClick: () => openTransferModal('move'),
-                isPro: !canUseFileManagement,
-              },
-              {
-                key: 'show-in-folder',
-                icon: <Folder className="w-4 h-4" />,
-                label: 'Show in Folder',
-                onClick: showInFolder,
-                isPro: false,
-              },
-              {
-                key: 'export',
-                icon: <Download className="w-4 h-4" />,
-                label: 'Export Image',
-                onClick: exportImage,
-                isPro: false,
-              },
-              ...(selectedCount > 1
-                ? [{
-                    key: 'batch-export',
-                    icon: <Package className="w-4 h-4" />,
-                    label: `Batch Export Selected (${selectedCount})`,
-                    onClick: handleBatchExport,
-                    isPro: !canUseBatchExport,
-                  }]
-                : []),
-            ];
+            const fileMenuItems = buildFileMenuItems({
+              onRename: () => openRenameModal(contextMenu.image),
+              onCopyTo: () => openTransferModal('copy'),
+              onMoveTo: () => openTransferModal('move'),
+              onShowInFolder: showInFolder,
+              onExport: exportImage,
+              onBatchExport: handleBatchExport,
+              selectedCount,
+              canUseFileManagement,
+              canUseBatchExport,
+            });
             const fileHasProItem = fileMenuItems.some((item) => item.isPro);
 
             return (

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -10,7 +10,9 @@ import { useThumbnail } from '../hooks/useThumbnail';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
+import { useGenerationProviderAvailability } from '../hooks/useGenerationProviderAvailability';
 import ProBadge from './ProBadge';
+import { ContextMenuButton, ContextMenuSubmenu } from './contextMenu/ContextMenuPrimitives';
 import TransferImagesModal, { type TransferDestination } from './TransferImagesModal';
 import { transferIndexedImages } from '../services/fileTransferService';
 import { RATING_VALUES, RatingValueIcons, getRatingBadgeClasses, getRatingChipClasses, getRatingLabel } from './RatingStars';
@@ -98,6 +100,7 @@ const ImageTable: React.FC<ImageTableProps> = ({
   const [isCopySubmenuOpen, setIsCopySubmenuOpen] = useState(false);
   const [isCollectionSubmenuOpen, setIsCollectionSubmenuOpen] = useState(false);
   const [isAddToCollectionSubmenuOpen, setIsAddToCollectionSubmenuOpen] = useState(false);
+  const [isFileSubmenuOpen, setIsFileSubmenuOpen] = useState(false);
   const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
   const [renameImage, setRenameImage] = useState<IndexedImage | null>(null);
   const [transferStatusText, setTransferStatusText] = useState<string>('');
@@ -108,7 +111,9 @@ const ImageTable: React.FC<ImageTableProps> = ({
   const addImagesToCollection = useImageStore((state) => state.addImagesToCollection);
   const removeImagesFromCollection = useImageStore((state) => state.removeImagesFromCollection);
   const updateCollection = useImageStore((state) => state.updateCollection);
-  const { canUseComfyUI, canUseFileManagement, canUseImageEditor, showProModal, initialized, canUseDuringTrialOrPro } = useFeatureAccess();
+  const { canUseComfyUI, canUseFileManagement, canUseImageEditor, canUseBatchExport, showProModal, initialized } = useFeatureAccess();
+  const { visibleProviders } = useGenerationProviderAvailability();
+  const isComfyUIProviderVisible = visibleProviders.some((provider) => provider.id === 'comfyui');
   const { isReparsing, reparseImages } = useReparseMetadata();
 
   const {
@@ -138,7 +143,10 @@ const ImageTable: React.FC<ImageTableProps> = ({
     if (!contextMenu.visible && isAddToCollectionSubmenuOpen) {
       setIsAddToCollectionSubmenuOpen(false);
     }
-  }, [contextMenu.visible, isAddToCollectionSubmenuOpen, isCollectionSubmenuOpen, isCopySubmenuOpen]);
+    if (!contextMenu.visible && isFileSubmenuOpen) {
+      setIsFileSubmenuOpen(false);
+    }
+  }, [contextMenu.visible, isAddToCollectionSubmenuOpen, isCollectionSubmenuOpen, isCopySubmenuOpen, isFileSubmenuOpen]);
 
   const selectedCount = selectedImages.size;
 
@@ -330,15 +338,10 @@ const ImageTable: React.FC<ImageTableProps> = ({
       hideContextMenu();
       return;
     }
-    if (!canUseFileManagement) {
-      showProModal('file_management');
-      hideContextMenu();
-      return;
-    }
 
     setRenameImage(image);
     hideContextMenu();
-  }, [canUseFileManagement, hideContextMenu, showProModal]);
+  }, [hideContextMenu]);
 
   const handleTransferConfirm = useCallback(async (directory: TransferDestination) => {
     if (!transferMode) {
@@ -817,18 +820,19 @@ const ImageTable: React.FC<ImageTableProps> = ({
             >
               <ImageIcon className="w-4 h-4" />
               <span className="flex-1">Edit Image</span>
-              {!canUseDuringTrialOrPro && initialized && <ProBadge size="sm" />}
+              {!canUseImageEditor && initialized && <ProBadge size="sm" variant="subtle" tooltip="Image Editor (Pro Feature) - start trial" />}
             </button>
           )}
 
-          {onOpenComfyUIWorkspace && (
+          {onOpenComfyUIWorkspace && isComfyUIProviderVisible && (
             <button
               onClick={openComfyUIWorkspace}
               className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-              title="Open this image in the ComfyUI workspace context panel"
+              title={canUseComfyUI ? 'Open this image in the ComfyUI workspace context panel' : 'Pro feature - start trial'}
             >
               <Workflow className="w-4 h-4" />
-              Open ComfyUI Workspace
+              <span className="flex-1">Open ComfyUI Workspace</span>
+              {!canUseComfyUI && <ProBadge size="sm" variant="subtle" tooltip="Pro feature - start trial" />}
             </button>
           )}
 
@@ -843,60 +847,79 @@ const ImageTable: React.FC<ImageTableProps> = ({
 
           <div className="border-t border-gray-600 my-1"></div>
 
-          <button
-            onClick={showInFolder}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-          >
-            <Folder className="w-4 h-4" />
-            Show in Folder
-          </button>
+          {(() => {
+            const fileMenuItems = [
+              {
+                key: 'rename',
+                icon: <Pencil className="w-4 h-4" />,
+                label: 'Rename...',
+                onClick: () => openRenameModal(contextMenu.image),
+                isPro: false,
+              },
+              {
+                key: 'copy-to',
+                icon: <Folder className="w-4 h-4" />,
+                label: 'Copy To...',
+                onClick: () => openTransferModal('copy'),
+                isPro: !canUseFileManagement,
+              },
+              {
+                key: 'move-to',
+                icon: <Folder className="w-4 h-4" />,
+                label: 'Move To...',
+                onClick: () => openTransferModal('move'),
+                isPro: !canUseFileManagement,
+              },
+              {
+                key: 'show-in-folder',
+                icon: <Folder className="w-4 h-4" />,
+                label: 'Show in Folder',
+                onClick: showInFolder,
+                isPro: false,
+              },
+              {
+                key: 'export',
+                icon: <Download className="w-4 h-4" />,
+                label: 'Export Image',
+                onClick: exportImage,
+                isPro: false,
+              },
+              ...(selectedCount > 1
+                ? [{
+                    key: 'batch-export',
+                    icon: <Package className="w-4 h-4" />,
+                    label: `Batch Export Selected (${selectedCount})`,
+                    onClick: handleBatchExport,
+                    isPro: !canUseBatchExport,
+                  }]
+                : []),
+            ];
+            const fileHasProItem = fileMenuItems.some((item) => item.isPro);
 
-          <button
-            onClick={() => openRenameModal(contextMenu.image)}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            title={!canUseFileManagement && initialized ? 'Pro feature - start trial' : undefined}
-          >
-            <Pencil className="w-4 h-4" />
-            <span className="flex-1">Rename...</span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-          </button>
-
-          <button
-            onClick={() => openTransferModal('copy')}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            title={!canUseFileManagement && initialized ? 'Pro feature - start trial' : undefined}
-          >
-            <Folder className="w-4 h-4" />
-            <span className="flex-1">Copy To...</span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-          </button>
-
-          <button
-            onClick={() => openTransferModal('move')}
-            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            title={!canUseFileManagement && initialized ? 'Pro feature - start trial' : undefined}
-          >
-            <Folder className="w-4 h-4" />
-            <span className="flex-1">Move To...</span>
-            {!canUseDuringTrialOrPro && <ProBadge size="sm" />}
-          </button>
-
-            <button
-              onClick={exportImage}
-              className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
-            >
-              <Download className="w-4 h-4" />
-              Export Image
-            </button>
-            {selectedCount > 1 && (
-              <button
-                onClick={handleBatchExport}
-                className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+            return (
+              <ContextMenuSubmenu
+                label="File"
+                icon={<Folder className="w-4 h-4" />}
+                isOpen={isFileSubmenuOpen}
+                onOpenChange={setIsFileSubmenuOpen}
+                horizontalClass={submenuHorizontalClass}
+                showProBadge={fileHasProItem && initialized}
+                proBadgeTooltip="Pro feature - start trial"
               >
-                <Package className="w-4 h-4" />
-                Batch Export Selected ({selectedCount})
-              </button>
-            )}
+                {fileMenuItems.map((item) => (
+                  <ContextMenuButton
+                    key={item.key}
+                    onClick={item.onClick}
+                    icon={item.icon}
+                    label={item.label}
+                    title={item.isPro && initialized ? 'Pro feature - start trial' : undefined}
+                    showProBadge={item.isPro}
+                    proBadgeTooltip="Pro feature - start trial"
+                  />
+                ))}
+              </ContextMenuSubmenu>
+            );
+          })()}
           </div>,
           document.body,
         )}

--- a/components/ProBadge.tsx
+++ b/components/ProBadge.tsx
@@ -4,16 +4,37 @@ import { Crown } from 'lucide-react';
 interface ProBadgeProps {
   size?: 'sm' | 'md';
   tooltip?: string;
+  /**
+   * 'pill' (default) is the solid purple badge used in toolbars/sidebars.
+   * 'subtle' is a muted, borderless crown-only variant meant for dense
+   * lists (e.g. context menu items) where a full pill per row is too loud.
+   * The Pro-feature information is still exposed to screen readers via
+   * an sr-only label + title even though it's visually minimal.
+   */
+  variant?: 'pill' | 'subtle';
 }
 
-const ProBadge: React.FC<ProBadgeProps> = ({ size = 'sm', tooltip }) => {
+const ProBadge: React.FC<ProBadgeProps> = ({ size = 'sm', tooltip, variant = 'pill' }) => {
   const sizeClasses = size === 'sm' ? 'text-xs px-1.5 py-0.5' : 'text-sm px-2 py-1';
   const iconSize = size === 'sm' ? 'w-3 h-3' : 'w-4 h-4';
+  const title = tooltip || 'Pro Feature';
+
+  if (variant === 'subtle') {
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-gray-500 shrink-0"
+        title={title}
+      >
+        <Crown className={iconSize} aria-hidden="true" />
+        <span className="sr-only">{title}</span>
+      </span>
+    );
+  }
 
   return (
     <span
       className={`inline-flex items-center gap-1 bg-purple-600/20 text-purple-400 font-bold rounded ${sizeClasses} border border-purple-600/30`}
-      title={tooltip || 'Pro Feature'}
+      title={title}
     >
       <Crown className={iconSize} />
       PRO

--- a/components/contextMenu/ContextMenuPrimitives.tsx
+++ b/components/contextMenu/ContextMenuPrimitives.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Pencil, Folder, Download, Package } from 'lucide-react';
 import ProBadge from '../ProBadge';
 
 /**
@@ -94,3 +94,85 @@ export const ContextMenuSubmenu: React.FC<ContextMenuSubmenuProps> = ({
     )}
   </div>
 );
+
+export interface FileMenuItem {
+  key: string;
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  isPro: boolean;
+}
+
+export interface BuildFileMenuItemsArgs {
+  onRename: () => void;
+  onCopyTo: () => void;
+  onMoveTo: () => void;
+  onShowInFolder: () => void;
+  onExport: () => void;
+  onBatchExport: () => void;
+  selectedCount: number;
+  canUseFileManagement: boolean;
+  canUseBatchExport: boolean;
+}
+
+/**
+ * Shared File submenu contents (Rename/Copy To/Move To/Show in Folder/
+ * Export/Batch Export) used identically by ImageGrid and ImageTable so the
+ * two menus can't drift out of sync.
+ */
+export const buildFileMenuItems = ({
+  onRename,
+  onCopyTo,
+  onMoveTo,
+  onShowInFolder,
+  onExport,
+  onBatchExport,
+  selectedCount,
+  canUseFileManagement,
+  canUseBatchExport,
+}: BuildFileMenuItemsArgs): FileMenuItem[] => [
+  {
+    key: 'rename',
+    icon: <Pencil className="w-4 h-4" />,
+    label: 'Rename...',
+    onClick: onRename,
+    isPro: false,
+  },
+  {
+    key: 'copy-to',
+    icon: <Folder className="w-4 h-4" />,
+    label: 'Copy To...',
+    onClick: onCopyTo,
+    isPro: !canUseFileManagement,
+  },
+  {
+    key: 'move-to',
+    icon: <Folder className="w-4 h-4" />,
+    label: 'Move To...',
+    onClick: onMoveTo,
+    isPro: !canUseFileManagement,
+  },
+  {
+    key: 'show-in-folder',
+    icon: <Folder className="w-4 h-4" />,
+    label: 'Show in Folder',
+    onClick: onShowInFolder,
+    isPro: false,
+  },
+  {
+    key: 'export',
+    icon: <Download className="w-4 h-4" />,
+    label: 'Export Image',
+    onClick: onExport,
+    isPro: false,
+  },
+  ...(selectedCount > 1
+    ? [{
+        key: 'batch-export',
+        icon: <Package className="w-4 h-4" />,
+        label: `Batch Export Selected (${selectedCount})`,
+        onClick: onBatchExport,
+        isPro: !canUseBatchExport,
+      }]
+    : []),
+];

--- a/components/contextMenu/ContextMenuPrimitives.tsx
+++ b/components/contextMenu/ContextMenuPrimitives.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { ChevronRight } from 'lucide-react';
+import ProBadge from '../ProBadge';
+
+/**
+ * Shared building blocks for the image context menus (Grid/Table today,
+ * potentially Modal later). Centralizes the visual classes and the
+ * Pro-badge-in-a-dense-list pattern so new groups (Generate, File, ...)
+ * don't re-hand-roll button/submenu markup per call site.
+ */
+
+export const CONTEXT_MENU_ITEM_CLASS =
+  'w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2';
+
+export const CONTEXT_MENU_ITEM_DISABLED_CLASS = `${CONTEXT_MENU_ITEM_CLASS} disabled:opacity-50 disabled:cursor-not-allowed`;
+
+export interface ContextMenuButtonProps {
+  onClick: () => void;
+  icon?: React.ReactNode;
+  label: React.ReactNode;
+  disabled?: boolean;
+  title?: string;
+  /** Show the discrete/subtle Pro badge for this specific item. */
+  showProBadge?: boolean;
+  proBadgeTooltip?: string;
+  className?: string;
+}
+
+export const ContextMenuButton: React.FC<ContextMenuButtonProps> = ({
+  onClick,
+  icon,
+  label,
+  disabled,
+  title,
+  showProBadge,
+  proBadgeTooltip,
+  className,
+}) => (
+  <button
+    onClick={onClick}
+    className={className ?? CONTEXT_MENU_ITEM_DISABLED_CLASS}
+    disabled={disabled}
+    title={title}
+  >
+    {icon}
+    <span className="flex-1">{label}</span>
+    {showProBadge && <ProBadge size="sm" variant="subtle" tooltip={proBadgeTooltip} />}
+  </button>
+);
+
+export interface ContextMenuSubmenuProps {
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  horizontalClass: string;
+  /** Single aggregate Pro badge shown on the parent when any child item is Pro-gated. */
+  showProBadge?: boolean;
+  proBadgeTooltip?: string;
+  minWidthClass?: string;
+  children: React.ReactNode;
+}
+
+export const ContextMenuSubmenu: React.FC<ContextMenuSubmenuProps> = ({
+  label,
+  icon,
+  isOpen,
+  onOpenChange,
+  horizontalClass,
+  showProBadge,
+  proBadgeTooltip,
+  minWidthClass = 'min-w-[210px]',
+  children,
+}) => (
+  <div
+    className="relative"
+    onMouseEnter={() => onOpenChange(true)}
+    onMouseLeave={() => onOpenChange(false)}
+  >
+    <button
+      onClick={() => onOpenChange(!isOpen)}
+      className={CONTEXT_MENU_ITEM_CLASS}
+    >
+      {icon}
+      <span className="flex-1">{label}</span>
+      {showProBadge && <ProBadge size="sm" variant="subtle" tooltip={proBadgeTooltip} />}
+      <ChevronRight className="w-4 h-4 text-gray-400" />
+    </button>
+
+    {isOpen && (
+      <div className={`absolute top-0 ${minWidthClass} rounded-lg border border-gray-600 bg-gray-800 py-1 shadow-xl ${horizontalClass}`}>
+        {children}
+      </div>
+    )}
+  </div>
+);


### PR DESCRIPTION
## Summary
- Groups File (Rename, Copy To, Move To, Show in Folder, Export, Batch Export) and Generate (Copy to A1111, Generate with A1111/ComfyUI, Open in ComfyUI Workspace) actions into submenus in the grid/table image context menu, each with a single aggregate PRO badge instead of one per item (19 top-level items down to ~12, 9 visible badges down to ~4)
- Filters A1111/ComfyUI menu items by configured provider via `useGenerationProviderAvailability`, matching behavior already used in the preview sidebar/modal; shortens labels to "Generate" when only one provider is configured
- Adds a `subtle` `ProBadge` variant (muted crown, no pill) for dense list use, keeping the existing pill badge for toolbar/sidebar
- Removes the PRO gate from inline Rename in both grid and table (Copy To / Move To remain PRO-gated, since they preserve tags/favorites/notes across folders)
- Switches PRO badges from the generic trial/pro flag to each feature's specific access flag (bulk tagging, comparison, image editor, A1111, ComfyUI, file management, batch export), so a single feature's tier can change independently
- No PRO feature is hidden from free users — only regrouped; hiding by unconfigured provider is intentional and unrelated to tier

## Test plan
- [x] `npx vitest run __tests__/ImageGrid.contextMenu.test.tsx __tests__/ImageTable.contextMenu.test.tsx __tests__/useContextMenu.test.tsx` — 29/29 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual check in-app: free user with no provider configured, free with only ComfyUI, free with both providers, and Pro — confirm no item disappears for Pro users and Rename works for free users