### PR TITLE
perf(viewer): decode neighbour images ahead of navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -800,6 +800,7 @@ Browser version uses File System Access API with limited capabilities.
 - Prefer touching one cache chunk over rewriting a directory cache; the id→chunk index exists for exactly this, and any write that finalizes a cache record must also rewrite that index. Deletes touch no chunk at all — they tombstone the id in `{cacheId}_removed.json` and let a later rewrite compact it. If you add a path that writes a cache record, decide what it does to that sidecar (`finalize-cache-write` makes you say so) and read `utils/cacheTombstones.mjs` first: a record and a sidecar that disagree must be left disagreeing, never quietly reconciled
 - Process files in background threads when possible
 - Use synchronous I/O (`fs.openSync`) for header reads during indexing to prevent disk contention (Phase B optimization)
+- Viewer navigation latency is the full image's fetch and decode, not React work. A prefetch that only resolves a source warms nothing — `mediaSourceCache` hands back a URL string without reading a byte — so neighbours are decoded ahead of time through `services/mediaDecodeCache.ts`, and `ImageModal` reads that warmth during render to swap in a single commit. Assigning `src` twice (thumbnail, then full) costs a second decode and a visible resolution pop, so it is worth avoiding whenever the full source is already warm
 
 ## Common Pitfalls
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ### Current Stack
 
-* **Version:** 0.18.0
+* **Version:** 0.18.1
 * **Renderer:** React 18 + TypeScript
 * **Desktop shell:** Electron 38
 * **State management:** Zustand
@@ -239,7 +239,7 @@ Metadata and thumbnails are cached separately.
 
 * `services/mediaSourceCache.ts` turns an image into a URL the renderer can display — an `imh-media://` stream URL in Electron, an object or data URL otherwise — keyed by `directoryPath::id::lastModified` and LRU-capped separately per kind.
 * **Resolving a source yields a string, not bytes.** On the Electron path it is a path resolution plus an `fs.access`; nothing is read and nothing is decoded. That fetch and decode is precisely what cannot fit in the frame where the viewer's `<img src>` changes, so warming a neighbour means decoding it, not resolving it.
-* `services/mediaDecodeCache.ts` is that second layer: a small LRU of decoded bitmaps keyed **by URL only**, with no knowledge of `IndexedImage` or directories. Holding the `HTMLImageElement` is what keeps Chromium from dropping the decoded copy. `ImageModal` warms two neighbours ahead in the direction of travel and one behind, serialized on `requestIdleCallback`, and deliberately without `prioritize` so it never pauses the grid's background thumbnail work.
+* `services/mediaDecodeCache.ts` is that second layer: a small LRU of decoded bitmaps keyed **by URL only**, with no knowledge of `IndexedImage` or directories. Holding the `HTMLImageElement` is what keeps Chromium from dropping the decoded copy. `ImageModal` warms two neighbours ahead in the direction of travel and one behind, serialized on `requestIdleCallback`, and deliberately without `prioritize` so it never pauses the grid's background thumbnail work. It only does so when the store's navigation list is the one the viewer is actually walking — a modal opened from Find Similar, a ComfyUI workflow or a scope steps through its own id list, and `currentIndex`/`totalImages` are what say so.
 * The viewer reads `mediaSourceCache.peek()` and `mediaDecodeCache.isWarm()` **during render**, not in an effect: an effect runs after paint, which would cost the frame the whole path exists to save. A warm source is swapped in the same commit as the image id change, skipping the thumbnail step entirely; a cold one falls back to thumbnail-then-full as before.
 * Both `peek()` and `isWarm()` are side-effect free on purpose. They run on every render, and touching LRU recency there would rank entries by how often a component re-rendered rather than by use.
 * The decode cache is refcounted (`retain`/`release`) because several viewer windows can be open at once — the last one to close is what drops the bitmaps.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -235,6 +235,15 @@ Metadata and thumbnails are cached separately.
 * Video thumbnails are generated from captured frames.
 * Thumbnail state is intentionally decoupled from the main image collection to avoid full-list re-renders as thumbnails arrive.
 
