### PR TITLE
fix: stop dating files on network shares to 1969

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Native Image Viewer Windows**: Images now open in separate native desktop windows with an optional always-on-top toggle and drag-and-drop support. Settings → Viewer → Behavior can restore the legacy in-app viewer. Generating with A1111 or ComfyUI from a separate window queues the job in the main window, so it runs normally, and dragging a file out of a viewer window no longer risks moving the wrong image if you later drop an unrelated file onto a folder.
 
+### Fixed
+
+- **Dates on Network Shares (SMB/CIFS)**: Fixed every image on an SMB/CIFS share being dated December 31, 1969, which collapsed date grouping into a single group and made sorting by newest or oldest meaningless. These mounts report no creation time, and MetaHub was storing that missing value as a date instead of falling back to the file's modification time. Sorting, date grouping, session grouping and the date shown in the viewer now use the modification time whenever a creation time isn't available. Folders already indexed are corrected on load — no reindex needed — though the affected thumbnails are regenerated once.
+
 ## [0.18.1] - 2026-08-01
 
 ### Added

--- a/__tests__/fileTimestamps.test.ts
+++ b/__tests__/fileTimestamps.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { isUsableTimestamp, normalizeBirthtimeMs, resolveFileSortDate } from '../utils/fileTimestamps.js';
+import { healCachedSortDate, type CacheImageMetadata } from '../services/cacheManager';
+
+const MTIME = 1_754_900_000_000;
+const BIRTHTIME = 1_754_800_000_000;
+
+const makeEntry = (overrides: Partial<CacheImageMetadata>): CacheImageMetadata => ({
+  id: 'root::a.png',
+  name: 'a.png',
+  metadataString: '',
+  metadata: {},
+  lastModified: MTIME,
+  models: [],
+  loras: [],
+  scheduler: '',
+  ...overrides,
+});
+
+describe('isUsableTimestamp', () => {
+  it('rejects the zero birth time SMB/CIFS shares report', () => {
+    expect(isUsableTimestamp(0)).toBe(false);
+  });
+
+  it('rejects negative, non-finite and non-numeric values', () => {
+    expect(isUsableTimestamp(-1)).toBe(false);
+    expect(isUsableTimestamp(NaN)).toBe(false);
+    expect(isUsableTimestamp(Infinity)).toBe(false);
+    expect(isUsableTimestamp(undefined)).toBe(false);
+    expect(isUsableTimestamp(null)).toBe(false);
+    expect(isUsableTimestamp('123')).toBe(false);
+  });
+
+  it('accepts a real timestamp', () => {
+    expect(isUsableTimestamp(MTIME)).toBe(true);
+  });
+});
+
+describe('normalizeBirthtimeMs', () => {
+  it('turns an unavailable birth time into undefined so ?? fallbacks trigger', () => {
+    expect(normalizeBirthtimeMs(0)).toBeUndefined();
+    expect(normalizeBirthtimeMs(undefined)).toBeUndefined();
+    expect(normalizeBirthtimeMs(0) ?? MTIME).toBe(MTIME);
+  });
+
+  it('keeps a real birth time', () => {
+    expect(normalizeBirthtimeMs(BIRTHTIME)).toBe(BIRTHTIME);
+  });
+});
+
+describe('resolveFileSortDate', () => {
+  it('prefers the birth time when the filesystem reports one', () => {
+    expect(resolveFileSortDate(BIRTHTIME, MTIME)).toBe(BIRTHTIME);
+  });
+
+  it('falls back to the modification time when the birth time is zero', () => {
+    expect(resolveFileSortDate(0, MTIME)).toBe(MTIME);
+  });
+
+  it('falls back to the explicit fallback before giving up on the clock', () => {
+    expect(resolveFileSortDate(0, 0, MTIME)).toBe(MTIME);
+  });
+
+  it('never returns an epoch-zero date', () => {
+    const resolved = resolveFileSortDate(0, 0, 0);
+    expect(resolved).toBeGreaterThan(0);
+  });
+});
+
+describe('healCachedSortDate', () => {
+  it('repairs entries cached with the epoch-zero birth time', () => {
+    const healed = healCachedSortDate(makeEntry({ lastModified: 0, contentModifiedMs: MTIME }));
+    expect(healed.lastModified).toBe(MTIME);
+    expect(new Date(healed.lastModified).getUTCFullYear()).toBe(2025);
+  });
+
+  it('leaves healthy entries untouched, without reallocating them', () => {
+    const entry = makeEntry({ lastModified: BIRTHTIME, contentModifiedMs: MTIME });
+    expect(healCachedSortDate(entry)).toBe(entry);
+  });
+
+  it('leaves the entry alone when there is no modification time to fall back to', () => {
+    const entry = makeEntry({ lastModified: 0 });
+    expect(healCachedSortDate(entry)).toBe(entry);
+  });
+});

