### PR TITLE
fix: improve viewer theme consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.2] - [2026-08-27]
 
+### Improved
+
+- **Bundled Dependencies**: Updated bundled dependencies with the available non-breaking security fixes while keeping the current Electron version unchanged.
+- **Viewer Theme Consistency**: Improved Light Mode contrast and visual hierarchy across the Image Modal, Image Preview sidebar, main sidebar, and Support / License settings, with clearer A1111 and ComfyUI actions and theme-aware surfaces for Dark, Dracula, Nord, and Ocean.
+
 ### Fixed
 
-- **ComfyUI Workspace Thumbnails**: Single-clicking a thumbnail now opens it in the workspace inspector, while double-clicking opens the full image viewer according to the configured inline or detached viewer setting without returning to the Library grid.
+- **ComfyUI Workspace Thumbnails**: Single-clicking a thumbnail now opens it in the workspace inspector, while double-clicking or pressing Enter opens the full image viewer according to the configured inline or detached viewer setting without returning to the Library grid.
 - **Detached Viewer Deletion**: Deleting the current image now advances to the next available image without closing, flashing, or reopening the detached viewer window.
+- **Light Mode Image Preview**: The preview title, file name, and metadata section headings now remain readable against the preview panel when using Light Mode.
 
 ## [0.19.1] - [2026-08-26]
 

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1144,7 +1144,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const { isReparsing, reparseImages } = useReparseMetadata();
 
   const { canUseA1111, canUseComfyUI, canUseComparison, canUseBatchExport, canUseImageEditor, canUseDuringTrialOrPro, showProModal, initialized } = useFeatureAccess();
-  const { a1111Enabled, comfyUIEnabled, visibleProviders, singleVisibleProvider } = useGenerationProviderAvailability();
+  const { a1111Enabled, comfyUIEnabled, singleVisibleProvider } = useGenerationProviderAvailability();
 
   const toggleFavorite = useImageStore((state) => state.toggleFavorite);
   const setImageRating = useImageStore((state) => state.setImageRating);
@@ -1195,7 +1195,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const showA1111Actions = !isPlayableMedia && a1111Enabled;
   const showComfyUIActions = !isPlayableMedia && comfyUIEnabled;
   const showComfyUIContext = !isVideo && !isAudio && comfyUIEnabled;
-  const showComfyUIHeading = showA1111Actions && visibleProviders.length > 1;
   const a1111GenerateLabel = singleVisibleProvider?.id === 'a1111' ? 'Generate' : 'Generate with A1111';
   const currentTags = liveImage.tags || [];
   const currentAutoTags = liveImage.autoTags || [];