+**Viewer media cache**
+
+* `services/mediaSourceCache.ts` turns an image into a URL the renderer can display — an `imh-media://` stream URL in Electron, an object or data URL otherwise — keyed by `directoryPath::id::lastModified` and LRU-capped separately per kind.
+* **Resolving a source yields a string, not bytes.** On the Electron path it is a path resolution plus an `fs.access`; nothing is read and nothing is decoded. That fetch and decode is precisely what cannot fit in the frame where the viewer's `<img src>` changes, so warming a neighbour means decoding it, not resolving it.
+* `services/mediaDecodeCache.ts` is that second layer: a small LRU of decoded bitmaps keyed **by URL only**, with no knowledge of `IndexedImage` or directories. Holding the `HTMLImageElement` is what keeps Chromium from dropping the decoded copy. `ImageModal` warms two neighbours ahead in the direction of travel and one behind, serialized on `requestIdleCallback`, and deliberately without `prioritize` so it never pauses the grid's background thumbnail work.
+* The viewer reads `mediaSourceCache.peek()` and `mediaDecodeCache.isWarm()` **during render**, not in an effect: an effect runs after paint, which would cost the frame the whole path exists to save. A warm source is swapped in the same commit as the image id change, skipping the thumbnail step entirely; a cold one falls back to thumbnail-then-full as before.
+* Both `peek()` and `isWarm()` are side-effect free on purpose. They run on every render, and touching LRU recency there would rank entries by how often a component re-rendered rather than by use.
+* The decode cache is refcounted (`retain`/`release`) because several viewer windows can be open at once — the last one to close is what drops the bitmaps.
+
 ## Filtering, Tags, and Curation
 
 The current filter system is intentionally explicit rather than implicit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New Images While Watching a Folder**: Adding, removing or enriching images no longer re-runs the whole filter and sort pipeline per event, so generating into a watched folder doesn't drop frames or block scrolling.
 - **Search Responsiveness**: Search text is computed once per image and reused instead of rebuilt on every keystroke.
 - **Image Lineage Rebuilds**: Lineage is no longer written to disk mid-interaction — rebuilds are coalesced and saved once things go quiet.
+- **Viewer Navigation**: Moving between images in the viewer no longer flashes a low-resolution thumbnail or a loading placeholder before the full image lands. The neighbouring images — two ahead in the direction you're browsing, one behind — are now read and fully decoded in the background while you look at the current one, so stepping onto them is immediate. The viewer previously only worked out a neighbour's file path in advance, which left the actual read and decode to happen at the moment you pressed the key. Holding an arrow key still scrubs through previews, and any image that hasn't been prepared yet behaves as before.
 
 ### Fixed
 

--- a/__tests__/ImageModal.comfyui-workflow.test.tsx
+++ b/__tests__/ImageModal.comfyui-workflow.test.tsx
@@ -73,6 +73,7 @@ vi.mock('../services/mediaSourceCache', () => ({
   getElectronAbsoluteMediaPath: () => null,
   mediaSourceCache: {
     getOrLoad: vi.fn(async () => 'blob:test-image'),
+    peek: vi.fn(() => null),
   },
 }));
 

--- a/__tests__/ImageModal.slideshow.test.tsx
+++ b/__tests__/ImageModal.slideshow.test.tsx
@@ -73,6 +73,7 @@ vi.mock('../services/mediaSourceCache', () => ({
   getElectronAbsoluteMediaPath: () => null,
   mediaSourceCache: {
     getOrLoad: vi.fn(async () => 'blob:test-image'),
+    peek: vi.fn(() => null),
   },
 }));
 

--- a/__tests__/ImageModal.videoPlayback.test.tsx
+++ b/__tests__/ImageModal.videoPlayback.test.tsx
@@ -74,6 +74,7 @@ vi.mock('../services/mediaSourceCache', () => ({
   getElectronAbsoluteMediaPath: () => null,
   mediaSourceCache: {
     getOrLoad: vi.fn(async () => 'blob:test-video'),
+    peek: vi.fn(() => null),
   },
 }));
 

--- a/__tests__/mediaDecodeCache.test.ts
+++ b/__tests__/mediaDecodeCache.test.ts
@@ -25,6 +25,12 @@ class FakeImage {
     return this.decodePromise;
   }
 
+  removeAttribute(name: string): void {
+    if (name === 'src') {
+      this.src = '';
+    }
+  }
+
   settle(): void {
     this.resolveDecode();
   }

