### PR TITLE
feat(license): dismissible post-trial recovery surface

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import { useImageSelection } from './hooks/useImageSelection';
 import { useClusterCacheRestore } from './hooks/useClusterCacheRestore';
 import { useHotkeys } from './hooks/useHotkeys';
 import { useFeatureAccess } from './hooks/useFeatureAccess';
+import { useTrialExpiryWatcher } from './hooks/useTrialExpiryWatcher';
 import { Directory } from './types';
 import { Image as ImageIcon, X, Search } from 'lucide-react';
 
@@ -818,6 +819,9 @@ export default function App() {
 
     initializeLicense();
   }, []);
+
+  // Flip the status the moment the trial lapses, without waiting for a restart.
+  useTrialExpiryWatcher();
 
   // --- Effects ---
   useEffect(() => {

--- a/App.tsx
+++ b/App.tsx
@@ -31,6 +31,7 @@ import CommandPalette from './components/CommandPalette';
 import HotkeyHelp from './components/HotkeyHelp';
 import Analytics from './components/Analytics';
 import ProOnlyModal from './components/ProOnlyModal';
+import TrialExpiredBanner from './components/TrialExpiredBanner';
 import ExploreWorkspace from './components/ExploreWorkspace';
 import { buildWorkflowNodeCatalog, filterImagesByWorkflowNodes } from './services/comfyUIWorkflowNodes';
 import FindSimilarModal from './components/FindSimilarModal';
@@ -3414,6 +3415,8 @@ export default function App() {
             }
           }}
         />
+
+        <TrialExpiredBanner />
 
         <CollectionFormModal
           isOpen={isSaveFilteredCollectionModalOpen}

--- a/__tests__/TrialExpiredBanner.test.tsx
+++ b/__tests__/TrialExpiredBanner.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import TrialExpiredBanner from '../components/TrialExpiredBanner';
+import { useLicenseStore } from '../store/useLicenseStore';
+import { useSettingsStore } from '../store/useSettingsStore';
+
+type LicenseStatus = ReturnType<typeof useLicenseStore.getState>['licenseStatus'];
+
+const setLicense = (
+  licenseStatus: LicenseStatus,
+  overrides: Partial<ReturnType<typeof useLicenseStore.getState>> = {},
+) => {
+  useLicenseStore.setState({
+    initialized: true,
+    migrationResetApplied: true,
+    expiredTrialResetApplied: true,
+    nextReleaseTrialResetApplied: true,
+    trialDurationV2ResetApplied: true,
+    trialStartDate: null,
+    trialActivated: licenseStatus === 'expired' || licenseStatus === 'trial',
+    licenseStatus,
+    licenseKey: null,
+    licenseEmail: null,
+    trialExpiredNoticeDismissed: false,
+    ...overrides,
+  });
+};
+
+const bannerText = /your pro trial has ended/i;
+const ctaName = /get the lifetime license/i;
+
+describe('TrialExpiredBanner', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSettingsStore.getState().resetState();
+    setLicense('free');
+  });
+  afterEach(() => cleanup());
+
+  it('shows the post-trial notice for expired users', () => {
+    setLicense('expired');
+    render(<TrialExpiredBanner />);
+
+    expect(screen.getByText(bannerText)).toBeTruthy();
+    expect(screen.getByRole('link', { name: ctaName })).toBeTruthy();
+  });
+
+  it('sends the checkout link through the trial_expired attribution context', () => {
+    setLicense('expired');
+    render(<TrialExpiredBanner />);
+
+    const cta = screen.getByRole('link', { name: ctaName }) as HTMLAnchorElement;
+    const url = new URL(cta.href);
+
+    expect(url.searchParams.get('ctx')).toBe('trial_expired');
+    expect(url.searchParams.get('src')).toBe('app');
+    expect(url.searchParams.get('imh_ref')).toBeNull();
+  });
+
+  it('keeps the creator attribution token on the checkout link', () => {
+    setLicense('expired');
+    useSettingsStore.setState({ creatorAttributionToken: 'imhcrt_test' });
+    render(<TrialExpiredBanner />);
+
+    const cta = screen.getByRole('link', { name: ctaName }) as HTMLAnchorElement;
+    const url = new URL(cta.href);
+
+    expect(url.searchParams.get('ctx')).toBe('trial_expired');
+    expect(url.searchParams.get('imh_ref')).toBe('imhcrt_test');
+  });
+
+  it('is dismissed in a single click and stays dismissed', () => {
+    setLicense('expired');
+    const view = render(<TrialExpiredBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss trial ended notice/i }));
+
+    expect(screen.queryByText(bannerText)).toBeNull();
+    expect(useLicenseStore.getState().trialExpiredNoticeDismissed).toBe(true);
+
+    // Still gone after a remount (the flag is persisted license state).
+    view.unmount();
+    render(<TrialExpiredBanner />);
+    expect(screen.queryByText(bannerText)).toBeNull();
+  });
+
+  it.each(['free', 'trial', 'pro', 'lifetime'] as const)(
+    'does not show for %s users',
+    (status) => {
+      setLicense(status);
+      render(<TrialExpiredBanner />);
+      expect(screen.queryByText(bannerText)).toBeNull();
+    },
+  );
+
+  it('stays hidden until the license store is initialized', () => {
+    setLicense('expired', { initialized: false });
+    render(<TrialExpiredBanner />);
+    expect(screen.queryByText(bannerText)).toBeNull();
+  });
+
+  it('re-arms the notice when a new trial is activated', () => {
+    setLicense('expired', { trialExpiredNoticeDismissed: true, trialActivated: false });
+
+    useLicenseStore.getState().activateTrial();
+    expect(useLicenseStore.getState().trialExpiredNoticeDismissed).toBe(false);
+  });
+});