@@ -3432,7 +3431,9 @@ const ImageModal: React.FC<ImageModalProps> = ({
     ? 'border-gray-800 bg-gray-950/95'
     : 'border-gray-700 bg-gray-800/95';
   const titleTextClass = isActive ? 'text-gray-100' : 'text-gray-400';
-  const titleMetaClass = isActive ? 'text-gray-500' : 'text-gray-600';
+  const titleMetaClass = isActive
+    ? 'text-gray-400 dark:text-gray-500'
+    : 'text-gray-500 dark:text-gray-600';
   const modalEntryAnimationClass = !enableAnimations || (wasMinimizedRef.current && !isMinimized)
     ? ''
     : 'animate-in fade-in zoom-in-95';
@@ -3531,7 +3532,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 </span>
                 {hasVerifiedTelemetry(liveImage) && (
                   <span
-                    className="shrink-0 rounded-full border border-green-500/20 bg-green-500/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-green-400"
+                    className="shrink-0 rounded-full border border-green-300 bg-green-100 px-1.5 py-0.5 text-[10px] font-medium leading-none text-green-700 dark:border-green-500/20 dark:bg-green-500/10 dark:text-green-400"
                     title="MetaHub Save Node"
                   >
                     MetaHub Save Node
@@ -3546,7 +3547,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                     Metadata conflict
                   </span>
                 )}
-                <span className="shrink-0 text-[10px] text-gray-500" title={createdAtLabel}>
+                <span className="shrink-0 text-[10px] text-gray-400 dark:text-gray-500" title={createdAtLabel}>
                   {createdAtLabel}
                 </span>
               </div>
@@ -3574,7 +3575,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 whileTap={{ scale: 0.9 }}
                 onPointerDown={(event) => event.stopPropagation()}
                 disabled={isIndexing}
-                className="rounded-lg border border-red-500/30 bg-red-500/10 p-1.5 text-red-400 transition-colors hover:border-red-500/50 hover:bg-red-500/15 hover:text-red-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
+                className="rounded-lg border border-red-300 bg-red-100 p-1.5 text-red-700 transition-colors hover:border-red-400 hover:bg-red-200 hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-400 dark:hover:border-red-500/50 dark:hover:bg-red-500/15 dark:hover:text-red-300"
                 title={isIndexing ? 'Cannot delete during indexing' : 'Delete image'}
                 aria-label={isIndexing ? 'Cannot delete during indexing' : 'Delete image'}
               >
@@ -4001,7 +4002,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
             showSidebarOnBottom
               ? `border-t border-gray-800/80 ${isResizingSidebar ? 'transition-none' : 'transition-[height] duration-300 ease-in-out'}`
               : `h-full border-l border-transparent ${isResizingSidebar ? 'transition-none' : 'transition-[width] duration-300 ease-in-out'}`
-          } relative flex flex-col`}
+          } relative flex flex-col bg-gray-900`}
           style={
             showSidebarOnBottom
               ? { height: sidebarHeight, minHeight: DETAILS_SIDEBAR_MIN_HEIGHT, maxHeight: `${DETAILS_SIDEBAR_MAX_RATIO * 100}%` }
@@ -4039,7 +4040,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                     }
                     onOpenImageEditor(liveImage);
                   }}
-                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-indigo-500/30 bg-indigo-500/10 px-3 py-2 text-sm font-medium text-indigo-100 transition-colors hover:border-indigo-400/50 hover:bg-indigo-500/20"
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-indigo-300 bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700 transition-colors hover:border-indigo-400 hover:bg-indigo-100 dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:text-indigo-100 dark:hover:border-indigo-400/50 dark:hover:bg-indigo-500/20"
                 >
                   <ImageIcon className="h-4 w-4" />
                   Open Image Editor
@@ -4057,7 +4058,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                     }
                     setIsAdjustmentPanelOpen(true);
                   }}
-                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-sm font-medium text-cyan-100 transition-colors hover:border-cyan-400/50 hover:bg-cyan-500/20"
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-cyan-300 bg-cyan-50 px-3 py-2 text-sm font-medium text-cyan-700 transition-colors hover:border-cyan-400 hover:bg-cyan-100 dark:border-cyan-500/30 dark:bg-cyan-500/10 dark:text-cyan-100 dark:hover:border-cyan-400/50 dark:hover:bg-cyan-500/20"
                 >
                   <SlidersHorizontal className="h-4 w-4" />
                   Adjust Image
@@ -4495,7 +4496,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 }
               }}
               whileTap={{ scale: 0.97 }}
-              className="w-full justify-center bg-blue-50 hover:bg-blue-100 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 text-blue-600 dark:text-blue-300 border border-blue-200 dark:border-blue-500/30 px-3 py-2 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-2"
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-gray-100"
             >
               {copiedPrompt ? <CheckCircle className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
               {copiedPrompt ? 'Copied!' : 'Copy Prompt'}
@@ -4510,7 +4511,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 }
               }}
               whileTap={{ scale: 0.97 }}
-              className="w-full justify-center bg-blue-50 hover:bg-blue-100 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 text-blue-600 dark:text-blue-300 border border-blue-200 dark:border-blue-500/30 px-3 py-2 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-2"
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-gray-100"
             >
               {copiedRawMetadata ? <CheckCircle className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
               {copiedRawMetadata ? 'Copied!' : 'Copy Raw Metadata'}
@@ -4524,7 +4525,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                 await showInExplorer(`${directoryPath}/${image.name}`);
               }}
               whileTap={{ scale: 0.97 }}
