### PR TITLE
Fix ComfyUI EXIF attribution when parameters are present

### DIFF
--- a/__tests__/fileIndexer.comfyui-exif-priority.test.ts
+++ b/__tests__/fileIndexer.comfyui-exif-priority.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { extractComfyUIExifGraphMetadata } from '../services/fileIndexer';
+import { parseImageMetadata } from '../services/parsers/metadataParserFactory';
+
+describe('ComfyUI EXIF graph priority (issue #502)', () => {
+  it('recognizes workflow/prompt EXIF tags before A1111-compatible parameters', async () => {
+    const graph = extractComfyUIExifGraphMetadata({
+      Make: `workflow:${JSON.stringify({ nodes: [] })}`,
+      Model: `prompt:${JSON.stringify({
+        '1': {
+          class_type: 'CLIPTextEncode',
+          inputs: { text: 'canonical ComfyUI prompt' },
+        },
+      })}`,
+      UserComment: 'wrong prompt\nSteps: 1, Sampler: wrong, Seed: 1',
+    });
+
+    expect(graph).toEqual({
+      workflow: { nodes: [] },
+      prompt: {
+        '1': {
+          class_type: 'CLIPTextEncode',
+          inputs: { text: 'canonical ComfyUI prompt' },
+        },
+      },
+    });
+
+    const result = await parseImageMetadata({
+      ...graph,
+      parameters: 'wrong prompt\nSteps: 1, Sampler: wrong, Seed: 1',
+    } as any);
+
+    expect(result?.generator).toBe('ComfyUI');
+  });
+
+  it('does not treat ordinary camera make/model values as ComfyUI graphs', () => {
+    expect(extractComfyUIExifGraphMetadata({
+      Make: 'Canon',
+      Model: 'EOS R5',
+    })).toBeNull();
+  });
+});

--- a/packages/metadata-engine/src/parsers/index.test.ts
+++ b/packages/metadata-engine/src/parsers/index.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getMetadataParser } from './index';
+
+describe('metadata-engine ComfyUI detection (issue #502)', () => {
+  it('prefers a valid ComfyUI graph over A1111-compatible parameters', () => {
+    const parser = getMetadataParser({
+      workflow: { nodes: [] },
+      prompt: {
+        '1': {
+          class_type: 'CLIPTextEncode',
+          inputs: { text: 'canonical ComfyUI prompt' },
+        },
+      },
+      parameters: 'wrong prompt\nSteps: 1, Sampler: wrong, Seed: 1',
+    });
+
+    expect(parser?.generator).toBe('ComfyUI');
+  });
+});

--- a/packages/metadata-engine/src/parsers/index.ts
+++ b/packages/metadata-engine/src/parsers/index.ts
@@ -129,11 +129,7 @@ export function getMetadataParser(metadata: ImageMetadata): ParserModule | null 
     const promptLooksLikeGraph = typeof promptCI === 'string' && /"class_type"|"inputs"/.test(promptCI);
     const promptOnlyGraph = isComfyPromptOnlyGraph(metadata as any);
 