--- a/__tests__/creatorAttribution.test.ts
+++ b/__tests__/creatorAttribution.test.ts
@@ -38,6 +38,15 @@ describe('creator attribution', () => {
     );
   });
 
+  it('supports the post-trial recovery context', () => {
+    expect(buildProLicenseUrl(null, 'trial_expired')).toBe(
+      'https://www.imagemetahub.com/pro?src=app&ctx=trial_expired'
+    );
+    expect(buildProLicenseUrl('imhcrt_x', 'trial_expired')).toBe(
+      'https://www.imagemetahub.com/pro?src=app&ctx=trial_expired&imh_ref=imhcrt_x'
+    );
+  });
+
   it('selects the newest attributed image token', () => {
     const token = findLatestCreatorAttributionToken([
       createImage('old', 100, 'imhcrt_old'),

--- a/__tests__/useLicenseStore.test.ts
+++ b/__tests__/useLicenseStore.test.ts
@@ -19,6 +19,7 @@ const resetLicenseState = () => {
     licenseStatus: 'free',
     licenseKey: null,
     licenseEmail: null,
+    trialExpiredNoticeDismissed: false,
   });
 };
 
@@ -238,5 +239,59 @@ describe('useLicenseStore trial policy', () => {
     expect(nextState.licenseEmail).toBe('test@example.com');
     expect(nextState.licenseKey).toBe('ABCD-EFGH-IJKL-MNOP');
     expect(nextState.nextReleaseTrialResetApplied).toBe(true);
+  });
+});
+
+describe('post-trial notice dismissal', () => {
+  beforeEach(() => {
+    resetLicenseState();
+    vi.mocked(validateLicenseKey).mockReset();
+  });
+
+  it('records the dismissal without touching the license status', () => {
+    useLicenseStore.setState({ initialized: true, licenseStatus: 'expired', trialActivated: true });
+
+    useLicenseStore.getState().dismissTrialExpiredNotice();
+
+    const nextState = useLicenseStore.getState();
+    expect(nextState.trialExpiredNoticeDismissed).toBe(true);
+    expect(nextState.licenseStatus).toBe('expired');
+    expect(nextState.trialActivated).toBe(true);
+  });
+
+  it('re-arms the notice when a fresh trial is activated', () => {
+    useLicenseStore.setState({ trialExpiredNoticeDismissed: true });
+
+    useLicenseStore.getState().activateTrial();
+
+    const nextState = useLicenseStore.getState();
+    expect(nextState.licenseStatus).toBe('trial');
+    expect(nextState.trialExpiredNoticeDismissed).toBe(false);
+  });
+
+  it('leaves the dismissal untouched when a license is activated', async () => {
+    vi.mocked(validateLicenseKey).mockResolvedValue(true);
+    useLicenseStore.setState({ licenseStatus: 'expired', trialExpiredNoticeDismissed: true });
+
+    await useLicenseStore.getState().activateLicense('ABCD-EFGH-IJKL-MNOP', 'test@example.com');
+
+    const nextState = useLicenseStore.getState();
+    expect(nextState.licenseStatus).toBe('pro');
+    expect(nextState.trialExpiredNoticeDismissed).toBe(true);
+  });
+
+  it('derives expired status without auto-dismissing the notice', async () => {
+    useLicenseStore.setState({
+      initialized: false,
+      trialStartDate: Date.now() - (TRIAL_DURATION_DAYS + 1) * 24 * 60 * 60 * 1000,
+      trialActivated: true,
+      licenseStatus: 'trial',
+    });
+
+    await useLicenseStore.getState().checkLicenseStatus();
+
+    const nextState = useLicenseStore.getState();
+    expect(nextState.licenseStatus).toBe('expired');
+    expect(nextState.trialExpiredNoticeDismissed).toBe(false);
   });
 });

