### PR TITLE
perf: stop rewriting the whole directory cache to delete one image

### DIFF
--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -62,15 +62,70 @@ export interface CacheDiff {
   needsFullRefresh: boolean;
 }
 
+// Entries-per-chunk is only an upper bound. Chunk files are read and rewritten
+// whole, so what actually matters is their size in bytes: on a ComfyUI library
+// a single entry carries the workflow graph, so 1024 entries produced ~58MB
+// chunk files (measured: 326MB across 7 chunks for 6.2k images) and removing
+// one image meant reading and rewriting all 326MB. Cap by bytes as well.
 const DEFAULT_INCREMENTAL_CHUNK_SIZE = 1024;
-const MAX_INLINE_RAW_METADATA_BYTES = 32 * 1024;
+const TARGET_CHUNK_BYTES = 2 * 1024 * 1024;
+
+// Raw metadata above this is stripped from the cache and replaced by a compact
+// summary; the full text is re-read from the file on demand by
+// hydrateImageRawMetadata (wired into ImageModal, ImagePreviewSidebar,
+// ImageEditorWorkspace and the ComfyUI workspace). Kept low deliberately: the
+// raw string is by far the biggest field and the cache only needs the derived
+// fields to drive search, filters and facets.
+const MAX_INLINE_RAW_METADATA_BYTES = 4 * 1024;
 const RAW_METADATA_PREVIEW_BYTES = 4096;