-              className="w-full justify-center bg-gray-100 hover:bg-gray-200 dark:bg-white/5 dark:hover:bg-white/10 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-white/10 px-3 py-2 rounded-lg text-xs font-medium transition-colors flex items-center gap-2"
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-gray-100"
             >
               <Folder className="w-3.5 h-3.5" />
               Show in Folder
@@ -4542,7 +4543,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
               }}
               whileTap={{ scale: 0.97 }}
               disabled={canUseComparison && comparisonCount >= 4}
-              className="w-full justify-center bg-purple-50 hover:bg-purple-100 dark:bg-purple-500/10 dark:hover:bg-purple-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-500/30 px-3 py-2 rounded-lg text-xs font-medium transition-colors flex items-center gap-1.5"
+              className="order-5 col-span-2 flex w-full items-center justify-center gap-1.5 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
               title={!canUseComparison ? "Comparison (Pro Feature)" : comparisonCount >= 4 ? "Comparison queue full" : "Add to comparison"}
             >
               <GitCompare className="w-3 h-3" />
@@ -4553,7 +4554,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
               onClick={() => onFindSimilar?.(image)}
               whileTap={{ scale: 0.97 }}
               disabled={!canFindSimilar}
-              className="w-full justify-center bg-teal-50 hover:bg-teal-100 dark:bg-teal-500/10 dark:hover:bg-teal-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed text-teal-700 dark:text-teal-300 border border-teal-200 dark:border-teal-500/30 px-3 py-2 rounded-lg text-xs font-medium transition-colors flex items-center gap-1.5"
+              className="order-4 flex w-full items-center justify-center gap-1.5 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
               title={canFindSimilar ? 'Find images with matching prompt and metadata' : 'Requires prompt metadata'}
             >
               <Search className="w-3 h-3" />
@@ -4574,7 +4575,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   setIsGenerateModalOpen(true);
                 }}
                 disabled={canUseA1111 && !effectiveMetadata?.prompt}
-                className="w-full bg-blue-50 hover:bg-blue-100 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-blue-200 dark:border-blue-500/50 hover:border-blue-300 dark:hover:border-blue-400 text-blue-700 dark:text-blue-100 px-4 py-3 rounded-lg text-sm font-semibold flex items-center justify-center gap-2 transition-all duration-200"
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-blue-500 bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isGenerating && canUseA1111 ? (
                   <>
@@ -4603,7 +4604,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   copyToA1111(generationImage, effectiveMetadata);
                 }}
                 disabled={canUseA1111 && (isCopying || !effectiveMetadata?.prompt)}
-                className="w-full bg-gray-50 hover:bg-gray-100 dark:bg-white/5 dark:hover:bg-white/10 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-lg text-xs font-medium flex items-center justify-center gap-2 transition-all duration-200"
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isCopying && canUseA1111 ? (
                   <>
@@ -4673,10 +4674,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
           {/* ComfyUI Integration */}
           {effectiveMetadata && showComfyUIActions && (
-            <div className={`mt-3 ${showComfyUIHeading ? 'pt-3 border-t border-gray-700' : ''}`}>
-              {showComfyUIHeading && (
-                <h4 className="text-xs text-gray-400 uppercase tracking-wider mb-2">ComfyUI</h4>
-              )}
+            <div className="mt-3 border-t border-gray-700 pt-3">
+              <h4 className="mb-2 text-xs uppercase tracking-wider text-gray-400">ComfyUI</h4>
 
               {/* One-click ComfyUI handoff */}
               <button
@@ -4687,7 +4686,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   }
                   onOpenComfyUIWorkflow?.(generationImage);
                 }}
-                className="w-full bg-purple-50 hover:bg-purple-100 dark:bg-purple-500/10 dark:hover:bg-purple-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-purple-200 dark:border-purple-500/50 hover:border-purple-300 dark:hover:border-purple-400 text-purple-700 dark:text-purple-100 px-4 py-3 rounded-lg text-sm font-semibold flex items-center justify-center gap-2 transition-all duration-200 mb-2"
+                className="mb-2 flex w-full items-center justify-center gap-2 rounded-lg border border-blue-500 bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <Workflow className="w-4 h-4" />
                 <span>Open Workflow in ComfyUI</span>
