### PR TITLE
fix: copy metadata to clipboard using native Electron clipboard API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Video Controls Click Targets**: Fixed the play/pause, mute, volume and loop controls near the edges of the video player triggering next/previous navigation instead of their own action, because the navigation hover zones painted on top of them.
+- **Copy Metadata to Clipboard**: Fixed "Failed to copy..." errors on Copy Prompt, Copy Negative Prompt, Copy to A1111/ComfyUI and other clipboard actions that could occur after clearing the library cache or reindexing a folder, until the app was restarted. Text copies now go through Electron's native clipboard API, the same way image copies already did, instead of the browser API that could lose focus after a reload.
 
 ## [0.18.0] - 2026-07-21
  

--- a/components/ComfyUIWorkspace.tsx
+++ b/components/ComfyUIWorkspace.tsx
@@ -35,6 +35,7 @@ import { useSettingsStore } from '../store/useSettingsStore';
 import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
+import { copyTextToClipboard } from '../utils/imageUtils';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useThumbnail } from '../hooks/useThumbnail';
 import { formatImageForComfyUI } from '../utils/comfyUIFormatter';
@@ -426,11 +427,11 @@ const WorkspaceImagePreviewModal: React.FC<{
       return;
     }
 
-    try {
-      await navigator.clipboard.writeText(parameterText);
+    const result = await copyTextToClipboard(parameterText);
+    if (result.success) {
       setParameterCopyStatus('Copied');
-    } catch (error) {
-      console.error('Failed to copy preview parameters:', error);
+    } else {
+      console.error('Failed to copy preview parameters:', result.error);
       setParameterCopyStatus('Copy failed');
     }
   };
@@ -1114,13 +1115,14 @@ const ComfyUIWorkspace: React.FC<ComfyUIWorkspaceProps> = ({
       return;
     }
 
-    navigator.clipboard.writeText(text)
-      .then(() => {
-        setAssetActionMessage(`${label} copied.`);
-      })
-      .catch((error) => {
-        console.error(`Failed to copy ${label}:`, error);
-        setAssetActionMessage(`Failed to copy ${label}.`);
+    copyTextToClipboard(text)
+      .then((result) => {
+        if (result.success) {
+          setAssetActionMessage(`${label} copied.`);
+        } else {
+          console.error(`Failed to copy ${label}:`, result.error);
+          setAssetActionMessage(`Failed to copy ${label}.`);
+        }
       });
   }, []);
 

--- a/components/ComparisonMetadataPanel.tsx
+++ b/components/ComparisonMetadataPanel.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo, useState } from 'react';
 import { ChevronDown, ChevronRight, Copy, AlertTriangle, CheckCircle } from 'lucide-react';
 import { ComparisonMetadataPanelProps, BaseMetadata } from '../types';
 import { compareField, formatFieldValue, diffText, DiffToken } from '../utils/metadataComparison';