+
+// Cheap proxy for an entry's serialized size. The raw metadata string dominates
+// every other field, so this avoids a JSON.stringify per entry just to measure.
+const estimateEntryBytes = (entry: CacheImageMetadata): number => {
+  const raw = typeof entry.metadataString === 'string' ? entry.metadataString.length : 0;
+  return raw + 1024;
+};
+
+// Splits entries so a chunk stays under both the entry-count and the byte cap.
+// A single oversized entry still gets its own chunk rather than being dropped.
+const chunkByBudget = (
+  entries: CacheImageMetadata[],
+  maxEntries: number
+): CacheImageMetadata[][] => {
+  const chunks: CacheImageMetadata[][] = [];
+  let current: CacheImageMetadata[] = [];
+  let currentBytes = 0;
+
+  for (const entry of entries) {
+    const entryBytes = estimateEntryBytes(entry);
+    if (current.length > 0 && (current.length >= maxEntries || currentBytes + entryBytes > TARGET_CHUNK_BYTES)) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(entry);
+    currentBytes += entryBytes;
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+
+  return chunks;
+};
 
 const logCachePerf = (
   event: string,
   details: Record<string, unknown> = {}
 ) => {
-  console.log('[cache:perf]', { event, ...details });
+  // Surface every *Ms field in the message itself. They were already being
+  // measured but sat behind a collapsed object in DevTools, so the one number
+  // that matters was never visible in a pasted log.
+  const timings = Object.entries(details)
+    .filter(([key, value]) => key.endsWith('Ms') && typeof value === 'number')
+    .map(([key, value]) => `${key}=${value}`)
+    .join(' ');
+  console.log(`[cache:perf] ${event}${timings ? ` | ${timings}` : ''}`, { event, ...details });
 };
 
 const toFixedMs = (durationMs: number) => Number(durationMs.toFixed(2));
@@ -772,8 +827,7 @@ class CacheManager {
     let chunkIndex = inlineMetadata.length > 0 ? 0 : (summary.chunkCount ?? 0);
     const indexUpdates: Record<string, number> = {};
 
-    for (let i = 0; i < inlineMetadata.length; i += chunkSize) {
-      const chunk = inlineMetadata.slice(i, i + chunkSize);
+    for (const chunk of chunkByBudget(inlineMetadata, chunkSize)) {
       const result = await window.electronAPI.writeCacheChunk({
         cacheId,
         chunkIndex,
@@ -813,8 +867,7 @@ class CacheManager {
       }
     }
 
-    for (let i = 0; i < metadata.length; i += chunkSize) {
-      const chunk = metadata.slice(i, i + chunkSize);
+    for (const chunk of chunkByBudget(metadata, chunkSize)) {
       const result = await window.electronAPI.writeCacheChunk({
         cacheId,
         chunkIndex,
@@ -1223,15 +1276,15 @@ class CacheManager {
     const candidateModes = Array.from(new Set([scanSubfolders, !scanSubfolders]));
     for (const mode of candidateModes) {
       const cacheId = `${directoryPath}-${mode ? 'recursive' : 'flat'}`;
-      // The index fast path only prunes by id. If there are also bare names to
-      // prune (e.g. subfolder files that only exist in the other scan-mode's
-      // cache and were never loaded into the current id-based index), it can't
-      // account for them — always go through the full scan-and-rewrite path
-      // (which matches by both id and name) in that case instead of silently
-      // dropping the name-based removals.
-      const removedByIndex = imageIds.length > 0 && imageNames.length === 0
+      // Names are resolved against the index too (see removeCacheVariantByIndex):
+      // its keys are the entry ids, and getRelativeCacheName derives the match
+      // name from the id, so a name-based removal needs no chunk reads either.
+      // This matters because the watcher path (App.tsx) always supplies names —
+      // gating the fast path on `imageNames.length === 0` meant the dominant
+      // delete path always fell through to the full 22s scan-and-rewrite.
+      const removedByIndex = (imageIds.length > 0 || imageNames.length > 0)
         ? await this.runChunkedCacheDeltaLocked(cacheId, () =>
-            this.removeCacheVariantByIndex(cacheId, directoryPath, directoryName, imageIds, mode)
+            this.removeCacheVariantByIndex(cacheId, directoryPath, directoryName, imageIds, imageNames, mode)
           )
         : false;
 
@@ -1261,6 +1314,7 @@ class CacheManager {
     directoryPath: string,
     directoryName: string,
     imageIds: string[],
+    imageNames: string[],
     scanSubfolders: boolean
   ): Promise<boolean> {
     const start = performance.now();
@@ -1287,13 +1341,32 @@ class CacheManager {
       // populated for this cache — appendToCache only maintains an index that
       // already existed, it doesn't create one from scratch). Treating a
       // missing-from-index id as "genuinely absent" in that case would report
-      // success without actually removing anything. Bail to the full scan,
-      // which rebuilds the index from a complete read.
+      // success without actually removing anything. Bail to the full scan in
+      // applyChunkedCacheDelta, which rebuilds the index from a complete read
+      // so this only costs a full rewrite once.
       return false;
     }
 
+    const targetIds = new Set(imageIds);
+    if (imageNames.length > 0) {
+      const wantedNames = new Set(
+        imageNames.map((name) => name.replace(/\\/g, '/').replace(/^\/+|\/+$/g, ''))
+      );
+      for (const id of Object.keys(index)) {
+        // getRelativeCacheName falls back to the entry's `name` field when the
+        // id carries no '::' separator, and the index doesn't hold names — so a
+        // name match can't be decided here. Bail to the full scan in that case.
+        if (id.indexOf('::') < 0) {
+          return false;
+        }
+        if (wantedNames.has(getRelativeCacheName(id, ''))) {
+          targetIds.add(id);
+        }
+      }
+    }
+
     const idsByChunk = new Map<number, Set<string>>();
-    for (const id of imageIds) {
+    for (const id of targetIds) {
       const targetChunk = index[id];
       if (typeof targetChunk !== 'number' || targetChunk < 0 || targetChunk >= chunkCount) {
         // Not in this cache variant per the index. Could genuinely be absent
@@ -1429,6 +1502,7 @@ class CacheManager {
     ];
     const outputChunkSize = DEFAULT_INCREMENTAL_CHUNK_SIZE;
     const outputBuffer: CacheImageMetadata[] = [];
+    let outputBufferBytes = 0;
     let outputChunkIndex = 0;
     let imageCount = 0;
     let readChunks = 0;
@@ -1436,12 +1510,25 @@ class CacheManager {
     let writeChunkMs = 0;
     let pruneMs = 0;
 
+    // Rebuilt as chunks stream out, so the id->chunk sidecar index survives this
+    // path. Without it the index kept the pre-delta lastScan, readValidCacheIndex
+    // rejected it, removeCacheVariantByIndex bailed, and every delete fell back
+    // here again — a full read+rewrite of every chunk, forever. Measured at 22.5s
+    // per deleted file on a 6.2k-image cache.
+    const rebuiltIds: Record<string, number> = {};
+
     const flushOutputChunk = async (force = false) => {
-      if (outputBuffer.length === 0 || (!force && outputBuffer.length < outputChunkSize)) {
+      const budgetReached =
+        outputBuffer.length >= outputChunkSize || outputBufferBytes >= TARGET_CHUNK_BYTES;
+      if (outputBuffer.length === 0 || (!force && !budgetReached)) {
         return;
       }
 
       const chunk = outputBuffer.splice(0, outputBuffer.length);
+      outputBufferBytes = 0;
+      for (const entry of chunk) {
+        rebuiltIds[entry.id] = outputChunkIndex;
+      }
       const writeStart = performance.now();
       const result = await window.electronAPI.writeCacheChunk({
         cacheId: outputCacheId,
@@ -1460,6 +1547,7 @@ class CacheManager {
     const appendOutputEntries = async (entries: CacheImageMetadata[]) => {
       for (const entry of entries) {
         outputBuffer.push(entry);
+        outputBufferBytes += estimateEntryBytes(entry);
         imageCount += 1;
         await flushOutputChunk();
       }
@@ -1497,6 +1585,7 @@ class CacheManager {
     await appendOutputEntries(upserts);
     await flushOutputChunk(true);
 
+    const newLastScan = Date.now();
     const finalizeResult = await window.electronAPI.finalizeCacheWrite({
       cacheId,
       sourceCacheId: outputCacheId,
@@ -1504,7 +1593,7 @@ class CacheManager {
         id: cacheId,
         directoryPath,
         directoryName: summary.directoryName ?? directoryName,
-        lastScan: Date.now(),
+        lastScan: newLastScan,
         imageCount,
         chunkCount: outputChunkIndex,
         parserVersion: PARSER_VERSION,
@@ -1514,6 +1603,13 @@ class CacheManager {
        if (!finalizeResult.success) {
       throw new Error(finalizeResult.error || 'Failed to finalize cache delta');
     }
+
+    // Must carry the same lastScan the record was just finalized with, or the
+    // next removal rejects the index and falls back here again.
+    await window.electronAPI.writeCacheIndex?.({
+      cacheId,
+      data: { lastScan: newLastScan, chunkCount: outputChunkIndex, ids: rebuiltIds },
+    });
 
     logCachePerf('chunked-delta:complete', {
       cacheId,

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -1730,17 +1730,61 @@ export const useImageStore = create<ImageState>((set, get) => {
         return buildLineageLibrarySignature(signatures, state.scanSubfolders);
     };
 
-    const persistLineageSnapshot = async (
-        snapshot: LineageRegistrySnapshot,
-        state: ImageState
-    ): Promise<void> => {
-        const directoryPaths = state.directories.map(directory => directory.path);
-        if (!snapshot.librarySignature || directoryPaths.length === 0) {
+    // Writing the snapshot ships the whole registry (one entry per image) across
+    // the Electron IPC boundary and rewrites the file. Measured at ~3s for a
+    // 17k-image library — and a single delete triggers two rebuilds (the local
+    // delete and the watcher echo), so it cost ~6-7s of frozen UI per deleted
+    // file. It's a disk cache that only has to be correct by the time the app is
+    // next opened, so it must never sit on the interactive path: coalesce to the
+    // newest snapshot and write it once the burst settles.
+    const LINEAGE_PERSIST_DEBOUNCE_MS = 5000;
+    let pendingLineagePersist: { snapshot: LineageRegistrySnapshot; state: ImageState } | null = null;
+    let lineagePersistTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const writePendingLineageSnapshot = async (): Promise<void> => {
+        lineagePersistTimer = null;
+        const pending = pendingLineagePersist;
+        pendingLineagePersist = null;
+        if (!pending) {
             return;
         }
 
-        await saveLineageRegistrySnapshot(directoryPaths, state.scanSubfolders, snapshot);
+        const directoryPaths = pending.state.directories.map(directory => directory.path);
+        if (!pending.snapshot.librarySignature || directoryPaths.length === 0) {
+            return;
+        }
+
+        await saveLineageRegistrySnapshot(directoryPaths, pending.state.scanSubfolders, pending.snapshot);
     };
+
+    const persistLineageSnapshot = (
+        snapshot: LineageRegistrySnapshot,
+        state: ImageState
+    ): void => {
+        // Newest snapshot wins: an older one is always superseded by it.
+        pendingLineagePersist = { snapshot, state };
+        if (lineagePersistTimer !== null) {
+            clearTimeout(lineagePersistTimer);
+        }
+        lineagePersistTimer = setTimeout(() => {
+            void writePendingLineageSnapshot();
+        }, LINEAGE_PERSIST_DEBOUNCE_MS);
+    };
+
+    const flushPendingLineagePersist = (): void => {
+        if (lineagePersistTimer !== null) {
+            clearTimeout(lineagePersistTimer);
+            lineagePersistTimer = null;
+        }
+        void writePendingLineageSnapshot();
+    };
+
+    // Best-effort flush so a quit inside the debounce window doesn't drop the
+    // snapshot. Losing it is not a correctness problem — loadLineageRegistrySnapshot
+    // validates by librarySignature and a miss just costs one rebuild at startup.
+    if (typeof window !== 'undefined') {
+        window.addEventListener('beforeunload', flushPendingLineagePersist);
+    }
 
     const scheduleLineageBuildInternal = (delayMs: number = 600) => {
         if (typeof Worker === 'undefined') {
@@ -1879,7 +1923,8 @@ export const useImageStore = create<ImageState>((set, get) => {
                         },
                     }));
 
-                    void persistLineageSnapshot(payload.snapshot, get());
+                    // Debounced + coalesced: no longer on the interactive path.
+                    persistLineageSnapshot(payload.snapshot, get());
                     break;
 
                 case 'error':
@@ -5074,6 +5119,8 @@ export const useImageStore = create<ImageState>((set, get) => {
         },
 
         resetState: () => {
+            // The pending snapshot belongs to the library being torn down.
+            flushPendingLineagePersist();
             pendingMetadataTagImportMap.clear();
             clearLineageBuildTimer();
             invalidateSearchWorkerDataset();


### PR DESCRIPTION
## Problem

Deleting a single file froze the UI for ~26s on a 17k-image library, and kept the app stuttering while navigating with arrow keys afterwards.

The store was never the problem — `removeImages` measured **3ms**. The cost was the **main process** being pegged rewriting the on-disk cache, which backs up every other IPC call, including the image reads that modal navigation needs.

Measured on a real 6.2k-image directory cache: **326 MB across 7 chunk files** (60/58/57/60/58/44/4 MB), read and rewritten in full to remove one entry.

```
chunked-delta:complete readChunkMs=11418 (~29 MB/s) writeChunkMs=12477 (~26 MB/s) durationMs=22506
```

## Causes and fixes

**1. Chunks were sized by entry count, never by bytes.** `DEFAULT_INCREMENTAL_CHUNK_SIZE = 1024` counts entries. On a ComfyUI library each entry carries the workflow graph (~57 KB), so 1024 entries is a 58 MB file; on an A1111 library the same count is ~2 MB and this would never have surfaced. Chunking now honours a 2 MB budget as well, at all three write sites.

**2. `MAX_INLINE_RAW_METADATA_BYTES` was 32 KB**, so entries just under it stored the full raw workflow inline *and* its parsed copy in `metadata`. Lowered to 4 KB. No new mechanism — this reuses the existing compaction path: compacted entries keep `normalizedMetadata` plus previews, and `hydrateImageRawMetadata` re-reads the full text on demand. That path is already wired into ImageModal, ImagePreviewSidebar, ImageEditorWorkspace and the ComfyUI workspace, so metadata views are unaffected.

**3. `applyChunkedCacheDelta` never rebuilt the id→chunk index.** It was the only method in the family that bumped `lastScan` via `finalizeCacheWrite` without writing the sidecar index, which made the fast path permanently unreachable: the index kept the old `lastScan`, `readValidCacheIndex` rejected it, `removeCacheVariantByIndex` bailed, and the fallback bumped `lastScan` again. The index is now rebuilt as chunks stream out (no extra reads) and written with the same `lastScan` the record is finalized with.

**4. The fast path was skipped whenever names were supplied.** `removeCachedImages` only tried it when `imageNames.length === 0`, but the watcher path always supplies names and is the only cache prune that runs in the modal-delete flow. Names don't need a chunk read: the index already accounts for every cached entry, its keys are the ids, and `getRelativeCacheName` derives the match name from the id. Ids with no `::` separator still fall back to the full scan.

**5. The lineage snapshot write sat on the interactive path.** `saveLineageRegistrySnapshot` ships the whole registry across the IPC boundary and rewrites the file — 3047ms and 3755ms per deleted file, and it runs twice (local delete + watcher echo). It's a disk cache validated by library signature on load, so a miss only costs one rebuild at startup. Now coalesced to the newest snapshot and written after 5s of quiet, flushed on `resetState` and `beforeunload`.

## Results

Same repro, 17k-image library:

| | before | after |
|---|---|---|
| cache write per delete | 22506ms, 7 of 7 chunks | **1909ms, 1 of 21 chunks** |
| `lineage.persist` | 3755ms | **13ms** |
| total freeze | ~26s | ~2s |

## Caveats

- Existing oversized chunks keep their size until rewritten or reindexed, so the **first** delete against an old cache still pays one full rewrite. A reindex does that rewrite once, outside the delete path.
- The remaining ~2s is one chunk read + write plus `get-cache-summary` (450-730ms). Making a removal O(1) regardless of chunk size needs tombstoned deletes — filter removed ids at load, compact during idle. That is a separate change and is not in this PR.

## Test plan

- [ ] Delete one image from the grid → no multi-second freeze
- [ ] Delete from the image modal, then keep navigating with arrow keys → navigation stays responsive
- [ ] Bulk delete a selection → progressive, no freeze
- [ ] Open the metadata view on a ComfyUI image → full raw metadata still shown (exercises the hydration path)
- [ ] Open the ComfyUI workflow workspace on a cached image → workflow still loads
- [ ] Reindex a directory → cache chunk files should now be ~2 MB each instead of ~58 MB
- [ ] Close and reopen the app → library loads from cache correctly, lineage registry intact