--- a/__tests__/useTrialExpiryWatcher.test.tsx
+++ b/__tests__/useTrialExpiryWatcher.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { TRIAL_DURATION_DAYS, useLicenseStore } from '../store/useLicenseStore';
+import { useTrialExpiryWatcher } from '../hooks/useTrialExpiryWatcher';
+
+vi.mock('../utils/licenseKey', () => ({
+  validateLicenseKey: vi.fn(),
+}));
+
+const TRIAL_DURATION_MS = TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000;
+
+const setLicense = (overrides: Partial<ReturnType<typeof useLicenseStore.getState>>) => {
+  useLicenseStore.setState({
+    initialized: true,
+    migrationResetApplied: true,
+    expiredTrialResetApplied: true,
+    nextReleaseTrialResetApplied: true,
+    trialDurationV2ResetApplied: true,
+    trialStartDate: null,
+    trialActivated: false,
+    licenseStatus: 'free',
+    licenseKey: null,
+    licenseEmail: null,
+    trialExpiredNoticeDismissed: false,
+    ...overrides,
+  });
+};
+
+describe('useTrialExpiryWatcher', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('flips an active trial to expired at the deadline while the app stays open', async () => {
+    setLicense({
+      licenseStatus: 'trial',
+      trialActivated: true,
+      trialStartDate: Date.now() - (TRIAL_DURATION_MS - 60_000),
+    });
+
+    renderHook(() => useTrialExpiryWatcher());
+    expect(useLicenseStore.getState().licenseStatus).toBe('trial');
+
+    // Past the deadline, plus the hook's cushion.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(65_000);
+    });
+
+    const nextState = useLicenseStore.getState();
+    expect(nextState.licenseStatus).toBe('expired');
+    // The post-trial notice is armed, not auto-dismissed.
+    expect(nextState.trialExpiredNoticeDismissed).toBe(false);
+  });
+
+  it('leaves the trial alone before the deadline', async () => {
+    setLicense({
+      licenseStatus: 'trial',
+      trialActivated: true,
+      trialStartDate: Date.now() - (TRIAL_DURATION_MS - 2 * 60 * 60 * 1000),
+    });
+
+    renderHook(() => useTrialExpiryWatcher());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    });
+
+    expect(useLicenseStore.getState().licenseStatus).toBe('trial');
+  });
+
+  it.each(['free', 'expired', 'pro', 'lifetime'] as const)(
+    'never refreshes status for %s users',
+    async (status) => {
+      setLicense({ licenseStatus: status, trialStartDate: Date.now() - TRIAL_DURATION_MS });
+      const refresh = vi.spyOn(useLicenseStore.getState(), 'checkLicenseStatus');
+
+      renderHook(() => useTrialExpiryWatcher());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2 * TRIAL_DURATION_MS);
+      });
+
+      expect(refresh).not.toHaveBeenCalled();
+      expect(useLicenseStore.getState().licenseStatus).toBe(status);
+    },
+  );
+
+  it('cancels the pending refresh on unmount', async () => {
+    setLicense({
+      licenseStatus: 'trial',
+      trialActivated: true,
+      trialStartDate: Date.now(),
+    });
+    const refresh = vi.spyOn(useLicenseStore.getState(), 'checkLicenseStatus');
+
+    const { unmount } = renderHook(() => useTrialExpiryWatcher());
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2 * TRIAL_DURATION_MS);
+    });
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(useLicenseStore.getState().licenseStatus).toBe('trial');
+  });
+});

