### PR TITLE
perf: reduce auto-watch and delete overhead

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { startTransition, useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import React, { startTransition, useState, useEffect, useCallback, useRef, useMemo, useDeferredValue } from 'react';
 import { useImageStore } from './store/useImageStore';
 import { useSettingsStore } from './store/useSettingsStore';
 import { useLicenseStore } from './store/useLicenseStore';
@@ -1121,18 +1121,16 @@ export default function App() {
     void (async () => {
       await waitForDirectoryActivityToSettle(pending.directory.id);
       const activeScanSubfolders = useImageStore.getState().scanSubfolders;
-      const cacheModes = Array.from(new Set([activeScanSubfolders, !activeScanSubfolders]));
 
-      for (const scanSubfoldersMode of cacheModes) {
-        await cacheManager.applyChunkedCacheDelta(
-          pending.directory.path,
-          pending.directory.name,
-          [],
-          removedIds,
-          removedNames,
-          scanSubfoldersMode,
-        );
-      }
+      // removeCachedImages already covers both scan-mode variants internally
+      // and only rewrites the chunk(s) that actually hold the removed ids.
+      await cacheManager.removeCachedImages(
+        pending.directory.path,
+        pending.directory.name,
+        removedIds,
+        removedNames,
+        activeScanSubfolders,
+      );
     })().catch((error) => {
       console.error('Failed to update cache after watched file removal:', error);
     });
@@ -1267,36 +1265,40 @@ export default function App() {
       if (!directory) return;
 
       const { removedIds, removedNames } = resolveWatchedRemovalIds(directory, data);
-      if (removedIds.length === 0 && removedNames.length === 0) {
+      if (removedIds.length === 0) {
+        // Nothing currently indexed matches these paths — either they were
+        // never indexed, or (the common case) this watcher event is just the
+        // filesystem catching up with a delete the app already handled itself
+        // (see useImageSelection's handleDeleteSelectedImages, which removes
+        // locally and patches the cache by id immediately). Skip the toast and
+        // the cache delta: falling back to a name-only full-cache rewrite here
+        // would pay the exact cost we're trying to avoid, for nothing to prune.
         return;
       }
 
-      if (removedIds.length > 0) {
-        removeImages(removedIds);
-        const removedIdSet = new Set(removedIds);
-        setOpenImageModals((current) =>
-          current.flatMap((modal) => {
-            const navigationImageIds = modal.navigationImageIds.filter((id) => !removedIdSet.has(id));
-            if (removedIdSet.has(modal.imageId)) {
-              return [];
-            }
-            return [{ ...modal, navigationImageIds }];
-          })
-        );
+      removeImages(removedIds);
+      const removedIdSet = new Set(removedIds);
+      setOpenImageModals((current) =>
+        current.flatMap((modal) => {
+          const navigationImageIds = modal.navigationImageIds.filter((id) => !removedIdSet.has(id));
+          if (removedIdSet.has(modal.imageId)) {
+            return [];
+          }
+          return [{ ...modal, navigationImageIds }];
+        })
+      );
 
-        useImageStore.setState((state) => ({
-          selectedImages: new Set(Array.from(state.selectedImages).filter((id) => !removedIdSet.has(id))),
-          previewImage: state.previewImage && removedIdSet.has(state.previewImage.id) ? null : state.previewImage,
-          selectedImage: state.selectedImage && removedIdSet.has(state.selectedImage.id) ? null : state.selectedImage,
-          comparisonImages: state.comparisonImages.filter((image) => !removedIdSet.has(image.id)),
-        }));
-      }
+      useImageStore.setState((state) => ({
+        selectedImages: new Set(Array.from(state.selectedImages).filter((id) => !removedIdSet.has(id))),
+        previewImage: state.previewImage && removedIdSet.has(state.previewImage.id) ? null : state.previewImage,
+        selectedImage: state.selectedImage && removedIdSet.has(state.selectedImage.id) ? null : state.selectedImage,
+        comparisonImages: state.comparisonImages.filter((image) => !removedIdSet.has(image.id)),
+      }));
 
       scheduleWatchedRemovalCacheDelta(directory, removedIds, removedNames);
 
-      const removedCount = Math.max(removedIds.length, removedNames.length);
       setNewImagesToast({
-        message: `${removedCount} file${removedCount !== 1 ? 's' : ''} removed from ${directory.name}`,
+        message: `${removedIds.length} file${removedIds.length !== 1 ? 's' : ''} removed from ${directory.name}`,
       });
     });
 
@@ -2508,7 +2510,12 @@ export default function App() {
     [safeFilteredImages, selectedNodes],
   );
 
-  const availableNodeCatalog = useMemo(() => buildWorkflowNodeCatalog(safeImages), [safeImages]);
+  // Deferred: buildWorkflowNodeCatalog scans every image's workflowNodes and is
+  // only used to populate the node-filter dropdown, not the displayed grid, so
+  // it's safe to lag a render or two behind rapid library changes (auto-watch
+  // adds, bulk deletes) instead of recomputing synchronously on every one.
+  const deferredSafeImages = useDeferredValue(safeImages);
+  const availableNodeCatalog = useMemo(() => buildWorkflowNodeCatalog(deferredSafeImages), [deferredSafeImages]);
   const availableNodes = useMemo(() => availableNodeCatalog.map((node) => node.name), [availableNodeCatalog]);
   const nodeFacetCounts = useMemo(() => {
     const map = new Map<string, number>();

--- a/App.tsx
+++ b/App.tsx
@@ -1265,14 +1265,22 @@ export default function App() {
       if (!directory) return;
 
       const { removedIds, removedNames } = resolveWatchedRemovalIds(directory, data);
-      if (removedIds.length === 0) {
-        // Nothing currently indexed matches these paths — either they were
-        // never indexed, or (the common case) this watcher event is just the
+      if (removedIds.length === 0 && removedNames.length === 0) {
+        // Nothing currently indexed matches these paths and there's nothing
+        // name-based to prune either — this watcher event is just the
         // filesystem catching up with a delete the app already handled itself
         // (see useImageSelection's handleDeleteSelectedImages, which removes
-        // locally and patches the cache by id immediately). Skip the toast and
-        // the cache delta: falling back to a name-only full-cache rewrite here
-        // would pay the exact cost we're trying to avoid, for nothing to prune.
+        // locally and patches the cache by id immediately). Skip entirely.
+        return;
+      }
+
+      if (removedIds.length === 0) {
+        // No in-memory images matched (e.g. the active scan mode is flat but
+        // the watcher — which always watches recursively — saw a subfolder
+        // file removed). Nothing to remove from the store, but a stale
+        // recursive-mode cache on disk may still hold these entries by name,
+        // so still queue the name-based cache prune.
+        scheduleWatchedRemovalCacheDelta(directory, removedIds, removedNames);
         return;
       }
 

--- a/App.tsx
+++ b/App.tsx
@@ -1281,6 +1281,9 @@ export default function App() {
         // recursive-mode cache on disk may still hold these entries by name,
         // so still queue the name-based cache prune.
         scheduleWatchedRemovalCacheDelta(directory, removedIds, removedNames);
+        setNewImagesToast({
+          message: `${removedNames.length} file${removedNames.length !== 1 ? 's' : ''} removed from ${directory.name}`,
+        });
         return;
       }
 

--- a/__tests__/cache-manager.workflow-nodes.test.ts
+++ b/__tests__/cache-manager.workflow-nodes.test.ts
@@ -1230,4 +1230,170 @@ describe('cacheManager workflowNodes hydration', () => {
     expect(finalizeCacheWrite.mock.calls[0][0].record.imageCount).toBe(2);
     expect(finalizeCacheWrite.mock.calls[0][0].record.chunkCount).toBe(2);
   });
+
+  it('tops off the last existing chunk before creating a new one, and updates the id->chunk index', async () => {
+    const getCacheChunk = vi.fn().mockResolvedValue({
+      success: true,
+      data: [{ id: 'dir-1::existing.png', name: 'existing.png', metadataString: '{}', metadata: {}, lastModified: 1, models: [], loras: [], scheduler: '' }],
+    });
+    const writeCacheChunk = vi.fn().mockResolvedValue({ success: true });
+    const finalizeCacheWrite = vi.fn().mockResolvedValue({ success: true });
+    const writeCacheIndex = vi.fn().mockResolvedValue({ success: true });
+    const readCacheIndex = vi.fn().mockResolvedValue({
+      success: true,
+      data: { lastScan: 1, chunkCount: 1, ids: { 'dir-1::existing.png': 0 } },
+    });
+
+    window.electronAPI = {
+      getCacheSummary: vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          id: 'D:/library-flat',
+          directoryPath: 'D:/library',
+          directoryName: 'Library',
+          lastScan: 1,
+          imageCount: 1,
+          chunkCount: 1,
+          parserVersion: PARSER_VERSION,
+        },
+      }),
+      getCacheChunk,
+      writeCacheChunk,
+      finalizeCacheWrite,
+      readCacheIndex,
+      writeCacheIndex,
+    };
+    (cacheManager as any).isElectron = true;
+
+    await cacheManager.appendToCache(
+      'D:/library',
+      'Library',
+      [
+        {
+          id: 'dir-1::new.png',
+          name: 'new.png',
+          handle: {} as any,
+          metadata: {},
+          metadataString: '{"new":true}',
+          lastModified: 2,
+          models: [],
+          loras: [],
+          scheduler: '',
+        } as any,
+      ],
+      false,
+      { chunkSize: 5 }
+    );
+
+    // Room in chunk 0 (1 entry, chunkSize 5) => topped off, no new chunk created.
+    expect(writeCacheChunk).toHaveBeenCalledTimes(1);
+    expect(writeCacheChunk.mock.calls[0][0].chunkIndex).toBe(0);
+    expect(writeCacheChunk.mock.calls[0][0].data.map((entry: any) => entry.id)).toEqual([
+      'dir-1::existing.png',
+      'dir-1::new.png',
+    ]);
+    expect(finalizeCacheWrite.mock.calls[0][0].record.imageCount).toBe(2);
+    expect(finalizeCacheWrite.mock.calls[0][0].record.chunkCount).toBe(1);
+    expect(writeCacheIndex).toHaveBeenCalledTimes(1);
+    expect(writeCacheIndex.mock.calls[0][0].data.ids).toEqual({
+      'dir-1::existing.png': 0,
+      'dir-1::new.png': 0,
+    });
+  });
+
+  it('removeCachedImages rewrites only the chunk holding the removed id and updates the index', async () => {
+    const getCacheChunk = vi.fn().mockImplementation(async ({ chunkIndex }) => ({
+      success: true,
+      data: chunkIndex === 0
+        ? [{ id: 'dir-1::a.png', name: 'a.png', metadataString: '{}', metadata: {}, lastModified: 1, models: [], loras: [], scheduler: '' }]
+        : [{ id: 'dir-1::b.png', name: 'b.png', metadataString: '{}', metadata: {}, lastModified: 1, models: [], loras: [], scheduler: '' }],
+    }));
+    const writeCacheChunk = vi.fn().mockResolvedValue({ success: true });
+    const finalizeCacheWrite = vi.fn().mockResolvedValue({ success: true });
+    const writeCacheIndex = vi.fn().mockResolvedValue({ success: true });
+    const readCacheIndex = vi.fn().mockResolvedValue({
+      success: true,
+      data: { lastScan: 1, chunkCount: 2, ids: { 'dir-1::a.png': 0, 'dir-1::b.png': 1 } },
+    });
+
+    window.electronAPI = {
+      getCacheSummary: vi.fn().mockImplementation(async (cacheId: string) =>
+        cacheId === 'D:/library-flat'
+          ? {
+              success: true,
+              data: {
+                id: 'D:/library-flat',
+                directoryPath: 'D:/library',
+                directoryName: 'Library',
+                lastScan: 1,
+                imageCount: 2,
+                chunkCount: 2,
+                parserVersion: PARSER_VERSION,
+              },
+            }
+          : { success: true, data: null }
+      ),
+      getCacheChunk,
+      writeCacheChunk,
+      finalizeCacheWrite,
+      readCacheIndex,
+      writeCacheIndex,
+    };
+    (cacheManager as any).isElectron = true;
+
+    await cacheManager.removeCachedImages('D:/library', 'Library', ['dir-1::b.png'], [], false);
+
+    // Only chunk 1 (holding b.png) is read and rewritten; chunk 0 (a.png) is untouched.
+    expect(getCacheChunk).toHaveBeenCalledTimes(1);
+    expect(getCacheChunk.mock.calls[0][0].chunkIndex).toBe(1);
+    expect(writeCacheChunk).toHaveBeenCalledTimes(1);
+    expect(writeCacheChunk.mock.calls[0][0]).toMatchObject({ chunkIndex: 1, data: [] });
+    expect(finalizeCacheWrite.mock.calls[0][0].record.imageCount).toBe(1);
+    expect(writeCacheIndex.mock.calls[0][0].data.ids).toEqual({ 'dir-1::a.png': 0 });
+  });
+
+  it('removeCachedImages falls back to a full scan when no id->chunk index exists', async () => {
+    const getCacheChunk = vi.fn().mockImplementation(async ({ chunkIndex }) => ({
+      success: true,
+      data: chunkIndex === 0
+        ? [{ id: 'dir-1::a.png', name: 'a.png', metadataString: '{}', metadata: {}, lastModified: 1, models: [], loras: [], scheduler: '' }]
+        : [{ id: 'dir-1::b.png', name: 'b.png', metadataString: '{}', metadata: {}, lastModified: 1, models: [], loras: [], scheduler: '' }],
+    }));
+    const writeCacheChunk = vi.fn().mockResolvedValue({ success: true });
+    const finalizeCacheWrite = vi.fn().mockResolvedValue({ success: true });
+    const writeCacheIndex = vi.fn().mockResolvedValue({ success: true });
+    const readCacheIndex = vi.fn().mockResolvedValue({ success: true, data: null });
+
+    window.electronAPI = {
+      getCacheSummary: vi.fn().mockImplementation(async (cacheId: string) =>
+        cacheId === 'D:/library-flat'
+          ? {
+              success: true,
+              data: {
+                id: 'D:/library-flat',
+                directoryPath: 'D:/library',
+                directoryName: 'Library',
+                lastScan: 1,
+                imageCount: 2,
+                chunkCount: 2,
+                parserVersion: PARSER_VERSION,
+              },
+            }
+          : { success: true, data: null }
+      ),
+      getCacheChunk,
+      writeCacheChunk,
+      finalizeCacheWrite,
+      readCacheIndex,
+      writeCacheIndex,
+    };
+    (cacheManager as any).isElectron = true;
+
+    await cacheManager.removeCachedImages('D:/library', 'Library', ['dir-1::b.png'], ['b.png'], false);
+
+    // No usable index => both chunks are scanned via the applyChunkedCacheDelta fallback.
+    expect(getCacheChunk).toHaveBeenCalledTimes(2);
+    const survivingIds = writeCacheChunk.mock.calls.flatMap((call: any) => call[0].data.map((entry: any) => entry.id));
+    expect(survivingIds).toEqual(['dir-1::a.png']);
+  });
 });

--- a/hooks/useClusterCacheRestore.ts
+++ b/hooks/useClusterCacheRestore.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useImageStore } from '../store/useImageStore';
 import { useFeatureAccess } from './useFeatureAccess';
 import { loadClusterCache } from '../services/clusterCacheManager';
