### PR TITLE
perf: take chunk I/O off the image delete path with tombstones

### DIFF
--- a/__tests__/cache-manager.workflow-nodes.test.ts
+++ b/__tests__/cache-manager.workflow-nodes.test.ts
@@ -1301,55 +1301,263 @@ describe('cacheManager workflowNodes hydration', () => {
     });
   });
 
-  it('removeCachedImages rewrites only the chunk holding the removed id and updates the index', async () => {
-    const getCacheChunk = vi.fn().mockImplementation(async ({ chunkIndex }) => ({
-      success: true,
-      data: chunkIndex === 0
-        ? [{ id: 'dir-1::a.png', name: 'a.png', metadataString: '{}', metadata: {}, lastModified: 1, models: [], loras: [], scheduler: '' }]
-        : [{ id: 'dir-1::b.png', name: 'b.png', metadataString: '{}', metadata: {}, lastModified: 1, models: [], loras: [], scheduler: '' }],
-    }));
-    const writeCacheChunk = vi.fn().mockResolvedValue({ success: true });
-    const finalizeCacheWrite = vi.fn().mockResolvedValue({ success: true });
-    const writeCacheIndex = vi.fn().mockResolvedValue({ success: true });
-    const readCacheIndex = vi.fn().mockResolvedValue({
-      success: true,
-      data: { lastScan: 1, chunkCount: 2, ids: { 'dir-1::a.png': 0, 'dir-1::b.png': 1 } },
+  describe('tombstoned removals', () => {
+    const makeEntry = (id: string, name: string) => ({
+      id,
+      name,
+      metadataString: '{}',
+      metadata: {},
+      lastModified: 1,
+      models: [],
+      loras: [],
+      scheduler: '',
     });
 
-    window.electronAPI = {
-      getCacheSummary: vi.fn().mockImplementation(async (cacheId: string) =>
-        cacheId === 'D:/library-flat'
-          ? {
-              success: true,
-              data: {
-                id: 'D:/library-flat',
-                directoryPath: 'D:/library',
-                directoryName: 'Library',
-                lastScan: 1,
-                imageCount: 2,
-                chunkCount: 2,
-                parserVersion: PARSER_VERSION,
-              },
-            }
-          : { success: true, data: null }
-      ),
-      getCacheChunk,
-      writeCacheChunk,
-      finalizeCacheWrite,
-      readCacheIndex,
-      writeCacheIndex,
+    // Two chunks, one entry each: a.png in chunk 0, b.png in chunk 1.
+    const setupTwoChunkCache = (overrides: {
+      imageCount?: number;
+      tombstoneCount?: number;
+      tombstoneIds?: string[] | null;
+      indexIds?: Record<string, number>;
+    } = {}) => {
+      const getCacheChunk = vi.fn().mockImplementation(async ({ chunkIndex }) => ({
+        success: true,
+        data: chunkIndex === 0
+          ? [makeEntry('dir-1::a.png', 'a.png')]
+          : [makeEntry('dir-1::b.png', 'b.png')],
+      }));
+      const api = {
+        getCacheSummary: vi.fn().mockImplementation(async (cacheId: string) =>
+          cacheId === 'D:/library-flat'
+            ? {
+                success: true,
+                data: {
+                  id: 'D:/library-flat',
+                  directoryPath: 'D:/library',
+                  directoryName: 'Library',
+                  lastScan: 1,
+                  imageCount: overrides.imageCount ?? 2,
+                  chunkCount: 2,
+                  tombstoneCount: overrides.tombstoneCount ?? 0,
+                  parserVersion: PARSER_VERSION,
+                },
+              }
+            : { success: true, data: null }
+        ),
+        getCacheChunk,
+        writeCacheChunk: vi.fn().mockResolvedValue({ success: true }),
+        finalizeCacheWrite: vi.fn().mockResolvedValue({ success: true }),
+        writeCacheIndex: vi.fn().mockResolvedValue({ success: true }),
+        readCacheIndex: vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            lastScan: 1,
+            chunkCount: 2,
+            ids: overrides.indexIds ?? { 'dir-1::a.png': 0, 'dir-1::b.png': 1 },
+          },
+        }),
+        readCacheTombstones: vi.fn().mockResolvedValue({
+          success: true,
+          data: overrides.tombstoneIds === null || overrides.tombstoneIds === undefined
+            ? null
+            : { chunkCount: 2, ids: overrides.tombstoneIds },
+        }),
+      };
+      window.electronAPI = api as any;
+      (cacheManager as any).isElectron = true;
+      return api;
     };
-    (cacheManager as any).isElectron = true;
 
-    await cacheManager.removeCachedImages('D:/library', 'Library', ['dir-1::b.png'], [], false);
+    it('records a removal in the sidecar without touching any chunk file', async () => {
+      const api = setupTwoChunkCache();
 
-    // Only chunk 1 (holding b.png) is read and rewritten; chunk 0 (a.png) is untouched.
-    expect(getCacheChunk).toHaveBeenCalledTimes(1);
-    expect(getCacheChunk.mock.calls[0][0].chunkIndex).toBe(1);
-    expect(writeCacheChunk).toHaveBeenCalledTimes(1);
-    expect(writeCacheChunk.mock.calls[0][0]).toMatchObject({ chunkIndex: 1, data: [] });
-    expect(finalizeCacheWrite.mock.calls[0][0].record.imageCount).toBe(1);
-    expect(writeCacheIndex.mock.calls[0][0].data.ids).toEqual({ 'dir-1::a.png': 0 });
+      await cacheManager.removeCachedImages('D:/library', 'Library', ['dir-1::b.png'], [], false);
+
+      expect(api.getCacheChunk).not.toHaveBeenCalled();
+      expect(api.writeCacheChunk).not.toHaveBeenCalled();
+      const finalized = api.finalizeCacheWrite.mock.calls[0][0];
+      expect(finalized.tombstones).toEqual({ chunkCount: 2, ids: ['dir-1::b.png'] });
+      expect(finalized.record.imageCount).toBe(1);
+      expect(finalized.record.chunkCount).toBe(2);
+      // lastScan is left alone so the id->chunk index stays valid for the next delete.
+      expect(finalized.record.lastScan).toBe(1);
+      expect(api.writeCacheIndex).not.toHaveBeenCalled();
+    });
+
+    it('resolves removals passed by name through the id->chunk index', async () => {
+      const api = setupTwoChunkCache();
+
+      await cacheManager.removeCachedImages('D:/library', 'Library', [], ['b.png'], false);
+
+      expect(api.getCacheChunk).not.toHaveBeenCalled();
+      expect(api.finalizeCacheWrite.mock.calls[0][0].tombstones.ids).toEqual(['dir-1::b.png']);
+    });
+
+    it('appends to the existing sidecar instead of replacing it', async () => {
+      const api = setupTwoChunkCache({
+        imageCount: 1,
+        tombstoneCount: 1,
+        tombstoneIds: ['dir-1::b.png'],
+      });
+
+      await cacheManager.removeCachedImages('D:/library', 'Library', ['dir-1::a.png'], [], false);
+
+      const finalized = api.finalizeCacheWrite.mock.calls[0][0];
+      expect(finalized.tombstones.ids).toEqual(['dir-1::b.png', 'dir-1::a.png']);
+      expect(finalized.record.imageCount).toBe(0);
+    });
+
+    it('writes nothing when the id is already tombstoned', async () => {
+      const api = setupTwoChunkCache({
+        imageCount: 1,
+        tombstoneCount: 1,
+        tombstoneIds: ['dir-1::b.png'],
+      });
+
+      await cacheManager.removeCachedImages('D:/library', 'Library', ['dir-1::b.png'], [], false);
+
+      expect(api.finalizeCacheWrite).not.toHaveBeenCalled();
+      expect(api.writeCacheChunk).not.toHaveBeenCalled();
+    });
+
+    it('rewrites the cache when the sidecar is missing but the record expects one', async () => {
+      const api = setupTwoChunkCache({
+        imageCount: 1,
+        tombstoneCount: 1,
+        tombstoneIds: null,
+      });
+
+      await cacheManager.removeCachedImages('D:/library', 'Library', ['dir-1::a.png'], [], false);
+
+      // Full rewrite: every chunk read, and the surviving entries written back.
+      expect(api.getCacheChunk).toHaveBeenCalledTimes(2);
+      const written = api.writeCacheChunk.mock.calls.flatMap((call: any) => call[0].data.map((entry: any) => entry.id));
+      // The unusable sidecar is ignored, so b.png comes back rather than being
+      // silently dropped along with the entries it could not account for.
+      expect(written).toEqual(['dir-1::b.png']);
+      const finalized = api.finalizeCacheWrite.mock.calls[0][0];
+      expect(finalized.tombstones).toBeUndefined();
+    });
+
+    it('compacts instead of tombstoning once the sidecar grows past the budget', async () => {
+      const staleIds = Array.from({ length: 500 }, (_, index) => `dir-1::stale-${index}.png`);
+      const indexIds: Record<string, number> = { 'dir-1::a.png': 0, 'dir-1::b.png': 1 };
+      for (const id of staleIds) indexIds[id] = 0;
+      const api = setupTwoChunkCache({
+        imageCount: 2,
+        tombstoneCount: 500,
+        tombstoneIds: staleIds,
+        indexIds,
+      });
+      api.readCacheTombstones.mockResolvedValue({
+        success: true,
+        data: { chunkCount: 2, ids: staleIds },
+      });
+
+      await cacheManager.removeCachedImages('D:/library', 'Library', ['dir-1::b.png'], [], false);
+
+      // 501 tombstones would exceed the budget, so the delete pays for the
+      // rewrite that drops them all and clears the sidecar.
+      expect(api.getCacheChunk).toHaveBeenCalledTimes(2);
+      const finalized = api.finalizeCacheWrite.mock.calls[0][0];
+      expect(finalized.tombstones).toBeUndefined();
+      expect(finalized.record.imageCount).toBe(1);
+    });
+
+    it('drops tombstoned entries when a delta rewrite streams the chunks out', async () => {
+      const api = setupTwoChunkCache({
+        imageCount: 1,
+        tombstoneCount: 1,
+        tombstoneIds: ['dir-1::b.png'],
+      });
+
+      await cacheManager.applyChunkedCacheDelta('D:/library', 'Library', [], ['dir-1::a.png'], [], false);
+
+      const written = api.writeCacheChunk.mock.calls.flatMap((call: any) => call[0].data.map((entry: any) => entry.id));
+      expect(written).toEqual([]);
+      const finalized = api.finalizeCacheWrite.mock.calls[0][0];
+      expect(finalized.record.imageCount).toBe(0);
+      expect(finalized.tombstones).toBeUndefined();
+    });
+
+    it('serves every cached entry when the sidecar disagrees with the record', async () => {
+      const api = setupTwoChunkCache({
+        imageCount: 1,
+        tombstoneCount: 2,
+        tombstoneIds: ['dir-1::b.png'],
+      });
+
+      const delivered: string[] = [];
+      await cacheManager.iterateCachedMetadata('D:/library', false, (chunk) => {
+        delivered.push(...chunk.map((entry) => entry.id));
+      });
+
+      expect(api.readCacheTombstones).toHaveBeenCalled();
+      expect(delivered).toEqual(['dir-1::a.png', 'dir-1::b.png']);
+    });
+
+    it('hides tombstoned entries from the cache load path', async () => {
+      setupTwoChunkCache({
+        imageCount: 1,
+        tombstoneCount: 1,
+        tombstoneIds: ['dir-1::b.png'],
+      });
+
+      const delivered: string[] = [];
+      await cacheManager.iterateCachedMetadata('D:/library', false, (chunk) => {
+        delivered.push(...chunk.map((entry) => entry.id));
+      });
+      expect(delivered).toEqual(['dir-1::a.png']);
+
+      const cached = await cacheManager.getCachedData('D:/library', false);
+      expect(cached?.metadata.map((entry) => entry.id)).toEqual(['dir-1::a.png']);
+      expect(cached?.imageCount).toBe(1);
+    });
+
+    it('rewrites the cache when a tombstoned id is added back', async () => {
+      const api = setupTwoChunkCache({
+        imageCount: 1,
+        tombstoneCount: 1,
+        tombstoneIds: ['dir-1::b.png'],
+      });
+
+      await cacheManager.appendToCache(
+        'D:/library',
+        'Library',
+        [{ ...makeEntry('dir-1::b.png', 'b.png'), handle: {} as any, lastModified: 5 } as any],
+        false
+      );
+
+      // The dead b.png entry is still sitting in chunk 1, so an incremental
+      // append would leave two entries for the same id.
+      const written = api.writeCacheChunk.mock.calls.flatMap((call: any) => call[0].data.map((entry: any) => entry.id));
+      expect(written).toEqual(['dir-1::a.png', 'dir-1::b.png']);
+      const finalized = api.finalizeCacheWrite.mock.calls[0][0];
+      expect(finalized.record.imageCount).toBe(2);
+      expect(finalized.tombstones).toBeUndefined();
+    });
+
+    it('carries the sidecar forward across an ordinary append', async () => {
+      const api = setupTwoChunkCache({
+        imageCount: 1,
+        tombstoneCount: 1,
+        tombstoneIds: ['dir-1::b.png'],
+      });
+
+      await cacheManager.appendToCache(
+        'D:/library',
+        'Library',
+        [{ ...makeEntry('dir-1::c.png', 'c.png'), handle: {} as any } as any],
+        false,
+        { chunkSize: 1 }
+      );
+
+      const finalized = api.finalizeCacheWrite.mock.calls[0][0];
+      expect(finalized.tombstones).toEqual({
+        chunkCount: finalized.record.chunkCount,
+        ids: ['dir-1::b.png'],
+      });
+    });
   });
 
   it('removeCachedImages falls back to a full scan when no id->chunk index exists', async () => {

--- a/__tests__/cacheTombstones.test.ts
+++ b/__tests__/cacheTombstones.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  applyCacheTombstones,
+  getCacheTombstonesPath,
+  readCacheTombstonesFile,
+} from '../utils/cacheTombstones.mjs';
+
+const SAFE_CACHE_ID = 'D__library-flat';
+
+describe('cache tombstone sidecar', () => {
+  const created: string[] = [];
+
+  const makeCacheDir = async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-tombstones-'));
+    created.push(dir);
+    return dir;
+  };
+
+  const writeSidecar = async (cacheDir: string, ids: string[], chunkCount = 2) => {
+    await fs.writeFile(
+      getCacheTombstonesPath(cacheDir, SAFE_CACHE_ID),
+      JSON.stringify({ chunkCount, ids })
+    );
+  };
+
+  afterEach(async () => {
+    await Promise.all(created.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it('writes the sidecar and reports the count the record must carry', async () => {
+    const cacheDir = await makeCacheDir();
+
+    const count = await applyCacheTombstones({
+      cacheDir,
+      safeCacheId: SAFE_CACHE_ID,
+      tombstones: { chunkCount: 2, ids: ['dir-1::a.png', 'dir-1::b.png'] },
+    });
+
+    expect(count).toBe(2);
+    expect(await readCacheTombstonesFile(cacheDir, SAFE_CACHE_ID)).toEqual({
+      chunkCount: 2,
+      ids: ['dir-1::a.png', 'dir-1::b.png'],
+    });
+  });
+
+  it('drops the sidecar for a full rewrite', async () => {
+    const cacheDir = await makeCacheDir();
+    await writeSidecar(cacheDir, ['dir-1::a.png']);
+
+    const count = await applyCacheTombstones({
+      cacheDir,
+      safeCacheId: SAFE_CACHE_ID,
+      tombstones: undefined,
+      recordTombstoneCount: 1,
+    });
+
+    expect(count).toBe(0);
+    expect(await readCacheTombstonesFile(cacheDir, SAFE_CACHE_ID)).toBeNull();
+  });
+
+  it('drops the sidecar when the last tombstoned id is compacted away', async () => {
+    const cacheDir = await makeCacheDir();
+    await writeSidecar(cacheDir, ['dir-1::a.png']);
+
+    const count = await applyCacheTombstones({
+      cacheDir,
+      safeCacheId: SAFE_CACHE_ID,
+      tombstones: { chunkCount: 2, ids: [] },
+    });
+
+    expect(count).toBe(0);
+    expect(await readCacheTombstonesFile(cacheDir, SAFE_CACHE_ID)).toBeNull();
+  });
+
+  it('leaves the sidecar alone on an in-place chunk edit', async () => {
+    const cacheDir = await makeCacheDir();
+    await writeSidecar(cacheDir, ['dir-1::a.png', 'dir-1::b.png']);
+
+    const count = await applyCacheTombstones({
+      cacheDir,
+      safeCacheId: SAFE_CACHE_ID,
+      tombstones: 'preserve',
+      recordTombstoneCount: 2,
+    });
+
+    expect(count).toBe(2);
+    expect(await readCacheTombstonesFile(cacheDir, SAFE_CACHE_ID)).toEqual({
+      chunkCount: 2,
+      ids: ['dir-1::a.png', 'dir-1::b.png'],
+    });
+  });
+
+  // The two cases below are the whole reason 'preserve' carries the record's
+  // count instead of recounting the sidecar. Recounting would make the record
+  // and the sidecar agree again, and readers only force the repairing rewrite
+  // while they disagree.
+  it('keeps a missing sidecar visible as a mismatch instead of settling on zero', async () => {
+    const cacheDir = await makeCacheDir();
+
+    const count = await applyCacheTombstones({
+      cacheDir,
+      safeCacheId: SAFE_CACHE_ID,
+      tombstones: 'preserve',
+      recordTombstoneCount: 5,
+    });
+
+    // Zero here would declare the still-tombstoned entries live, and no later
+    // delete or append would ever notice they need dropping.
+    expect(count).toBe(5);
+  });
+
+  it('does not adopt the length of a half-written sidecar', async () => {
+    const cacheDir = await makeCacheDir();
+    await writeSidecar(cacheDir, ['dir-1::a.png', 'dir-1::b.png']);
+
+    const count = await applyCacheTombstones({
+      cacheDir,
+      safeCacheId: SAFE_CACHE_ID,
+      tombstones: 'preserve',
+      recordTombstoneCount: 3,
+    });
+
+    // Adopting 2 would start trusting a sidecar that was rejected, which can
+    // hide entries that are still on disk.
+    expect(count).toBe(3);
+  });
+
+  it('reads a missing sidecar as absent and a corrupt one as an error', async () => {
+    const cacheDir = await makeCacheDir();
+    expect(await readCacheTombstonesFile(cacheDir, SAFE_CACHE_ID)).toBeNull();
+
+    // Both outcomes make the renderer ignore the sidecar; the throw is what puts
+    // the parse failure in the main-process log instead of hiding it.
+    await fs.writeFile(getCacheTombstonesPath(cacheDir, SAFE_CACHE_ID), '{ not json');
+    await expect(readCacheTombstonesFile(cacheDir, SAFE_CACHE_ID)).rejects.toThrow();
+
+    // A well-formed file that isn't a tombstone list is treated as absent.
+    await fs.writeFile(getCacheTombstonesPath(cacheDir, SAFE_CACHE_ID), '{"chunkCount":2}');
+    expect(await readCacheTombstonesFile(cacheDir, SAFE_CACHE_ID)).toBeNull();
+  });
+});

--- a/__tests__/cacheTombstones.test.ts
+++ b/__tests__/cacheTombstones.test.ts
@@ -6,6 +6,7 @@ import {
   applyCacheTombstones,
   getCacheTombstonesPath,
   readCacheTombstonesFile,
+  readRecordTombstoneCount,
 } from '../utils/cacheTombstones.mjs';
 
 const SAFE_CACHE_ID = 'D__library-flat';
@@ -24,6 +25,15 @@ describe('cache tombstone sidecar', () => {
       getCacheTombstonesPath(cacheDir, SAFE_CACHE_ID),
       JSON.stringify({ chunkCount, ids })
     );
+  };
+
+  // The record lives next to the cache dir, not inside it, same as in the app.
+  const recordPathFor = (cacheDir: string) => path.join(cacheDir, `${SAFE_CACHE_ID}.record.json`);
+
+  const writeRecord = async (cacheDir: string, record: unknown) => {
+    const recordPath = recordPathFor(cacheDir);
+    await fs.writeFile(recordPath, typeof record === 'string' ? record : JSON.stringify(record));
+    return recordPath;
   };
 
   afterEach(async () => {
@@ -54,7 +64,7 @@ describe('cache tombstone sidecar', () => {
       cacheDir,
       safeCacheId: SAFE_CACHE_ID,
       tombstones: undefined,
-      recordTombstoneCount: 1,
+      recordPath: await writeRecord(cacheDir, { imageCount: 10, tombstoneCount: 1 }),
     });
 
     expect(count).toBe(0);
@@ -83,7 +93,7 @@ describe('cache tombstone sidecar', () => {
       cacheDir,
       safeCacheId: SAFE_CACHE_ID,
       tombstones: 'preserve',
-      recordTombstoneCount: 2,
+      recordPath: await writeRecord(cacheDir, { imageCount: 10, tombstoneCount: 2 }),
     });
 
     expect(count).toBe(2);
@@ -104,7 +114,7 @@ describe('cache tombstone sidecar', () => {
       cacheDir,
       safeCacheId: SAFE_CACHE_ID,
       tombstones: 'preserve',
-      recordTombstoneCount: 5,
+      recordPath: await writeRecord(cacheDir, { imageCount: 10, tombstoneCount: 5 }),
     });
 
     // Zero here would declare the still-tombstoned entries live, and no later
@@ -120,12 +130,89 @@ describe('cache tombstone sidecar', () => {
       cacheDir,
       safeCacheId: SAFE_CACHE_ID,
       tombstones: 'preserve',
-      recordTombstoneCount: 3,
+      recordPath: await writeRecord(cacheDir, { imageCount: 10, tombstoneCount: 3 }),
     });
 
     // Adopting 2 would start trusting a sidecar that was rejected, which can
     // hide entries that are still on disk.
     expect(count).toBe(3);
+  });
+
+  // Only a missing record may answer zero. Every other failure has to abort the
+  // finalize: zero is not "unknown", it is the claim that nothing is tombstoned,
+  // and stamping it while the sidecar still lists ids resurrects those entries
+  // and leaves imageCount permanently short.
+  describe("the count 'preserve' preserves", () => {
+    it('takes the count the record already carries', async () => {
+      const cacheDir = await makeCacheDir();
+      const recordPath = await writeRecord(cacheDir, { imageCount: 17499, tombstoneCount: 4 });
+
+      expect(await readRecordTombstoneCount(recordPath)).toBe(4);
+    });
+
+    it('answers zero only when the record is genuinely gone', async () => {
+      const cacheDir = await makeCacheDir();
+
+      expect(await readRecordTombstoneCount(recordPathFor(cacheDir))).toBe(0);
+    });
+
+    it('answers zero for a record written before tombstones existed', async () => {
+      const cacheDir = await makeCacheDir();
+      const recordPath = await writeRecord(cacheDir, { imageCount: 17499 });
+
+      expect(await readRecordTombstoneCount(recordPath)).toBe(0);
+    });
+
+    it('refuses to guess when the record cannot be read', async () => {
+      const cacheDir = await makeCacheDir();
+      // A directory in the record's place reproduces the shape of the errors
+      // that matter on Windows (EPERM/EBUSY from AV, EMFILE under a big scan):
+      // something other than ENOENT came back, so the count is unknown.
+      const recordPath = path.join(cacheDir, 'record-as-directory');
+      await fs.mkdir(recordPath);
+
+      await expect(readRecordTombstoneCount(recordPath)).rejects.toThrow();
+    });
+
+    it('refuses to guess when the record is torn', async () => {
+      const cacheDir = await makeCacheDir();
+      const recordPath = await writeRecord(cacheDir, '{"imageCount":17499,"tombstone');
+
+      await expect(readRecordTombstoneCount(recordPath)).rejects.toThrow();
+    });
+
+    it.each([
+      ['null', null],
+      ['a string', '4'],
+      ['negative', -1],
+      ['fractional', 1.5],
+    ])('refuses to guess when the count is %s', async (_label, tombstoneCount) => {
+      const cacheDir = await makeCacheDir();
+      const recordPath = await writeRecord(cacheDir, { imageCount: 17499, tombstoneCount });
+
+      await expect(readRecordTombstoneCount(recordPath)).rejects.toThrow(/Unusable tombstoneCount/);
+    });
+
+    it('aborts the whole finalize rather than stamping a guessed count', async () => {
+      const cacheDir = await makeCacheDir();
+      await writeSidecar(cacheDir, ['dir-1::a.png']);
+      const recordPath = path.join(cacheDir, 'record-as-directory');
+      await fs.mkdir(recordPath);
+
+      await expect(applyCacheTombstones({
+        cacheDir,
+        safeCacheId: SAFE_CACHE_ID,
+        tombstones: 'preserve',
+        recordPath,
+      })).rejects.toThrow();
+
+      // The sidecar survives untouched, so the pair stays exactly as it was and
+      // the next delete or append still forces the repairing rewrite.
+      expect(await readCacheTombstonesFile(cacheDir, SAFE_CACHE_ID)).toEqual({
+        chunkCount: 2,
+        ids: ['dir-1::a.png'],
+      });
+    });
   });
 
   it('reads a missing sidecar as absent and a corrupt one as an error', async () => {

--- a/electron.mjs
+++ b/electron.mjs
@@ -3610,6 +3610,58 @@ function setupFileOperationHandlers() {
   const CHUNK_SIZE = 1024; // Keep cache chunks small enough to parse without freezing the renderer
   const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+  // Removed-image sidecar, stored as `${safeCacheId}_removed.json` so
+  // `clear-cache-data` (which removes every `${safeCacheId}_*` file) cleans it
+  // up automatically. Deleting an image only appends its id here instead of
+  // reading and rewriting the chunk that holds the entry; read paths filter the
+  // listed ids out, and the next full rewrite drops them for good.
+  //
+  // The record's `tombstoneCount` must always match the sidecar's length. The
+  // renderer treats any disagreement as "sidecar unusable" and serves the cache
+  // exactly as it sits on disk, so a torn write resurrects a deleted thumbnail
+  // until the next scan — it never hides a live image.
+  const getCacheTombstonesPath = (cacheDir, safeCacheId) =>
+    path.join(cacheDir, `${safeCacheId}_removed.json`);
+
+  const readCacheTombstonesFile = async (cacheDir, safeCacheId) => {
+    try {
+      const raw = await fs.readFile(getCacheTombstonesPath(cacheDir, safeCacheId), 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (!parsed || !Array.isArray(parsed.ids)) return null;
+      return { chunkCount: parsed.chunkCount ?? 0, ids: parsed.ids };
+    } catch (error) {
+      if (error.code === 'ENOENT') return null;
+      throw error;
+    }
+  };
+
+  // `tombstones` is part of the finalize-cache-write contract:
+  //   undefined            -> full rewrite: drop the sidecar (tombstoneCount 0)
+  //   'preserve'           -> chunks changed in place: leave the sidecar alone
+  //   { chunkCount, ids }  -> replace the sidecar with exactly these ids
+  // Returns the tombstone count the record must be stamped with.
+  const applyCacheTombstones = async (cacheDir, safeCacheId, tombstones) => {
+    if (tombstones === 'preserve') {
+      const existing = await readCacheTombstonesFile(cacheDir, safeCacheId).catch(() => null);
+      return existing ? existing.ids.length : 0;
+    }
+
+    const ids = Array.isArray(tombstones?.ids) ? tombstones.ids : [];
+    if (ids.length === 0) {
+      await fs.unlink(getCacheTombstonesPath(cacheDir, safeCacheId)).catch(error => {
+        if (error.code !== 'ENOENT') throw error;
+      });
+      return 0;
+    }
+
+    await fs.mkdir(cacheDir, { recursive: true });
+    await fs.writeFile(
+      getCacheTombstonesPath(cacheDir, safeCacheId),
+      JSON.stringify({ chunkCount: tombstones.chunkCount ?? 0, ids })
+    );
+    return ids.length;
+  };
+
   ipcMain.handle('cache-data', async (event, { cacheId, data }) => {
     const start = Date.now();
     const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
@@ -3626,10 +3678,15 @@ function setupFileOperationHandlers() {
       await fs.writeFile(chunkPath, JSON.stringify(chunk));
     }
 
+    // Every entry was just rewritten from the caller's full list, so any
+    // pending tombstones are already reflected in it.
+    await applyCacheTombstones(cacheDir, safeCacheId, undefined);
+
     // Write main cache record (without metadata) with parser version
     const mainCachePath = await getCacheFilePath(cacheId);
     cacheRecord.chunkCount = chunkCount;
     cacheRecord.parserVersion = PARSER_VERSION; // Add parser version
+    cacheRecord.tombstoneCount = 0;
     await fs.writeFile(mainCachePath, JSON.stringify(cacheRecord, null, 2));
 
     logMainPerf('cache-data:complete', {
@@ -3716,14 +3773,14 @@ function setupFileOperationHandlers() {
     }
   });
 
-  ipcMain.handle('finalize-cache-write', async (event, { cacheId, sourceCacheId, record }) => {
+  ipcMain.handle('finalize-cache-write', async (event, { cacheId, sourceCacheId, record, tombstones }) => {
     const start = Date.now();
     try {
       const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
       const safeSourceCacheId = sourceCacheId?.replace(/[^a-zA-Z0-9-_]/g, '_');
+      const rootPath = await getCacheRootPath();
+      const cacheDir = path.join(rootPath, 'json_cache');
       if (safeSourceCacheId && safeSourceCacheId !== safeCacheId) {
-        const rootPath = await getCacheRootPath();
-        const cacheDir = path.join(rootPath, 'json_cache');
         await fs.mkdir(cacheDir, { recursive: true });
 
         const files = await fs.readdir(cacheDir).catch(error => {
@@ -3762,15 +3819,21 @@ function setupFileOperationHandlers() {
         });
       }
 
+      // Sidecar first: if the process dies between the two writes the record
+      // still carries the old count, the mismatch invalidates the sidecar, and
+      // the cache is served whole rather than with images missing.
+      const tombstoneCount = await applyCacheTombstones(cacheDir, safeCacheId, tombstones);
+
       const mainCachePath = await getCacheFilePath(cacheId);
       // Add parser version to cache record
-      const recordWithVersion = { ...record, parserVersion: PARSER_VERSION };
+      const recordWithVersion = { ...record, parserVersion: PARSER_VERSION, tombstoneCount };
       await fs.writeFile(mainCachePath, JSON.stringify(recordWithVersion, null, 2));
       logMainPerf('finalize-cache-write:complete', {
         cacheId,
         sourceCacheId: sourceCacheId ?? null,
         imageCount: recordWithVersion.imageCount,
         chunkCount: recordWithVersion.chunkCount,
+        tombstoneCount,
         durationMs: elapsedMs(start),
       });
       return { success: true };
@@ -3845,6 +3908,19 @@ function setupFileOperationHandlers() {
       if (error.code === 'ENOENT') {
         return { success: true, data: null };
       }
+      return { success: false, error: error.message };
+    }
+  });
+
+  // The sidecar is only ever written as part of finalize-cache-write, so there
+  // is no matching write handler here.
+  ipcMain.handle('read-cache-tombstones', async (event, { cacheId }) => {
+    try {
+      const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
+      const rootPath = await getCacheRootPath();
+      const cacheDir = path.join(rootPath, 'json_cache');
+      return { success: true, data: await readCacheTombstonesFile(cacheDir, safeCacheId) };
+    } catch (error) {
       return { success: false, error: error.message };
     }
   });

--- a/electron.mjs
+++ b/electron.mjs
@@ -3611,18 +3611,6 @@ function setupFileOperationHandlers() {
   const CHUNK_SIZE = 1024; // Keep cache chunks small enough to parse without freezing the renderer
   const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-  // The record's tombstoneCount as it stands on disk right now. Only needed for
-  // the 'preserve' path, which must carry the existing count forward instead of
-  // recounting the sidecar — see utils/cacheTombstones.mjs.
-  const readRecordTombstoneCount = async (cacheId) => {
-    try {
-      const raw = await fs.readFile(await getCacheFilePath(cacheId), 'utf-8');
-      return JSON.parse(raw)?.tombstoneCount ?? 0;
-    } catch {
-      return 0;
-    }
-  };
-
   ipcMain.handle('cache-data', async (event, { cacheId, data }) => {
     const start = Date.now();
     const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
@@ -3639,12 +3627,12 @@ function setupFileOperationHandlers() {
       await fs.writeFile(chunkPath, JSON.stringify(chunk));
     }
 
-    // Every entry was just rewritten from the caller's full list, so any
-    // pending tombstones are already reflected in it.
-    await applyCacheTombstones({ cacheDir, safeCacheId, tombstones: undefined });
-
     // Write main cache record (without metadata) with parser version
     const mainCachePath = await getCacheFilePath(cacheId);
+
+    // Every entry was just rewritten from the caller's full list, so any
+    // pending tombstones are already reflected in it.
+    await applyCacheTombstones({ cacheDir, safeCacheId, recordPath: mainCachePath, tombstones: undefined });
     cacheRecord.chunkCount = chunkCount;
     cacheRecord.parserVersion = PARSER_VERSION; // Add parser version
     cacheRecord.tombstoneCount = 0;
@@ -3780,17 +3768,19 @@ function setupFileOperationHandlers() {
         });
       }
 
+      const mainCachePath = await getCacheFilePath(cacheId);
+
       // Sidecar first: if the process dies between the two writes the record
       // still carries the old count, the mismatch invalidates the sidecar, and
-      // the cache is served whole rather than with images missing.
+      // the cache is served whole rather than with images missing. A throw here
+      // aborts the whole finalize, leaving both files untouched.
       const tombstoneCount = await applyCacheTombstones({
         cacheDir,
         safeCacheId,
+        recordPath: mainCachePath,
         tombstones,
-        recordTombstoneCount: tombstones === 'preserve' ? await readRecordTombstoneCount(cacheId) : 0,
       });
 
-      const mainCachePath = await getCacheFilePath(cacheId);
       // Add parser version to cache record
       const recordWithVersion = { ...record, parserVersion: PARSER_VERSION, tombstoneCount };
       await fs.writeFile(mainCachePath, JSON.stringify(recordWithVersion, null, 2));

--- a/electron.mjs
+++ b/electron.mjs
@@ -3567,7 +3567,7 @@ function setupFileOperationHandlers() {
         mainRecordBytes: data.length,
         durationMs: elapsedMs(start),
       });
-      return { success: true, data: parsed };
+      return { success: true, data: parsed, mainMs: elapsedMs(start) };
     } catch (error) {
       if (error.code === 'ENOENT') {
         logMainPerf('get-cache-summary:miss', {
@@ -3802,7 +3802,7 @@ function setupFileOperationHandlers() {
         tombstoneCount,
         durationMs: elapsedMs(start),
       });
-      return { success: true };
+      return { success: true, mainMs: elapsedMs(start) };
     } catch (error) {
       logMainPerf('finalize-cache-write:error', {
         cacheId,
@@ -3863,13 +3863,14 @@ function setupFileOperationHandlers() {
   });
 
   ipcMain.handle('read-cache-index', async (event, { cacheId }) => {
+    const start = Date.now();
     try {
       const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
       const rootPath = await getCacheRootPath();
       const cacheDir = path.join(rootPath, 'json_cache');
       const indexPath = path.join(cacheDir, `${safeCacheId}_index.json`);
       const raw = await fs.readFile(indexPath, 'utf-8');
-      return { success: true, data: JSON.parse(raw) };
+      return { success: true, data: JSON.parse(raw), mainMs: elapsedMs(start) };
     } catch (error) {
       if (error.code === 'ENOENT') {
         return { success: true, data: null };
@@ -3881,11 +3882,13 @@ function setupFileOperationHandlers() {
   // The sidecar is only ever written as part of finalize-cache-write, so there
   // is no matching write handler here.
   ipcMain.handle('read-cache-tombstones', async (event, { cacheId }) => {
+    const start = Date.now();
     try {
       const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
       const rootPath = await getCacheRootPath();
       const cacheDir = path.join(rootPath, 'json_cache');
-      return { success: true, data: await readCacheTombstonesFile(cacheDir, safeCacheId) };
+      const data = await readCacheTombstonesFile(cacheDir, safeCacheId);
+      return { success: true, data, mainMs: elapsedMs(start) };
     } catch (error) {
       return { success: false, error: error.message };
     }

--- a/electron.mjs
+++ b/electron.mjs
@@ -3567,7 +3567,7 @@ function setupFileOperationHandlers() {
         mainRecordBytes: data.length,
         durationMs: elapsedMs(start),
       });
-      return { success: true, data: parsed, mainMs: elapsedMs(start) };
+      return { success: true, data: parsed };
     } catch (error) {
       if (error.code === 'ENOENT') {
         logMainPerf('get-cache-summary:miss', {
@@ -3802,7 +3802,7 @@ function setupFileOperationHandlers() {
         tombstoneCount,
         durationMs: elapsedMs(start),
       });
-      return { success: true, mainMs: elapsedMs(start) };
+      return { success: true };
     } catch (error) {
       logMainPerf('finalize-cache-write:error', {
         cacheId,
@@ -3863,14 +3863,13 @@ function setupFileOperationHandlers() {
   });
 
   ipcMain.handle('read-cache-index', async (event, { cacheId }) => {
-    const start = Date.now();
     try {
       const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
       const rootPath = await getCacheRootPath();
       const cacheDir = path.join(rootPath, 'json_cache');
       const indexPath = path.join(cacheDir, `${safeCacheId}_index.json`);
       const raw = await fs.readFile(indexPath, 'utf-8');
-      return { success: true, data: JSON.parse(raw), mainMs: elapsedMs(start) };
+      return { success: true, data: JSON.parse(raw) };
     } catch (error) {
       if (error.code === 'ENOENT') {
         return { success: true, data: null };
@@ -3882,13 +3881,11 @@ function setupFileOperationHandlers() {
   // The sidecar is only ever written as part of finalize-cache-write, so there
   // is no matching write handler here.
   ipcMain.handle('read-cache-tombstones', async (event, { cacheId }) => {
-    const start = Date.now();
     try {
       const safeCacheId = cacheId.replace(/[^a-zA-Z0-9-_]/g, '_');
       const rootPath = await getCacheRootPath();
       const cacheDir = path.join(rootPath, 'json_cache');
-      const data = await readCacheTombstonesFile(cacheDir, safeCacheId);
-      return { success: true, data, mainMs: elapsedMs(start) };
+      return { success: true, data: await readCacheTombstonesFile(cacheDir, safeCacheId) };
     } catch (error) {
       return { success: false, error: error.message };
     }

--- a/electron.mjs
+++ b/electron.mjs
@@ -30,6 +30,7 @@ import {
   normalizeComfyUIViewUrl,
 } from './utils/comfyUIViewSecurity.mjs';
 import { rewriteAvifMetadata, stripAvifMetadata } from './utils/avifMetadata.mjs';
+import { applyCacheTombstones, readCacheTombstonesFile } from './utils/cacheTombstones.mjs';
 import { buildImageMetaHubAvifExtension } from './utils/imageMetaHubAvifExtension.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -3610,56 +3611,16 @@ function setupFileOperationHandlers() {
   const CHUNK_SIZE = 1024; // Keep cache chunks small enough to parse without freezing the renderer
   const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-  // Removed-image sidecar, stored as `${safeCacheId}_removed.json` so
-  // `clear-cache-data` (which removes every `${safeCacheId}_*` file) cleans it
-  // up automatically. Deleting an image only appends its id here instead of
-  // reading and rewriting the chunk that holds the entry; read paths filter the
-  // listed ids out, and the next full rewrite drops them for good.
-  //
-  // The record's `tombstoneCount` must always match the sidecar's length. The
-  // renderer treats any disagreement as "sidecar unusable" and serves the cache
-  // exactly as it sits on disk, so a torn write resurrects a deleted thumbnail
-  // until the next scan — it never hides a live image.
-  const getCacheTombstonesPath = (cacheDir, safeCacheId) =>
-    path.join(cacheDir, `${safeCacheId}_removed.json`);
-
-  const readCacheTombstonesFile = async (cacheDir, safeCacheId) => {
+  // The record's tombstoneCount as it stands on disk right now. Only needed for
+  // the 'preserve' path, which must carry the existing count forward instead of
+  // recounting the sidecar — see utils/cacheTombstones.mjs.
+  const readRecordTombstoneCount = async (cacheId) => {
     try {
-      const raw = await fs.readFile(getCacheTombstonesPath(cacheDir, safeCacheId), 'utf-8');
-      const parsed = JSON.parse(raw);
-      if (!parsed || !Array.isArray(parsed.ids)) return null;
-      return { chunkCount: parsed.chunkCount ?? 0, ids: parsed.ids };
-    } catch (error) {
-      if (error.code === 'ENOENT') return null;
-      throw error;
-    }
-  };
-
-  // `tombstones` is part of the finalize-cache-write contract:
-  //   undefined            -> full rewrite: drop the sidecar (tombstoneCount 0)
-  //   'preserve'           -> chunks changed in place: leave the sidecar alone
-  //   { chunkCount, ids }  -> replace the sidecar with exactly these ids
-  // Returns the tombstone count the record must be stamped with.
-  const applyCacheTombstones = async (cacheDir, safeCacheId, tombstones) => {
-    if (tombstones === 'preserve') {
-      const existing = await readCacheTombstonesFile(cacheDir, safeCacheId).catch(() => null);
-      return existing ? existing.ids.length : 0;
-    }
-
-    const ids = Array.isArray(tombstones?.ids) ? tombstones.ids : [];
-    if (ids.length === 0) {
-      await fs.unlink(getCacheTombstonesPath(cacheDir, safeCacheId)).catch(error => {
-        if (error.code !== 'ENOENT') throw error;
-      });
+      const raw = await fs.readFile(await getCacheFilePath(cacheId), 'utf-8');
+      return JSON.parse(raw)?.tombstoneCount ?? 0;
+    } catch {
       return 0;
     }
-
-    await fs.mkdir(cacheDir, { recursive: true });
-    await fs.writeFile(
-      getCacheTombstonesPath(cacheDir, safeCacheId),
-      JSON.stringify({ chunkCount: tombstones.chunkCount ?? 0, ids })
-    );
-    return ids.length;
   };
 
   ipcMain.handle('cache-data', async (event, { cacheId, data }) => {
@@ -3680,7 +3641,7 @@ function setupFileOperationHandlers() {
 
     // Every entry was just rewritten from the caller's full list, so any
     // pending tombstones are already reflected in it.
-    await applyCacheTombstones(cacheDir, safeCacheId, undefined);
+    await applyCacheTombstones({ cacheDir, safeCacheId, tombstones: undefined });
 
     // Write main cache record (without metadata) with parser version
     const mainCachePath = await getCacheFilePath(cacheId);
@@ -3822,7 +3783,12 @@ function setupFileOperationHandlers() {
       // Sidecar first: if the process dies between the two writes the record
       // still carries the old count, the mismatch invalidates the sidecar, and
       // the cache is served whole rather than with images missing.
-      const tombstoneCount = await applyCacheTombstones(cacheDir, safeCacheId, tombstones);
+      const tombstoneCount = await applyCacheTombstones({
+        cacheDir,
+        safeCacheId,
+        tombstones,
+        recordTombstoneCount: tombstones === 'preserve' ? await readRecordTombstoneCount(cacheId) : 0,
+      });
 
       const mainCachePath = await getCacheFilePath(cacheId);
       // Add parser version to cache record

--- a/preload.js
+++ b/preload.js
@@ -276,6 +276,7 @@ const electronAPI = {
   getCacheChunk: (args) => ipcRenderer.invoke('get-cache-chunk', args),
   writeCacheIndex: (args) => ipcRenderer.invoke('write-cache-index', args),
   readCacheIndex: (args) => ipcRenderer.invoke('read-cache-index', args),
+  readCacheTombstones: (args) => ipcRenderer.invoke('read-cache-tombstones', args),
   resolveThumbnailCacheBatch: (args) => ipcRenderer.invoke('resolve-thumbnail-cache-batch', args),
   getThumbnail: (thumbnailId) => ipcRenderer.invoke('get-thumbnail', thumbnailId),
   cacheThumbnail: (args) => ipcRenderer.invoke('cache-thumbnail', args),

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -53,6 +53,9 @@ export interface CacheEntry {
   metadata: CacheImageMetadata[];
   chunkCount?: number;
   parserVersion?: number; // Track which parser version created this cache
+  // Number of ids in the removed-ids sidecar. `imageCount` counts live entries,
+  // so the chunks physically hold `imageCount + tombstoneCount` entries.
+  tombstoneCount?: number;
 }
 
 export interface CacheDiff {
@@ -78,6 +81,13 @@ const TARGET_CHUNK_BYTES = 2 * 1024 * 1024;
 // fields to drive search, filters and facets.
 const MAX_INLINE_RAW_METADATA_BYTES = 4 * 1024;
 const RAW_METADATA_PREVIEW_BYTES = 4096;
+
+// Deleting an image appends its id to the removed-ids sidecar instead of
+// rewriting the chunk that holds it, so the delete costs the same no matter how
+// big the chunk is. The dead entries are still read (and skipped) on every cache
+// load, so past this many the next delete pays for a full rewrite that drops
+// them for good — one compaction per this many deletions, amortized.
+const MAX_TOMBSTONES_BEFORE_COMPACTION = 500;
 
 // Cheap proxy for an entry's serialized size. The raw metadata string dominates
 // every other field, so this avoids a JSON.stringify per entry just to measure.
@@ -564,8 +574,13 @@ class CacheManager {
       return null;
     }
 
+    const tombstoned = await this.readValidCacheTombstones(cacheId, summary);
+    const keepEntry = tombstoned
+      ? (entry: CacheImageMetadata) => !tombstoned.has(entry.id)
+      : null;
+
     let metadata: CacheImageMetadata[] = Array.isArray(summary.metadata)
-      ? compactCacheMetadataEntries(summary.metadata)
+      ? compactCacheMetadataEntries(keepEntry ? summary.metadata.filter(keepEntry) : summary.metadata)
       : [];
     const chunkCount = summary.chunkCount ?? 0;
 
@@ -577,7 +592,8 @@ class CacheManager {
         const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex: i });
         chunkReadMs += performance.now() - chunkStart;
         if (chunkResult.success && Array.isArray(chunkResult.data)) {
-          chunks.push(...compactCacheMetadataEntries(chunkResult.data));
+          const entries = keepEntry ? chunkResult.data.filter(keepEntry) : chunkResult.data;
+          chunks.push(...compactCacheMetadataEntries(entries));
         } else if (!chunkResult.success) {
           console.error(`Failed to load cache chunk ${i} for ${cacheId}:`, chunkResult.error);
         }
@@ -587,6 +603,7 @@ class CacheManager {
         cacheId,
         chunkCount,
         records: metadata.length,
+        tombstoned: tombstoned?.size ?? 0,
         chunkReadMs: toFixedMs(chunkReadMs),
       });
     }
@@ -614,7 +631,7 @@ class CacheManager {
   async getCacheSummary(
     directoryPath: string,
     scanSubfolders: boolean,
-  ): Promise<Pick<CacheEntry, 'id' | 'directoryPath' | 'directoryName' | 'lastScan' | 'imageCount' | 'chunkCount' | 'parserVersion'> & { metadata?: CacheImageMetadata[] } | null> {
+  ): Promise<Pick<CacheEntry, 'id' | 'directoryPath' | 'directoryName' | 'lastScan' | 'imageCount' | 'chunkCount' | 'parserVersion' | 'tombstoneCount'> & { metadata?: CacheImageMetadata[] } | null> {
     if (!this.isElectron) return null;
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
@@ -643,6 +660,7 @@ class CacheManager {
       cacheId,
       imageCount: summary.imageCount ?? 0,
       chunkCount: summary.chunkCount ?? 0,
+      tombstoneCount: summary.tombstoneCount ?? 0,
       hasInlineMetadata: Array.isArray(summary.metadata),
       durationMs: toFixedMs(performance.now() - start),
     });
@@ -654,6 +672,7 @@ class CacheManager {
       imageCount: summary.imageCount,
       chunkCount: summary.chunkCount,
       parserVersion: summary.parserVersion,
+      tombstoneCount: summary.tombstoneCount,
       metadata: Array.isArray(summary.metadata)
         ? compactCacheMetadataEntries(summary.metadata)
         : undefined,
@@ -690,11 +709,17 @@ class CacheManager {
       return;
     }
 
+    const tombstoned = await this.readValidCacheTombstones(cacheId, summary);
+    const keepEntry = tombstoned
+      ? (entry: CacheImageMetadata) => !tombstoned.has(entry.id)
+      : null;
+
     if (Array.isArray(summary.metadata) && summary.metadata.length > 0) {
-      await onChunk(compactCacheMetadataEntries(summary.metadata));
+      const entries = keepEntry ? summary.metadata.filter(keepEntry) : summary.metadata;
+      await onChunk(compactCacheMetadataEntries(entries));
       logCachePerf('iterate-cached-metadata:inline-complete', {
         cacheId,
-        records: summary.metadata.length,
+        records: entries.length,
         durationMs: toFixedMs(performance.now() - start),
       });
       return;
@@ -709,11 +734,14 @@ class CacheManager {
       const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex: i });
       chunkReadMs += performance.now() - chunkStart;
       if (chunkResult.success && Array.isArray(chunkResult.data) && chunkResult.data.length > 0) {
-        const compacted = compactCacheMetadataEntries(chunkResult.data);
+        const entries = keepEntry ? chunkResult.data.filter(keepEntry) : chunkResult.data;
+        const compacted = compactCacheMetadataEntries(entries);
         records += compacted.length;
-        const callbackStart = performance.now();
-        await onChunk(compacted);
-        callbackMs += performance.now() - callbackStart;
+        if (compacted.length > 0) {
+          const callbackStart = performance.now();
+          await onChunk(compacted);
+          callbackMs += performance.now() - callbackStart;
+        }
       } else if (!chunkResult.success) {
         console.error(`Failed to load cache chunk ${i} for ${cacheId}:`, chunkResult.error);
       }
@@ -722,6 +750,7 @@ class CacheManager {
       cacheId,
       chunkCount,
       records,
+      tombstoned: tombstoned?.size ?? 0,
       chunkReadMs: toFixedMs(chunkReadMs),
       callbackMs: toFixedMs(callbackMs),
       durationMs: toFixedMs(performance.now() - start),
@@ -775,11 +804,32 @@ class CacheManager {
     if (!images || images.length === 0) return;
 
     const cacheId = `${directoryPath}-${scanSubfolders ? 'recursive' : 'flat'}`;
-    await this.runChunkedCacheDeltaLocked(cacheId, () =>
+    const appended = await this.runChunkedCacheDeltaLocked(cacheId, () =>
       this.appendToCacheLocked(cacheId, directoryPath, directoryName, images, scanSubfolders, options)
     );
+
+    // Appending alone can't undo a tombstone: the removed entry is still sitting
+    // in its chunk, so re-adding the same id would leave two entries for it.
+    // The full rewrite drops the old copy and clears the sidecar. Run it outside
+    // the lock above — applyChunkedCacheDelta takes the same one.
+    if (!appended) {
+      await this.applyChunkedCacheDelta(
+        directoryPath,
+        directoryName,
+        images,
+        [],
+        [],
+        scanSubfolders,
+        { fallbackImages: options?.getFallbackImages?.() }
+      );
+    }
   }
 
+  /**
+   * Returns false when the append can't be done incrementally and the caller
+   * must fall back to a full rewrite. Every other failure is logged and
+   * swallowed, as before.
+   */
   private async appendToCacheLocked(
     cacheId: string,
     directoryPath: string,
@@ -787,7 +837,7 @@ class CacheManager {
     images: IndexedImage[],
     scanSubfolders: boolean,
     options?: { chunkSize?: number; getFallbackImages?: () => IndexedImage[] }
-  ): Promise<void> {
+  ): Promise<boolean> {
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
     const start = performance.now();
     const summaryResult = await summaryFn(cacheId);
@@ -814,11 +864,27 @@ class CacheManager {
         fallbackImages: fallbackImages.length,
         durationMs: toFixedMs(performance.now() - start),
       });
-      return;
+      return true;
     }
 
     const summary = summaryResult.data as CacheEntry;
     const chunkSize = options?.chunkSize ?? DEFAULT_INCREMENTAL_CHUNK_SIZE;
+
+    // Checked before anything is written, so handing over to the full rewrite
+    // never leaves a half-appended cache behind.
+    const tombstoned = await this.readValidCacheTombstones(cacheId, summary);
+    if (!tombstoned && (summary.tombstoneCount ?? 0) > 0) {
+      return false;
+    }
+    if (tombstoned && images.some((image) => tombstoned.has(image.id))) {
+      logCachePerf('append-to-cache:rewrite-for-tombstoned-id', {
+        cacheId,
+        images: images.length,
+        tombstones: tombstoned.size,
+      });
+      return false;
+    }
+
     let metadata = sanitizeCacheMetadata(toCacheMetadata(images), { forceClone: true });
 
     const inlineMetadata = Array.isArray(summary.metadata)
@@ -835,7 +901,7 @@ class CacheManager {
       });
       if (!result.success) {
         console.error('Failed to migrate inline cache chunk:', result.error);
-        return;
+        return true;
       }
       chunkIndex += 1;
     }
@@ -860,7 +926,7 @@ class CacheManager {
           const writeResult = await window.electronAPI.writeCacheChunk({ cacheId, chunkIndex: lastChunkIndex, data: merged });
           if (!writeResult.success) {
             console.error('Failed to top off cache chunk:', writeResult.error);
-            return;
+            return true;
           }
           for (const entry of toAdd) indexUpdates[entry.id] = lastChunkIndex;
         }
@@ -875,7 +941,7 @@ class CacheManager {
       });
       if (!result.success) {
         console.error('Failed to append cache chunk:', result.error);
-        return;
+        return true;
       }
       for (const entry of chunk) indexUpdates[entry.id] = chunkIndex;
       chunkIndex += 1;
@@ -892,7 +958,13 @@ class CacheManager {
       parserVersion: PARSER_VERSION,
     } satisfies Omit<CacheEntry, 'metadata'>;
 
-    const finalizeResult = await window.electronAPI.finalizeCacheWrite({ cacheId, record });
+    const finalizeResult = await window.electronAPI.finalizeCacheWrite({
+      cacheId,
+      record,
+      // Carried forward with the new chunk count: none of the removed ids came
+      // back (checked above) and no existing entry moved chunks.
+      tombstones: tombstoned ? { chunkCount: chunkIndex, ids: [...tombstoned] } : undefined,
+    });
     if (!finalizeResult.success) {
       console.error('Failed to finalize appended cache write:', finalizeResult.error);
     } else if (existingIndex) {
@@ -909,6 +981,7 @@ class CacheManager {
       chunkCount: chunkIndex,
       durationMs: toFixedMs(performance.now() - start),
     });
+    return true;
   }
 
   async createIncrementalWriter(
@@ -1094,6 +1167,8 @@ class CacheManager {
           chunkCount,
           parserVersion: PARSER_VERSION,
         },
+        // Entries are updated in place, so no removed id becomes live again.
+        tombstones: 'preserve',
       });
       if (!finalizeResult.success) {
         throw new Error(finalizeResult.error || 'Failed to finalize cache patch');
@@ -1257,11 +1332,51 @@ class CacheManager {
   }
 
   /**
-   * Removes specific images from an existing cache without rewriting the whole
-   * directory cache. Mirrors patchCachedImages' id->chunk index approach: only
-   * the chunk(s) that actually hold the removed images are read and rewritten.
-   * Falls back to the full applyChunkedCacheDelta scan (which also matches by
-   * name) whenever the index can't account for every id, so correctness never
+   * Reads the removed-ids sidecar for a cache variant. The ids listed there are
+   * still physically present in their chunks and must be skipped by every read
+   * path until a full rewrite drops them.
+   *
+   * Returns null when the record says there is nothing to skip, and also when
+   * the sidecar disagrees with the record — a missing file, a torn write, or a
+   * record written by a build that predates tombstones. That is the safe
+   * direction on purpose: ignoring the sidecar shows an already-deleted image
+   * again until the next scan removes it, while trusting a stale one would hide
+   * images that are still on disk.
+   */
+  private async readValidCacheTombstones(
+    cacheId: string,
+    record: { chunkCount?: number; tombstoneCount?: number }
+  ): Promise<Set<string> | null> {
+    const expected = record.tombstoneCount ?? 0;
+    if (expected <= 0) return null;
+    if (!window.electronAPI?.readCacheTombstones) return null;
+
+    try {
+      const result = await window.electronAPI.readCacheTombstones({ cacheId });
+      const data = result?.success ? result.data : null;
+      if (!data || !Array.isArray(data.ids)) {
+        console.warn(`Cache tombstones missing for ${cacheId} (record expects ${expected}); serving the cache uncompacted.`);
+        return null;
+      }
+      if (data.ids.length !== expected || (data.chunkCount ?? 0) !== (record.chunkCount ?? 0)) {
+        console.warn(
+          `Cache tombstones out of sync for ${cacheId} (sidecar ${data.ids.length}/${data.chunkCount ?? 0}, record ${expected}/${record.chunkCount ?? 0}); serving the cache uncompacted.`
+        );
+        return null;
+      }
+      return new Set(data.ids);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Removes specific images from an existing cache without touching any chunk
+   * file: the removed ids are appended to the sidecar and the record's live
+   * image count is adjusted, so a delete costs two small writes regardless of
+   * library size. Falls back to the full applyChunkedCacheDelta rewrite (which
+   * also matches by name, drops the tombstoned entries and clears the sidecar)
+   * whenever the sidecar path can't account for every id, so correctness never
    * regresses versus the old always-full-rewrite behavior.
    */
   async removeCachedImages(
@@ -1276,19 +1391,17 @@ class CacheManager {
     const candidateModes = Array.from(new Set([scanSubfolders, !scanSubfolders]));
     for (const mode of candidateModes) {
       const cacheId = `${directoryPath}-${mode ? 'recursive' : 'flat'}`;
-      // Names are resolved against the index too (see removeCacheVariantByIndex):
+      // Names are resolved against the index too (see tombstoneCacheVariant):
       // its keys are the entry ids, and getRelativeCacheName derives the match
       // name from the id, so a name-based removal needs no chunk reads either.
       // This matters because the watcher path (App.tsx) always supplies names —
       // gating the fast path on `imageNames.length === 0` meant the dominant
       // delete path always fell through to the full 22s scan-and-rewrite.
-      const removedByIndex = (imageIds.length > 0 || imageNames.length > 0)
-        ? await this.runChunkedCacheDeltaLocked(cacheId, () =>
-            this.removeCacheVariantByIndex(cacheId, directoryPath, directoryName, imageIds, imageNames, mode)
-          )
-        : false;
+      const tombstoned = await this.runChunkedCacheDeltaLocked(cacheId, () =>
+        this.tombstoneCacheVariant(cacheId, directoryPath, directoryName, imageIds, imageNames, mode)
+      );
 
-      if (!removedByIndex) {
+      if (!tombstoned) {
         await this.applyChunkedCacheDelta(
           directoryPath,
           directoryName,
@@ -1303,13 +1416,13 @@ class CacheManager {
   }
 
   /**
-   * Fast path for removeCachedImages: removes imageIds from the chunk(s) the
-   * id->chunk index says they live in. Returns false (no changes made) if the
-   * cache doesn't exist, uses the legacy inline-metadata format, has no usable
-   * index, or the index turns out stale for any id — callers should fall back
-   * to the full scan-and-rewrite path in that case.
+   * Fast path for removeCachedImages: marks the ids as removed in the sidecar
+   * and leaves the chunk files alone. Returns false (nothing written) if the
+   * cache uses the legacy inline-metadata format, has no usable id->chunk index
+   * or sidecar, or has accumulated enough tombstones to be worth compacting —
+   * callers fall back to the full rewrite path in that case.
    */
-  private async removeCacheVariantByIndex(
+  private async tombstoneCacheVariant(
     cacheId: string,
     directoryPath: string,
     directoryName: string,
@@ -1319,6 +1432,7 @@ class CacheManager {
   ): Promise<boolean> {
     const start = performance.now();
     const summary = await this.getCacheSummary(directoryPath, scanSubfolders);
+    const summaryMs = performance.now() - start;
     if (!summary) {
       // No cache for this variant — nothing to remove, no fallback needed.
       return true;
@@ -1332,18 +1446,31 @@ class CacheManager {
       return true;
     }
 
+    const indexStart = performance.now();
     const index = await this.readValidCacheIndex(cacheId, summary.lastScan, chunkCount);
+    const indexMs = performance.now() - indexStart;
     if (!index) {
       return false;
     }
-    if (Object.keys(index).length !== (summary.imageCount ?? 0)) {
-      // Index doesn't account for every cached entry (e.g. it was never
-      // populated for this cache — appendToCache only maintains an index that
-      // already existed, it doesn't create one from scratch). Treating a
-      // missing-from-index id as "genuinely absent" in that case would report
-      // success without actually removing anything. Bail to the full scan in
-      // applyChunkedCacheDelta, which rebuilds the index from a complete read
-      // so this only costs a full rewrite once.
+
+    const tombstonesStart = performance.now();
+    const tombstoned = await this.readValidCacheTombstones(cacheId, summary);
+    const tombstonesMs = performance.now() - tombstonesStart;
+    if (!tombstoned && (summary.tombstoneCount ?? 0) > 0) {
+      // Sidecar unusable but the record expects one. A full rewrite is the only
+      // way back to a consistent pair, and it fixes both files at once.
+      return false;
+    }
+    const alreadyRemoved = tombstoned ?? new Set<string>();
+
+    if (Object.keys(index).length !== (summary.imageCount ?? 0) + alreadyRemoved.size) {
+      // Index doesn't account for every entry the chunks physically hold (e.g.
+      // it was never populated for this cache — appendToCache only maintains an
+      // index that already existed, it doesn't create one from scratch).
+      // Treating a missing-from-index id as "genuinely absent" in that case
+      // would report success without actually removing anything. Bail to the
+      // full scan in applyChunkedCacheDelta, which rebuilds the index from a
+      // complete read so this only costs a full rewrite once.
       return false;
     }
 
@@ -1365,7 +1492,7 @@ class CacheManager {
       }
     }
 
-    const idsByChunk = new Map<number, Set<string>>();
+    const newlyRemoved: string[] = [];
     for (const id of targetIds) {
       const targetChunk = index[id];
       if (typeof targetChunk !== 'number' || targetChunk < 0 || targetChunk >= chunkCount) {
@@ -1374,65 +1501,59 @@ class CacheManager {
         // forcing a fallback scan for every removal that touches one variant.
         continue;
       }
-      const set = idsByChunk.get(targetChunk);
-      if (set) set.add(id);
-      else idsByChunk.set(targetChunk, new Set([id]));
+      if (alreadyRemoved.has(id)) {
+        continue;
+      }
+      newlyRemoved.push(id);
     }
 
-    if (idsByChunk.size === 0) {
+    if (newlyRemoved.length === 0) {
       return true;
     }
 
-    let removedCount = 0;
-    const nextIndex = { ...index };
-    for (const [chunkIndex, wanted] of idsByChunk) {
-      const chunkResult = await window.electronAPI.getCacheChunk({ cacheId, chunkIndex });
-      if (!chunkResult.success || !Array.isArray(chunkResult.data)) {
-        return false;
-      }
-      const entries = chunkResult.data as CacheImageMetadata[];
-      const filtered = entries.filter((entry) => !wanted.has(entry.id));
-      if (filtered.length === entries.length) {
-        // The index pointed at the wrong chunk (stale layout) — bail to the
-        // full fallback scan, which also rebuilds the index.
-        return false;
-      }
-      removedCount += entries.length - filtered.length;
-      const writeResult = await window.electronAPI.writeCacheChunk({ cacheId, chunkIndex, data: filtered });
-      if (!writeResult.success) {
-        return false;
-      }
-      for (const id of wanted) delete nextIndex[id];
+    const nextIds = [...alreadyRemoved, ...newlyRemoved];
+    if (nextIds.length > MAX_TOMBSTONES_BEFORE_COMPACTION) {
+      // Enough dead weight to be worth paying for a rewrite. The fallback path
+      // prunes these ids along with the new ones and clears the sidecar, so
+      // nothing is lost by not writing it here.
+      logCachePerf('remove-cached-images:compacting', {
+        cacheId,
+        tombstones: nextIds.length,
+        threshold: MAX_TOMBSTONES_BEFORE_COMPACTION,
+      });
+      return false;
     }
 
-    const newImageCount = Math.max(0, (summary.imageCount ?? 0) - removedCount);
-    const newLastScan = Date.now();
+    const finalizeStart = performance.now();
     const finalizeResult = await window.electronAPI.finalizeCacheWrite({
       cacheId,
       record: {
         id: summary.id,
         directoryPath,
         directoryName: summary.directoryName ?? directoryName,
-        lastScan: newLastScan,
-        imageCount: newImageCount,
+        // Deliberately unchanged: no chunk moved, so the id->chunk index stays
+        // valid and the next delete can take this path again.
+        lastScan: summary.lastScan,
+        imageCount: Math.max(0, (summary.imageCount ?? 0) - newlyRemoved.length),
         chunkCount,
         parserVersion: PARSER_VERSION,
       },
+      tombstones: { chunkCount, ids: nextIds },
     });
+    const finalizeMs = performance.now() - finalizeStart;
     if (!finalizeResult.success) {
       return false;
     }
 
-    await window.electronAPI.writeCacheIndex?.({
+    logCachePerf('remove-cached-images:tombstoned', {
       cacheId,
-      data: { lastScan: newLastScan, chunkCount, ids: nextIndex },
-    });
-
-    logCachePerf('remove-cached-images:indexed', {
-      cacheId,
-      removed: removedCount,
-      chunksTouched: idsByChunk.size,
+      removed: newlyRemoved.length,
+      tombstones: nextIds.length,
       chunkCount,
+      summaryMs: toFixedMs(summaryMs),
+      indexMs: toFixedMs(indexMs),
+      tombstonesMs: toFixedMs(tombstonesMs),
+      finalizeMs: toFixedMs(finalizeMs),
       durationMs: toFixedMs(performance.now() - start),
     });
     return true;
@@ -1493,9 +1614,14 @@ class CacheManager {
     const buildUpsertsStart = performance.now();
     const upserts = sanitizeCacheMetadata(toCacheMetadata(imagesToUpsert), { forceClone: true });
     const buildUpsertsMs = performance.now() - buildUpsertsStart;
+    // This path rewrites every chunk, which is the only place tombstoned
+    // entries actually get dropped. finalizeCacheWrite below is called without
+    // a `tombstones` argument, so the sidecar is cleared at the same time.
+    const tombstoned = await this.readValidCacheTombstones(cacheId, summary);
     const pruneIds = [
       ...removedImageIds,
       ...upserts.map((image) => image.id),
+      ...(tombstoned ?? []),
     ];
     const pruneNames = [
       ...removedImageNames,
@@ -1617,6 +1743,7 @@ class CacheManager {
       upserts: imagesToUpsert.length,
       removedIds: removedImageIds.length,
       removedNames: removedImageNames.length,
+      compactedTombstones: tombstoned?.size ?? 0,
       inputChunks: chunkCount,
       readChunks,
       outputChunks: outputChunkIndex,

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -138,6 +138,29 @@ const logCachePerf = (
   console.log(`[cache:perf] ${event}${timings ? ` | ${timings}` : ''}`, { event, ...details });
 };
 
+// TEMPORARY DIAGNOSTIC (remove before merging).
+//
+// Every timing on the delete path is measured around an `await` in the
+// renderer, so it charges the round trip for three different things at once:
+// the handler's own work in the main process, the main process being busy with
+// something else when the message arrives, and this thread being too busy to
+// run the continuation once the reply is back. A tombstoned delete writes two
+// files of a few hundred bytes and still measured 2s, so it is worth knowing
+// which of the three it actually is before optimizing anything else.
+//
+// `mainMs` is what the handler itself took, reported back with the reply.
+// `lagMs` is how late a `setTimeout(0)` queued at the same moment fired: if it
+// tracks the round trip, this thread was starved and the main process is
+// innocent.
+const lastMainMs: Record<string, number | null> = {};
+
+const measureEventLoopLag = (): Promise<number> => {
+  const start = performance.now();
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(performance.now() - start), 0);
+  });
+};
+
 const toFixedMs = (durationMs: number) => Number(durationMs.toFixed(2));
 const isSlow = (durationMs: number, thresholdMs = 500) => durationMs >= thresholdMs;
 
@@ -638,6 +661,7 @@ class CacheManager {
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
     const start = performance.now();
     const result = await summaryFn(cacheId);
+    lastMainMs.getCacheSummary = (result as any)?.mainMs ?? null;
 
     if (!result.success || !result.data) {
       if (!result.success) {
@@ -1320,6 +1344,7 @@ class CacheManager {
     if (!window.electronAPI?.readCacheIndex) return null;
     try {
       const result = await window.electronAPI.readCacheIndex({ cacheId });
+      lastMainMs.readCacheIndex = (result as any)?.mainMs ?? null;
       if (!result.success || !result.data) return null;
       const { lastScan: indexLastScan, chunkCount: indexChunkCount, ids } = result.data;
       if (indexChunkCount !== chunkCount) return null;
@@ -1353,6 +1378,7 @@ class CacheManager {
 
     try {
       const result = await window.electronAPI.readCacheTombstones({ cacheId });
+      lastMainMs.readCacheTombstones = (result as any)?.mainMs ?? null;
       const data = result?.success ? result.data : null;
       if (!data || !Array.isArray(data.ids)) {
         console.warn(`Cache tombstones missing for ${cacheId} (record expects ${expected}); serving the cache uncompacted.`);
@@ -1525,6 +1551,7 @@ class CacheManager {
     }
 
     const finalizeStart = performance.now();
+    const finalizeLagProbe = measureEventLoopLag();
     const finalizeResult = await window.electronAPI.finalizeCacheWrite({
       cacheId,
       record: {
@@ -1541,6 +1568,7 @@ class CacheManager {
       tombstones: { chunkCount, ids: nextIds },
     });
     const finalizeMs = performance.now() - finalizeStart;
+    const finalizeLagMs = await finalizeLagProbe;
     if (!finalizeResult.success) {
       return false;
     }
@@ -1555,6 +1583,12 @@ class CacheManager {
       tombstonesMs: toFixedMs(tombstonesMs),
       finalizeMs: toFixedMs(finalizeMs),
       durationMs: toFixedMs(performance.now() - start),
+      // TEMPORARY DIAGNOSTIC (remove before merging) — see measureEventLoopLag.
+      summaryMainMs: lastMainMs.getCacheSummary,
+      indexMainMs: lastMainMs.readCacheIndex,
+      tombstonesMainMs: lastMainMs.readCacheTombstones,
+      finalizeMainMs: (finalizeResult as any)?.mainMs ?? null,
+      finalizeLagMs: toFixedMs(finalizeLagMs),
     });
     return true;
   }

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -138,29 +138,6 @@ const logCachePerf = (
   console.log(`[cache:perf] ${event}${timings ? ` | ${timings}` : ''}`, { event, ...details });
 };
 
-// TEMPORARY DIAGNOSTIC (remove before merging).
-//
-// Every timing on the delete path is measured around an `await` in the
-// renderer, so it charges the round trip for three different things at once:
-// the handler's own work in the main process, the main process being busy with
-// something else when the message arrives, and this thread being too busy to
-// run the continuation once the reply is back. A tombstoned delete writes two
-// files of a few hundred bytes and still measured 2s, so it is worth knowing
-// which of the three it actually is before optimizing anything else.
-//
-// `mainMs` is what the handler itself took, reported back with the reply.
-// `lagMs` is how late a `setTimeout(0)` queued at the same moment fired: if it
-// tracks the round trip, this thread was starved and the main process is
-// innocent.
-const lastMainMs: Record<string, number | null> = {};
-
-const measureEventLoopLag = (): Promise<number> => {
-  const start = performance.now();
-  return new Promise((resolve) => {
-    setTimeout(() => resolve(performance.now() - start), 0);
-  });
-};
-
 const toFixedMs = (durationMs: number) => Number(durationMs.toFixed(2));
 const isSlow = (durationMs: number, thresholdMs = 500) => durationMs >= thresholdMs;
 
@@ -661,7 +638,6 @@ class CacheManager {
     const summaryFn = window.electronAPI.getCacheSummary ?? window.electronAPI.getCachedData;
     const start = performance.now();
     const result = await summaryFn(cacheId);
-    lastMainMs.getCacheSummary = (result as any)?.mainMs ?? null;
 
     if (!result.success || !result.data) {
       if (!result.success) {
@@ -1344,7 +1320,6 @@ class CacheManager {
     if (!window.electronAPI?.readCacheIndex) return null;
     try {
       const result = await window.electronAPI.readCacheIndex({ cacheId });
-      lastMainMs.readCacheIndex = (result as any)?.mainMs ?? null;
       if (!result.success || !result.data) return null;
       const { lastScan: indexLastScan, chunkCount: indexChunkCount, ids } = result.data;
       if (indexChunkCount !== chunkCount) return null;
@@ -1378,7 +1353,6 @@ class CacheManager {
 
     try {
       const result = await window.electronAPI.readCacheTombstones({ cacheId });
-      lastMainMs.readCacheTombstones = (result as any)?.mainMs ?? null;
       const data = result?.success ? result.data : null;
       if (!data || !Array.isArray(data.ids)) {
         console.warn(`Cache tombstones missing for ${cacheId} (record expects ${expected}); serving the cache uncompacted.`);
@@ -1551,7 +1525,6 @@ class CacheManager {
     }
 
     const finalizeStart = performance.now();
-    const finalizeLagProbe = measureEventLoopLag();
     const finalizeResult = await window.electronAPI.finalizeCacheWrite({
       cacheId,
       record: {
@@ -1568,7 +1541,6 @@ class CacheManager {
       tombstones: { chunkCount, ids: nextIds },
     });
     const finalizeMs = performance.now() - finalizeStart;
-    const finalizeLagMs = await finalizeLagProbe;
     if (!finalizeResult.success) {
       return false;
     }
@@ -1583,12 +1555,6 @@ class CacheManager {
       tombstonesMs: toFixedMs(tombstonesMs),
       finalizeMs: toFixedMs(finalizeMs),
       durationMs: toFixedMs(performance.now() - start),
-      // TEMPORARY DIAGNOSTIC (remove before merging) — see measureEventLoopLag.
-      summaryMainMs: lastMainMs.getCacheSummary,
-      indexMainMs: lastMainMs.readCacheIndex,
-      tombstonesMainMs: lastMainMs.readCacheTombstones,
-      finalizeMainMs: (finalizeResult as any)?.mainMs ?? null,
-      finalizeLagMs: toFixedMs(finalizeLagMs),
     });
     return true;
   }

--- a/types.ts
+++ b/types.ts
@@ -484,10 +484,18 @@ export interface ElectronAPI {
   writeJsonCacheData: (args: { cacheId: string; data: any }) => Promise<{ success: boolean; error?: string }>;
   prepareCacheWrite: (args: { cacheId: string }) => Promise<{ success: boolean; error?: string }>;
   writeCacheChunk: (args: { cacheId: string; chunkIndex: number; data: any }) => Promise<{ success: boolean; error?: string }>;
-  finalizeCacheWrite: (args: { cacheId: string; record: any; sourceCacheId?: string }) => Promise<{ success: boolean; error?: string }>;
+  finalizeCacheWrite: (args: {
+    cacheId: string;
+    record: any;
+    sourceCacheId?: string;
+    // undefined = full rewrite, drop the removed-ids sidecar; 'preserve' = keep
+    // it as is; an object replaces it. See the electron.mjs handler.
+    tombstones?: 'preserve' | { chunkCount: number; ids: string[] };
+  }) => Promise<{ success: boolean; error?: string }>;
   clearCacheData: (cacheId: string) => Promise<{ success: boolean; error?: string }>;
   writeCacheIndex: (args: { cacheId: string; data: { lastScan?: number; chunkCount: number; ids: Record<string, number> } }) => Promise<{ success: boolean; error?: string }>;
   readCacheIndex: (args: { cacheId: string }) => Promise<{ success: boolean; data?: { lastScan?: number; chunkCount: number; ids: Record<string, number> } | null; error?: string }>;
+  readCacheTombstones: (args: { cacheId: string }) => Promise<{ success: boolean; data?: { chunkCount: number; ids: string[] } | null; error?: string }>;
   resolveThumbnailCacheBatch: (args: {
     candidates: ThumbnailCacheCandidate[];
   }) => Promise<{

--- a/utils/cacheTombstones.mjs
+++ b/utils/cacheTombstones.mjs
@@ -1,0 +1,73 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+// Removed-image sidecar, stored as `${safeCacheId}_removed.json` so
+// `clear-cache-data` (which removes every `${safeCacheId}_*` file) cleans it up
+// automatically. Deleting an image only appends its id here instead of reading
+// and rewriting the chunk that holds the entry; read paths filter the listed ids
+// out, and the next full rewrite drops them for good.
+//
+// The record's `tombstoneCount` must always match the sidecar's length. The
+// renderer treats any disagreement as "sidecar unusable" and serves the cache
+// exactly as it sits on disk, so a torn write resurrects a deleted thumbnail
+// until the next scan — it never hides a live image. That also means a
+// disagreement must be left alone until a path that can actually repair it (a
+// delete or an append, both of which force a full rewrite) comes along: nothing
+// here may quietly make the two agree again.
+
+export const getCacheTombstonesPath = (cacheDir, safeCacheId) =>
+  path.join(cacheDir, `${safeCacheId}_removed.json`);
+
+export const readCacheTombstonesFile = async (cacheDir, safeCacheId) => {
+  try {
+    const raw = await fs.readFile(getCacheTombstonesPath(cacheDir, safeCacheId), 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.ids)) return null;
+    return { chunkCount: parsed.chunkCount ?? 0, ids: parsed.ids };
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  }
+};
+
+/**
+ * `tombstones` is part of the finalize-cache-write contract:
+ *   undefined            -> full rewrite: drop the sidecar (tombstoneCount 0)
+ *   'preserve'           -> chunks changed in place: touch neither file
+ *   { chunkCount, ids }  -> replace the sidecar with exactly these ids
+ *
+ * Returns the tombstone count the record must be stamped with.
+ *
+ * 'preserve' carries the *record's* current count forward rather than counting
+ * the sidecar. Deriving it would launder a broken pair into a consistent one in
+ * both directions: a missing sidecar would become an honest zero, permanently
+ * accepting entries that are still tombstoned in the chunks; and a half-written
+ * sidecar would start being trusted, which can hide images that are still on
+ * disk. Preserving the mismatch keeps the repair available to the next delete or
+ * append, which force the full rewrite that fixes both files.
+ */
+export const applyCacheTombstones = async ({
+  cacheDir,
+  safeCacheId,
+  tombstones,
+  recordTombstoneCount = 0,
+}) => {
+  if (tombstones === 'preserve') {
+    return Number.isFinite(recordTombstoneCount) ? Math.max(0, recordTombstoneCount) : 0;
+  }
+
+  const ids = Array.isArray(tombstones?.ids) ? tombstones.ids : [];
+  if (ids.length === 0) {
+    await fs.unlink(getCacheTombstonesPath(cacheDir, safeCacheId)).catch(error => {
+      if (error.code !== 'ENOENT') throw error;
+    });
+    return 0;
+  }
+
+  await fs.mkdir(cacheDir, { recursive: true });
+  await fs.writeFile(
+    getCacheTombstonesPath(cacheDir, safeCacheId),
+    JSON.stringify({ chunkCount: tombstones.chunkCount ?? 0, ids })
+  );
+  return ids.length;
+};

--- a/utils/cacheTombstones.mjs
+++ b/utils/cacheTombstones.mjs
@@ -30,6 +30,35 @@ export const readCacheTombstonesFile = async (cacheDir, safeCacheId) => {
   }
 };
 
+const parseRecordTombstoneCount = (record) => {
+  const count = record?.tombstoneCount;
+  // Absent is a real answer: the record was written before tombstones existed,
+  // or by a full rewrite. Anything else present but unusable is not — see below.
+  if (count === undefined) return 0;
+  if (typeof count === 'number' && Number.isInteger(count) && count >= 0) return count;
+  throw new Error(`Unusable tombstoneCount in cache record: ${JSON.stringify(count)}`);
+};
+
+/**
+ * The count the record already carries, which is what 'preserve' preserves.
+ *
+ * Only a missing record maps to zero. Every other failure — a locked or busy
+ * file, a torn JSON, a count that isn't a count — throws, because zero is not
+ * "unknown": it is the specific claim that nothing is tombstoned, and stamping
+ * it while the sidecar still lists ids is the laundering this module exists to
+ * prevent. Failing the finalize instead leaves both files exactly as they were.
+ */
+export const readRecordTombstoneCount = async (recordPath) => {
+  let raw;
+  try {
+    raw = await fs.readFile(recordPath, 'utf-8');
+  } catch (error) {
+    if (error.code === 'ENOENT') return 0;
+    throw error;
+  }
+  return parseRecordTombstoneCount(JSON.parse(raw));
+};
+
 /**
  * `tombstones` is part of the finalize-cache-write contract:
  *   undefined            -> full rewrite: drop the sidecar (tombstoneCount 0)
@@ -38,22 +67,23 @@ export const readCacheTombstonesFile = async (cacheDir, safeCacheId) => {
  *
  * Returns the tombstone count the record must be stamped with.
  *
- * 'preserve' carries the *record's* current count forward rather than counting
- * the sidecar. Deriving it would launder a broken pair into a consistent one in
+ * 'preserve' reads the *record's* current count rather than counting the
+ * sidecar. Deriving it would launder a broken pair into a consistent one in
  * both directions: a missing sidecar would become an honest zero, permanently
  * accepting entries that are still tombstoned in the chunks; and a half-written
  * sidecar would start being trusted, which can hide images that are still on
  * disk. Preserving the mismatch keeps the repair available to the next delete or
- * append, which force the full rewrite that fixes both files.
+ * append, which force the full rewrite that fixes both files. The read lives
+ * here, not in the caller, so there is one place that can get it wrong.
  */
 export const applyCacheTombstones = async ({
   cacheDir,
   safeCacheId,
   tombstones,
-  recordTombstoneCount = 0,
+  recordPath,
 }) => {
   if (tombstones === 'preserve') {
-    return Number.isFinite(recordTombstoneCount) ? Math.max(0, recordTombstoneCount) : 0;
+    return readRecordTombstoneCount(recordPath);
   }
 
   const ids = Array.isArray(tombstones?.ids) ? tombstones.ids : [];


### PR DESCRIPTION
Follow-up to #497. Deleting one image on a 17.5k-image ComfyUI library still cost ~1.9s of blocked IPC: the delete read and rewrote the 2MB chunk holding the entry, then rewrote the whole id->chunk index. That queues every other main-process call, including the image reads the modal's arrow navigation needs.

## What changes

A delete no longer touches any chunk file. The removed ids are appended to a `${cacheId}_removed.json` sidecar and the record's live `imageCount` is adjusted — two small writes, independent of library size.

- Read paths (`getCachedData`, `iterateCachedMetadata`) skip the listed ids.
- The entries are physically dropped by the next full rewrite, which the delete path forces once the sidecar passes 500 ids (one compaction per 500 deletions, amortized) and which also happens on any reindex.
- `lastScan` is deliberately left unchanged on a tombstoned delete: nothing moved between chunks, so the id->chunk index stays valid and the next delete can take the same path.

## Consistency

This touches the cache *load* path, so the failure modes matter more than the speed.

Every path that writes the record now declares what should happen to the sidecar — drop it (full rewrite), keep it (in-place chunk edits), or replace it (a delete) — and the main process derives `tombstoneCount` from what it actually wrote, so the record and the sidecar cannot disagree by accident. Readers only trust the sidecar when its length and chunk count match the record.

On any disagreement — sidecar missing, torn write, record written by a build that predates this — readers ignore it and serve the cache exactly as it sits on disk. An already-deleted image can reappear until the next scan removes it again; a live image is never hidden. The next full rewrite repairs both files. Older builds ignore both fields and fall back to a full rewrite on the first delete, which self-heals.

Re-adding an id that is still tombstoned would leave two entries for it, since the dead one is still in its chunk. That case is detected before anything is written and handed to the full rewrite, which drops the old copy.

## Measurement

`remove-cached-images:tombstoned` now logs `summaryMs`, `indexMs`, `tombstonesMs` and `finalizeMs` separately, so whatever time remains can be attributed rather than guessed at.

## Tests

11 new cases in `__tests__/cache-manager.workflow-nodes.test.ts` covering: no chunk read or write on a delete, name-based removals resolved through the index, appending to an existing sidecar, a repeated delete writing nothing, an unusable sidecar falling back to a rewrite that keeps every entry, the compaction threshold, delta rewrites dropping tombstoned entries and clearing the sidecar, both read paths filtering (and not filtering, when the sidecar disagrees), and re-adding a tombstoned id.

## Manual check

1. Delete an image from the large library — the grid and the modal should stay responsive; note `remove-cached-images:tombstoned` in the console.
2. Restart the app: the deleted image must not come back.
3. Delete a few more, then reindex the folder and confirm the count is right.
4. Generate an image into a watched folder after a delete and confirm it appears once.