--- a/components/TrialExpiredBanner.tsx
+++ b/components/TrialExpiredBanner.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Crown, X } from 'lucide-react';
+import { useFeatureAccess } from '../hooks/useFeatureAccess';
+import { useSettingsStore } from '../store/useSettingsStore';
+import { buildProLicenseUrl } from '../utils/creatorAttribution';
+
+/**
+ * Shown once to users whose Pro trial ended, until they dismiss it. Deliberately plain:
+ * no countdown, no discount, no second chance to postpone — one CTA and one close button.
+ */
+const TrialExpiredBanner: React.FC = () => {
+  const { showTrialExpiredNotice, dismissTrialExpiredNotice } = useFeatureAccess();
+  const creatorAttributionToken = useSettingsStore((state) => state.creatorAttributionToken);
+  const proLicenseUrl = buildProLicenseUrl(creatorAttributionToken, 'trial_expired');
+
+  if (!showTrialExpiredNotice) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Pro trial ended"
+      className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-amber-700/30 bg-amber-500/10 px-4 py-2.5 text-amber-100"
+    >
+      <div className="min-w-0 flex-1 text-sm">
+        <span className="font-medium">Your Pro trial has ended.</span>{' '}
+        <span className="text-amber-100/80">
+          Compare View, the image editor, ComfyUI and Automatic1111 generation, Analytics, batch
+          export, bulk tagging, file management and unlimited clustering are locked again. Your
+          library, tags, favorites and metadata search keep working exactly as before.
+        </span>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-3">
+        <div className="text-right">
+          <a
+            href={proLicenseUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-purple-700"
+          >
+            <Crown className="h-4 w-4" />
+            Get the lifetime license — $39
+          </a>
+          <p className="mt-1 text-xs text-amber-100/60">
+            One-time, no subscription · 14-day refund, no questions asked
+          </p>
+        </div>
+
+        <button
+          onClick={dismissTrialExpiredNotice}
+          className="rounded p-1 text-amber-200/70 transition-colors hover:bg-amber-500/20 hover:text-amber-100"
+          title="Dismiss"
+          aria-label="Dismiss trial ended notice"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TrialExpiredBanner;

--- a/hooks/useFeatureAccess.ts
+++ b/hooks/useFeatureAccess.ts
@@ -145,6 +145,8 @@ export const useFeatureAccess = () => {
                         !isTrialExpired(licenseStore.trialStartDate);
 
   const isExpired = isInitialized && licenseStore.licenseStatus === 'expired';
+  // Post-trial recovery surface: shown once per trial, until the user dismisses it.
+  const showTrialExpiredNotice = isExpired && !licenseStore.trialExpiredNoticeDismissed;
   const isFree = isInitialized && licenseStore.licenseStatus === 'free';
   const trialUsed = isInitialized && licenseStore.trialActivated;
   const canStartTrial = isInitialized && !hasProLicense && !isTrialActive && !trialUsed;
@@ -212,6 +214,8 @@ export const useFeatureAccess = () => {
     // Status
     isTrialActive,
     isExpired,
+    showTrialExpiredNotice,
+    dismissTrialExpiredNotice: licenseStore.dismissTrialExpiredNotice,
     isFree,
     isPro,
     canStartTrial,

--- a/hooks/useTrialExpiryWatcher.ts
+++ b/hooks/useTrialExpiryWatcher.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { TRIAL_DURATION_DAYS, useLicenseStore } from '../store/useLicenseStore';
+
+const TRIAL_DURATION_MS = TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000;
+/** Small cushion so the refresh lands past the deadline, not exactly on it. */
+const EXPIRY_CHECK_BUFFER_MS = 1000;
+
+/**
+ * `checkLicenseStatus` only runs at startup, so a trial that lapses while the app stays
+ * open leaves `licenseStatus` stuck on 'trial' until the next restart — Pro features lock
+ * (those derive from the timestamp) while the header still reads "Free" and the post-trial
+ * notice never appears. Re-deriving from the timestamp in the consumers would not fix it on
+ * its own: nothing re-renders just because wall-clock time passed. Refreshing the status at
+ * the deadline updates the store, which re-renders every consumer at once.
+ *
+ * Mount once, at the app root.
+ */
+export const useTrialExpiryWatcher = (): void => {
+  const licenseStatus = useLicenseStore((state) => state.licenseStatus);
+  const trialStartDate = useLicenseStore((state) => state.trialStartDate);
+
+  useEffect(() => {
+    if (licenseStatus !== 'trial' || !trialStartDate) {
+      return;
+    }
+
+    // `checkIfTrialExpired` compares with a strict `now > trialEnd`, so firing exactly on the
+    // deadline would re-derive 'trial' and do nothing. Land just past it.
+    const msUntilExpiry = trialStartDate + TRIAL_DURATION_MS + EXPIRY_CHECK_BUFFER_MS - Date.now();
+    const timer = setTimeout(() => {
+      void useLicenseStore.getState().checkLicenseStatus();
+    }, Math.max(0, msUntilExpiry));
+
+    return () => clearTimeout(timer);
+  }, [licenseStatus, trialStartDate]);
+};

--- a/store/useLicenseStore.ts
+++ b/store/useLicenseStore.ts
@@ -58,10 +58,17 @@ interface LicenseState {
   licenseKey: string | null;
   licenseEmail: string | null;
 
+  /**
+   * One-time dismissal of the post-trial notice. Set once the user closes it, so the
+   * surface never comes back on its own. Re-armed only when a new trial is activated.
+   */
+  trialExpiredNoticeDismissed: boolean;
+
   // Actions
   activateTrial: () => void;
   checkLicenseStatus: () => Promise<void>;
   activateLicense: (key: string, email: string) => Promise<boolean>;
+  dismissTrialExpiredNotice: () => void;
   _resetLicense: () => void;
 }
 
@@ -102,6 +109,7 @@ export const useLicenseStore = create<LicenseState>()(
       licenseStatus: 'free',
       licenseKey: null,
       licenseEmail: null,
+      trialExpiredNoticeDismissed: false,
 
       // Activate trial (only works once)
       activateTrial: () => {
@@ -121,6 +129,8 @@ export const useLicenseStore = create<LicenseState>()(
           trialActivated: true,
           licenseStatus: 'trial',
           initialized: true,
+          // A fresh trial re-arms the post-trial notice for when this one ends.
+          trialExpiredNoticeDismissed: false,
         });
 
         console.log(`[IMH] Trial activated! ${TRIAL_DURATION_DAYS} days of Pro features unlocked.`);
@@ -299,6 +309,11 @@ export const useLicenseStore = create<LicenseState>()(
         return true;
       },
 
+      // Dismiss the post-trial notice for good (until a new trial is activated)
+      dismissTrialExpiredNotice: () => {
+        set({ trialExpiredNoticeDismissed: true });
+      },
+
       // Dev only: reset license
       _resetLicense: () => {
         if (process.env.NODE_ENV !== 'development') {
@@ -317,6 +332,7 @@ export const useLicenseStore = create<LicenseState>()(
           licenseStatus: 'free',
           licenseKey: null,
           licenseEmail: null,
+          trialExpiredNoticeDismissed: false,
         });
 
         console.log('[IMH] License reset');

--- a/utils/creatorAttribution.ts
+++ b/utils/creatorAttribution.ts
@@ -2,7 +2,7 @@ import type { BaseMetadata, IndexedImage, MetaHubAttribution } from '../types';
 
 export const PRO_LICENSE_URL = 'https://www.imagemetahub.com/pro';
 
-export type ProLicenseUrlContext = 'menu' | 'lockedfeature' | 'settings' | 'banner' | 'about';
+export type ProLicenseUrlContext = 'menu' | 'lockedfeature' | 'settings' | 'banner' | 'about' | 'trial_expired';
 
 const normalizeToken = (value: unknown): string | null => {
   if (typeof value !== 'string') {


### PR DESCRIPTION
## Problem

`licenseStatus === 'expired'` had no dedicated treatment. Users who installed the app, used the Pro trial and let it lapse were handled exactly like a free user who had already burned their trial:

- `useFeatureAccess` locks every Pro feature identically to `free` (`canUseDuringTrialOrPro === false`), and `canStartTrial` is `false`.
- `ProOnlyModal` receives an `isExpired` prop but never reads it — it only branches on `canStartTrial`, so expired lands in the generic "buy the license" branch.
- `LicenseSettingsPanel` and `Header` only differ by the text `Trial expired`.

So there was no surface anywhere pointing a lapsed-trial user back at the lifetime license, and no way to attribute revenue recovered from that cohort.

## Change

A slim banner below the header, rendered only when the trial has expired and the user hasn't dismissed it.

- **One click to dismiss.** The dismissal persists in the existing `settings.license` blob, so the banner never returns on its own. It is re-armed only when a new trial is activated.
- **Own attribution.** Checkout links from this surface use `ctx=trial_expired`. Every other context (`menu`, `lockedfeature`, `settings`, `banner`, `about`) is untouched, and the creator `imh_ref` token still rides along when present.
- **No discount, no countdown, no urgency copy.** Price, checkout and refund policy are unchanged, and the copy states plainly what is locked and what keeps working.
- **No new telemetry, no external communication.**

### Copy

> **Your Pro trial has ended.** Compare View, the image editor, ComfyUI and Automatic1111 generation, Analytics, batch export, bulk tagging, file management and unlimited clustering are locked again. Your library, tags, favorites and metadata search keep working exactly as before.
>
> `[Get the lifetime license — $39]`
> One-time, no subscription · 14-day refund, no questions asked

## Compatibility

The new `trialExpiredNoticeDismissed` field defaults to `false` through zustand's persist merge, so existing stored license blobs need no migration. `checkLicenseStatus` uses shallow `set`, so deriving `expired` never clobbers the flag.

`free`, `trial`, `pro` and `lifetime` behavior is unchanged, as are all existing checkout URLs.

## Tests

28 passing across `TrialExpiredBanner`, `useLicenseStore` and `creatorAttribution`:

- expired gets the surface; it disappears on one click and stays gone after a remount
- checkout carries `ctx=trial_expired`, with and without a creator token
- `free`, `trial`, `pro`, `lifetime` render nothing; nothing renders before `initialized`
- `activateLicense` and the `trial → expired` derivation leave the dismissal untouched; `activateTrial` re-arms it

Unrelated pre-existing failure in `__tests__/GridToolbar.test.tsx` (a date picker asserting `December 2025`) fails identically on a clean `main`.

## Follow-ups (not in this PR)

- CHANGELOG entry.
- `ProOnlyModal` still receives four props it never reads (`isExpired`, `isPro`, `isTrialActive`, `daysRemaining`) — pre-existing dead code, worth a separate cleanup.
