### PR TITLE
Keep the previewed card visible when the grid resizes

### DIFF
--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ImageGrid from '../components/ImageGrid';
 import { useImageSelection } from '../hooks/useImageSelection';
 import { useImageStore } from '../store/useImageStore';
@@ -763,6 +763,50 @@ describe('ImageGrid selection opening behavior', () => {
 
     expect(onImageClick).toHaveBeenCalledTimes(1);
     expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
+  });
+
+  it('keeps the previewed card visible when the static grid loses columns', async () => {
+    const images = createImages(8);
+    let resizeCallback: ResizeObserverCallback | null = null;
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    });
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    useSettingsStore.setState({ doubleClickToOpen: true } as any);
+    setupImageGridState(images);
+
+    try {
+      render(<Harness images={images} />);
+
+      const imageThumb = screen.getByAltText('image-6.png');
+      fireEvent.mouseDown(imageThumb, { button: 0 });
+      fireEvent.click(imageThumb);
+      await waitFor(() => expect(useImageStore.getState().previewImage?.id).toBe('img-6'));
+      scrollIntoView.mockClear();
+
+      act(() => {
+        resizeCallback?.([
+          { contentRect: { width: 272 } } as ResizeObserverEntry,
+        ], {} as ResizeObserver);
+      });
+
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({
+        block: 'nearest',
+        inline: 'nearest',
+      }));
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      vi.unstubAllGlobals();
+    }
   });
 
   it('preserves checked images when middle-clicking an image', () => {

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1135,6 +1135,8 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const imageCardsRef = useRef<Map<string, HTMLDivElement>>(new Map());
   const cardRefCallbacksRef = useRef<Map<string, (el: HTMLDivElement | null) => void>>(new Map());
   const columnCountRef = useRef<number>(1);
+  // Re-run the focused-card reveal when a sidebar or window resize changes the wrapping.
+  const [observedColumnCount, setObservedColumnCount] = useState<number>(1);
   const lastWarmupWindowRef = useRef<string>('');
   const lastScrollResetKeyRef = useRef<string | undefined>(scrollResetKey);
   const lastRestoredScrollKeyRef = useRef<string>('');
@@ -1295,6 +1297,42 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     const measuredWidth = gridBackground?.clientWidth ?? gridScopeRef.current?.clientWidth ?? 0;
     const measuredColumnCount = Math.floor((measuredWidth + GAP_SIZE) / (imageSize + GAP_SIZE));
     return Math.max(1, measuredColumnCount || columnCountRef.current || 1);
+  }, [imageSize, isInfinite]);
+
+  const handleVirtualGridResize = useCallback(({ width }: { width: number }) => {
+    const nextColumnCount = Math.max(1, Math.floor(width / (imageSize + GAP_SIZE)));
+    setObservedColumnCount((currentColumnCount) =>
+      currentColumnCount === nextColumnCount ? currentColumnCount : nextColumnCount
+    );
+  }, [imageSize]);
+
+  useEffect(() => {
+    if (isInfinite || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const gridElement = gridScopeRef.current;
+    if (!gridElement) {
+      return;
+    }
+
+    const updateColumnCount = (width: number) => {
+      const nextColumnCount = Math.max(1, Math.floor((width + GAP_SIZE) / (imageSize + GAP_SIZE)));
+      columnCountRef.current = nextColumnCount;
+      setObservedColumnCount((currentColumnCount) =>
+        currentColumnCount === nextColumnCount ? currentColumnCount : nextColumnCount
+      );
+    };
+
+    updateColumnCount(gridElement.getBoundingClientRect().width);
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      if (entry) {
+        updateColumnCount(entry.contentRect.width);
+      }
+    });
+    resizeObserver.observe(gridElement);
+
+    return () => resizeObserver.disconnect();
   }, [imageSize, isInfinite]);
 
   const getRenderedIndexInItems = useCallback((imageIndex: number | null, renderItems: GridRenderItem[]): number => {
@@ -2082,7 +2120,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       virtualGridRef.current?.scrollToItem({
         rowIndex: Math.floor(renderedIndex / columnCount),
         columnIndex: renderedIndex % columnCount,
-        align: 'auto',
+        align: 'smart',
       });
       return;
     }
@@ -2099,7 +2137,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         inline: 'nearest',
       });
     }
-  }, [focusedImageIndex, getRenderedIndexInItems, isInfinite, itemsToRender]);
+  }, [focusedImageIndex, getRenderedIndexInItems, isInfinite, itemsToRender, observedColumnCount]);
 
   useEffect(() => {
     if (!jumpToGroupRequest || effectiveGroupBy === 'none') {
@@ -2836,7 +2874,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             onMouseMove={handleMouseMove}
             onMouseUp={handleMouseUp}
           >
-            <AutoSizer>
+            <AutoSizer onResize={handleVirtualGridResize}>
               {({ height, width }) => {
                 const columnCount = Math.floor(width / (imageSize + GAP_SIZE));
                 const safeColumnCount = columnCount > 0 ? columnCount : 1;


### PR DESCRIPTION
## What changed

- observe Card View column-count changes in virtualized and paginated layouts
- rerun the focused-card reveal with smart alignment after the preview sidebar changes grid wrapping
- add regression coverage for a previewed card surviving a column-count reduction

## Why

Opening Image Preview for the first time narrows the grid. The same image index moves to a later row while the scroll position stays fixed, so the card the user clicked can disappear several rows below the viewport.

## Impact

The preview sidebar remains optional and adjacent to the grid. When opening it, or otherwise resizing the grid, the focused card is kept visible with the minimum necessary scroll. Later thumbnail navigation is unchanged.

## Validation

- `npx vitest run __tests__/ImageGrid.contextMenu.test.tsx --maxWorkers=1` — 25/25 passed
- `npx eslint components/ImageGrid.tsx __tests__/ImageGrid.contextMenu.test.tsx` — 0 errors
- `git diff --check origin/main...HEAD`

## Manual validation

- Confirm the first card selected after launch remains visible when Image Preview opens.
- Confirm subsequent navigation with the preview already open does not introduce extra scrolling.

This supersedes #523 with a clean branch created from `main` after #522 was merged.

Relates to #508.