--- a/electron.mjs
+++ b/electron.mjs
@@ -27,6 +27,7 @@ import {
   isModel3DFileName,
   isSupportedMediaFileName,
 } from './utils/mediaTypes.js';
+import { normalizeBirthtimeMs, resolveFileSortDate } from './utils/fileTimestamps.js';
 import {
   isComfyUIViewUrlAllowed,
   normalizeComfyUIViewUrl,
@@ -2997,13 +2998,14 @@ async function statMediaEntries(directory, entries, baseDirectory) {
     const lowerName = entry.name.toLowerCase();
     const fullPath = path.join(directory, entry.name);
     const stats = await fs.stat(fullPath);
+    const birthtimeMs = normalizeBirthtimeMs(stats.birthtimeMs);
     return {
       name: path.relative(baseDirectory, fullPath).replace(/\\/g, '/'),
-      lastModified: stats.birthtimeMs ?? stats.mtimeMs,
+      lastModified: resolveFileSortDate(birthtimeMs, stats.mtimeMs),
       contentModifiedMs: stats.mtimeMs,
       size: stats.size,
       type: getMimeTypeFromName(lowerName),
-      birthtimeMs: stats.birthtimeMs,
+      birthtimeMs,
     };
   });
 

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -9,6 +9,7 @@ import { createCacheDebugSnapshot, isCacheDebugEnabled, traceCacheDebug } from '
 import { areFilesystemPathsEqual } from '../utils/filesystemPath';
 import { waitForDirectoryActivityToSettle } from '../utils/directoryActivity';
 import { inferMimeTypeFromName, isImageFileName } from '../utils/mediaTypes.js';
+import { normalizeBirthtimeMs } from '../utils/fileTimestamps.js';
 
 // Configure logging level
 const DEBUG = false;
@@ -581,7 +582,7 @@ export function useImageLoader() {
             allCurrentFiles.map(file => [file.name, {
                 size: file.size,
                 type: file.type,
-                birthtimeMs: file.birthtimeMs ?? file.lastModified,
+                birthtimeMs: normalizeBirthtimeMs(file.birthtimeMs ?? file.lastModified),
                 contentModifiedMs: file.contentModifiedMs ?? file.lastModified,
             }])
         );
@@ -654,7 +655,7 @@ export function useImageLoader() {
                             ...file,
                             size: fileStatsMap.get(file.name)?.size ?? file.size,
                             type: fileStatsMap.get(file.name)?.type ?? file.type,
-                            birthtimeMs: fileStatsMap.get(file.name)?.birthtimeMs ?? file.birthtimeMs ?? file.lastModified,
+                            birthtimeMs: normalizeBirthtimeMs(fileStatsMap.get(file.name)?.birthtimeMs ?? file.birthtimeMs ?? file.lastModified),
                             contentModifiedMs: fileStatsMap.get(file.name)?.contentModifiedMs ?? file.contentModifiedMs ?? file.lastModified,
                         }))
                     : [];
