### PR TITLE
Refactor ProOnlyModal copy and CTA hierarchy

### DIFF
--- a/components/ProOnlyModal.tsx
+++ b/components/ProOnlyModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
-import { X, Crown, Sparkles, GitCompare, BarChart3, CheckCircle2, Download, Tag, Image as ImageIcon } from 'lucide-react';
-import { ProFeature } from '../hooks/useFeatureAccess';
+import { X, Crown, Sparkles, GitCompare, BarChart3, CheckCircle2, Download, Tag, Image as ImageIcon, LucideIcon } from 'lucide-react';
+import { ProFeature, CLUSTERING_FREE_TIER_LIMIT, useProModalStore } from '../hooks/useFeatureAccess';
 import { TRIAL_DURATION_DAYS } from '../store/useLicenseStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { buildProLicenseUrl } from '../utils/creatorAttribution';
@@ -18,159 +18,184 @@ interface ProOnlyModalProps {
   isPro: boolean;
 }
 
-const featureInfo = {
-  a1111: {
-    name: 'A1111 Integration',
-    icon: Sparkles,
-    description: 'Generate image variations and copy parameters to Automatic1111',
-    benefits: [
-      'One-click generation of variations',
-      'Automatic parameter copying',
-      'Real-time generation progress',
-      'Batch generation support',
-    ],
-  },
-  comfyui: {
-    name: 'ComfyUI Integration',
-    icon: Sparkles,
-    description: 'Generate variations or copy workflows to ComfyUI',
-    benefits: [
-      'Quick generation from metadata',
-      'Real-time WebSocket progress tracking',
-      'Workflow copy for manual editing',
-      'Automatic metadata-rich saves',
-    ],
-  },
+type FeatureCopy = {
+  contextLine: string;
+  headline: string;
+  featureName: string;
+  icon: LucideIcon;
+  bullets: string[];
+  alsoUnlocks: string;
+  freeTierNote?: string;
+};
+
+const featureInfo: Record<ProFeature, FeatureCopy> = {
   comparison: {
-    name: 'Image Comparison',
+    contextLine: "Looks like you're comparing generations.",
+    headline: 'Compare 2–4 images, pixel and parameter',
+    featureName: 'Compare View',
     icon: GitCompare,
-    description: 'Side-by-side comparison of images with metadata diff',
-    benefits: [
-      'Compare two images side-by-side',
-      'Synchronized zoom and pan',
-      'Metadata differences highlighted',
-      'Quick image swapping',
+    bullets: [
+      'Diff map, edge overlay, flicker, loupe and slider',
+      'Token-level prompt diff, plus seed, CFG, sampler and LoRA changes highlighted',
+      'Zoom and pan locked across every panel — no lining them up by hand',
     ],
+    alsoUnlocks: 'Pro also unlocks ComfyUI generation, the image editor, and 6 more.',
   },
-  analytics: {
-    name: 'Analytics Dashboard',
-    icon: BarChart3,
-    description: 'Detailed insights and statistics about your image collection',
-    benefits: [
-      'Generation trends over time',
-      'Model and LoRA usage stats',
-      'Creative habit analysis',
-      'Dimension and parameter insights',
-    ],
-  },
-  clustering: {
-    name: 'Unlimited Clustering',
-    icon: Sparkles,
-    description: 'Analyze your entire image library for duplicate groups and prompt similarities',
-    benefits: [
-      'Process unlimited images',
-      'Find all duplicate variations',
-      'Organize massive libraries efficiently',
-      'Save hours of manual sorting',
-    ],
-  },
-  batch_export: {
-    name: 'Batch Export',
-    icon: Download,
-    description: 'Export multiple images at once to a folder or ZIP archive',
-    benefits: [
-      'Export selected or filtered images',
-      'Automatic filename conflict resolution',
-      'Flattened output for easy sharing',
-      'ZIP creation for quick backups',
-    ],
-  },
-  bulk_tagging: {
-    name: 'Bulk Tagging',
-    icon: Tag,
-    description: 'Add or remove tags from multiple images at once',
-    benefits: [
-      'Tag thousands of images instantly',
-      'Consistent tagging across collections',
-      'Smart autocomplete suggestions',
-      'Remove tags from multiple files',
-    ],
-  },
-  file_management: {
-    name: 'File Management',
-    icon: Download,
-    description: 'Copy or move images between indexed folders while preserving library data',
-    benefits: [
-      'Copy or move files without leaving the app',
-      'Preserve tags, favorites, and shadow metadata',
-      'Organize multiple images in a single action',
-      'Resolve filename conflicts automatically',
-    ],
-  },
+
   image_editor: {
-    name: 'Image Editor',
+    contextLine: 'Editing this one?',
+    headline: 'Edit and keep the workflow inside the file',
+    featureName: 'Image Editor',
     icon: ImageIcon,
-    description: 'Edit images with adjustments, crop, transform, annotations, and metadata-preserving PNG exports',
-    benefits: [
-      'Open images in the dedicated editor workspace',
-      'Adjust brightness, contrast, saturation, and hue',
-      'Crop, transform, annotate, and inspect edits',
-      'Save edited PNGs while preserving metadata',
+    bullets: [
+      'Save As or Overwrite with prompt, seed and workflow intact',
+      'Adjust, crop, transform, resize, enhance, annotate',
+      'Edits return to your library already indexed — no re-scan',
     ],
+    alsoUnlocks: 'Pro also unlocks Compare View, ComfyUI generation, and 6 more.',
   },
+
+  file_management: {
+    contextLine: 'Moving this somewhere else?',
+    headline: 'Move files without losing what the app knows about them',
+    featureName: 'File Management',
+    icon: Download,
+    bullets: [
+      "Tags, favorites and notes travel with the file — move it in Explorer and they're gone",
+      'Copy or move dozens between indexed folders in one action, nothing to re-tag afterwards',
+      'Filename conflicts resolved automatically',
+    ],
+    alsoUnlocks: 'Pro also unlocks Compare View, the image editor, and 6 more.',
+  },
+
+  comfyui: {
+    contextLine: 'Want to regenerate this from its own workflow?',
+    headline: 'Send any image back to ComfyUI',
+    featureName: 'ComfyUI Integration',
+    icon: Sparkles,
+    bullets: [
+      'Workflow pulled straight from the image and queued — no rebuilding the graph by hand',
+      'Step-by-step preview in the embedded workspace',
+      'Output saved with full metadata and indexed on arrival',
+    ],
+    alsoUnlocks: 'Pro also unlocks Compare View, the image editor, and 6 more.',
+  },
+
+  a1111: {
+    contextLine: 'Want another round from these parameters?',
+    headline: 'Regenerate with every parameter already filled in',
+    featureName: 'Automatic1111 Integration',
+    icon: Sparkles,
+    bullets: [
+      'Prompt, seed, sampler, CFG and dimensions pulled from this image — nothing retyped',
+      'Queue a batch and track progress without switching windows',
+      'New outputs indexed next to the original',
+    ],
+    alsoUnlocks: 'Pro also unlocks Compare View, the image editor, and 6 more.',
+  },
+
+  analytics: {
+    contextLine: 'Curious what your library actually looks like?',
+    headline: 'See which models and settings you really use',
+    featureName: 'Analytics Explorer',
+    icon: BarChart3,
+    bullets: [
+      'Top checkpoints, LoRAs and samplers, ranked over any period',
+      'Generation habits by day and hour, and output volume over time',
+      'Generation time and VRAM by GPU, from verified telemetry — no spreadsheet needed',
+    ],
+    alsoUnlocks: 'Pro also unlocks Compare View, ComfyUI generation, and 6 more.',
+  },
+
+  clustering: {
+    contextLine: 'Library bigger than the free limit?',
+    headline: 'Cluster your entire library, not the first 300 images',
+    featureName: 'Unlimited Clustering',
+    icon: Sparkles,
+    bullets: [
+      'Prompt-similarity clustering across every indexed image',
+      'TF-IDF auto-tags computed over the full set, not a sample',
+      'Duplicate and near-variation groups surfaced in one pass',
+    ],
+    alsoUnlocks: 'Pro also unlocks Compare View, the image editor, and 6 more.',
+    freeTierNote: `Free clusters up to ${CLUSTERING_FREE_TIER_LIMIT} images.`,
+  },
+
+  batch_export: {
+    contextLine: 'Exporting more than one?',
+    headline: 'Export the whole selection in one pass',
+    featureName: 'Batch Export',
+    icon: Download,
+    bullets: [
+      'Export a selection or an entire filtered result set',
+      'Flattened output with filename conflicts resolved automatically',
+      'ZIP straight out of the app — nothing to zip afterwards',
+    ],
+    alsoUnlocks: 'Pro also unlocks Compare View, the image editor, and 6 more.',
+    freeTierNote: 'Free exports one image at a time.',
+  },
+
+  bulk_tagging: {
+    contextLine: 'Tagging more than one?',
+    headline: 'Tag hundreds of images in a single action',
+    featureName: 'Bulk Tagging',
+    icon: Tag,
+    bullets: [
+      'Apply or remove tags across an entire selection at once',
+      'Autocomplete from tags already in your library, so naming stays consistent',
+      'Works on filtered results — no clicking through images one by one',
+    ],
+    alsoUnlocks: 'Pro also unlocks Compare View, ComfyUI generation, and 6 more.',
+  },
+};
+
+const blockedAttemptsCopy: Record<ProFeature, (count: number) => string> = {
+  comparison: (n) => `You've tried to compare images ${n} times.`,
+  image_editor: (n) => `You've tried to edit an image ${n} times.`,
+  file_management: (n) => `You've tried to move or copy files ${n} times.`,
+  comfyui: (n) => `You've tried to send images to ComfyUI ${n} times.`,
+  a1111: (n) => `You've tried to generate with Automatic1111 ${n} times.`,
+  analytics: (n) => `You've opened Analytics ${n} times.`,
+  clustering: (n) => `You've hit the clustering limit ${n} times.`,
+  batch_export: (n) => `You've tried to export in bulk ${n} times.`,
+  bulk_tagging: (n) => `You've tried to tag in bulk ${n} times.`,
 };
 
 const ProOnlyModal: React.FC<ProOnlyModalProps> = ({
   isOpen,
   onClose,
   feature,
-  isTrialActive,
-  daysRemaining,
   canStartTrial,
   onStartTrial,
-  isExpired,
-  isPro,
 }) => {
   const creatorAttributionToken = useSettingsStore((state) => state.creatorAttributionToken);
-  const proLicenseUrl = buildProLicenseUrl(creatorAttributionToken, 'lockedfeature');
+  const blockedAttempts = useProModalStore((state) => state.blockedAttempts[feature] ?? 0);
+  const proLicenseUrl = buildProLicenseUrl(creatorAttributionToken, 'lockedfeature', feature);
 
   if (!isOpen) return null;
 
   const info = featureInfo[feature] ?? {
-    name: 'Pro Feature',
+    contextLine: 'Unlock this feature.',
+    headline: 'Unlock Pro',
+    featureName: 'Pro Feature',
     icon: Sparkles,
-    description: 'Unlock additional features with Pro access',
-    benefits: ['Pro-only functionality'],
+    bullets: ['Pro-only functionality'],
+    alsoUnlocks: 'Pro unlocks every feature in the app.',
   };
   const Icon = info.icon;
 
-  const trialCopy = (() => {
-    if (canStartTrial) {
-      return `This is a Pro feature. Would you like to start your ${TRIAL_DURATION_DAYS}-day trial now to test it?`;
-    }
-    if (isTrialActive) {
-      return `Trial active: ${daysRemaining} ${daysRemaining === 1 ? 'day' : 'days'} remaining.`;
-    }
-    if (isExpired) {
-      return 'Your trial has ended. Activate a license to continue using Pro features.';
-    }
-    if (isPro) {
-      return 'You are already on Pro. Thank you for supporting the project!';
-    }
-    return 'This is a Pro feature. Activate the trial or a license to continue.';
-  })();
-  const showBatchExportLimitNote = feature === 'batch_export' && !isPro && !isTrialActive;
+  const showBlockedAttemptsLine = !canStartTrial && blockedAttempts >= 3;
+  const contextLine = showBlockedAttemptsLine
+    ? (blockedAttemptsCopy[feature]?.(blockedAttempts) ?? info.contextLine)
+    : info.contextLine;
 
   const modalContent = (
     <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/80 backdrop-blur-sm">
       <div className="bg-gray-900 rounded-xl shadow-2xl w-full max-w-lg mx-4 border border-gray-700">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-gray-700">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-purple-600/20 rounded-lg">
-              <Crown className="w-6 h-6 text-purple-400" />
-            </div>
-            <h2 className="text-xl font-bold text-white">Pro Feature</h2>
+          <div className="p-2 bg-purple-600/20 rounded-lg">
+            <Crown className="w-6 h-6 text-purple-400" />
           </div>
           <button
             onClick={onClose}
@@ -185,62 +210,74 @@ const ProOnlyModal: React.FC<ProOnlyModalProps> = ({
         {/* Content */}
         <div className="p-6 space-y-6">
           {/* Feature Info */}
-          <div className="text-center">
-            <div className="inline-flex p-4 bg-purple-600/10 rounded-full mb-4">
-              <Icon className="w-12 h-12 text-purple-400" />
-            </div>
-            <h3 className="text-2xl font-bold text-white mb-2">{info.name}</h3>
-            <p className="text-gray-400 mb-4">{info.description}</p>
-          </div>
-
-          {/* Trial / License prompt */}
-          <div className="bg-gray-800/70 border border-gray-700 rounded-lg p-4 space-y-2">
-            <p className="text-gray-100 font-semibold">This is a Pro feature.</p>
-            <p className="text-gray-300 text-sm">{trialCopy}</p>
-            {showBatchExportLimitNote && (
-              <p className="text-gray-400 text-sm">Free users can export 1 image at a time.</p>
-            )}
-          </div>
-
-          {/* Benefits */}
           <div>
-            <h4 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
-              What you unlock:
-            </h4>
-            <ul className="space-y-2">
-              {info.benefits.map((benefit, index) => (
-                <li key={index} className="flex items-start gap-2 text-gray-300">
-                  <CheckCircle2 className="text-green-400 w-4 h-4 mt-0.5" />
-                  <span>{benefit}</span>
-                </li>
-              ))}
-            </ul>
+            <div className="inline-flex p-2.5 bg-purple-600/10 rounded-full mb-3">
+              <Icon className="w-6 h-6 text-purple-400" />
+            </div>
+            <p className="text-gray-400 text-sm italic mb-1">{contextLine}</p>
+            <h3 className="text-2xl font-bold text-white mb-1">{info.headline}</h3>
+            <p className="text-gray-500 text-sm">{info.featureName} · Pro</p>
           </div>
+
+          {/* Bullets */}
+          <ul className="space-y-2">
+            {info.bullets.map((bullet, index) => (
+              <li key={index} className="flex items-start gap-2 text-gray-300">
+                <CheckCircle2 className="text-green-400 w-4 h-4 mt-0.5 shrink-0" />
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+
+          {info.freeTierNote && (
+            <p className="text-gray-400 text-sm">{info.freeTierNote}</p>
+          )}
+
+          <p className="text-gray-500 text-sm italic">{info.alsoUnlocks}</p>
 
           {/* CTA */}
           <div className="space-y-3">
-            {canStartTrial && (
-              <button
-                onClick={() => {
-                  onStartTrial();
-                  onClose();
-                }}
-                className="w-full inline-flex items-center justify-center gap-2 bg-purple-600 hover:bg-purple-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
-              >
-                <Crown className="w-5 h-5" />
-                Start {TRIAL_DURATION_DAYS}-day trial
-              </button>
+            {canStartTrial ? (
+              <>
+                <button
+                  onClick={() => {
+                    onStartTrial();
+                    onClose();
+                  }}
+                  className="w-full inline-flex items-center justify-center gap-2 bg-purple-600 hover:bg-purple-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                >
+                  <Crown className="w-5 h-5" />
+                  Start {TRIAL_DURATION_DAYS}-day trial
+                </button>
+                <p className="text-center text-xs text-gray-400">No card, no account.</p>
+                <a
+                  href={proLicenseUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block text-center text-xs text-gray-500 hover:text-gray-400 underline"
+                >
+                  Or get the lifetime license now — $39
+                </a>
+              </>
+            ) : (
+              <>
+                <p className="text-center text-xs text-gray-400">
+                  $39 · one-time, no subscription · includes every Pro feature and all future updates
+                </p>
+                <a
+                  href={proLicenseUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full inline-flex items-center justify-center gap-2 bg-purple-600 hover:bg-purple-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                >
+                  <Crown className="w-5 h-5" />
+                  Get Lifetime License — $39
+                </a>
+                <p className="text-center text-xs text-gray-500">
+                  14-day refund, no questions asked · Open source, MPL 2.0
+                </p>
+              </>
             )}
-            <p className="text-center text-xs text-gray-400">$39 · one-time payment · lifetime license</p>
-            <a
-              href={proLicenseUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="w-full inline-flex items-center justify-center gap-2 bg-purple-500/20 hover:bg-purple-500/30 text-purple-200 font-semibold py-3 px-6 rounded-lg transition-colors border border-purple-500/40"
-            >
-              <Crown className="w-5 h-5" />
-              Buy Pro license
-            </a>
             {creatorAttributionToken ? (
               <p className="text-center text-xs text-gray-500">Creator attribution will be included at checkout.</p>
             ) : null}

--- a/hooks/useFeatureAccess.ts
+++ b/hooks/useFeatureAccess.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { create } from 'zustand';
+import { persist, createJSONStorage, StateStorage } from 'zustand/middleware';
 import { useLicenseStore, TRIAL_DURATION_DAYS } from '../store/useLicenseStore';
 
 export type ProFeature = 'a1111' | 'comfyui' | 'comparison' | 'analytics' | 'clustering' | 'batch_export' | 'bulk_tagging' | 'file_management' | 'image_editor';
@@ -22,19 +23,84 @@ export const isDevProLicenseOverride = (): boolean =>
   typeof window !== 'undefined' &&
   localStorage.getItem('IMH_DEV_LICENSE') === 'pro';
 
+export type ProModalBlockedAttempts = Record<ProFeature, number>;
+
+const EMPTY_BLOCKED_ATTEMPTS: ProModalBlockedAttempts = {
+  a1111: 0,
+  comfyui: 0,
+  comparison: 0,
+  analytics: 0,
+  clustering: 0,
+  batch_export: 0,
+  bulk_tagging: 0,
+  file_management: 0,
+  image_editor: 0,
+};
+
+// --- Electron IPC-based storage for the Pro modal's blocked-attempt counters ---
+const electronProModalStorage: StateStorage = {
+  getItem: async (name: string): Promise<string | null> => {
+    if (window.electronAPI) {
+      const settings = await window.electronAPI.getSettings();
+      const blockedAttempts = settings?.proModalBlockedAttempts;
+      if (!blockedAttempts) return null;
+
+      return JSON.stringify({ state: { blockedAttempts } });
+    }
+    return null;
+  },
+  setItem: async (name: string, value: string): Promise<void> => {
+    if (window.electronAPI) {
+      const { state } = JSON.parse(value);
+      const currentSettings = await window.electronAPI.getSettings();
+      const result = await window.electronAPI.saveSettings({
+        ...currentSettings,
+        proModalBlockedAttempts: state.blockedAttempts,
+      });
+      if (!result?.success) {
+        throw new Error(result?.error || 'Failed to persist Pro modal attempt counts.');
+      }
+    }
+  },
+  removeItem: async (name: string): Promise<void> => {
+    console.warn('Clearing Pro modal attempt counts is not implemented.');
+  },
+};
+
+const isElectron = typeof window !== 'undefined' && !!window.electronAPI;
+
 type ProModalState = {
   proModalOpen: boolean;
   proModalFeature: ProFeature;
+  blockedAttempts: ProModalBlockedAttempts;
   openProModal: (feature: ProFeature) => void;
   closeProModal: () => void;
 };
 
-export const useProModalStore = create<ProModalState>((set) => ({
-  proModalOpen: false,
-  proModalFeature: 'a1111',
-  openProModal: (feature) => set({ proModalOpen: true, proModalFeature: feature }),
-  closeProModal: () => set({ proModalOpen: false }),
-}));
+export const useProModalStore = create<ProModalState>()(
+  persist(
+    (set) => ({
+      proModalOpen: false,
+      proModalFeature: 'a1111',
+      blockedAttempts: { ...EMPTY_BLOCKED_ATTEMPTS },
+      openProModal: (feature) =>
+        set((state) => ({
+          proModalOpen: true,
+          proModalFeature: feature,
+          blockedAttempts: {
+            ...state.blockedAttempts,
+            [feature]: (state.blockedAttempts[feature] ?? 0) + 1,
+          },
+        })),
+      closeProModal: () => set({ proModalOpen: false }),
+    }),
+    {
+      name: 'image-metahub-pro-modal',
+      storage: createJSONStorage(() => (isElectron ? electronProModalStorage : localStorage)),
+      partialize: (state) => ({ blockedAttempts: state.blockedAttempts }),
+    }
+  )
+);
 
 // Helper: Check if trial has expired
 const isTrialExpired = (trialStartDate: number | null): boolean => {

--- a/utils/creatorAttribution.ts
+++ b/utils/creatorAttribution.ts
@@ -43,7 +43,8 @@ export const findLatestCreatorAttributionToken = (images: IndexedImage[]): strin
 
 export const buildProLicenseUrl = (
   token?: string | null,
-  ctx?: ProLicenseUrlContext
+  ctx?: ProLicenseUrlContext,
+  feature?: string
 ): string => {
   const url = new URL(PRO_LICENSE_URL);
   url.searchParams.set('src', 'app');
@@ -53,6 +54,9 @@ export const buildProLicenseUrl = (
   const normalizedToken = normalizeToken(token);
   if (normalizedToken) {
     url.searchParams.set('imh_ref', normalizedToken);
+  }
+  if (feature) {
+    url.searchParams.set('feature', feature);
   }
   return url.toString();
 };


### PR DESCRIPTION
## Summary
- Replace the generic feature-list copy with outcome-led headlines, per-feature context lines, and exactly 3 bullets each.
- Invert the visual hierarchy: headline is now the largest text, the redundant "This is a Pro feature" block and the "Pro Feature" header label are gone.
- Simplify the CTA: primary trial button when available, otherwise the lifetime-license button becomes primary (with refund/OSS note).
- Add a persisted per-feature blocked-attempt counter (`useProModalStore`) that swaps in a "you've tried N times" line after 3+ blocks, shown only when no trial is offered.
- Tag the license purchase URL with `&feature=<ProFeature>` via a new optional param on `buildProLicenseUrl`, without touching `imh_ref`.

No changes to licensing/gating logic in `useFeatureAccess.ts` or `useLicenseStore.ts`.

## Test plan
- [ ] Trigger each of the 9 Pro features on Free w/ unused trial — headline/bullets render, no fallback copy
- [ ] Trigger same feature 3+ times — context line switches to the attempt-count line
- [ ] Simulate exhausted trial — lifetime-license CTA becomes primary
- [ ] Confirm purchase links carry `&feature=<feature>`
- [ ] Reload app after triggering blocks — counts persist