@@ -4704,7 +4703,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   copyToComfyUI(generationImage, effectiveMetadata);
                 }}
                 disabled={canUseComfyUI && (isCopyingComfyUI || !effectiveMetadata?.prompt)}
-                className="w-full bg-gray-50 hover:bg-gray-100 dark:bg-white/5 dark:hover:bg-white/10 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-lg text-xs font-medium flex items-center justify-center gap-2 transition-all duration-200"
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isCopyingComfyUI && canUseComfyUI ? (
                   <>

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -113,13 +113,13 @@ const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPromp
   };
 
   return (
-    <div className="bg-gray-50 dark:bg-gray-900/50 p-3 rounded-md border border-gray-200 dark:border-gray-700/50 relative group hover:bg-gray-100 dark:hover:bg-gray-800/80 transition-colors">
+    <div className="relative rounded-md border border-gray-700/50 bg-gray-900/50 p-3 transition-colors hover:bg-gray-800/80 group">
       <div className="flex justify-between items-start">
-        <p className="font-semibold text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">{label}</p>
+        <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">{label}</p>
         {onCopy && (
             <button
               onClick={handleCopy}
-              className={`transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded-sm ${copied ? 'opacity-100 text-green-500 dark:text-green-400' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-gray-900 dark:hover:text-gray-50'}`}
+              className={`rounded-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${copied ? 'opacity-100 text-green-400' : 'opacity-0 text-gray-400 group-hover:opacity-100 hover:text-gray-100 focus-visible:opacity-100'}`}
               title={copied ? 'Copied!' : `Copy ${label}`}
               aria-label={copied ? 'Copied!' : `Copy ${label}`}
             >
@@ -128,9 +128,9 @@ const MetadataItem: FC<{ label: string; value?: string | number | any[]; isPromp
         )}
       </div>
       {isPrompt ? (
-        <pre className="text-gray-700 dark:text-gray-200 whitespace-pre-wrap break-words font-mono text-sm mt-1">{displayValue}</pre>
+        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-sm text-gray-200">{displayValue}</pre>
       ) : (
-        <p className="text-gray-700 dark:text-gray-200 break-words font-mono text-sm mt-1">{displayValue}</p>
+        <p className="mt-1 break-words font-mono text-sm text-gray-200">{displayValue}</p>
       )}
     </div>
   );
@@ -207,7 +207,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const { generateWithComfyUI, isGenerating: isGeneratingComfyUI, generateStatus: generateStatusComfyUI } = useGenerateWithComfyUI();
 
   const { canUseA1111, canUseComfyUI, canUseBatchExport, showProModal, initialized } = useFeatureAccess();
-  const { a1111Enabled, comfyUIEnabled, visibleProviders, singleVisibleProvider } = useGenerationProviderAvailability();
+  const { a1111Enabled, comfyUIEnabled, singleVisibleProvider } = useGenerationProviderAvailability();
 
   const activeImage = previewImageFromStore || previewImage;
   const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata } = useShadowMetadata(activeImage?.id);
@@ -221,7 +221,6 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     : undefined;
   const showA1111Actions = !isVideo && !isAudio && !isModel3D && a1111Enabled;
   const showComfyUIActions = !isVideo && !isAudio && !isModel3D && comfyUIEnabled;
-  const showComfyUIHeading = showA1111Actions && visibleProviders.length > 1;
   const a1111GenerateLabel = singleVisibleProvider?.id === 'a1111' ? 'Generate' : 'Generate with A1111';
   const comfyGenerateLabel = singleVisibleProvider?.id === 'comfyui' ? 'Generate' : 'Generate with ComfyUI';
   const preferredThumbnailUrl = thumbnail?.thumbnailUrl ?? null;
@@ -517,7 +516,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
       data-area="preview"
       tabIndex={-1}
       style={{ width }}
-      className={`fixed right-0 top-0 h-full bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 z-40 flex flex-col shadow-xl ${isResizing ? 'transition-none' : 'transition-[width] duration-300 ease-in-out'}`}
+      className={`fixed right-0 top-0 z-40 flex h-full flex-col border-l border-gray-700 bg-gray-900 shadow-xl ${isResizing ? 'transition-none' : 'transition-[width] duration-300 ease-in-out'}`}
       onClick={hideContextMenu}
     >
       <div
