### PR TITLE
fix: bind Resend fetch in license worker

### DIFF
--- a/packages/license-server/__tests__/resendClient.test.ts
+++ b/packages/license-server/__tests__/resendClient.test.ts
@@ -4,9 +4,8 @@ import { ResendDeliveryClient } from '../src/resendClient.js';
 
 describe('ResendDeliveryClient', () => {
   it('invokes fetch with the global receiver required by Cloudflare Workers', async () => {
-    let receiver: unknown;
     const fetchImpl = function (this: unknown) {
-      receiver = this;
+      expect(this).toBe(globalThis);
       return Promise.resolve(new Response(JSON.stringify({ id: 'email_1' }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -26,7 +25,6 @@ describe('ResendDeliveryClient', () => {
       expiresAt: '2026-09-27T00:00:00.000Z',
     });
 
-    expect(receiver).toBe(globalThis);
     expect(result).toEqual({ ok: true, messageId: 'email_1' });
   });
 });

--- a/packages/license-server/__tests__/resendClient.test.ts
+++ b/packages/license-server/__tests__/resendClient.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { ResendDeliveryClient } from '../src/resendClient.js';
+
+describe('ResendDeliveryClient', () => {
+  it('invokes fetch with the global receiver required by Cloudflare Workers', async () => {
+    let receiver: unknown;
+    const fetchImpl = function (this: unknown) {
+      receiver = this;
+      return Promise.resolve(new Response(JSON.stringify({ id: 'email_1' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }));
+    };
+    const client = new ResendDeliveryClient({
+      apiKey: 're_test',
+      from: 'Image MetaHub <delivery@licenses.imagemetahub.com>',
+      fetchImpl,
+    });
+
+    const result = await client.sendLicense({
+      outboxId: 'delivery_1',
+      email: 'buyer@example.com',
+      licenseKey: 'IMH2-TEST',
+      plan: 'monthly',
+      expiresAt: '2026-09-27T00:00:00.000Z',
+    });
+
+    expect(receiver).toBe(globalThis);
+    expect(result).toEqual({ ok: true, messageId: 'email_1' });
+  });
+});

--- a/packages/license-server/src/resendClient.js
+++ b/packages/license-server/src/resendClient.js
@@ -54,7 +54,7 @@ export class ResendDeliveryClient {
     };
     let response;
     try {
-      response = await this.fetchImpl(RESEND_ENDPOINT, {
+      response = await this.fetchImpl.call(globalThis, RESEND_ENDPOINT, {
         method: 'POST',
         headers: {
           authorization: `Bearer ${this.apiKey}`,


### PR DESCRIPTION
## Summary
- invoke the Resend fetch implementation with the global receiver required by Cloudflare Workers
- add a regression test covering the receiver binding

## Verification
- `npx vitest run packages/license-server/__tests__` — 49 tests passed
- production deploy workflow completed successfully, including preflight, dry-run, D1 migration check, entitlement smoke test, and no rollback

## Production
- deployed Worker version: `2c636e39-847b-407a-8d75-646b6ec498e5`
- deploy run: https://github.com/LuqP2/Image-MetaHub/actions/runs/33067126999