+import { copyTextToClipboard } from '../utils/imageUtils';
 
 // Helper component for individual metadata fields
 const MetadataField: FC<{
@@ -130,8 +131,8 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
 
   const copyToClipboard = async (value: string, label: string) => {
     if (navigator.clipboard && window.isSecureContext) {
-      try {
-        await navigator.clipboard.writeText(value);
+      const result = await copyTextToClipboard(value);
+      if (result.success) {
         // Show notification
         const notification = document.createElement('div');
         notification.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-50';
@@ -143,8 +144,8 @@ const ComparisonMetadataPanel: FC<ComparisonMetadataPanelProps> = ({
           }
         }, 2000);
         return true;
-      } catch (err) {
-        console.error('Failed to copy to clipboard:', err);
+      } else {
+        console.error('Failed to copy to clipboard:', result.error);
         return false;
       }
     } else {

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -19,6 +19,7 @@ import { Heart, Info, Copy, CheckCircle, Folder, Clipboard, Sparkles, GitCompare
   Image as ImageIcon,
   Workflow
 } from 'lucide-react';
+import { copyTextToClipboard } from '../utils/imageUtils';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useGenerateWithComfyUI } from '../hooks/useGenerateWithComfyUI';
@@ -335,12 +336,12 @@ const ImageCard: React.FC<ImageCardProps> = React.memo(({ image, onImageClick, e
   const handleCopyClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
     if (image.prompt) {
-      try {
-        await navigator.clipboard.writeText(image.prompt);
+      const result = await copyTextToClipboard(image.prompt);
+      if (result.success) {
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
-      } catch (err) {
-        console.error('Failed to copy prompt:', err);
+      } else {
+        console.error('Failed to copy prompt:', result.error);
       }
     }
   };

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1941,30 +1941,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     return true;
   };
 
-  const copyToClipboardElectron = async (text: string, type: string) => {
-    if (!text) {
-      alert(`No ${type} to copy.`);
-      return false;
-    }
-
-    const result = await copyTextToClipboard(text);
-    if (!result.success) {
-      console.error(`Failed to copy ${type}:`, result.error);
-      alert(`Failed to copy ${type}.`);
-      return false;
-    }
-
-    const notification = document.createElement('div');
-    notification.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-50';
-    notification.textContent = `${type} copied to clipboard!`;
-    document.body.appendChild(notification);
-    setTimeout(() => {
-      if (document.body.contains(notification)) {
-        document.body.removeChild(notification);
-      }
-    }, 2000);
-    return true;
-  };
+  const copyToClipboardElectron = (text: string, type: string) => copyToClipboard(text, type);
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect, useState, FC, useCallback, useMemo, 
 import { type IndexedImage, type BaseMetadata, type LoRAInfo, type SmartCollection, type ImageEditRecipe } from '../types';
 import { FileOperations } from '../services/fileOperations';
 import { getRenameBasename, renameIndexedImage } from '../services/imageRenameService';
-import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
+import { copyImageToClipboard, copyTextToClipboard, showInExplorer } from '../utils/imageUtils';
 import { motion } from 'framer-motion';
 import { AlertTriangle, Copy, Pencil, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Repeat1, Shuffle, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw, SlidersHorizontal, Workflow, Image as ImageIcon, ExternalLink } from 'lucide-react';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
@@ -1921,36 +1921,13 @@ const ImageModal: React.FC<ImageModalProps> = ({
         alert(`No ${type} to copy.`);
         return false;
     }
-    try {
-      await navigator.clipboard.writeText(text);
-      if (!silent) {
-        const notification = document.createElement('div');
-        notification.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-50';
-        notification.textContent = `${type} copied to clipboard!`;
-        document.body.appendChild(notification);
-        setTimeout(() => {
-          if (document.body.contains(notification)) {
-            document.body.removeChild(notification);
-          }
-        }, 2000);
-      }
-      return true;
-    } catch (err) {
-      console.error(`Failed to copy ${type}:`, err);
+    const result = await copyTextToClipboard(text);
+    if (!result.success) {
+      console.error(`Failed to copy ${type}:`, result.error);
       alert(`Failed to copy ${type}.`);
       return false;
     }
-  };
-
-  const copyToClipboardElectron = async (text: string, type: string) => {
-    if (!text) {
-      alert(`No ${type} to copy.`);
-      return false;
-    }
-
-    try {
-      await navigator.clipboard.writeText(text);
-
+    if (!silent) {
       const notification = document.createElement('div');
       notification.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-50';
       notification.textContent = `${type} copied to clipboard!`;
@@ -1960,12 +1937,33 @@ const ImageModal: React.FC<ImageModalProps> = ({
           document.body.removeChild(notification);
         }
       }, 2000);
-      return true;
-    } catch (err) {
-      console.error(`Failed to copy ${type}:`, err);
+    }
+    return true;
+  };
+
+  const copyToClipboardElectron = async (text: string, type: string) => {
+    if (!text) {
+      alert(`No ${type} to copy.`);
+      return false;
+    }
+
+    const result = await copyTextToClipboard(text);
+    if (!result.success) {
+      console.error(`Failed to copy ${type}:`, result.error);
       alert(`Failed to copy ${type}.`);
       return false;
     }
+
+    const notification = document.createElement('div');
+    notification.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-50';
+    notification.textContent = `${type} copied to clipboard!`;
+    document.body.appendChild(notification);
+    setTimeout(() => {
+      if (document.body.contains(notification)) {
+        document.body.removeChild(notification);
+      }
+    }, 2000);
+    return true;
   };
 
   const handleContextMenu = (e: React.MouseEvent) => {

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -13,6 +13,7 @@ import { A1111GenerateModal, type GenerationParams as A1111GenerationParams } fr
 import { ComfyUIGenerateModal, type GenerationParams as ComfyUIGenerationParams } from './ComfyUIGenerateModal';
 import ProBadge from './ProBadge';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
+import { copyTextToClipboard } from '../utils/imageUtils';
 import { getAvifCarrierConflicts } from '../utils/imageMetaHubAvifExtension.mjs';
 import { getElectronAbsoluteMediaPath, getRelativeImagePath, mediaSourceCache } from '../services/mediaSourceCache';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
@@ -429,13 +430,12 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
 
   const copyToClipboard = async (text: string, type: string) => {
     if(!text) return false;
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch (err) {
-      console.error(`Failed to copy ${type}:`, err);
+    const result = await copyTextToClipboard(text);
+    if (!result.success) {
+      console.error(`Failed to copy ${type}:`, result.error);
       return false;
     }
+    return true;
   };
 
   const hideContextMenu = () => {

--- a/components/MetadataEditorModal.tsx
+++ b/components/MetadataEditorModal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { X, Plus, Trash2, Save, Copy, Clipboard, RefreshCw } from 'lucide-react';
 import { ShadowMetadata, ShadowResource } from '../types';
 import { applyShadowMetadataUpdates } from '../utils/editableMetadata';
+import { copyTextToClipboard } from '../utils/imageUtils';
 
 const EDITABLE_METADATA_SCHEMA = 'imagemetahub/editable-metadata';
 const EDITABLE_METADATA_VERSION = 1;
@@ -483,7 +484,10 @@ export const MetadataEditorModal: React.FC<MetadataEditorModalProps> = ({
       if (onCopyEditableMetadata) {
         await onCopyEditableMetadata(portableMetadata, serialized);
       } else if (navigator.clipboard && window.isSecureContext) {
-        await navigator.clipboard.writeText(serialized);
+        const result = await copyTextToClipboard(serialized);
+        if (!result.success) {
+          throw new Error(result.error || 'Unknown error occurred');
+        }
       } else {
         throw new Error('Clipboard access is not available in this context.');
       }

--- a/electron.mjs
+++ b/electron.mjs
@@ -5307,6 +5307,21 @@ function setupFileOperationHandlers() {
     }
   });
 
+  // Handle copying text to clipboard (avoids the renderer's "Document is not focused" error)
+  ipcMain.handle('copy-text-to-clipboard', async (event, text) => {
+    try {
+      if (typeof text !== 'string') {
+        return { success: false, error: 'No text provided' };
+      }
+
+      electron.clipboard.writeText(text);
+      return { success: true };
+    } catch (error) {
+      console.error('Error copying text to clipboard:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
   // Handle getting file statistics (creation date, etc.)
   ipcMain.handle('get-file-stats', async (event, filePath) => {
     try {

--- a/hooks/useContextMenu.ts
+++ b/hooks/useContextMenu.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useLayoutEffect, useRef } from 'react';
 import { type IndexedImage } from '../types';
-import { copyImageToClipboard, showInExplorer } from '../utils/imageUtils';
+import { copyImageToClipboard, copyTextToClipboard, showInExplorer } from '../utils/imageUtils';
 import { A1111ApiClient } from '../services/a1111ApiClient';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
@@ -156,11 +156,13 @@ export const useContextMenu = () => {
 
   const copyToClipboardElectron = (text: string, label: string) => {
     if (navigator.clipboard && window.isSecureContext) {
-      navigator.clipboard.writeText(text).then(() => {
-        showNotification(`${label} copied to clipboard!`);
-      }).catch(err => {
-        console.error('Failed to copy to clipboard:', err);
-        alert(`Failed to copy ${label} to clipboard`);
+      copyTextToClipboard(text).then((result) => {
+        if (result.success) {
+          showNotification(`${label} copied to clipboard!`);
+        } else {
+          console.error('Failed to copy to clipboard:', result.error);
+          alert(`Failed to copy ${label} to clipboard`);
+        }
       });
     } else {
       const textArea = document.createElement('textarea');
@@ -281,7 +283,10 @@ export const useContextMenu = () => {
       const formattedText = formatMetadataForA1111(metadata);
 
       // Copy to clipboard
-      await navigator.clipboard.writeText(formattedText);
+      const result = await copyTextToClipboard(formattedText);
+      if (!result.success) {
+        throw new Error(result.error || 'Unknown error occurred');
+      }
 
       showNotification('Copied! Paste into A1111 prompt box and click the Blue Arrow.');
     } catch (error: unknown) {

--- a/hooks/useCopyToA1111.ts
+++ b/hooks/useCopyToA1111.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { BaseMetadata, IndexedImage } from '../types';
 import { formatMetadataForA1111 } from '../utils/a1111Formatter';
+import { copyTextToClipboard } from '../utils/imageUtils';
 import {
   getClipboardErrorMessage,
   getNormalizedMetadata,
@@ -38,7 +39,10 @@ export function useCopyToA1111() {
       const formattedText = formatMetadataForA1111(metadata);
 
       // Copy to clipboard
-      await navigator.clipboard.writeText(formattedText);
+      const result = await copyTextToClipboard(formattedText);
+      if (!result.success) {
+        throw new Error(result.error || 'Unknown error occurred');
+      }
 
       setCopyStatus({
         success: true,

--- a/hooks/useCopyToComfyUI.ts
+++ b/hooks/useCopyToComfyUI.ts
@@ -7,6 +7,7 @@ import { useState, useCallback } from 'react';
 import { BaseMetadata, IndexedImage } from '../types';
 import { formatImageForComfyUI, formatMetadataForComfyUI } from '../utils/comfyUIFormatter';
 import { hydrateImageForEmbeddedComfyWorkflow } from '../services/comfyUIWorkflowHydration';
+import { copyTextToClipboard } from '../utils/imageUtils';
 import {
   getClipboardErrorMessage,
   getNormalizedMetadata,
@@ -50,7 +51,10 @@ export function useCopyToComfyUI() {
         : formatImageForComfyUI(sourceImage);
 
       // Copy to clipboard
-      await navigator.clipboard.writeText(workflowJSON);
+      const result = await copyTextToClipboard(workflowJSON);
+      if (!result.success) {
+        throw new Error(result.error || 'Unknown error occurred');
+      }
 
       setCopyStatus({
         success: true,

--- a/preload.js
+++ b/preload.js
@@ -263,6 +263,7 @@ const electronAPI = {
 
   // --- Caching ---
   copyImageToClipboard: (filePath) => ipcRenderer.invoke('copy-image-to-clipboard', filePath),
+  copyTextToClipboard: (text) => ipcRenderer.invoke('copy-text-to-clipboard', text),
   getCachedData: (cacheId) => ipcRenderer.invoke('get-cached-data', cacheId),
   getJsonCacheData: (cacheId) => ipcRenderer.invoke('get-json-cache-data', cacheId),
   getCacheSummary: (cacheId) => ipcRenderer.invoke('get-cache-summary', cacheId),

--- a/types.ts
+++ b/types.ts
@@ -473,6 +473,7 @@ export interface ElectronAPI {
   resolveMediaUrl: (filePath: string) => Promise<{ success: boolean; url?: string; error?: string; errorType?: string; errorCode?: string }>;
   startFileDrag: (args: { directoryPath: string; relativePath: string }) => void;
   copyImageToClipboard: (filePath: string) => Promise<{ success: boolean; error?: string }>;
+  copyTextToClipboard: (text: string) => Promise<{ success: boolean; error?: string }>;
   
   // --- Caching ---
   getCachedData: (cacheId: string) => Promise<{ success: boolean; data?: any; error?: string }>;

--- a/utils/imageUtils.ts
+++ b/utils/imageUtils.ts
@@ -76,6 +76,43 @@ export const copyImageToClipboard = async (image: IndexedImage, directoryPath?: 
 };
 
 /**
+ * Copies text to the clipboard, preferring Electron's native clipboard API.
+ * Falls back to the Web Clipboard API, which throws a "Document is not focused"
+ * error when the renderer's document loses focus (e.g. after a page reload
+ * triggered by clearing the library cache).
+ * @param text - The text to copy
+ * @returns Promise with operation result
+ */
+export const copyTextToClipboard = async (text: string): Promise<OperationResult> => {
+  try {
+    if (typeof window !== 'undefined' && window.electronAPI?.copyTextToClipboard) {
+      const result = await window.electronAPI.copyTextToClipboard(text);
+      if (result.success) {
+        return { success: true };
+      }
+      console.warn('Native clipboard copy failed, falling back to Web API:', result.error);
+    }
+
+    // Web API fallback (or if native failed)
+    // Ensure document has focus before clipboard operation (browser requirement)
+    if (typeof document !== 'undefined' && (document.hidden || !document.hasFocus())) {
+      window.focus();
+      // Short delay to allow focus to take effect
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    await navigator.clipboard.writeText(text);
+    return { success: true };
+  } catch (error) {
+    console.error('Failed to copy text to clipboard:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error occurred'
+    };
+  }
+};
+
+/**
  * Shows the image file in the system's file explorer
  * @param imageOrPath - The IndexedImage object or full file path string
  * @returns Promise with operation result
@@ -166,12 +203,6 @@ export const showInExplorer = async (imageOrPath: IndexedImage | string): Promis
  */
 export const copyFilePathToClipboard = async (image: IndexedImage): Promise<OperationResult> => {
   try {
-    // Ensure document has focus before clipboard operation
-    if (document.hidden || !document.hasFocus()) {
-      window.focus();
-      await new Promise(resolve => setTimeout(resolve, 100));
-    }
-
     // Determine the path to copy based on environment
     const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
     let pathToCopy: string;
@@ -191,16 +222,9 @@ export const copyFilePathToClipboard = async (image: IndexedImage): Promise<Oper
       pathToCopy = image.id;
     }
 
-    await navigator.clipboard.writeText(pathToCopy);
-
-    // Show confirmation messages
-    if (isElectron) {
-      // Electron handles its own confirmation
-    } else {
-      // Show additional context if we have directory name
-      if (image.directoryName) {
-        // Browser-specific handling
-      }
+    const result = await copyTextToClipboard(pathToCopy);
+    if (!result.success) {
+      throw new Error(result.error || 'Unknown error occurred');
     }
 
     return { success: true };

--- a/utils/imageUtils.ts
+++ b/utils/imageUtils.ts
@@ -86,11 +86,16 @@ export const copyImageToClipboard = async (image: IndexedImage, directoryPath?: 
 export const copyTextToClipboard = async (text: string): Promise<OperationResult> => {
   try {
     if (typeof window !== 'undefined' && window.electronAPI?.copyTextToClipboard) {
-      const result = await window.electronAPI.copyTextToClipboard(text);
-      if (result.success) {
-        return { success: true };
+      try {
+        const result = await window.electronAPI.copyTextToClipboard(text);
+        if (result.success) {
+          return { success: true };
+        }
+        console.warn('Native clipboard copy failed, falling back to Web API:', result.error);
+      } catch (nativeError) {
+        // e.g. the main process has no handler registered - still worth trying the Web API
+        console.warn('Native clipboard copy threw, falling back to Web API:', nativeError);
       }
-      console.warn('Native clipboard copy failed, falling back to Web API:', result.error);
     }
 
     // Web API fallback (or if native failed)


### PR DESCRIPTION
## Summary
- Text copy actions (Copy Prompt, Copy to A1111/ComfyUI, context-menu copies, etc.) called `navigator.clipboard.writeText` directly, which throws a "Document is not focused" error once the renderer's document loses OS focus — e.g. after the page reload triggered by "Clear library cache", or after a reindex.
- Added a native Electron clipboard IPC path for text (`copy-text-to-clipboard`), mirroring the existing image clipboard copy path, with a focus-nudge + Web Clipboard API fallback for non-Electron contexts.
- Updated all real text-copy call sites to use the new shared `copyTextToClipboard` helper.

Fixes #495

## Test plan
- [x] `imageMetadata.test.ts` and `ComfyUIWorkspace.preview.test.tsx` pass
- [ ] Repro steps from #495: clear library cache twice with a folder refresh in between, then immediately click "Copy Prompt" (and Copy Negative Prompt / Copy to A1111 / Copy to ComfyUI / context-menu copy) — should succeed without restarting the app
- [x] Sanity-check normal copy flows still work when the app has focus (no regression)