@@ -768,7 +769,7 @@ export function useImageLoader() {
                         ...file,
                         size: fileStatsMap.get(file.name)?.size ?? file.size,
                         type: fileStatsMap.get(file.name)?.type ?? file.type,
-                        birthtimeMs: fileStatsMap.get(file.name)?.birthtimeMs ?? file.birthtimeMs ?? file.lastModified,
+                        birthtimeMs: normalizeBirthtimeMs(fileStatsMap.get(file.name)?.birthtimeMs ?? file.birthtimeMs ?? file.lastModified),
                         contentModifiedMs: fileStatsMap.get(file.name)?.contentModifiedMs ?? file.contentModifiedMs ?? file.lastModified,
                     }))
                 : [];
@@ -1152,7 +1153,7 @@ export function useImageLoader() {
                 allCurrentFiles.map(file => [file.name, {
                     size: file.size,
                     type: file.type,
-                    birthtimeMs: file.birthtimeMs ?? file.lastModified,
+                    birthtimeMs: normalizeBirthtimeMs(file.birthtimeMs ?? file.lastModified),
                     contentModifiedMs: file.contentModifiedMs ?? file.lastModified,
                 }])
             );
@@ -1273,7 +1274,7 @@ export function useImageLoader() {
                 ...file,
                 size: fileStatsMap.get(file.name)?.size ?? file.size,
                 type: fileStatsMap.get(file.name)?.type ?? file.type,
-                birthtimeMs: fileStatsMap.get(file.name)?.birthtimeMs ?? file.birthtimeMs ?? file.lastModified,
+                birthtimeMs: normalizeBirthtimeMs(fileStatsMap.get(file.name)?.birthtimeMs ?? file.birthtimeMs ?? file.lastModified),
                 contentModifiedMs: fileStatsMap.get(file.name)?.contentModifiedMs ?? file.contentModifiedMs ?? file.lastModified,
             }));
 
@@ -1828,7 +1829,7 @@ export function useImageLoader() {
                 contentModifiedMs: file.contentModifiedMs ?? file.lastModified,
                 size: file.size,
                 type: file.normalizedType,
-                birthtimeMs: file.lastModified
+                birthtimeMs: normalizeBirthtimeMs(file.lastModified)
             }));
 
             // Criar file stats map
@@ -1836,7 +1837,7 @@ export function useImageLoader() {
                 newFiles.map(f => [f.relativePath || f.normalizedName, {
                     size: f.size,
                     type: f.normalizedType,
-                    birthtimeMs: f.lastModified,
+                    birthtimeMs: normalizeBirthtimeMs(f.lastModified),
                     contentModifiedMs: f.contentModifiedMs ?? f.lastModified,
                 }])
             );

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -5,6 +5,7 @@ import {
   type ThumbnailCacheResolveResult,
   type ThumbnailGenerateToCacheRequest,
 } from '../types';