--- a/__tests__/mediaDecodeCache.test.ts
+++ b/__tests__/mediaDecodeCache.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mediaDecodeCache } from '../services/mediaDecodeCache';
+
+class FakeImage {
+  static instances: FakeImage[] = [];
+
+  decoding = 'sync';
+  onload: unknown = () => {};
+  onerror: unknown = () => {};
+  src = '';
+
+  private resolveDecode!: () => void;
+  private rejectDecode!: (error: Error) => void;
+  private readonly decodePromise: Promise<void>;
+
+  constructor() {
+    this.decodePromise = new Promise<void>((resolve, reject) => {
+      this.resolveDecode = resolve;
+      this.rejectDecode = reject;
+    });
+    FakeImage.instances.push(this);
+  }
+
+  decode(): Promise<void> {
+    return this.decodePromise;
+  }
+
+  settle(): void {
+    this.resolveDecode();
+  }
+
+  fail(message = 'decode failed'): void {
+    this.rejectDecode(new Error(message));
+  }
+}
+
+const lastInstance = (): FakeImage => FakeImage.instances[FakeImage.instances.length - 1]!;
+
+/** Starts a warm and lets its decode succeed, resolving once the cache has recorded it. */
+const warmAndSettle = async (url: string): Promise<void> => {
+  const warming = mediaDecodeCache.warm(url);
+  lastInstance().settle();
+  await warming;
+};
+
+describe('mediaDecodeCache', () => {
+  let originalImage: typeof globalThis.Image;
+  let clock = 0;
+
+  beforeEach(() => {
+    originalImage = globalThis.Image;
+    FakeImage.instances = [];
+    globalThis.Image = FakeImage as unknown as typeof globalThis.Image;
+
+    // Real timestamps collide across fast successive calls, which would make LRU order arbitrary.
+    clock = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => (clock += 1));
+  });
+
+  afterEach(() => {
+    mediaDecodeCache.clear();
+    globalThis.Image = originalImage;
+    vi.restoreAllMocks();
+  });
+
+  it('reports warmth only once the decode has resolved', async () => {
+    const warming = mediaDecodeCache.warm('a.png');
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(false);
+
+    lastInstance().settle();
+    await warming;
+
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(true);
+  });
+
+  it('decodes a url once even when warmed concurrently', async () => {
+    const first = mediaDecodeCache.warm('a.png');
+    const second = mediaDecodeCache.warm('a.png');
+
+    expect(FakeImage.instances).toHaveLength(1);
+
+    lastInstance().settle();
+    await Promise.all([first, second]);
+
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(true);
+  });
+
+  it('serves an already decoded url without building another image', async () => {
+    await warmAndSettle('a.png');
+    expect(FakeImage.instances).toHaveLength(1);
+
+    await mediaDecodeCache.warm('a.png');
+
+    expect(FakeImage.instances).toHaveLength(1);
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(true);
+  });
+
+  it('evicts the least recently used decoded entry past the cap', async () => {
+    for (const url of ['a.png', 'b.png', 'c.png', 'd.png', 'e.png']) {
+      await warmAndSettle(url);
+    }
+
+    await warmAndSettle('f.png');
+
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(false);
+    expect(mediaDecodeCache.isWarm('b.png')).toBe(true);
+    expect(mediaDecodeCache.isWarm('f.png')).toBe(true);
+  });
+
+  it('promotes an entry when it is warmed again', async () => {
+    for (const url of ['a.png', 'b.png', 'c.png', 'd.png', 'e.png']) {
+      await warmAndSettle(url);
+    }
+
+    await mediaDecodeCache.warm('a.png');
+    await warmAndSettle('f.png');
+
+    // Warming 'a.png' again counted as real usage, so 'b.png' became the oldest instead.
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(true);
+    expect(mediaDecodeCache.isWarm('b.png')).toBe(false);
+  });
+
+  it('does not let repeated warmth checks keep an entry alive', async () => {
+    for (const url of ['a.png', 'b.png', 'c.png', 'd.png', 'e.png']) {
+      await warmAndSettle(url);
+    }
+
+    for (let index = 0; index < 20; index += 1) {
+      mediaDecodeCache.isWarm('a.png');
+    }
+
+    await warmAndSettle('f.png');
+
+    // isWarm runs on every render, so it must not register as use of the cache.
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(false);
+    expect(mediaDecodeCache.isWarm('b.png')).toBe(true);
+  });
+
+  it('never evicts a decode that is still in flight', async () => {
+    for (const url of ['a.png', 'b.png', 'c.png', 'd.png', 'e.png']) {
+      await warmAndSettle(url);
+    }
+
+    const pending = mediaDecodeCache.warm('f.png');
+    const pendingImage = lastInstance();
+
+    // Completing another entry triggers a prune while 'f.png' is mid-decode.
+    await warmAndSettle('g.png');
+
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(false);
+    expect(pendingImage.src).toBe('f.png');
+
+    pendingImage.settle();
+    await pending;
+
+    expect(mediaDecodeCache.isWarm('f.png')).toBe(true);
+  });
+
+  it('swallows a failed decode and leaves the url cold', async () => {
+    const warming = mediaDecodeCache.warm('broken.png');
+    const failedImage = lastInstance();
+    failedImage.fail();
+
+    await expect(warming).resolves.toBeUndefined();
+    expect(mediaDecodeCache.isWarm('broken.png')).toBe(false);
+    expect(failedImage.src).toBe('');
+    expect(failedImage.onload).toBeNull();
+    expect(failedImage.onerror).toBeNull();
+  });
+
+  it('drops every bitmap once the last holder releases it', async () => {
+    mediaDecodeCache.retain();
+    mediaDecodeCache.retain();
+    await warmAndSettle('a.png');
+    const image = lastInstance();
+
+    mediaDecodeCache.release();
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(true);
+
+    mediaDecodeCache.release();
+
+    expect(mediaDecodeCache.isWarm('a.png')).toBe(false);
+    expect(image.src).toBe('');
+    expect(image.onload).toBeNull();
+  });
+});

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -23,6 +23,7 @@ import hotkeyManager from '../services/hotkeyManager';
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { getElectronAbsoluteMediaPath, mediaSourceCache } from '../services/mediaSourceCache';
+import { mediaDecodeCache } from '../services/mediaDecodeCache';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import cacheManager from '../services/cacheManager';
 import { indexImageFileAtPath, reparseIndexedImage } from '../services/fileIndexer';
