### PR TITLE
Simplify Viewer settings copy

### DIFF
--- a/components/settings/ViewerSettingsPanel.tsx
+++ b/components/settings/ViewerSettingsPanel.tsx
@@ -36,26 +36,31 @@ export const ViewerSettingsPanel: React.FC = () => {
   const setSlideshowShowFilename = useSettingsStore((state) => state.setSlideshowShowFilename);
 
   return (
-    <SettingsPanel title="Viewer" description="Control what appears in the library and how images open.">
+    <SettingsPanel title="Viewer">
       <SettingsSectionCard title="Behavior">
         <SettingRow
-          label="Show filenames"
-          description="Display the image filename under thumbnails."
+          label="Show filenames on grid"
           control={<SettingSwitch checked={showFilenames} onChange={setShowFilenames} />}
         />
         <SettingRow
           label="Show full path"
-          description="Show folder path context instead of only the filename."
-          control={<SettingSwitch checked={showFullFilePath} onChange={setShowFullFilePath} />}
+          className={!showFilenames ? 'opacity-50' : ''}
+          control={
+            <input
+              type="checkbox"
+              checked={showFullFilePath}
+              disabled={!showFilenames}
+              onChange={(event) => setShowFullFilePath(event.target.checked)}
+              className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed"
+            />
+          }
         />
         <SettingRow
           label="Double-click to open"
-          description="Keep single click for selection and open details on double click."
           control={<SettingSwitch checked={doubleClickToOpen} onChange={setDoubleClickToOpen} />}
         />
         <SettingRow
           label="Skip delete confirmation"
-          description="Bypass the confirmation dialog when deleting files to the trash."
           control={<SettingSwitch checked={skipDeleteConfirmation} onChange={setSkipDeleteConfirmation} />}
         />
       </SettingsSectionCard>
@@ -63,15 +68,13 @@ export const ViewerSettingsPanel: React.FC = () => {
       <SettingsSectionCard title="Playback">
         <SettingRow
           label="Auto-play video and audio"
-          description="Start playback automatically when a video or audio file opens. When off, press Play to start."
           control={<SettingSwitch checked={autoPlayMedia} onChange={setAutoPlayMedia} />}
         />
       </SettingsSectionCard>
 
       <SettingsSectionCard title="Slideshow">
         <SettingRow
-          label="Default interval"
-          description={`Seconds between slides. Range ${MIN_SLIDESHOW_INTERVAL_SECONDS}-${MAX_SLIDESHOW_INTERVAL_SECONDS}.`}
+          label="Default interval (seconds)"
           control={
             <input
               type="number"


### PR DESCRIPTION
## What changed

- Removed redundant explanatory copy from the Viewer settings.
- Clarified that filename visibility applies to the grid.
- Changed **Show full path** to a checkbox that is disabled when grid filenames are hidden.
- Added the unit directly to **Default interval (seconds)**.

## Why

The labels already communicate the behavior, while the repeated descriptions added unnecessary visual noise. The full-path option only has an effect when filenames are visible, so the UI now expresses that dependency directly.

## Impact

Viewer settings are more concise and the relationship between filename visibility and full-path display is clear.

## Validation

- `git diff --check`
- Reviewed the staged diff and committed only `components/settings/ViewerSettingsPanel.tsx`
- No build or automated tests run; this is a scoped settings copy/control-state change.