+import { isUsableTimestamp } from '../utils/fileTimestamps.js';
 
 /**
  * Parser version - increment when parser logic changes significantly
@@ -159,7 +160,21 @@ const warnParserVersionMismatch = (cacheId: string, parserVersion: number | unde
   );
 };
 
-function compactCacheMetadataEntry(entry: CacheImageMetadata): CacheImageMetadata {
+/**
+ * Repairs entries indexed before birth times of 0 were rejected (SMB/CIFS shares
+ * report one, which dated every image 1970-01-01 UTC). The cache diff only looks
+ * at contentModifiedMs, which stayed correct, so these entries would never be
+ * reindexed on their own.
+ */
+export function healCachedSortDate(entry: CacheImageMetadata): CacheImageMetadata {
+  if (isUsableTimestamp(entry.lastModified) || !isUsableTimestamp(entry.contentModifiedMs)) {
+    return entry;
+  }
+  return { ...entry, lastModified: entry.contentModifiedMs as number };
+}
+
+function compactCacheMetadataEntry(rawEntry: CacheImageMetadata): CacheImageMetadata {
+  const entry = healCachedSortDate(rawEntry);
   const metadataString = typeof entry.metadataString === 'string' ? entry.metadataString : '';
   if (metadataString.length <= MAX_INLINE_RAW_METADATA_BYTES) {
     return entry;

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -12,6 +12,7 @@ import { parseA1111Metadata } from './parsers/automatic1111Parser';
 import { parseSwarmUIMetadata } from './parsers/swarmUIParser';
 import { traceCacheDebug } from '../utils/cacheDebugTrace';
 import { buildSupportedMediaRegex, getFileExtension, inferMimeTypeFromName, isAudioFileName, isModel3DFileName, isVideoFileName } from '../utils/mediaTypes.js';
+import { normalizeBirthtimeMs, resolveFileSortDate } from '../utils/fileTimestamps.js';
 import { getAvifDimensions, isAvifBuffer, parseAvifMetadata } from '../utils/avifMetadata.mjs';
 import { applyImageMetaHubAvifExtension } from '../utils/imageMetaHubAvifExtension.mjs';
 
@@ -1946,7 +1947,11 @@ if (normalizedMetadata && isModel3D) {
     const workflowNodes = extractWorkflowNodeTypesFromMetadata(rawMetadata);
 
     // Determine the best date for sorting (generation date vs file date)
-    const sortDate = fileEntry.birthtimeMs ?? fileEntry.lastModified ?? Date.now();
+    const sortDate = resolveFileSortDate(
+      fileEntry.birthtimeMs,
+      fileEntry.contentModifiedMs,
+      fileEntry.lastModified
+    );
 
     if (profile) {
       profile.totalMs = performance.now() - totalStart;
@@ -2040,7 +2045,7 @@ export async function reparseIndexedImage(
       : (image.contentModifiedMs ?? image.lastModified),
     size: typeof stats?.size === 'number' ? stats.size : image.fileSize,
     type: image.fileType ?? inferMimeTypeFromName(image.name),
-    birthtimeMs: typeof stats?.birthtimeMs === 'number' ? stats.birthtimeMs : undefined,
+    birthtimeMs: normalizeBirthtimeMs(stats?.birthtimeMs),
   };
 
   return processSingleFileOptimized(
@@ -2104,7 +2109,7 @@ export async function indexImageFileAtPath(
     contentModifiedMs: typeof stats?.mtimeMs === 'number' ? stats.mtimeMs : undefined,
     size: typeof stats?.size === 'number' ? stats.size : fileData.byteLength,
     type: inferMimeTypeFromName(fileName),
-    birthtimeMs: typeof stats?.birthtimeMs === 'number' ? stats.birthtimeMs : undefined,
+    birthtimeMs: normalizeBirthtimeMs(stats?.birthtimeMs),
   };
 
   const indexed = await processSingleFileOptimized(fileEntry, directory.id, fileData);
@@ -2603,7 +2608,11 @@ export async function processFiles(
     const stat = statsLookup.get(entry.path);
     const fileSize = entry.size ?? stat?.size;
     const inferredType = resolveCatalogMimeType(entry.handle.name, entry.type, stat?.type);
-    const sortDate = entry.birthtimeMs ?? stat?.birthtimeMs ?? entry.lastModified;
+    const sortDate = resolveFileSortDate(
+      normalizeBirthtimeMs(entry.birthtimeMs) ?? normalizeBirthtimeMs(stat?.birthtimeMs),
+      entry.contentModifiedMs,
+      entry.lastModified
+    );
     const catalogMetadata = {
       phase: 'catalog',
       fileSize,

--- a/services/fileWatcher.mjs
+++ b/services/fileWatcher.mjs
@@ -2,6 +2,7 @@ import chokidar from 'chokidar';
 import path from 'path';
 import fs from 'fs';
 import { SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
+import { normalizeBirthtimeMs, resolveFileSortDate } from '../utils/fileTimestamps.js';
 
 // Active watchers: directoryId -> watcher instance
 const activeWatchers = new Map();
@@ -349,7 +350,7 @@ function processBatch(directoryId, dirPath, mainWindow) {
       return {
         name: path.basename(filePath),
         path: filePath,
-        lastModified: stats.birthtimeMs ?? stats.mtimeMs,
+        lastModified: resolveFileSortDate(normalizeBirthtimeMs(stats.birthtimeMs), stats.mtimeMs),
         contentModifiedMs: stats.mtimeMs,
         size: stats.size,
         type: path.extname(filePath).slice(1),

--- a/services/fileWatcher.ts
+++ b/services/fileWatcher.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { BrowserWindow } from 'electron';
 import fs from 'fs';
 import { SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
+import { normalizeBirthtimeMs, resolveFileSortDate } from '../utils/fileTimestamps.js';
 
 // Active watchers: directoryId -> watcher instance
 const activeWatchers = new Map<string, FSWatcher>();
@@ -193,7 +194,7 @@ function processBatch(
       return {
         name: path.basename(filePath),
         path: filePath,
-        lastModified: stats.birthtimeMs ?? stats.mtimeMs,
+        lastModified: resolveFileSortDate(normalizeBirthtimeMs(stats.birthtimeMs), stats.mtimeMs),
         contentModifiedMs: stats.mtimeMs,
         size: stats.size,
         type: path.extname(filePath).slice(1)

--- a/utils/fileTimestamps.js
+++ b/utils/fileTimestamps.js
@@ -1,0 +1,33 @@
+/**
+ * Filesystem timestamp helpers shared by the Electron main process and the renderer.
+ *
+ * Some filesystems have no birth time to report and hand back 0 instead of
+ * omitting it — SMB/CIFS mounts on Linux are the common case. A plain
+ * `birthtimeMs ?? mtimeMs` fallback keeps that 0, because `??` only reacts to
+ * null/undefined, and every affected file ends up dated 1970-01-01 UTC
+ * (December 31, 1969 in negative offsets). Treat a non-positive or
+ * non-finite timestamp as "not available" instead.
+ */
+
+export function isUsableTimestamp(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Normalizes a raw `stats.birthtimeMs` into either a usable timestamp or
+ * `undefined`, so downstream `??` fallbacks behave as intended.
+ */
+export function normalizeBirthtimeMs(value) {
+  return isUsableTimestamp(value) ? value : undefined;
+}
+
+/**
+ * Resolves the date used for sorting, date grouping and session grouping:
+ * birth time when the filesystem reports one, modification time otherwise.
+ */
+export function resolveFileSortDate(birthtimeMs, modifiedMs, fallbackMs) {
+  if (isUsableTimestamp(birthtimeMs)) return birthtimeMs;
+  if (isUsableTimestamp(modifiedMs)) return modifiedMs;
+  if (isUsableTimestamp(fallbackMs)) return fallbackMs;
+  return Date.now();
+}


### PR DESCRIPTION
SMB/CIFS mounts report no birth time and hand back 0 instead of omitting it. The scanner used `stats.birthtimeMs ?? stats.mtimeMs`, and `??` only reacts to null/undefined, so the 0 survived and every image on the share landed on 1970-01-01 UTC — December 31, 1969 in negative offsets. Date grouping collapsed into one group and sorting by newest/oldest became meaningless.

Treat a non-positive or non-finite timestamp as "not available" through a shared helper, and normalize birthtimeMs at the source so the existing `??` fallbacks downstream behave as intended. Covers the directory scan, the file watcher, the indexing pipeline, the catalog stub and reparse — reparse previously re-read the zero and rewrote 1969, leaving the user with no way out.

Folders already indexed are repaired on cache read: the diff only compares contentModifiedMs, which stayed correct, so those entries would never be reindexed on their own. Healthy entries return by identity, so the read path keeps its allocation-free fast path.

Fixes #513