@@ -531,7 +530,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
         <div className={`h-16 w-1 rounded-full transition-colors duration-150 ${isResizing ? 'bg-blue-400/90 shadow-[0_0_16px_rgba(96,165,250,0.55)]' : 'bg-gray-500/70 hover:bg-blue-400/80'}`} />
       </div>
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between border-b border-gray-700 p-4">
         <h2 className="text-lg font-semibold text-gray-200">Image Preview</h2>
         <button
           onClick={() => setPreviewImage(null)}
@@ -614,7 +613,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
             <h2 className="text-lg font-bold text-gray-100 break-all">{activeImage.name}</h2>
             {hasVerifiedTelemetry(activeImage) && (
               <span
-                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gradient-to-r from-green-500/20 to-emerald-500/20 text-green-400 border border-green-500/30 shadow-sm shadow-green-500/20"
+                className="inline-flex items-center gap-1 rounded-full border border-green-300 bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400"
                 title="MetaHub Save Node - Includes accurate performance metrics: generation time, VRAM usage, GPU device, and software versions."
               >
                 <CheckCircle size={12} className="flex-shrink-0" />
@@ -631,14 +630,14 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
               </span>
             )}
           </div>
-          <p className="text-xs text-blue-400 font-mono break-all">{new Date(activeImage.lastModified).toLocaleString()}</p>
+          <p className="break-all font-mono text-xs text-gray-400 dark:text-gray-500">{new Date(activeImage.lastModified).toLocaleString()}</p>
         </div>
 
         {/* Annotations Section */}
-        <div className="bg-gray-50 dark:bg-gray-900/50 p-3 rounded-lg border border-gray-200 dark:border-gray-700/50 space-y-2">
+        <div className="space-y-2 rounded-lg border border-gray-700/50 bg-gray-900/50 p-3">
           {/* Favorite, Rating, and Tags */}
           <div className="space-y-3">
-            <div className="flex w-fit items-center gap-2 rounded-lg border border-gray-200 bg-white/70 px-2 py-1.5 dark:border-gray-700/60 dark:bg-gray-950/30">
+            <div className="flex w-fit items-center gap-2 rounded-lg border border-gray-700/60 bg-gray-950/30 px-2 py-1.5">
               <motion.button
                 onClick={handleToggleFavorite}
                 whileTap={{ scale: 0.9 }}
@@ -652,7 +651,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
               >
                 <Heart className={`w-5 h-5 ${activeImage.isFavorite ? 'fill-current' : ''}`} />
               </motion.button>
-              <div className="h-5 w-px bg-gray-300/80 dark:bg-gray-700/70" />
+              <div className="h-5 w-px bg-gray-700/70" />
               <RatingStars rating={activeImage.rating ?? null} onChange={handleSetRating} size={16} />
             </div>
 
@@ -669,7 +668,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 excludedTags={activeImage.tags ?? []}
                 suggestionLimit={tagSuggestionLimit}
                 placeholder="Add tag..."
-                inputClassName="w-full bg-white dark:bg-gray-700/50 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder-gray-400 dark:placeholder-gray-500"
+                inputClassName="w-full rounded border border-gray-600 bg-gray-700/50 px-2 py-1 text-xs text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
                 dropdownClassName="absolute z-10 mt-1 max-h-32 w-full overflow-y-auto rounded-lg border border-gray-600 bg-gray-800 shadow-lg"
                 optionClassName="w-full text-left px-2 py-1.5 text-xs text-gray-200 hover:bg-gray-700 flex justify-between items-center"
                 activeOptionClassName="bg-gray-700 text-white"
@@ -705,7 +704,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                     <button
                       key={tag}
                       onClick={() => addTagToImage(activeImage.id, tag)}
-                      className="text-xs bg-gray-200 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 px-1.5 py-0.5 rounded hover:bg-gray-300 dark:hover:bg-gray-600 hover:text-gray-800 dark:hover:text-gray-200"
+                      className="rounded bg-gray-700/30 px-1.5 py-0.5 text-xs text-gray-400 hover:bg-gray-600 hover:text-gray-200"
                     >
                       {tag}
                     </button>