+import type { IndexedImage } from '../types';
 import {
   buildClusterSourceSignature,
   buildClusterStateSignature,
@@ -9,6 +10,8 @@ import {
   getPromptImagesForClustering,
   isClusterCacheCompatible,
 } from '../utils/smartLibraryClusterState';
+
+const EMPTY_IMAGES: IndexedImage[] = [];
 
 /**
  * Restores compatible cached clusters on launch and keeps their access-gated metadata in sync.
@@ -30,8 +33,20 @@ export function useClusterCacheRestore(): void {
   const clusterMetadataSignatureRef = useRef<string | null>(null);
 
   const primaryPath = directories[0]?.path ?? '';
-  const promptImages = useMemo(() => getPromptImagesForClustering(images), [images]);
-  const clusterSourceSignature = useMemo(() => buildClusterSourceSignature(images), [images]);
+  // promptImages/clusterSourceSignature only feed the cache-restore effect
+  // below, which is a no-op once clusters already exist. buildClusterSourceSignature
+  // hashes every prompt character-by-character, so recomputing it on every
+  // images change (e.g. one auto-watch add at a time) after clustering has
+  // already run once is pure waste — skip it once clusters.length > 0.
+  const hasClusters = clusters.length > 0;
+  const promptImages = useMemo(
+    () => (hasClusters ? EMPTY_IMAGES : getPromptImagesForClustering(images)),
+    [images, hasClusters],
+  );
+  const clusterSourceSignature = useMemo(
+    () => (hasClusters ? '' : buildClusterSourceSignature(images)),
+    [images, hasClusters],
+  );
   const currentClusteringMetadata = useMemo(
     () => buildClusteringMetadata(images, canUseFullClustering),
     [canUseFullClustering, images],

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -1935,16 +1935,20 @@ export function useImageLoader() {
                     // appendToCache falls back to a full cacheData write — pass the
                     // full in-memory directory image list so that fallback doesn't
                     // regress to a cache containing only this batch's new files.
+                    // Computed lazily: appendToCache only needs this when it hits the
+                    // no-cache-yet branch, which isn't the common case once a
+                    // directory's cache already exists.
                     if (enrichedForCache.length > 0) {
-                        const directoryImages = useImageStore.getState().images.filter(
-                            image => image.directoryId === directory.id
-                        );
                         await cacheManager.appendToCache(
                             directory.path,
                             directory.name,
                             enrichedForCache,
                             shouldScanSubfolders,
-                            { fallbackImages: directoryImages }
+                            {
+                                getFallbackImages: () => useImageStore.getState().images.filter(
+                                    image => image.directoryId === directory.id
+                                ),
+                            }
                         );
                     }
                 } catch (err) {

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -1931,14 +1931,20 @@ export function useImageLoader() {
                     }
 
                     // New entries: append to the last chunk / new chunks instead of
-                    // rewriting the whole directory cache. appendToCache already falls
-                    // back to a full cacheData write when there's no cache yet.
+                    // rewriting the whole directory cache. If there's no cache yet,
+                    // appendToCache falls back to a full cacheData write — pass the
+                    // full in-memory directory image list so that fallback doesn't
+                    // regress to a cache containing only this batch's new files.
                     if (enrichedForCache.length > 0) {
+                        const directoryImages = useImageStore.getState().images.filter(
+                            image => image.directoryId === directory.id
+                        );
                         await cacheManager.appendToCache(
                             directory.path,
                             directory.name,
                             enrichedForCache,
-                            shouldScanSubfolders
+                            shouldScanSubfolders,
+                            { fallbackImages: directoryImages }
                         );
                     }
                 } catch (err) {

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -5,7 +5,7 @@ import { cacheManager, IncrementalCacheWriter } from '../services/cacheManager';
 import { thumbnailManager } from '../services/thumbnailManager';
 import { IndexedImage, Directory } from '../types';
 import { useSettingsStore } from '../store/useSettingsStore';
-import { createCacheDebugSnapshot, traceCacheDebug } from '../utils/cacheDebugTrace';
+import { createCacheDebugSnapshot, isCacheDebugEnabled, traceCacheDebug } from '../utils/cacheDebugTrace';
 import { areFilesystemPathsEqual } from '../utils/filesystemPath';
 import { waitForDirectoryActivityToSettle } from '../utils/directoryActivity';
 import { inferMimeTypeFromName, isImageFileName } from '../utils/mediaTypes.js';
@@ -1846,7 +1846,9 @@ export function useImageLoader() {
 
             // Callback para processar batches de imagens
             const handleBatchProcessed = (batch: IndexedImage[]) => {
-                console.log('[auto-watch] Phase A processed', batch.length, 'images (not adding yet, waiting for Phase B)');
+                if (isCacheDebugEnabled()) {
+                    console.log('[auto-watch] Phase A processed', batch.length, 'images (not adding yet, waiting for Phase B)');
+                }
             };
 
             // Processar novos arquivos usando o pipeline existente
@@ -1865,11 +1867,16 @@ export function useImageLoader() {
                     fileStats: fileStatsMap,
                     onEnrichmentBatch: (enrichedBatch) => {
                         // Phase B: Enriquecimento completo - adicionar as imagens agora
-                        console.log('[auto-watch] Phase B enriched', enrichedBatch.length, 'images - adding to store');
+                        if (isCacheDebugEnabled()) {
+                            console.log('[auto-watch] Phase B enriched', enrichedBatch.length, 'images - adding to store');
+                        }
                         const refreshedBatch = enrichedBatch.filter(image => forceReindexExistingIds.has(image.id));
                         const newBatch = enrichedBatch.filter(image => !forceReindexExistingIds.has(image.id));
                         const addStart = performance.now();
                         if (newBatch.length > 0) {
+                            // addImages coalesces into a single _updateState via its own
+                            // ~100ms flush timer — no need to force an immediate flush here,
+                            // which used to pay a full _updateState per enrichment batch.
                             addImages(newBatch);
                             enrichedForCache.push(...newBatch);
                         }
@@ -1878,46 +1885,62 @@ export function useImageLoader() {
                             refreshedForCache.push(...refreshedBatch);
                         }
                         const addDurationMs = performance.now() - addStart;
-                        // Force flush imediatamente
-                        const flushPendingImages = useImageStore.getState().flushPendingImages;
-                        setTimeout(() => {
-                            console.log('[auto-watch] Flushing enriched images');
-                            const flushStart = performance.now();
-                            flushPendingImages();
-                            const flushDurationMs = performance.now() - flushStart;
-                            traceCacheDebug('loader:autoWatch:flushPendingImages', () => ({
-                                directoryId: directory.id,
-                                batchCount: enrichedBatch.length,
-                                details: {
-                                    addDurationMs: Number(addDurationMs.toFixed(2)),
-                                    flushDurationMs: Number(flushDurationMs.toFixed(2)),
-                                },
-                                snapshot: createCacheDebugSnapshot(useImageStore.getState()),
-                            }));
-                        }, 0);
+                        traceCacheDebug('loader:autoWatch:enrichmentBatchQueued', () => ({
+                            directoryId: directory.id,
+                            batchCount: enrichedBatch.length,
+                            details: {
+                                addDurationMs: Number(addDurationMs.toFixed(2)),
+                            },
+                            snapshot: createCacheDebugSnapshot(useImageStore.getState()),
+                        }));
                     },
                 }
             );
 
             // Aguardar Phase B completar
-            console.log('[auto-watch] Waiting for Phase B to complete...');
             await phaseB;
-            console.log('[auto-watch] Phase B completed!');
 
             if (getIsElectron() && (enrichedForCache.length > 0 || refreshedForCache.length > 0)) {
                 try {
-                    const directoryImages = useImageStore.getState().images.filter(
-                        image => image.directoryId === directory.id
-                    );
-                    await cacheManager.applyChunkedCacheDelta(
-                        directory.path,
-                        directory.name,
-                        [...enrichedForCache, ...refreshedForCache],
-                        [],
-                        [],
-                        shouldScanSubfolders,
-                        { fallbackImages: directoryImages }
-                    );
+                    const fallbackToFullDelta = async (imagesToUpsert: IndexedImage[]) => {
+                        const directoryImages = useImageStore.getState().images.filter(
+                            image => image.directoryId === directory.id
+                        );
+                        await cacheManager.applyChunkedCacheDelta(
+                            directory.path,
+                            directory.name,
+                            imagesToUpsert,
+                            [],
+                            [],
+                            shouldScanSubfolders,
+                            { fallbackImages: directoryImages }
+                        );
+                    };
+
+                    // Existing entries: patch only the chunk(s) that hold them.
+                    if (refreshedForCache.length > 0) {
+                        const patched = await cacheManager.patchCachedImages(
+                            directory.path,
+                            directory.name,
+                            refreshedForCache,
+                            shouldScanSubfolders
+                        );
+                        if (!patched) {
+                            await fallbackToFullDelta(refreshedForCache);
+                        }
+                    }
+
+                    // New entries: append to the last chunk / new chunks instead of
+                    // rewriting the whole directory cache. appendToCache already falls
+                    // back to a full cacheData write when there's no cache yet.
+                    if (enrichedForCache.length > 0) {
+                        await cacheManager.appendToCache(
+                            directory.path,
+                            directory.name,
+                            enrichedForCache,
+                            shouldScanSubfolders
+                        );
+                    }
                 } catch (err) {
                     console.error('Failed to upsert auto-watch cache entries:', err);
                 }

--- a/hooks/useImageSelection.ts
+++ b/hooks/useImageSelection.ts
@@ -3,6 +3,7 @@ import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { IndexedImage } from '../types';
 import { FileOperations } from '../services/fileOperations';
+import cacheManager from '../services/cacheManager';
 
 let isDeletingSelectedImages = false;
 
@@ -78,7 +79,7 @@ export function useImageSelection() {
     }, [toggleImageSelection, setSelectedImage, setFocusedImageIndex]);
 
     const handleDeleteSelectedImages = useCallback(async () => {
-        const { selectedImages, images, directories } = useImageStore.getState();
+        const { selectedImages, images } = useImageStore.getState();
         const { skipDeleteConfirmation } = useSettingsStore.getState();
         if (selectedImages.size === 0) return;
         if (isDeletingSelectedImages) return;
@@ -92,45 +93,57 @@ export function useImageSelection() {
             }
 
             const imagesToDelete = Array.from(selectedImages);
-            const deletedIdsHandledLocally: string[] = [];
-            const deletedIdsAwaitingWatcher: string[] = [];
+            const imageById = new Map(images.map((img) => [img.id, img]));
 
-            for (const imageId of imagesToDelete) {
-                const image = images.find(img => img.id === imageId);
-                if (image) {
-                    try {
-                        const result = await FileOperations.deleteFile(image);
-                        if (result.success) {
-                            const watchedDirectory = directories.find((directory) => directory.id === image.directoryId);
-                            const shouldAwaitWatcherRemoval = Boolean(window.electronAPI && watchedDirectory?.autoWatch);
-
-                            if (shouldAwaitWatcherRemoval) {
-                                deletedIdsAwaitingWatcher.push(imageId);
-                            } else {
-                                deletedIdsHandledLocally.push(imageId);
-                            }
-                        } else {
-                            setError(`Failed to delete ${image.name}: ${result.error}`);
-                        }
-                    } catch (err) {
-                        setError(`Error deleting ${image.name}: ${err instanceof Error ? err.message : 'Unknown error'}`);
+            // Directories are no longer consulted to decide whether to wait for the
+            // watcher: removeImages is a no-op when the ids are already gone (see
+            // useImageStore), so removing locally right away and letting a later
+            // watcher event land as a harmless no-op is strictly faster than waiting.
+            const deletions = await Promise.all(imagesToDelete.map(async (imageId) => {
+                const image = imageById.get(imageId);
+                if (!image) return null;
+                try {
+                    const result = await FileOperations.deleteFile(image);
+                    if (result.success) {
+                        return imageId;
                     }
+                    setError(`Failed to delete ${image.name}: ${result.error}`);
+                } catch (err) {
+                    setError(`Error deleting ${image.name}: ${err instanceof Error ? err.message : 'Unknown error'}`);
                 }
-            }
+                return null;
+            }));
 
-            if (deletedIdsHandledLocally.length > 0) {
-                removeImages(deletedIdsHandledLocally);
-            }
-
-            const deletedIds = [...deletedIdsHandledLocally, ...deletedIdsAwaitingWatcher];
+            const deletedIds = deletions.filter((id): id is string => id !== null);
             if (deletedIds.length > 0) {
                 const deletedIdSet = new Set(deletedIds);
+                removeImages(deletedIds);
                 useImageStore.setState((state) => ({
                     selectedImages: new Set(Array.from(state.selectedImages).filter((id) => !deletedIdSet.has(id))),
                     previewImage: state.previewImage && deletedIdSet.has(state.previewImage.id) ? null : state.previewImage,
                     selectedImage: state.selectedImage && deletedIdSet.has(state.selectedImage.id) ? null : state.selectedImage,
                     comparisonImages: state.comparisonImages.filter((image) => !deletedIdSet.has(image.id)),
                 }));
+
+                // Keep the on-disk cache in sync right away (by id, while we still
+                // know it), instead of waiting on the watcher event to prune it —
+                // see cacheManager.removeCachedImages for the chunk-scoped fast path.
+                const { directories, scanSubfolders } = useImageStore.getState();
+                const idsByDirectory = new Map<string, string[]>();
+                for (const imageId of deletedIds) {
+                    const image = imageById.get(imageId);
+                    if (!image?.directoryId) continue;
+                    const list = idsByDirectory.get(image.directoryId);
+                    if (list) list.push(imageId);
+                    else idsByDirectory.set(image.directoryId, [imageId]);
+                }
+                for (const [directoryId, ids] of idsByDirectory) {
+                    const directory = directories.find((dir) => dir.id === directoryId);
+                    if (!directory) continue;
+                    void cacheManager
+                        .removeCachedImages(directory.path, directory.name, ids, [], scanSubfolders)
+                        .catch((err) => console.error('Failed to update cache after delete:', err));
+                }
             } else {
                 clearImageSelection();
             }

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -720,6 +720,19 @@ class CacheManager {
     if (!images || images.length === 0) return;
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
+    await this.runChunkedCacheDeltaLocked(cacheId, () =>
+      this.appendToCacheLocked(cacheId, directoryPath, directoryName, images, scanSubfolders, options)
+    );
+  }
+
+  private async appendToCacheLocked(
+    cacheId: string,
+    directoryPath: string,
+    directoryName: string,
+    images: IndexedImage[],
+    scanSubfolders: boolean,
+    options?: { chunkSize?: number }
+  ): Promise<void> {
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
     const start = performance.now();
     const summaryResult = await summaryFn(cacheId);
@@ -736,12 +749,13 @@ class CacheManager {
 
     const summary = summaryResult.data as CacheEntry;
     const chunkSize = options?.chunkSize ?? DEFAULT_INCREMENTAL_CHUNK_SIZE;
-    const metadata = sanitizeCacheMetadata(toCacheMetadata(images), { forceClone: true });
+    let metadata = sanitizeCacheMetadata(toCacheMetadata(images), { forceClone: true });
 
     const inlineMetadata = Array.isArray(summary.metadata)
       ? compactCacheMetadataEntries(summary.metadata)
       : [];
     let chunkIndex = inlineMetadata.length > 0 ? 0 : (summary.chunkCount ?? 0);
+    const indexUpdates: Record<string, number> = {};
 
     for (let i = 0; i < inlineMetadata.length; i += chunkSize) {
       const chunk = inlineMetadata.slice(i, i + chunkSize);
@@ -757,6 +771,33 @@ class CacheManager {
       chunkIndex += 1;
     }
 
+    // Top off the last existing chunk before creating new ones, so a steady
+    // trickle of single-file appends (auto-watch) doesn't fragment the cache
+    // into many tiny chunk files. Only applies to the already-chunked case —
+    // the inline-metadata migration above always starts a fresh chunk layout.
+    const existingIndex = inlineMetadata.length === 0 && (summary.chunkCount ?? 0) > 0
+      ? await this.readValidCacheIndex(cacheId, summary.lastScan, summary.chunkCount ?? 0)
+      : null;
+    if (inlineMetadata.length === 0 && chunkIndex > 0 && metadata.length > 0) {
+      const lastChunkIndex = chunkIndex - 1;
+      const lastChunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex: lastChunkIndex });
+      if (lastChunkResult.success && Array.isArray(lastChunkResult.data)) {
+        const lastChunkEntries = lastChunkResult.data as CacheImageMetadata[];
+        const room = chunkSize - lastChunkEntries.length;
+        if (room > 0) {
+          const toAdd = metadata.slice(0, room);
+          metadata = metadata.slice(room);
+          const merged = [...lastChunkEntries, ...toAdd];
+          const writeResult = await window.electronAPI.writeCacheChunk({ cacheId, chunkIndex: lastChunkIndex, data: merged });
+          if (!writeResult.success) {
+            console.error('Failed to top off cache chunk:', writeResult.error);
+            return;
+          }
+          for (const entry of toAdd) indexUpdates[entry.id] = lastChunkIndex;
+        }
+      }
+    }
+
     for (let i = 0; i < metadata.length; i += chunkSize) {
       const chunk = metadata.slice(i, i + chunkSize);
       const result = await window.electronAPI.writeCacheChunk({
@@ -768,14 +809,16 @@ class CacheManager {
         console.error('Failed to append cache chunk:', result.error);
         return;
       }
+      for (const entry of chunk) indexUpdates[entry.id] = chunkIndex;
       chunkIndex += 1;
     }
 
+    const newLastScan = Date.now();
     const record = {
       id: cacheId,
       directoryPath,
       directoryName: summary.directoryName ?? directoryName,
-      lastScan: Date.now(),
+      lastScan: newLastScan,
       imageCount: (inlineMetadata.length > 0 ? inlineMetadata.length : (summary.imageCount ?? 0)) + images.length,
       chunkCount: chunkIndex,
       parserVersion: PARSER_VERSION,
@@ -784,6 +827,13 @@ class CacheManager {
     const finalizeResult = await window.electronAPI.finalizeCacheWrite({ cacheId, record });
     if (!finalizeResult.success) {
       console.error('Failed to finalize appended cache write:', finalizeResult.error);
+    } else if (existingIndex) {
+      // Keep the id->chunk index in sync so a subsequent patch/remove call can
+      // still use its own fast path instead of falling back to a full scan.
+      await window.electronAPI.writeCacheIndex?.({
+        cacheId,
+        data: { lastScan: newLastScan, chunkCount: chunkIndex, ids: { ...existingIndex, ...indexUpdates } },
+      });
     }
     logCachePerf(finalizeResult.success ? 'append-to-cache:complete' : 'append-to-cache:error', {
       cacheId,
@@ -1138,6 +1188,14 @@ class CacheManager {
     }
   }
 
+  /**
+   * Removes specific images from an existing cache without rewriting the whole
+   * directory cache. Mirrors patchCachedImages' id->chunk index approach: only
+   * the chunk(s) that actually hold the removed images are read and rewritten.
+   * Falls back to the full applyChunkedCacheDelta scan (which also matches by
+   * name) whenever the index can't account for every id, so correctness never
+   * regresses versus the old always-full-rewrite behavior.
+   */
   async removeCachedImages(
     directoryPath: string,
     directoryName: string,
@@ -1149,38 +1207,132 @@ class CacheManager {
 
     const candidateModes = Array.from(new Set([scanSubfolders, !scanSubfolders]));
     for (const mode of candidateModes) {
-      const existing = await this.getCachedData(directoryPath, mode);
-      if (!existing) {
-        continue;
-      }
-
-      const metadata = pruneCacheMetadata(existing.metadata, {
-        ids: imageIds,
-        names: imageNames,
-      });
-
-      if (metadata.length === existing.metadata.length) {
-        continue;
-      }
-
       const cacheId = `${directoryPath}-${mode ? 'recursive' : 'flat'}`;
-      const result = await window.electronAPI.cacheData({
-        cacheId,
-        data: {
-          id: existing.id,
-          directoryPath,
-          directoryName: existing.directoryName ?? directoryName,
-          lastScan: Date.now(),
-          imageCount: metadata.length,
-          metadata,
-          parserVersion: PARSER_VERSION,
-        },
-      });
+      const removedByIndex = imageIds.length > 0
+        ? await this.runChunkedCacheDeltaLocked(cacheId, () =>
+            this.removeCacheVariantByIndex(cacheId, directoryPath, directoryName, imageIds, mode)
+          )
+        : false;
 
-      if (!result.success) {
-        console.error('Failed to remove cached images:', result.error);
+      if (!removedByIndex) {
+        await this.applyChunkedCacheDelta(
+          directoryPath,
+          directoryName,
+          [],
+          imageIds,
+          imageNames,
+          mode,
+          { createIfMissing: false }
+        );
       }
     }
+  }
+
+  /**
+   * Fast path for removeCachedImages: removes imageIds from the chunk(s) the
+   * id->chunk index says they live in. Returns false (no changes made) if the
+   * cache doesn't exist, uses the legacy inline-metadata format, has no usable
+   * index, or the index turns out stale for any id — callers should fall back
+   * to the full scan-and-rewrite path in that case.
+   */
+  private async removeCacheVariantByIndex(
+    cacheId: string,
+    directoryPath: string,
+    directoryName: string,
+    imageIds: string[],
+    scanSubfolders: boolean
+  ): Promise<boolean> {
+    const start = performance.now();
+    const summary = await this.getCacheSummary(directoryPath, scanSubfolders);
+    if (!summary) {
+      // No cache for this variant — nothing to remove, no fallback needed.
+      return true;
+    }
+    if (Array.isArray(summary.metadata) && summary.metadata.length > 0) {
+      return false;
+    }
+
+    const chunkCount = summary.chunkCount ?? 0;
+    if (chunkCount === 0) {
+      return true;
+    }
+
+    const index = await this.readValidCacheIndex(cacheId, summary.lastScan, chunkCount);
+    if (!index) {
+      return false;
+    }
+
+    const idsByChunk = new Map<number, Set<string>>();
+    for (const id of imageIds) {
+      const targetChunk = index[id];
+      if (typeof targetChunk !== 'number' || targetChunk < 0 || targetChunk >= chunkCount) {
+        // Not in this cache variant per the index. Could genuinely be absent
+        // (e.g. only exists in the other scan-mode variant) — skip rather than
+        // forcing a fallback scan for every removal that touches one variant.
+        continue;
+      }
+      const set = idsByChunk.get(targetChunk);
+      if (set) set.add(id);
+      else idsByChunk.set(targetChunk, new Set([id]));
+    }
+
+    if (idsByChunk.size === 0) {
+      return true;
+    }
+
+    let removedCount = 0;
+    const nextIndex = { ...index };
+    for (const [chunkIndex, wanted] of idsByChunk) {
+      const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex });
+      if (!chunkResult.success || !Array.isArray(chunkResult.data)) {
+        return false;
+      }
+      const entries = chunkResult.data as CacheImageMetadata[];
+      const filtered = entries.filter((entry) => !wanted.has(entry.id));
+      if (filtered.length === entries.length) {
+        // The index pointed at the wrong chunk (stale layout) — bail to the
+        // full fallback scan, which also rebuilds the index.
+        return false;
+      }
+      removedCount += entries.length - filtered.length;
+      const writeResult = await window.electronAPI.writeCacheChunk({ cacheId, chunkIndex, data: filtered });
+      if (!writeResult.success) {
+        return false;
+      }
+      for (const id of wanted) delete nextIndex[id];
+    }
+
+    const newImageCount = Math.max(0, (summary.imageCount ?? 0) - removedCount);
+    const newLastScan = Date.now();
+    const finalizeResult = await window.electronAPI.finalizeCacheWrite({
+      cacheId,
+      record: {
+        id: summary.id,
+        directoryPath,
+        directoryName: summary.directoryName ?? directoryName,
+        lastScan: newLastScan,
+        imageCount: newImageCount,
+        chunkCount,
+        parserVersion: PARSER_VERSION,
+      },
+    });
+    if (!finalizeResult.success) {
+      return false;
+    }
+
+    await window.electronAPI.writeCacheIndex?.({
+      cacheId,
+      data: { lastScan: newLastScan, chunkCount, ids: nextIndex },
+    });
+
+    logCachePerf('remove-cached-images:indexed', {
+      cacheId,
+      removed: removedCount,
+      chunksTouched: idsByChunk.size,
+      chunkCount,
+      durationMs: toFixedMs(performance.now() - start),
+    });
+    return true;
   }
 
   async applyChunkedCacheDelta(

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -714,7 +714,7 @@ class CacheManager {
     directoryName: string,
     images: IndexedImage[],
     scanSubfolders: boolean,
-    options?: { chunkSize?: number }
+    options?: { chunkSize?: number; fallbackImages?: IndexedImage[] }
   ): Promise<void> {
     if (!this.isElectron) return;
     if (!images || images.length === 0) return;
@@ -731,17 +731,31 @@ class CacheManager {
     directoryName: string,
     images: IndexedImage[],
     scanSubfolders: boolean,
-    options?: { chunkSize?: number }
+    options?: { chunkSize?: number; fallbackImages?: IndexedImage[] }
   ): Promise<void> {
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
     const start = performance.now();
     const summaryResult = await summaryFn(cacheId);
 
     if (!summaryResult.success || !summaryResult.data) {
-      await this.cacheData(directoryPath, directoryName, images, scanSubfolders);
+      // No cache exists for this variant yet (missing/cleared/invalidated, or
+      // a prior write failed). Writing just `images` here would create a
+      // cache that only knows about this batch's new files, so the next
+      // launch would think the directory has nothing else and reparse every
+      // pre-existing file. Merge in the caller-supplied full directory image
+      // list first, same fallback pattern as applyChunkedCacheDelta.
+      const merged = new Map<string, IndexedImage>();
+      for (const image of options?.fallbackImages ?? []) {
+        merged.set(image.id, image);
+      }
+      for (const image of images) {
+        merged.set(image.id, image);
+      }
+      await this.cacheData(directoryPath, directoryName, Array.from(merged.values()), scanSubfolders);
       logCachePerf('append-to-cache:fallback-cache-data', {
         cacheId,
         images: images.length,
+        fallbackImages: options?.fallbackImages?.length ?? 0,
         durationMs: toFixedMs(performance.now() - start),
       });
       return;
@@ -1208,7 +1222,13 @@ class CacheManager {
     const candidateModes = Array.from(new Set([scanSubfolders, !scanSubfolders]));
     for (const mode of candidateModes) {
       const cacheId = `${directoryPath}-${mode ? 'recursive' : 'flat'}`;
-      const removedByIndex = imageIds.length > 0
+      // The index fast path only prunes by id. If there are also bare names to
+      // prune (e.g. subfolder files that only exist in the other scan-mode's
+      // cache and were never loaded into the current id-based index), it can't
+      // account for them — always go through the full scan-and-rewrite path
+      // (which matches by both id and name) in that case instead of silently
+      // dropping the name-based removals.
+      const removedByIndex = imageIds.length > 0 && imageNames.length === 0
         ? await this.runChunkedCacheDeltaLocked(cacheId, () =>
             this.removeCacheVariantByIndex(cacheId, directoryPath, directoryName, imageIds, mode)
           )

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -714,7 +714,7 @@ class CacheManager {
     directoryName: string,
     images: IndexedImage[],
     scanSubfolders: boolean,
-    options?: { chunkSize?: number; fallbackImages?: IndexedImage[] }
+    options?: { chunkSize?: number; getFallbackImages?: () => IndexedImage[] }
   ): Promise<void> {
     if (!this.isElectron) return;
     if (!images || images.length === 0) return;
@@ -731,7 +731,7 @@ class CacheManager {
     directoryName: string,
     images: IndexedImage[],
     scanSubfolders: boolean,
-    options?: { chunkSize?: number; fallbackImages?: IndexedImage[] }
+    options?: { chunkSize?: number; getFallbackImages?: () => IndexedImage[] }
   ): Promise<void> {
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
     const start = performance.now();
@@ -744,8 +744,9 @@ class CacheManager {
       // launch would think the directory has nothing else and reparse every
       // pre-existing file. Merge in the caller-supplied full directory image
       // list first, same fallback pattern as applyChunkedCacheDelta.
+      const fallbackImages = options?.getFallbackImages?.() ?? [];
       const merged = new Map<string, IndexedImage>();
-      for (const image of options?.fallbackImages ?? []) {
+      for (const image of fallbackImages) {
         merged.set(image.id, image);
       }
       for (const image of images) {
@@ -755,7 +756,7 @@ class CacheManager {
       logCachePerf('append-to-cache:fallback-cache-data', {
         cacheId,
         images: images.length,
-        fallbackImages: options?.fallbackImages?.length ?? 0,
+        fallbackImages: fallbackImages.length,
         durationMs: toFixedMs(performance.now() - start),
       });
       return;
@@ -1279,6 +1280,15 @@ class CacheManager {
 
     const index = await this.readValidCacheIndex(cacheId, summary.lastScan, chunkCount);
     if (!index) {
+      return false;
+    }
+    if (Object.keys(index).length !== (summary.imageCount ?? 0)) {
+      // Index doesn't account for every cached entry (e.g. it was never
+      // populated for this cache — appendToCache only maintains an index that
+      // already existed, it doesn't create one from scratch). Treating a
+      // missing-from-index id as "genuinely absent" in that case would report
+      // success without actually removing anything. Bail to the full scan,
+      // which rebuilds the index from a complete read.
       return false;
     }
 

--- a/services/fileWatcher.mjs
+++ b/services/fileWatcher.mjs
@@ -77,9 +77,12 @@ const toRelativePath = (rootPath, targetPath) => {
   return relativePath.replace(/\\/g, '/');
 };
 
-const sendWatcherDebug = (mainWindow, message) => {
+// Nothing in the renderer subscribes to the 'watcher-debug' channel (checked:
+// no electronAPI.onWatcherDebug call anywhere in the app), so sending it was
+// a pure-waste IPC round-trip + structured clone on every watcher event
+// (multiple per added/removed file). Keep the main-process console.log only.
+const sendWatcherDebug = (_mainWindow, message) => {
   console.log(message);
-  sendToRenderer(mainWindow, 'watcher-debug', { message });
 };
 
 const sendToRenderer = (mainWindow, channel, payload) => {

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -1232,7 +1232,12 @@ export const useImageStore = create<ImageState>((set, get) => {
             } else {
                 queueMetadataTagImports(addedImages);
             }
-            maybeQueueLineageBuild(700);
+            // Longer debounce here specifically: this path also carries the
+            // auto-watch drip-add flow, where images can land one at a time a
+            // few seconds apart. A longer window gives back-to-back generations
+            // a real chance to coalesce into a single lineage rebuild instead of
+            // paying a full images.map() + worker spawn per file.
+            maybeQueueLineageBuild(2500);
         }
 
         traceCacheDebug('store:flushPendingImages', () => ({
@@ -3227,8 +3232,17 @@ export const useImageStore = create<ImageState>((set, get) => {
         },
 
         removeImages: (imageIds) => {
+            if (!imageIds || imageIds.length === 0) {
+                return;
+            }
             const idsToRemove = new Set(imageIds);
             flushPendingImages(true);
+            // Callers (e.g. the watched-files-removed handler) may re-request removal
+            // of ids a manual delete already removed locally. Skip the full recompute
+            // entirely when none of the ids are actually present.
+            if (!get().images.some(img => idsToRemove.has(img.id))) {
+                return;
+            }
             set(state => {
                 const remainingImages = state.images.filter(img => !idsToRemove.has(img.id));
                 return _updateState(state, remainingImages);
@@ -3241,6 +3255,9 @@ export const useImageStore = create<ImageState>((set, get) => {
         },
 
         removeImage: (imageId) => {
+            if (!get().images.some(img => img.id === imageId)) {
+                return;
+            }
             flushPendingImages(true);
             set(state => {
                 const remainingImages = state.images.filter(img => img.id !== imageId);

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -3255,10 +3255,10 @@ export const useImageStore = create<ImageState>((set, get) => {
         },
 
         removeImage: (imageId) => {
+            flushPendingImages(true);
             if (!get().images.some(img => img.id === imageId)) {
                 return;
             }
-            flushPendingImages(true);
             set(state => {
                 const remainingImages = state.images.filter(img => img.id !== imageId);
                 return _updateState(state, remainingImages);


### PR DESCRIPTION
## Summary

- **Cache writes scoped to affected chunks only**: `appendToCache` tops off the last chunk + maintains id→chunk index; `removeCachedImages` resolves affected chunks via index instead of full rewrite. Fallback to full scan when index is missing/stale.
- **Removed forced flush** that defeated the 100ms coalescer — each enrichment batch was triggering a full `_updateState`.
- **removeImages/removeImage are no-ops** when ids are already gone, eliminating redundant recompute from watcher echoes after manual delete.
- **Bulk delete parallelized**: `Promise.all` + `Map` lookup instead of sequential `.find()` loop. Cache updated immediately by known ids.
- **Expensive work gated/deferred**: cluster source signature skipped when clusters exist, watcher-debug IPC cut, console.log behind debug flag, lineage debounce bumped to 2500ms, workflow node catalog wrapped in `useDeferredValue`.

## Test plan

- [ ] Auto-watch: generate 1 image in watched folder → grid updates without perceptible frame drop
- [ ] Auto-watch burst: copy 50 files into watched folder → UI stays responsive (scroll/hover work)
- [ ] Sidecar `.json`: generate image with sidecar → metadata updates without full recompute
- [ ] Single delete (watched + non-watched folders) → no freeze, no duplicate pipeline run
- [ ] Bulk delete (200 images) → progressive and responsive
- [ ] Cache integrity: close and reopen app → library loads from cache correctly
- [ ] Run existing test suite — no regressions