@@ -1039,6 +1040,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const pendingKeyboardNavigationRef = useRef<'next' | 'previous' | null>(null);
   const keyboardNavigationIdleTimeoutRef = useRef<number | null>(null);
   const isRapidKeyboardNavigatingRef = useRef(false);
+  // Which way the user is travelling, so the neighbour prefetch can spend its budget ahead of
+  // them instead of splitting it evenly. Forward until they tell us otherwise.
+  const navigationDirectionRef = useRef<'next' | 'previous'>('next');
   const onWindowStateChangeRef = useRef(onWindowStateChange);
   const lastReportedWindowStateRef = useRef<ModalWindowState | null>(null);
   const slideshowTimeoutRef = useRef<number | null>(null);
@@ -1245,7 +1249,20 @@ const ImageModal: React.FC<ImageModalProps> = ({
     hasImageEditChanges &&
     !isShowingOriginalForAdjustmentCompare &&
     !(imageEditorTab === 'crop' && normalizedImageEditRecipe.crop.enabled);
-  const displayedImageUrl = shouldShowEditedPreview && editedPreviewUrl ? editedPreviewUrl : imageUrl;
+  // Resolved during render, not in an effect: an effect runs after paint, which would cost the
+  // frame this whole path exists to save. When the neighbour prefetch already decoded this
+  // source, the <img> can swap straight to it in the same commit as the image id change.
+  const warmFullImageUrl = useMemo(() => {
+    if (isPlayableMedia) {
+      return null;
+    }
+
+    const cachedUrl = mediaSourceCache.peek(liveImage, directoryPath);
+    return cachedUrl && mediaDecodeCache.isWarm(cachedUrl) ? cachedUrl : null;
+  }, [liveImage, directoryPath, isPlayableMedia]);
+  const displayedImageUrl = shouldShowEditedPreview && editedPreviewUrl
+    ? editedPreviewUrl
+    : (warmFullImageUrl ?? imageUrl);
 
   useEffect(() => {
     let isMounted = true;
@@ -2692,8 +2709,15 @@ const ImageModal: React.FC<ImageModalProps> = ({
     const hasPreview = Boolean(preferredThumbnailUrl);
     const sourceLoadStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
 
-    setIsFullImageSourceReady(false);
-    setImageUrl(isPlayableMedia ? null : (preferredThumbnailUrl ?? null));
+    if (warmFullImageUrl) {
+      // Already fetched and decoded by the neighbour prefetch. Showing the thumbnail first would
+      // only add a second decode and a visible resolution pop, so go straight to the full source.
+      setImageUrl(warmFullImageUrl);
+      setIsFullImageSourceReady(true);
+    } else {
+      setIsFullImageSourceReady(false);
+      setImageUrl(isPlayableMedia ? null : (preferredThumbnailUrl ?? null));
+    }
 
     const loadImage = async () => {
       if (!isMounted) return;
@@ -2719,20 +2743,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
             isPlayableMedia,
           });
 
-          const state = useImageStore.getState();
-          const navigationImages = state.clusterNavigationContext || state.filteredImages;
-          const currentNavigationIndex = navigationImages.findIndex((candidate) => candidate.id === liveImage.id);
-          if (currentNavigationIndex !== -1) {
-            const directoryMap = new Map(state.directories.map((dir) => [dir.id, dir.path]));
-            const neighborCandidates = [
-              navigationImages[currentNavigationIndex - 1],
-              navigationImages[currentNavigationIndex + 1],
-            ].filter(Boolean) as IndexedImage[];
-
-            for (const neighbor of neighborCandidates) {
-              const neighborDirectoryPath = directoryMap.get(neighbor.directoryId || '');
-              mediaSourceCache.prefetch(neighbor, neighborDirectoryPath);
-            }
+          // Keep the image we are showing in the decode cache too, so stepping back onto it is
+          // as instant as stepping forward. Neighbours are warmed by their own effect below.
+          if (!isPlayableMedia) {
+            void mediaDecodeCache.warm(url);
           }
         }
       } catch (loadError) {
@@ -2754,7 +2768,107 @@ const ImageModal: React.FC<ImageModalProps> = ({
     return () => {
       isMounted = false;
     };
+    // warmFullImageUrl is read from the closure on purpose. It is computed in the same render as
+    // the image id change, so the run that matters already sees the right value; adding it here
+    // would re-run the whole load when a later prefetch flips warmth for the image on screen.
   }, [diagnosticsFlowId, liveImage.id, liveImage.handle, liveImage.thumbnailHandle, liveImage.name, liveImage.lastModified, directoryPath, preferredThumbnailUrl, isPlayableMedia, isVideo]);
+
+  // Decoded bitmaps are worth tens of megabytes, so they only stay alive while a modal is open.
+  useEffect(() => {
+    mediaDecodeCache.retain();
+    return () => {
+      mediaDecodeCache.release();
+    };
+  }, []);
+
+  // Warm the neighbours the user is most likely to land on next. Resolving a source only produces
+  // a URL string, so this decodes the bytes as well: that decode is the part that cannot fit in
+  // the frame where the <img> src changes.
+  useEffect(() => {
+    // Waiting on isFullImageSourceReady keeps the image on screen ahead of the ones that are not,
+    // without chaining this to the load promise. During a held-arrow burst the user outruns any
+    // decode we could start, so queueing work there would only compete with the image they stop on.
+    if (isPlayableMedia || !isFullImageSourceReady || isRapidKeyboardNavigating) {
+      return;
+    }
+
+    const state = useImageStore.getState();
+    const navigationImages = state.clusterNavigationContext || state.filteredImages;
+    const currentNavigationIndex = navigationImages.findIndex((candidate) => candidate.id === liveImage.id);
+
+    if (currentNavigationIndex === -1) {
+      return;
+    }
+
+    const step = navigationDirectionRef.current === 'previous' ? -1 : 1;
+    const directoryMap = new Map(state.directories.map((dir) => [dir.id, dir.path]));
+    // Two ahead, one behind: people rarely alternate directions, so spending the budget on the way
+    // they are heading buys a much better hit rate for the same number of decoded bitmaps.
+    const neighbors = [
+      navigationImages[currentNavigationIndex + step],
+      navigationImages[currentNavigationIndex + step * 2],
+      navigationImages[currentNavigationIndex - step],
+    ].filter((candidate): candidate is IndexedImage =>
+      Boolean(candidate)
+      && !isVideoFileName(candidate.name, candidate.fileType)
+      && !isAudioFileName(candidate.name, candidate.fileType));
+
+    if (neighbors.length === 0) {
+      return;
+    }
+
+    let isMounted = true;
+    let idleHandle: number | null = null;
+    let timeoutHandle: number | null = null;
+
+    const scheduleIdle = (callback: () => void) => {
+      if (typeof window.requestIdleCallback === 'function') {
+        idleHandle = window.requestIdleCallback(callback, { timeout: 500 });
+        return;
+      }
+
+      timeoutHandle = window.setTimeout(callback, 32);
+    };
+
+    let queueIndex = 0;
+    const warmNextNeighbor = () => {
+      if (!isMounted || queueIndex >= neighbors.length) {
+        return;
+      }
+
+      const neighbor = neighbors[queueIndex++]!;
+
+      void (async () => {
+        try {
+          // No prioritize here: this must not pause the grid's background thumbnail work.
+          const url = await mediaSourceCache.getOrLoad(neighbor, directoryMap.get(neighbor.directoryId || ''));
+          if (isMounted) {
+            await mediaDecodeCache.warm(url);
+          }
+        } catch {
+          // A neighbour that refuses to load is not worth surfacing: the user may never reach it,
+          // and opening it directly still reports the failure through the load effect.
+        }
+
+        // One at a time, so three multi-megabyte decodes never land on the main thread together.
+        if (isMounted) {
+          scheduleIdle(warmNextNeighbor);
+        }
+      })();
+    };
+
+    scheduleIdle(warmNextNeighbor);
+
+    return () => {
+      isMounted = false;
+      if (idleHandle !== null && typeof window.cancelIdleCallback === 'function') {
+        window.cancelIdleCallback(idleHandle);
+      }
+      if (timeoutHandle !== null) {
+        window.clearTimeout(timeoutHandle);
+      }
+    };
+  }, [isFullImageSourceReady, isPlayableMedia, isRapidKeyboardNavigating, liveImage.id]);
 
   useEffect(() => {
     if (!preferredThumbnailUrl || hasMarkedPreviewVisibleRef.current) {
@@ -2955,6 +3069,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   // land on obeys the auto-play setting again.
   const navigateManually = useCallback((direction: 'next' | 'previous') => {
     setIsChainedPlayback(false);
+    navigationDirectionRef.current = direction;
 
     if (direction === 'next') {
       // Shuffle randomizes forward navigation as well, the way a shuffled playlist does. It only

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2751,8 +2751,13 @@ const ImageModal: React.FC<ImageModalProps> = ({
         }
       } catch (loadError) {
         console.error('Failed to load full image source:', loadError);
-        if (isMounted && !hasPreview) {
-          setImageUrl(null);
+        if (isMounted) {
+          // The warm branch above marks the source ready before this confirms it, so a failure
+          // here has to take that back: otherwise export and editing stay enabled over nothing.
+          setIsFullImageSourceReady(false);
+          if (!hasPreview) {
+            setImageUrl(null);
+          }
         }
       } finally {
         recordPerformanceDuration('modal.full-source-load', (typeof performance !== 'undefined' ? performance.now() : Date.now()) - sourceLoadStartedAt, {
@@ -2797,6 +2802,14 @@ const ImageModal: React.FC<ImageModalProps> = ({
     const currentNavigationIndex = navigationImages.findIndex((candidate) => candidate.id === liveImage.id);
 
     if (currentNavigationIndex === -1) {
+      return;
+    }
+
+    // The store's list is not always the one this modal navigates: a viewer opened from Find
+    // Similar, a ComfyUI workflow or a scope walks its own id list, and currentIndex/totalImages
+    // are the props derived from it. When they disagree, the neighbours here are somebody else's
+    // images — decoding them would evict the useful entries from a five-slot cache for nothing.
+    if (navigationImages.length !== totalImages || currentNavigationIndex !== currentIndex) {
       return;
     }
 
@@ -2851,7 +2864,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         }
 
         // One at a time, so three multi-megabyte decodes never land on the main thread together.
-        if (isMounted) {
+        if (isMounted && queueIndex < neighbors.length) {
           scheduleIdle(warmNextNeighbor);
         }
       })();
@@ -2868,7 +2881,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         window.clearTimeout(timeoutHandle);
       }
     };
-  }, [isFullImageSourceReady, isPlayableMedia, isRapidKeyboardNavigating, liveImage.id]);
+  }, [currentIndex, isFullImageSourceReady, isPlayableMedia, isRapidKeyboardNavigating, liveImage.id, totalImages]);
 
   useEffect(() => {
     if (!preferredThumbnailUrl || hasMarkedPreviewVisibleRef.current) {

--- a/services/mediaDecodeCache.ts
+++ b/services/mediaDecodeCache.ts
@@ -1,0 +1,151 @@
+import { recordPerformanceCounter } from '../utils/performanceDiagnostics';
+
+type DecodeEntry = {
+  element: HTMLImageElement;
+  decoded: boolean;
+  lastAccess: number;
+  loading?: Promise<void>;
+};
+
+const MAX_DECODED_ENTRIES = 5;
+
+/**
+ * Keeps a handful of fully decoded bitmaps alive so swapping an <img> src can paint in the
+ * same frame instead of paying for a protocol fetch plus a multi-megabyte PNG decode.
+ *
+ * Holding the HTMLImageElement reference is what keeps Chromium from dropping the decoded
+ * copy, so entries stay in the map until they are pruned or the cache is cleared.
+ *
+ * This cache only knows about URLs. Resolving an image to a URL is the caller's job, which
+ * keeps it usable for imh-media://, blob:, file: and data URLs alike.
+ */
+class MediaDecodeCache {
+  private entries = new Map<string, DecodeEntry>();
+  private retainCount = 0;
+
+  /**
+   * Several image modals can be open at once, so the cache is released by refcount: the last one
+   * to close drops the bitmaps, and closing one window never blanks the warmth of another.
+   */
+  retain(): void {
+    this.retainCount += 1;
+  }
+
+  release(): void {
+    this.retainCount = Math.max(0, this.retainCount - 1);
+    if (this.retainCount === 0) {
+      this.clear();
+    }
+  }
+
+  async warm(url: string): Promise<void> {
+    if (!url) {
+      return;
+    }
+
+    const existing = this.entries.get(url);
+
+    if (existing?.decoded) {
+      this.touch(url);
+      recordPerformanceCounter('media-decode-cache.hit', { url });
+      return;
+    }
+
+    if (existing?.loading) {
+      return existing.loading;
+    }
+
+    recordPerformanceCounter('media-decode-cache.miss', { url });
+
+    const element = new Image();
+    element.decoding = 'async';
+
+    const loading = (async () => {
+      try {
+        element.src = url;
+        await element.decode();
+
+        const entry = this.entries.get(url);
+        // A clear() or a failed sibling may have dropped us while the decode was in flight.
+        if (!entry || entry.element !== element) {
+          this.destroyElement(element);
+          return;
+        }
+
+        entry.decoded = true;
+        entry.loading = undefined;
+        entry.lastAccess = Date.now();
+        this.prune();
+      } catch (error) {
+        const entry = this.entries.get(url);
+        if (entry?.element === element) {
+          this.entries.delete(url);
+        }
+        this.destroyElement(element);
+        recordPerformanceCounter('media-decode-cache.warm-error', {
+          url,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+
+    this.entries.set(url, {
+      element,
+      decoded: false,
+      lastAccess: Date.now(),
+      loading,
+    });
+
+    return loading;
+  }
+
+  /**
+   * Synchronous and deliberately side-effect free: this runs during render, and touching the
+   * LRU here would let frequent re-renders keep images alive long after the user moved past them.
+   */
+  isWarm(url: string): boolean {
+    return this.entries.get(url)?.decoded === true;
+  }
+
+  clear(): void {
+    for (const entry of this.entries.values()) {
+      this.destroyElement(entry.element);
+    }
+    this.entries.clear();
+  }
+
+  private touch(url: string): void {
+    const entry = this.entries.get(url);
+    if (entry) {
+      entry.lastAccess = Date.now();
+    }
+  }
+
+  private destroyElement(element: HTMLImageElement): void {
+    element.onload = null;
+    element.onerror = null;
+    element.src = '';
+  }
+
+  private prune(): void {
+    // In-flight decodes are never evicted: aborting one throws away exactly the work we want.
+    // Serialized prefetching keeps at most one or two pending, so the overshoot is bounded.
+    const sortedEntries = [...this.entries.entries()]
+      .filter(([, entry]) => entry.decoded)
+      .sort((a, b) => a[1].lastAccess - b[1].lastAccess);
+
+    let evictIndex = 0;
+    while (sortedEntries.length - evictIndex > MAX_DECODED_ENTRIES) {
+      const [url, entry] = sortedEntries[evictIndex++]!;
+      this.entries.delete(url);
+      this.destroyElement(entry.element);
+      recordPerformanceCounter('media-decode-cache.evicted', {
+        url,
+        cacheSize: this.entries.size,
+        maxCacheEntries: MAX_DECODED_ENTRIES,
+      });
+    }
+  }
+}
+
+export const mediaDecodeCache = new MediaDecodeCache();

--- a/services/mediaDecodeCache.ts
+++ b/services/mediaDecodeCache.ts
@@ -8,6 +8,16 @@ type DecodeEntry = {
 };
 
 const MAX_DECODED_ENTRIES = 5;
+const MAX_LOGGED_URL_CHARS = 96;
+
+/**
+ * A source can be a `data:` URL holding a whole base64 PNG, and diagnostics keep 2000 events plus
+ * console-log every counter. Log something bounded that still identifies the entry.
+ */
+const describeUrl = (url: string): string =>
+  url.length > MAX_LOGGED_URL_CHARS
+    ? `${url.slice(0, MAX_LOGGED_URL_CHARS)}…(${url.length} chars)`
+    : url;
 
 /**
  * Keeps a handful of fully decoded bitmaps alive so swapping an <img> src can paint in the
@@ -47,7 +57,7 @@ class MediaDecodeCache {
 
     if (existing?.decoded) {
       this.touch(url);
-      recordPerformanceCounter('media-decode-cache.hit', { url });
+      recordPerformanceCounter('media-decode-cache.hit', { url: describeUrl(url) });
       return;
     }
 
@@ -55,19 +65,28 @@ class MediaDecodeCache {
       return existing.loading;
     }
 
-    recordPerformanceCounter('media-decode-cache.miss', { url });
+    recordPerformanceCounter('media-decode-cache.miss', { url: describeUrl(url) });
 
     const element = new Image();
     element.decoding = 'async';
+
+    // Registered before the decode starts: `decode()` can throw synchronously where it is not
+    // implemented, and a catch that runs before the entry exists would leave a never-decoded
+    // entry with a settled `loading` behind, permanently blocking any retry of this url.
+    const entry: DecodeEntry = {
+      element,
+      decoded: false,
+      lastAccess: Date.now(),
+    };
+    this.entries.set(url, entry);
 
     const loading = (async () => {
       try {
         element.src = url;
         await element.decode();
 
-        const entry = this.entries.get(url);
         // A clear() or a failed sibling may have dropped us while the decode was in flight.
-        if (!entry || entry.element !== element) {
+        if (this.entries.get(url) !== entry) {
           this.destroyElement(element);
           return;
         }
@@ -77,24 +96,18 @@ class MediaDecodeCache {
         entry.lastAccess = Date.now();
         this.prune();
       } catch (error) {
-        const entry = this.entries.get(url);
-        if (entry?.element === element) {
+        if (this.entries.get(url) === entry) {
           this.entries.delete(url);
         }
         this.destroyElement(element);
         recordPerformanceCounter('media-decode-cache.warm-error', {
-          url,
+          url: describeUrl(url),
           error: error instanceof Error ? error.message : String(error),
         });
       }
     })();
 
-    this.entries.set(url, {
-      element,
-      decoded: false,
-      lastAccess: Date.now(),
-      loading,
-    });
+    entry.loading = loading;
 
     return loading;
   }
@@ -124,7 +137,9 @@ class MediaDecodeCache {
   private destroyElement(element: HTMLImageElement): void {
     element.onload = null;
     element.onerror = null;
-    element.src = '';
+    // Assigning '' would resolve against the document URL and fetch the renderer's own page as an
+    // image; removing the attribute is what actually drops the source.
+    element.removeAttribute('src');
   }
 
   private prune(): void {
@@ -140,7 +155,7 @@ class MediaDecodeCache {
       this.entries.delete(url);
       this.destroyElement(entry.element);
       recordPerformanceCounter('media-decode-cache.evicted', {
-        url,
+        url: describeUrl(url),
         cacheSize: this.entries.size,
         maxCacheEntries: MAX_DECODED_ENTRIES,
       });

--- a/services/mediaSourceCache.ts
+++ b/services/mediaSourceCache.ts
@@ -177,8 +177,15 @@ class MediaSourceCache {
     return loading;
   }
 
-  prefetch(image: IndexedImage, directoryPath?: string): void {
-    void this.getOrLoad(image, directoryPath).catch(() => {});
+  /**
+   * Synchronous lookup for callers that need to know during render whether a source is already
+   * resolved. Deliberately does not touch lastAccess: render frequency is not cache usage, and
+   * the getOrLoad that follows a render promotes the entry anyway.
+   */
+  peek(image: IndexedImage, directoryPath?: string): string | null {
+    // Entries still loading are stored with an empty url, so this also filters those out.
+    const entry = this.entries.get(this.getCacheKey(image, directoryPath));
+    return entry?.url ? entry.url : null;
   }
 
   async getRendererOwnedObjectUrl(


### PR DESCRIPTION
## Problem

Stepping between images in the viewer had a visible delay — small in milliseconds, but enough to make navigation feel clunky.

The cause is structural rather than a hot spot. When the arrow key is pressed, the `<img>` src changes to a URL Chromium has never fetched, so it still has to read the file over the `imh-media://` protocol **and** decode a 1–4 MB PNG before it can paint. That cannot happen in the same frame.

The neighbour prefetch that was meant to cover this never warmed anything. `mediaSourceCache.prefetch` → `getOrLoad` returns a **URL string** on the Electron path: a path resolution plus an `fs.access`, no bytes read, no pixels decoded. There was no `new Image()` or `.decode()` anywhere in the flow.

Two smaller problems on top of it:

- `src` was assigned twice per navigation — thumbnail first, then the full source — costing a second decode and a visible resolution pop, or an `animate-pulse` skeleton when the neighbour had no thumbnail generated yet.
- The prefetch was nested inside the current image's load `.then()` and always symmetric ±1, ignoring which way the user was actually browsing.

## Change

**`services/mediaDecodeCache.ts` (new)** — an LRU of five decoded bitmaps keyed by URL only, with no knowledge of `IndexedImage` or directories. Holding the `HTMLImageElement` is what stops Chromium from dropping the decoded copy. `warm()` dedupes in-flight decodes and never rejects; `isWarm()` is a synchronous read.

**`services/mediaSourceCache.ts`** — added a synchronous `peek()`. Removed `prefetch()`, which this change left without any call sites.

**`components/ImageModal.tsx`** — the prefetch moved out of the load promise into its own effect: two neighbours ahead in the direction of travel and one behind, serialized on `requestIdleCallback`, without `prioritize` so it never pauses the grid's background thumbnail work, and skipped while a held arrow key is scrubbing past faster than anything could be decoded.

The swap is resolved **during render** via `peek()` + `isWarm()`, so a warm source lands in the same commit as the image id change and the thumbnail step is skipped entirely. Doing this in an effect would run after paint and cost the exact frame the change exists to save. A cold source still falls back to thumbnail-then-full, so nothing regresses when the prefetch hasn't caught up.

Both `peek()` and `isWarm()` are deliberately side-effect free. They run on every render, and this modal re-renders several times per navigation — touching LRU recency there would rank entries by render frequency instead of by use, keeping images alive long after the user passed them.

The decode cache is refcounted (`retain`/`release`) because several viewer windows can be open at once, so closing one never blanks another's warmth.

## Trade-offs

- **Memory.** A 1024² PNG is ~4 MB decoded, a 2048² is ~16 MB. Five entries puts the realistic peak around 40–80 MB on a ComfyUI library, released when the last viewer closes and pruned by LRU meanwhile. If this proves too aggressive the knob is `MAX_DECODED_ENTRIES`.
- **Idle I/O and CPU.** Up to three files the user may never open get read and decoded. Bounded by waiting on the current image, skipping keyboard bursts, `requestIdleCallback`, and never using `prioritize`.
- **Coverage.** First open, a search-result click, or a long jump still take the thumbnail-first path. The gain is in sequential navigation, which is where the delay was noticeable.
- Chromium can still drop bitmaps under memory pressure, in which case the swap costs a decode again — today's behaviour, not a regression.

## Scope

Deliberately limited to the image-swap path. The render-side cleanups found while tracing this — the full file re-read per navigation for compacted metadata, the `state.images.find()` linear scans, the un-memoized `buildEffectiveMetadata` — are left out so this change's effect can be measured on its own. `window.__IMH_PERF__.printPerformanceSummary()` shows whether `modal.full-source-load` drops to ~0 on warm navigations; if latency remains after that, the render path is what's left.

## Testing

- `__tests__/mediaDecodeCache.test.ts` — 9 cases covering the LRU invariants: warmth only after the decode resolves, dedupe of concurrent warms, no new `Image` for an already-decoded URL, eviction order, `isWarm` not counting as use, in-flight decodes never evicted, failed decodes swallowed and left cold, and refcounted release.
- Existing `ImageModal` suites pass (26 tests total). Their partial `mediaSourceCache` mocks needed `peek` added; returning `null` keeps them on the cold path they already exercise.
- Manually verified in the app on a ~17.5k image ComfyUI library.