@@ -761,7 +760,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                   <motion.button
                     onClick={() => setShowOriginal((current) => !current)}
                     whileTap={{ scale: 0.95 }}
-                    className={`p-1.5 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${showOriginal ? 'bg-blue-900/50 text-blue-300' : 'bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-900 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white'}`}
+                    className={`rounded-md p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${showOriginal ? 'bg-blue-900/50 text-blue-300' : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-100'}`}
                     title={showOriginal ? 'Show edited metadata' : 'Show original metadata'}
                     aria-label={showOriginal ? 'Show edited metadata' : 'Show original metadata'}
                   >
@@ -771,7 +770,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 <motion.button
                   onClick={() => setIsMetadataEditorOpen(true)}
                   whileTap={{ scale: 0.95 }}
-                  className="p-1.5 rounded-md transition-colors bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-900 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                  className="rounded-md bg-gray-800 p-1.5 text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   title="Edit metadata overrides"
                   aria-label="Edit metadata overrides"
                 >
@@ -780,7 +779,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                 <motion.button
                   onClick={openBatchExport}
                   whileTap={{ scale: 0.95 }}
-                  className="p-1.5 rounded-md transition-colors bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-900 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                  className="rounded-md bg-gray-800 p-1.5 text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   title={exportSelectionIds.size > 1 && !canUseBatchExport && initialized ? 'Pro feature' : 'Open export flow'}
                   aria-label={exportSelectionIds.size > 1 && !canUseBatchExport && initialized ? 'Pro feature' : 'Open export flow'}
                 >
@@ -955,7 +954,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                   setIsGenerateModalOpen(true);
                 }}
                 disabled={canUseA1111 && !effectiveMetadata?.prompt}
-                className="w-full bg-blue-50 hover:bg-blue-100 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-blue-200 dark:border-blue-500/50 hover:border-blue-300 dark:hover:border-blue-400 text-blue-700 dark:text-blue-100 px-4 py-3 rounded-md text-sm font-semibold flex items-center justify-center gap-2 transition-all duration-200"
+                className="flex w-full items-center justify-center gap-2 rounded-md border border-blue-500 bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isGenerating && canUseA1111 ? (
                   <>
@@ -984,7 +983,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                   copyToA1111(generationImage, effectiveMetadata);
                 }}
                 disabled={canUseA1111 && (isCopying || !effectiveMetadata?.prompt)}
-                className="w-full bg-gray-50 hover:bg-gray-100 dark:bg-white/5 dark:hover:bg-white/10 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-md text-xs font-medium flex items-center justify-center gap-2 transition-all duration-200"
+                className="flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isCopying && canUseA1111 ? (
                   <>
@@ -1043,10 +1042,8 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
 
             {/* ComfyUI Actions */}
             {showComfyUIActions && (
-            <div className={`mt-3 ${showComfyUIHeading ? 'pt-3 border-t border-gray-200 dark:border-gray-700' : ''}`}>
-              {showComfyUIHeading && (
-                <h4 className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">ComfyUI</h4>
-              )}
+            <div className="mt-3 border-t border-gray-700 pt-3">
+              <h4 className="mb-2 text-xs uppercase tracking-wider text-gray-400">ComfyUI</h4>
 
               {/* Generate Button */}
               <button
@@ -1058,7 +1055,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                   setIsComfyUIGenerateModalOpen(true);
                 }}
                 disabled={canUseComfyUI && !effectiveMetadata?.prompt}
-                className="w-full bg-purple-50 hover:bg-purple-100 dark:bg-purple-500/10 dark:hover:bg-purple-500/20 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-purple-200 dark:border-purple-500/50 hover:border-purple-300 dark:hover:border-purple-400 text-purple-700 dark:text-purple-100 px-4 py-3 rounded-md text-sm font-semibold flex items-center justify-center gap-2 mb-2 transition-all duration-200"
+                className="mb-2 flex w-full items-center justify-center gap-2 rounded-md border border-blue-500 bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isGeneratingComfyUI && canUseComfyUI ? (
                   <>
