### PR TITLE
Preserve preview card position when the sidebar opens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { startTransition, useState, useEffect, useCallback, useRef, useMemo, useDeferredValue } from 'react';
+import React, { startTransition, useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo, useDeferredValue } from 'react';
 import { useImageStore } from './store/useImageStore';
 import { useSettingsStore } from './store/useSettingsStore';
 import { useSemanticStore } from './store/useSemanticStore';
@@ -704,6 +704,11 @@ export default function App() {
 
   const hasLeftSidebar = hasDirectories && libraryView !== 'comfyui' && libraryView !== 'editor';
   const hasRightSidebar = Boolean(isQueueOpen || (previewImage && libraryView !== 'comfyui' && libraryView !== 'editor'));
+  const previousHasRightSidebarRef = useRef(hasRightSidebar);
+  const rightSidebarVisibilityChanged = previousHasRightSidebarRef.current !== hasRightSidebar;
+  useLayoutEffect(() => {
+    previousHasRightSidebarRef.current = hasRightSidebar;
+  }, [hasRightSidebar]);
   const { leftWidth: sidebarWidth, rightWidth: rightSidebarWidth } = useMemo(
     () =>
       resolveSidebarWidths({
@@ -3934,7 +3939,7 @@ export default function App() {
       )}
 
       <div
-        className={`h-screen flex flex-col ${isSidebarResizing ? 'transition-none' : 'transition-[margin] duration-300 ease-in-out'}`}
+        className={`h-screen flex flex-col ${isSidebarResizing || rightSidebarVisibilityChanged ? 'transition-none' : 'transition-[margin] duration-300 ease-in-out'}`}
         style={{ marginLeft: mainContentMarginLeft, marginRight: mainContentMarginRight }}
       >
         <Header
@@ -4229,6 +4234,7 @@ export default function App() {
                           initialScrollTop={libraryGridScrollTopRef.current}
                           onScrollPositionChange={handleLibraryGridScrollPositionChange}
                           scrollResetKey={libraryGridSignature}
+                          hasRightSidebar={hasRightSidebar}
                         />
                       ) : (
                         <ImageTable
@@ -4285,6 +4291,7 @@ export default function App() {
                         initialScrollTop={collectionsGridScrollTopRef.current}
                         onScrollPositionChange={handleCollectionsGridScrollPositionChange}
                         scrollResetKey={collectionsGridSignature}
+                        hasRightSidebar={hasRightSidebar}
                       />
                     ) : (
                       <ImageTable

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ImageGrid from '../components/ImageGrid';
 import { useImageSelection } from '../hooks/useImageSelection';
 import { useImageStore } from '../store/useImageStore';
@@ -9,6 +9,9 @@ import type { ImageStack, IndexedImage } from '../types';
 
 const renameIndexedImageMock = vi.hoisted(() => vi.fn());
 const stackedItemsMock = vi.hoisted(() => ({ value: null as (IndexedImage | ImageStack)[] | null }));
+const autoSizerResizeMock = vi.hoisted(() => ({
+  callback: null as null | ((size: { height: number; width: number }) => void),
+}));
 const showContextMenuMock = vi.fn();
 const hideContextMenuMock = vi.fn();
 const contextMenuStateMock = {
@@ -38,8 +41,13 @@ vi.mock('../hooks/useContextMenu', () => ({
 }));
 
 vi.mock('react-virtualized-auto-sizer', () => ({
-  default: ({ children }: { children: (size: { height: number; width: number }) => React.ReactNode }) =>
-    children({ height: 600, width: 408 }),
+  default: ({ children, onResize }: {
+    children: (size: { height: number; width: number }) => React.ReactNode;
+    onResize?: (size: { height: number; width: number }) => void;
+  }) => {
+    autoSizerResizeMock.callback = onResize ?? null;
+    return children({ height: 600, width: 408 });
+  },
 }));
 
 vi.mock('../services/imageRenameService', () => ({
@@ -158,11 +166,12 @@ const createImages = (count: number): IndexedImage[] =>
     }),
   );
 
-const Harness = ({ images, onFindSimilar, onFindVisuallySimilar, canFindVisuallySimilar = false }: {
+const Harness = ({ images, onFindSimilar, onFindVisuallySimilar, canFindVisuallySimilar = false, hasRightSidebar = false }: {
   images: IndexedImage[];
   onFindSimilar?: (image: IndexedImage) => void;
   onFindVisuallySimilar?: (image: IndexedImage) => void;
   canFindVisuallySimilar?: boolean;
+  hasRightSidebar?: boolean;
 }) => {
   const selectedImages = useImageStore((state) => state.selectedImages);
 
@@ -178,6 +187,7 @@ const Harness = ({ images, onFindSimilar, onFindVisuallySimilar, canFindVisually
       onFindSimilar={onFindSimilar}
       onFindVisuallySimilar={onFindVisuallySimilar}
       canFindVisuallySimilar={canFindVisuallySimilar}
+      hasRightSidebar={hasRightSidebar}
     />
   );
 };
@@ -765,11 +775,35 @@ describe('ImageGrid selection opening behavior', () => {
     expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
   });
 
-  it('keeps the previewed card visible when the static grid loses columns', async () => {
+  it('preserves the previewed card position once when the sidebar opens without locking later scroll', async () => {
     const images = createImages(8);
     let resizeCallback: ResizeObserverCallback | null = null;
-    const scrollIntoView = vi.fn();
-    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    let sidebarOpen = false;
+    const requestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      });
+    const cancelAnimationFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    const getBoundingClientRect = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const top = this.dataset.imageId === 'img-6'
+          ? (sidebarOpen ? 500 : 300)
+          : this.dataset.area === 'grid'
+            ? 100
+            : 0;
+        return {
+          x: 0,
+          y: top,
+          top,
+          left: 0,
+          right: 120,
+          bottom: top + 120,
+          width: 120,
+          height: 120,
+          toJSON: () => ({}),
+        };
+      });
 
     vi.stubGlobal('ResizeObserver', class {
       constructor(callback: ResizeObserverCallback) {
@@ -780,32 +814,86 @@ describe('ImageGrid selection opening behavior', () => {
       unobserve() {}
       disconnect() {}
     });
-    HTMLElement.prototype.scrollIntoView = scrollIntoView;
     useSettingsStore.setState({ doubleClickToOpen: true } as any);
     setupImageGridState(images);
 
     try {
-      render(<Harness images={images} />);
+      const { container, rerender } = render(<Harness images={images} />);
+      const grid = container.querySelector<HTMLElement>('[data-area="grid"]')!;
+      grid.scrollTop = 100;
 
       const imageThumb = screen.getByAltText('image-6.png');
       fireEvent.mouseDown(imageThumb, { button: 0 });
       fireEvent.click(imageThumb);
       await waitFor(() => expect(useImageStore.getState().previewImage?.id).toBe('img-6'));
-      scrollIntoView.mockClear();
 
-      act(() => {
-        resizeCallback?.([
-          { contentRect: { width: 272 } } as ResizeObserverEntry,
-        ], {} as ResizeObserver);
+      sidebarOpen = true;
+      rerender(<Harness images={images} hasRightSidebar />);
+      resizeCallback?.([
+        { contentRect: { width: 272 } } as ResizeObserverEntry,
+      ], {} as ResizeObserver);
+
+      await waitFor(() => expect(grid.scrollTop).toBe(300));
+
+      grid.scrollTop = 500;
+      fireEvent.scroll(grid);
+      rerender(<Harness images={images} hasRightSidebar />);
+      expect(grid.scrollTop).toBe(500);
+    } finally {
+      requestAnimationFrame.mockRestore();
+      cancelAnimationFrame.mockRestore();
+      getBoundingClientRect.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('preserves the previewed card position in the virtual grid after its final resize', async () => {
+    const images = createImages(8);
+    let sidebarOpen = false;
+    const getBoundingClientRect = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const top = this.dataset.imageId === 'img-6'
+          ? (sidebarOpen ? 500 : 300)
+          : 0;
+        return {
+          x: 0,
+          y: top,
+          top,
+          left: 0,
+          right: 120,
+          bottom: top + 120,
+          width: 120,
+          height: 120,
+          toJSON: () => ({}),
+        };
       });
 
-      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({
-        block: 'nearest',
-        inline: 'nearest',
-      }));
+    useSettingsStore.setState({ doubleClickToOpen: true, itemsPerPage: -1 } as any);
+    setupImageGridState(images);
+
+    try {
+      const { container, rerender } = render(<Harness images={images} />);
+      const grid = container.querySelector<HTMLElement>('.no-scrollbar-if-needed')!;
+      expect(grid).toBeTruthy();
+      grid.scrollTop = 100;
+
+      const imageThumb = screen.getByAltText('image-6.png');
+      fireEvent.mouseDown(imageThumb, { button: 0 });
+      fireEvent.click(imageThumb);
+      await waitFor(() => expect(useImageStore.getState().previewImage?.id).toBe('img-6'));
+
+      sidebarOpen = true;
+      rerender(<Harness images={images} hasRightSidebar />);
+      autoSizerResizeMock.callback?.({ height: 600, width: 272 });
+
+      await waitFor(() => expect(grid.scrollTop).toBe(300));
+
+      grid.scrollTop = 500;
+      fireEvent.scroll(grid);
+      rerender(<Harness images={images} hasRightSidebar />);
+      expect(grid.scrollTop).toBe(500);
     } finally {
-      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
-      vi.unstubAllGlobals();
+      getBoundingClientRect.mockRestore();
     }
   });
 

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1,7 +1,7 @@
 import { VariableSizeGrid as Grid, GridChildComponentProps, areEqual } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
 import { type IndexedImage, type BaseMetadata, type Directory, ImageStack, SmartCollection } from '../types';
@@ -1072,6 +1072,7 @@ interface ImageGridProps {
   initialScrollTop?: number;
   onScrollPositionChange?: (scrollTop: number) => void;
   scrollResetKey?: string;
+  hasRightSidebar?: boolean;
 }
 
 const InnerGridElement = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => (
@@ -1101,6 +1102,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   initialScrollTop = 0,
   onScrollPositionChange,
   scrollResetKey,
+  hasRightSidebar = false,
 }) => {
   const imageSize = useSettingsStore((state) => state.imageSize);
   const itemsPerPage = useSettingsStore((state) => state.itemsPerPage);
@@ -1135,8 +1137,11 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const imageCardsRef = useRef<Map<string, HTMLDivElement>>(new Map());
   const cardRefCallbacksRef = useRef<Map<string, (el: HTMLDivElement | null) => void>>(new Map());
   const columnCountRef = useRef<number>(1);
-  // Re-run the focused-card reveal when a sidebar or window resize changes the wrapping.
-  const [observedColumnCount, setObservedColumnCount] = useState<number>(1);
+  const lastFocusedRevealImageIdRef = useRef<string | null>(null);
+  const previousHasRightSidebarRef = useRef(hasRightSidebar);
+  const previewAnchorCandidateRef = useRef<{ imageId: string; viewportOffsetY: number } | null>(null);
+  const pendingPreviewAnchorRef = useRef<{ imageId: string; viewportOffsetY: number } | null>(null);
+  const previewAnchorFramesRef = useRef({ first: 0, second: 0 });
   const lastWarmupWindowRef = useRef<string>('');
   const lastScrollResetKeyRef = useRef<string | undefined>(scrollResetKey);
   const lastRestoredScrollKeyRef = useRef<string>('');
@@ -1157,6 +1162,14 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const setPreviewImage = useImageStore((state) => state.setPreviewImage);
   const previewImage = useImageStore((state) => state.previewImage);
   const transferProgress = useImageStore((state) => state.transferProgress);
+  const previewAnchorDataRef = useRef({
+    itemsToRender,
+    isInfinite,
+  });
+  previewAnchorDataRef.current = {
+    itemsToRender,
+    isInfinite,
+  };
 
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
@@ -1232,6 +1245,26 @@ const ImageGrid: React.FC<ImageGridProps> = ({
 
   const getGridScrollElement = useCallback(() => gridScrollRef.current ?? gridScopeRef.current, []);
 
+  const capturePreviewAnchorCandidate = useCallback((event: React.MouseEvent) => {
+    if (event.button !== 0) {
+      return;
+    }
+
+    const cardElement = (event.target as HTMLElement).closest<HTMLElement>('[data-image-id]');
+    const scrollElement = getGridScrollElement();
+    const imageId = cardElement?.dataset.imageId;
+    if (!cardElement || !scrollElement || !imageId) {
+      return;
+    }
+
+    const cardRect = cardElement.getBoundingClientRect();
+    const scrollRect = scrollElement.getBoundingClientRect();
+    previewAnchorCandidateRef.current = {
+      imageId,
+      viewportOffsetY: cardRect.top - scrollRect.top,
+    };
+  }, [getGridScrollElement]);
+
   const restoreGridScrollPosition = useCallback((scrollTop: number) => {
     const nextScrollTop = Math.max(0, scrollTop);
 
@@ -1297,42 +1330,6 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     const measuredWidth = gridBackground?.clientWidth ?? gridScopeRef.current?.clientWidth ?? 0;
     const measuredColumnCount = Math.floor((measuredWidth + GAP_SIZE) / (imageSize + GAP_SIZE));
     return Math.max(1, measuredColumnCount || columnCountRef.current || 1);
-  }, [imageSize, isInfinite]);
-
-  const handleVirtualGridResize = useCallback(({ width }: { width: number }) => {
-    const nextColumnCount = Math.max(1, Math.floor(width / (imageSize + GAP_SIZE)));
-    setObservedColumnCount((currentColumnCount) =>
-      currentColumnCount === nextColumnCount ? currentColumnCount : nextColumnCount
-    );
-  }, [imageSize]);
-
-  useEffect(() => {
-    if (isInfinite || typeof ResizeObserver === 'undefined') {
-      return;
-    }
-
-    const gridElement = gridScopeRef.current;
-    if (!gridElement) {
-      return;
-    }
-
-    const updateColumnCount = (width: number) => {
-      const nextColumnCount = Math.max(1, Math.floor((width + GAP_SIZE) / (imageSize + GAP_SIZE)));
-      columnCountRef.current = nextColumnCount;
-      setObservedColumnCount((currentColumnCount) =>
-        currentColumnCount === nextColumnCount ? currentColumnCount : nextColumnCount
-      );
-    };
-
-    updateColumnCount(gridElement.getBoundingClientRect().width);
-    const resizeObserver = new ResizeObserver(([entry]) => {
-      if (entry) {
-        updateColumnCount(entry.contentRect.width);
-      }
-    });
-    resizeObserver.observe(gridElement);
-
-    return () => resizeObserver.disconnect();
   }, [imageSize, isInfinite]);
 
   const getRenderedIndexInItems = useCallback((imageIndex: number | null, renderItems: GridRenderItem[]): number => {
@@ -2103,9 +2100,20 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!gridKeyboardActiveRef.current || focusedImageIndex == null || focusedImageIndex < 0) {
+    const focusedImageId = focusedImageIndex != null && focusedImageIndex >= 0
+      ? images[focusedImageIndex]?.id ?? null
+      : null;
+
+    if (!gridKeyboardActiveRef.current || !focusedImageId) {
+      lastFocusedRevealImageIdRef.current = null;
       return;
     }
+
+    // A rerender must not pull the viewport back to an unchanged focused card.
+    if (lastFocusedRevealImageIdRef.current === focusedImageId) {
+      return;
+    }
+    lastFocusedRevealImageIdRef.current = focusedImageId;
 
     const columnCount = Math.max(1, columnCountRef.current);
     const activeItems = isInfinite
@@ -2120,7 +2128,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
       virtualGridRef.current?.scrollToItem({
         rowIndex: Math.floor(renderedIndex / columnCount),
         columnIndex: renderedIndex % columnCount,
-        align: 'smart',
+        align: 'auto',
       });
       return;
     }
@@ -2137,7 +2145,126 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         inline: 'nearest',
       });
     }
-  }, [focusedImageIndex, getRenderedIndexInItems, isInfinite, itemsToRender, observedColumnCount]);
+  }, [focusedImageIndex, getRenderedIndexInItems, images, isInfinite, itemsToRender]);
+
+  const cancelScheduledPreviewAnchor = useCallback(() => {
+    window.cancelAnimationFrame(previewAnchorFramesRef.current.first);
+    window.cancelAnimationFrame(previewAnchorFramesRef.current.second);
+    previewAnchorFramesRef.current = { first: 0, second: 0 };
+  }, []);
+
+  const revealPendingPreviewAnchor = useCallback(() => {
+    const anchor = pendingPreviewAnchorRef.current;
+    if (!anchor) {
+      return;
+    }
+
+    const latest = previewAnchorDataRef.current;
+    const columnCount = Math.max(1, columnCountRef.current);
+    const activeItems = latest.isInfinite
+      ? expandGroupedItemsForColumns(latest.itemsToRender, columnCount)
+      : latest.itemsToRender;
+    const renderedIndex = activeItems.findIndex((item) =>
+      isImageRenderItem(item) && (isImageStack(item)
+        ? item.images.some((stackImage) => stackImage.id === anchor.imageId)
+        : item.id === anchor.imageId)
+    );
+    if (renderedIndex < 0) {
+      pendingPreviewAnchorRef.current = null;
+      return;
+    }
+
+    const anchoredItem = activeItems[renderedIndex];
+    if (!anchoredItem || !isImageRenderItem(anchoredItem)) {
+      pendingPreviewAnchorRef.current = null;
+      return;
+    }
+
+    const anchoredElement = imageCardsRef.current.get(getWarmupImage(anchoredItem).id);
+    const scrollElement = getGridScrollElement();
+    if (!anchoredElement || !scrollElement) {
+      if (latest.isInfinite) {
+        virtualGridRef.current?.scrollToItem({
+          rowIndex: Math.floor(renderedIndex / columnCount),
+          columnIndex: renderedIndex % columnCount,
+          align: 'smart',
+        });
+        return;
+      }
+
+      pendingPreviewAnchorRef.current = null;
+      return;
+    }
+
+    const currentOffsetY = anchoredElement.getBoundingClientRect().top - scrollElement.getBoundingClientRect().top;
+    const nextScrollTop = Math.max(0, scrollElement.scrollTop + currentOffsetY - anchor.viewportOffsetY);
+    if (latest.isInfinite) {
+      virtualGridRef.current?.scrollTo({ scrollTop: nextScrollTop, scrollLeft: scrollElement.scrollLeft });
+    } else {
+      scrollElement.scrollTop = nextScrollTop;
+    }
+    pendingPreviewAnchorRef.current = null;
+  }, [getGridScrollElement]);
+
+  const schedulePendingPreviewAnchor = useCallback(() => {
+    if (!pendingPreviewAnchorRef.current) {
+      return;
+    }
+
+    cancelScheduledPreviewAnchor();
+    previewAnchorFramesRef.current.first = window.requestAnimationFrame(() => {
+      previewAnchorFramesRef.current.second = window.requestAnimationFrame(() => {
+        previewAnchorFramesRef.current = { first: 0, second: 0 };
+        revealPendingPreviewAnchor();
+      });
+    });
+  }, [cancelScheduledPreviewAnchor, revealPendingPreviewAnchor]);
+
+  useLayoutEffect(() => {
+    const wasOpen = previousHasRightSidebarRef.current;
+    previousHasRightSidebarRef.current = hasRightSidebar;
+
+    if (!hasRightSidebar) {
+      if (wasOpen) {
+        previewAnchorCandidateRef.current = null;
+        pendingPreviewAnchorRef.current = null;
+        cancelScheduledPreviewAnchor();
+      }
+      return;
+    }
+
+    if (!wasOpen && previewImage) {
+      const candidate = previewAnchorCandidateRef.current;
+      previewAnchorCandidateRef.current = null;
+      if (candidate?.imageId === previewImage.id) {
+        pendingPreviewAnchorRef.current = candidate;
+      }
+    }
+  }, [cancelScheduledPreviewAnchor, hasRightSidebar, previewImage]);
+
+  const handleVirtualGridResize = useCallback(() => {
+    schedulePendingPreviewAnchor();
+  }, [schedulePendingPreviewAnchor]);
+
+  useEffect(() => {
+    if (isInfinite || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const gridElement = gridScopeRef.current;
+    if (!gridElement) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      schedulePendingPreviewAnchor();
+    });
+    resizeObserver.observe(gridElement);
+
+    return () => resizeObserver.disconnect();
+  }, [isInfinite, schedulePendingPreviewAnchor]);
+
+  useEffect(() => cancelScheduledPreviewAnchor, [cancelScheduledPreviewAnchor]);
 
   useEffect(() => {
     if (!jumpToGroupRequest || effectiveGroupBy === 'none') {
@@ -2868,6 +2995,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             onMouseDownCapture={(event) => {
               if (!isTypingTarget(event.target)) {
                 gridKeyboardActiveRef.current = true;
+                capturePreviewAnchorCandidate(event);
               }
             }}
             onMouseDown={handleMouseDown}
@@ -2950,6 +3078,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
                       });
                     }}
                     onItemsRendered={({ visibleColumnStartIndex, visibleColumnStopIndex, visibleRowStartIndex, visibleRowStopIndex, overscanRowStopIndex }) => {
+                      schedulePendingPreviewAnchor();
                       const itemsRenderedStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
                       const visibleStartIndex = (visibleRowStartIndex * safeColumnCount) + visibleColumnStartIndex;
                       const visibleStopIndex = Math.min(
@@ -3073,6 +3202,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
         onMouseDownCapture={(event) => {
           if (!isTypingTarget(event.target)) {
             gridKeyboardActiveRef.current = true;
+            capturePreviewAnchorCandidate(event);
           }
         }}
         onClick={() => {


### PR DESCRIPTION
## What changed

- remove the animated main-content margin when the right sidebar opens or closes
- capture the clicked card's viewport position before the preview changes the grid width
- after the final grid resize, adjust scroll only by the card's vertical position delta
- clear the anchor immediately so subsequent user scrolling remains unrestricted
- cover both paginated/static and virtualized/infinite Card View layouts

## Root cause

Opening Image Preview changes the available grid width and therefore the column count. The virtual grid is keyed by its column count, so it can remount while preserving the old pixel `scrollTop`; the clicked image then moves to another row and disappears from view.

The earlier #524 fix reacted to later focus/layout rerenders, which could keep pulling the viewport back to the selected thumbnail. This replaces that behavior with a single spatial anchor tied only to the sidebar-opening resize.

## Impact

The thumbnail stays at approximately the same vertical screen position where it was clicked. Once the layout adjustment is complete, navigation and manual scrolling are unchanged.

## Validation

- `npx vitest run __tests__/ImageGrid.contextMenu.test.tsx --maxWorkers=1` — 26/26 passed
- `npx eslint App.tsx components/ImageGrid.tsx __tests__/ImageGrid.contextMenu.test.tsx` — 0 errors
- `git diff --check`
- manually validated in the Electron development app

Relates to #508.