-    const hasParameters = 'parameters' in metadata &&
-        typeof metadata.parameters === 'string' &&
-        metadata.parameters.trim().length > 0;
-
-    if (!hasParameters && (workflowCI !== undefined || (promptCI && typeof promptCI === 'object') || promptLooksLikeGraph || promptOnlyGraph)) {
+    if (workflowCI !== undefined || (promptCI && typeof promptCI === 'object') || promptLooksLikeGraph || promptOnlyGraph) {
         return {
             parse: (data: ComfyUIMetadata) => {
                 // Parse workflow and prompt if they are strings

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -119,6 +119,51 @@ function sanitizeJson(jsonString: string): string {
     return jsonString.replace(/:\s*NaN/g, ': null');
 }
 
+function parseComfyExifGraphValue(
+  value: unknown,
+  prefix?: 'workflow' | 'prompt',
+): ComfyUIMetadata['workflow'] | ComfyUIMetadata['prompt'] | undefined {
+  if (value && typeof value === 'object') {
+    return value as ComfyUIMetadata['workflow'] | ComfyUIMetadata['prompt'];
+  }
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  const marker = prefix ? `${prefix}:` : '';
+  if (marker && !trimmed.toLowerCase().startsWith(marker)) {
+    return undefined;
+  }
+
+  const json = marker ? trimmed.slice(marker.length).trim() : trimmed;
+  if (!json) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(sanitizeJson(json));
+    return parsed && typeof parsed === 'object'
+      ? parsed as ComfyUIMetadata['workflow'] | ComfyUIMetadata['prompt']
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function extractComfyUIExifGraphMetadata(
+  exifData: Record<string, unknown>,
+): ComfyUIMetadata | null {
+  const workflow = parseComfyExifGraphValue(exifData.workflow)
+    ?? parseComfyExifGraphValue(exifData.Workflow)
+    ?? parseComfyExifGraphValue(exifData.Make, 'workflow');
+  const prompt = parseComfyExifGraphValue(exifData.prompt)
+    ?? parseComfyExifGraphValue(exifData.Prompt)
+    ?? parseComfyExifGraphValue(exifData.Model, 'prompt');
+
+  return workflow || prompt ? { workflow, prompt } : null;
+}
+
 const trimJsonChunkPadding = (value: string): string => {
   let end = value.length;
   while (end > 0) {
@@ -697,6 +742,11 @@ async function parseJPEGMetadata(buffer: ArrayBuffer): Promise<ImageMetadata | n
       }
     }
 
+    const comfyExifGraph = extractComfyUIExifGraphMetadata(exifData);
+    if (comfyExifGraph) {
+      return comfyExifGraph;
+    }
+
     // Check all possible field names for UserComment (A1111 and SwarmUI store metadata here in JPEGs)
     // Also check XMP Description for Draw Things and other XMP-based metadata
     let metadataText: string | Uint8Array | undefined =
@@ -1098,6 +1148,11 @@ export async function parseWebPMetadata(
       } catch (e) {
         // Not JSON or not MetaHub metadata, continue with normal parsing
       }
+    }
+
+    const comfyExifGraph = extractComfyUIExifGraphMetadata(exifData);
+    if (comfyExifGraph) {
+      return comfyExifGraph;
     }
 
     // Fall back to regular JPEG parsing logic (UserComment, etc.)
@@ -1682,11 +1737,10 @@ if (rawMetadata) {
   }
 
   // Priority 1: Check for text-based formats (A1111, Forge, Fooocus all use 'parameters' string)
-  // An AVIF can carry both a ComfyUI graph (prompt/workflow) and an Image MetaHub
-  // 'parameters' string. Let the ComfyUI graph parser (Priority 2) win in that case
-  // instead of misparsing the compact 'parameters' string through the A1111 fallback.
+  // ComfyUI save nodes can include an A1111-compatible `parameters` string beside
+  // their canonical prompt/workflow graph. Let the graph parser win in that case.
   if (!normalizedMetadata && 'parameters' in rawMetadata && typeof rawMetadata.parameters === 'string'
-      && !(isAvifCarrier && isComfyUIMetadata(rawMetadata))) {
+      && !isComfyUIMetadata(rawMetadata)) {
     const params = rawMetadata.parameters;
     
     // Sub-priority 2.0: Check if parameters contains SwarmUI JSON format


### PR DESCRIPTION
## What changed

- recognize ComfyUI `workflow:`/`prompt:` graphs stored in EXIF Make/Model before A1111-compatible `parameters`
- apply the same graph-over-parameters priority in the app indexer and standalone metadata engine
- add regression coverage for EXIF graph extraction, false-positive camera values, and metadata-engine routing

## Root cause

WebP/JPEG EXIF parsing selected `UserComment` first. ComfyUI save nodes often store Civitai-compatible A1111 parameters there while keeping the canonical workflow and prompt in EXIF Make/Model, so the graph was discarded and the generator became A1111.

## Impact

Valid ComfyUI workflow/prompt graphs now determine attribution even when compatible A1111 parameters are also embedded. Metadata-free and sidecar-only cases are unchanged.

Fixes #502.

## Validation

- `npx vitest run __tests__/fileIndexer.comfyui-exif-priority.test.ts packages/metadata-engine/src/parsers/index.test.ts __tests__/comfyui-parser.test.ts --reporter=verbose` — 37/37 passed
- `npx tsc -b --pretty false` — passed
- `git diff --check` — passed
- reproduced against the public WebP attached to #502: before `parameters` only / A1111 path; after `workflow`, `prompt`, generator `ComfyUI`