@@ -1087,7 +1084,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                   copyToComfyUI(generationImage, effectiveMetadata);
                 }}
                 disabled={canUseComfyUI && (isCopyingComfyUI || !effectiveMetadata?.prompt)}
-                className="w-full bg-gray-50 hover:bg-gray-100 dark:bg-white/5 dark:hover:bg-white/10 disabled:bg-gray-100 dark:disabled:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-md text-xs font-medium flex items-center justify-center gap-2 transition-all duration-200"
+                className="flex w-full items-center justify-center gap-2 rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isCopyingComfyUI && canUseComfyUI ? (
                   <>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -280,7 +280,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         <div className="flex items-center gap-3 px-4 py-3">
           <img src="logo1.png" alt="Image MetaHub" className="h-11 w-11 flex-shrink-0 rounded-xl object-contain" />
           <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
-            <h1 className="truncate text-lg font-semibold tracking-tight text-white">
+            <h1 className="truncate text-lg font-semibold tracking-tight text-gray-100">
               {isPro ? 'Image MetaHub Pro' : isTrialActive ? 'Image MetaHub Pro Trial' : 'Image MetaHub'}
             </h1>
             <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">v0.19.2</span>

--- a/components/settings/LicenseSettingsPanel.tsx
+++ b/components/settings/LicenseSettingsPanel.tsx
@@ -9,10 +9,10 @@ import { formatLicenseValidity, licensePlanLabel } from '../../utils/licenseDisp
 
 const licenseStatusClassName: Record<string, string> = {
   free: 'border-gray-700 bg-gray-800 text-gray-300',
-  trial: 'border-yellow-500/30 bg-yellow-500/10 text-yellow-200',
-  expired: 'border-red-500/30 bg-red-500/10 text-red-200',
-  pro: 'border-green-500/30 bg-green-500/10 text-green-200',
-  lifetime: 'border-green-500/30 bg-green-500/10 text-green-200',
+  trial: 'border-yellow-300 bg-yellow-100 text-yellow-800 dark:border-yellow-500/30 dark:bg-yellow-500/10 dark:text-yellow-200',
+  expired: 'border-red-300 bg-red-100 text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-200',
+  pro: 'border-green-300 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/10 dark:text-green-200',
+  lifetime: 'border-green-300 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/10 dark:text-green-200',
 };
 
 const licenseStatusLabel: Record<string, string> = {

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.2] - [2026-08-27]
 
+### Improved
+
+- **Bundled Dependencies**: Updated bundled dependencies with the available non-breaking security fixes while keeping the current Electron version unchanged.
+- **Viewer Theme Consistency**: Improved Light Mode contrast and visual hierarchy across the Image Modal, Image Preview sidebar, main sidebar, and Support / License settings, with clearer A1111 and ComfyUI actions and theme-aware surfaces for Dark, Dracula, Nord, and Ocean.
+
 ### Fixed
 
-- **ComfyUI Workspace Thumbnails**: Single-clicking a thumbnail now opens it in the workspace inspector, while double-clicking opens the full image viewer according to the configured inline or detached viewer setting without returning to the Library grid.
+- **ComfyUI Workspace Thumbnails**: Single-clicking a thumbnail now opens it in the workspace inspector, while double-clicking or pressing Enter opens the full image viewer according to the configured inline or detached viewer setting without returning to the Library grid.
 - **Detached Viewer Deletion**: Deleting the current image now advances to the next available image without closing, flashing, or reopening the detached viewer window.
+- **Light Mode Image Preview**: The preview title, file name, and metadata section headings now remain readable against the preview panel when using Light Mode.
 
 ## [0.19.1] - [2026-08-26]
 


### PR DESCRIPTION
## Summary
- improve Light Mode contrast across the Image Modal, Image Preview sidebar, main sidebar, and license settings
- simplify viewer action hierarchy and align A1111 and ComfyUI primary actions with the app blue
- make Image Preview surfaces follow Light, Dark, Dracula, Nord, and Ocean theme variables
- update both 0.19.2 changelogs under Improved while preserving their existing pending entries

## Validation
- git diff --check
- focused ESLint on the four changed components (0 errors; existing warnings only)
- changelog copies verified identical
- visual acceptance left for manual verification