### PR TITLE
fix: add delete to image grid context menu

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4254,6 +4254,7 @@ export default function App() {
                           totalPages={totalPages}
                           onPageChange={setCurrentPage}
                           onBatchExport={handleOpenBatchExport}
+                          onDeleteSelected={handleDeleteSelectedImages}
                           onImageRenamed={handleImageRenamed}
                           onFindSimilar={(image) => openFindSimilar(image, displayImages, { checkpointMode: 'ignore' })}
                           onFindVisuallySimilar={runVisualSimilar}
@@ -4309,6 +4310,7 @@ export default function App() {
                         totalPages={totalPages}
                         onPageChange={setCurrentPage}
                         onBatchExport={handleOpenBatchExport}
+                        onDeleteSelected={handleDeleteSelectedImages}
                         activeCollection={activeCollection}
                         isCollectionsView
                         onImageRenamed={handleImageRenamed}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ComfyUI Workspace Thumbnails**: Single-clicking a thumbnail now opens it in the workspace inspector, while double-clicking or pressing Enter opens the full image viewer according to the configured inline or detached viewer setting without returning to the Library grid.
 - **Detached Viewer Deletion**: Deleting the current image now advances to the next available image without closing, flashing, or reopening the detached viewer window.
+- **Image Grid Deletion**: Added a Delete action to the image grid context menu, applying to the clicked image or the current multi-selection.
 - **Light Mode Image Preview**: The preview title, file name, and metadata section headings now remain readable against the preview panel when using Light Mode.
 
 ## [0.19.1] - [2026-08-26]

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -166,12 +166,13 @@ const createImages = (count: number): IndexedImage[] =>
     }),
   );
 
-const Harness = ({ images, onFindSimilar, onFindVisuallySimilar, canFindVisuallySimilar = false, hasRightSidebar = false }: {
+const Harness = ({ images, onFindSimilar, onFindVisuallySimilar, canFindVisuallySimilar = false, hasRightSidebar = false, onDeleteSelected }: {
   images: IndexedImage[];
   onFindSimilar?: (image: IndexedImage) => void;
   onFindVisuallySimilar?: (image: IndexedImage) => void;
   canFindVisuallySimilar?: boolean;
   hasRightSidebar?: boolean;
+  onDeleteSelected?: () => void;
 }) => {
   const selectedImages = useImageStore((state) => state.selectedImages);
 
@@ -188,6 +189,7 @@ const Harness = ({ images, onFindSimilar, onFindVisuallySimilar, canFindVisually
       onFindVisuallySimilar={onFindVisuallySimilar}
       canFindVisuallySimilar={canFindVisuallySimilar}
       hasRightSidebar={hasRightSidebar}
+      onDeleteSelected={onDeleteSelected}
     />
   );
 };
@@ -515,6 +517,41 @@ describe('ImageGrid context menu', () => {
 
     expect(screen.getByRole('textbox', { name: /rename alpha\.png/i })).toBeTruthy();
     expect(hideContextMenuMock).toHaveBeenCalled();
+  });
+
+  it('deletes only the context image when it is outside the current selection', () => {
+    const onDeleteSelected = vi.fn();
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    const otherImage = createImage({ id: 'img-2', name: 'beta.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+    setupImageGridState([image, otherImage]);
+    useImageStore.setState({ selectedImages: new Set(['img-2']) });
+
+    render(<Harness images={[image, otherImage]} onDeleteSelected={onDeleteSelected} />);
+
+    fireEvent.click(screen.getByText('Delete'));
+
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1']));
+    expect(onDeleteSelected).toHaveBeenCalledTimes(1);
+    expect(hideContextMenuMock).toHaveBeenCalled();
+  });
+
+  it('deletes the current selection when the context image is selected', () => {
+    const onDeleteSelected = vi.fn();
+    const image = createImage({ id: 'img-1', name: 'alpha.png' });
+    const otherImage = createImage({ id: 'img-2', name: 'beta.png' });
+    contextMenuStateMock.visible = true;
+    contextMenuStateMock.image = image;
+    setupImageGridState([image, otherImage]);
+    useImageStore.setState({ selectedImages: new Set(['img-1', 'img-2']) });
+
+    render(<Harness images={[image, otherImage]} onDeleteSelected={onDeleteSelected} />);
+
+    fireEvent.click(screen.getByText('Delete Selected (2)'));
+
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
+    expect(onDeleteSelected).toHaveBeenCalledTimes(1);
   });
 
   it('shows collection actions in the image context menu', () => {

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -537,20 +537,21 @@ describe('ImageGrid context menu', () => {
     expect(hideContextMenuMock).toHaveBeenCalled();
   });
 
-  it('deletes the current selection when the context image is selected', () => {
+  it('shows and deletes the full global selection when some selected images are outside the grid', () => {
     const onDeleteSelected = vi.fn();
     const image = createImage({ id: 'img-1', name: 'alpha.png' });
     const otherImage = createImage({ id: 'img-2', name: 'beta.png' });
+    const hiddenImage = createImage({ id: 'img-3', name: 'hidden.png' });
     contextMenuStateMock.visible = true;
     contextMenuStateMock.image = image;
-    setupImageGridState([image, otherImage]);
-    useImageStore.setState({ selectedImages: new Set(['img-1', 'img-2']) });
+    setupImageGridState([image, otherImage, hiddenImage]);
+    useImageStore.setState({ selectedImages: new Set(['img-1', 'img-2', 'img-3']) });
 
     render(<Harness images={[image, otherImage]} onDeleteSelected={onDeleteSelected} />);
 
-    fireEvent.click(screen.getByText('Delete Selected (2)'));
+    fireEvent.click(screen.getByText('Delete Selected (3)'));
 
-    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2']));
+    expect(useImageStore.getState().selectedImages).toEqual(new Set(['img-1', 'img-2', 'img-3']));
     expect(onDeleteSelected).toHaveBeenCalledTimes(1);
   });
 

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -18,7 +18,8 @@ import { Heart, Info, Copy, CheckCircle, Folder, Clipboard, Sparkles, GitCompare
   Tag,
   RefreshCw,
   Image as ImageIcon,
-  Workflow
+  Workflow,
+  Trash2
 } from 'lucide-react';
 import { copyTextToClipboard } from '../utils/imageUtils';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
@@ -1056,6 +1057,7 @@ interface ImageGridProps {
   totalPages: number;
   onPageChange: (page: number) => void;
   onBatchExport: () => void;
+  onDeleteSelected?: () => void | Promise<void>;
   activeCollection?: SmartCollection | null;
   isCollectionsView?: boolean;
   onImageRenamed?: (oldImageId: string, newImageId: string) => void;
@@ -1087,6 +1089,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   totalPages,
   onPageChange,
   onBatchExport,
+  onDeleteSelected,
   activeCollection = null,
   isCollectionsView = false,
   onImageRenamed,
@@ -1686,6 +1689,20 @@ const ImageGrid: React.FC<ImageGridProps> = ({
     setRenamingImageId(image.id);
     hideContextMenu();
   }, [hideContextMenu]);
+
+  const handleDeleteFromContextMenu = useCallback(() => {
+    if (!contextMenu.image || !onDeleteSelected) {
+      hideContextMenu();
+      return;
+    }
+
+    if (!selectedImages.has(contextMenu.image.id)) {
+      useImageStore.setState({ selectedImages: new Set([contextMenu.image.id]) });
+    }
+
+    hideContextMenu();
+    void onDeleteSelected();
+  }, [contextMenu.image, hideContextMenu, onDeleteSelected, selectedImages]);
 
   const closeInlineRename = useCallback((result?: ImageRenameResult) => {
     if (result) {
@@ -2782,6 +2799,19 @@ const ImageGrid: React.FC<ImageGridProps> = ({
               </>
             );
           })()}
+
+          {onDeleteSelected && (
+            <>
+              <div className="border-t border-gray-600 my-1"></div>
+              <ContextMenuButton
+                onClick={handleDeleteFromContextMenu}
+                icon={<Trash2 className="w-4 h-4" />}
+                label={getContextTargetImages().length > 1
+                  ? `Delete Selected (${getContextTargetImages().length})`
+                  : 'Delete'}
+              />
+            </>
+          )}
         </div>,
         document.body,
       )

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -1573,6 +1573,9 @@ const ImageGrid: React.FC<ImageGridProps> = ({
 
     return [contextMenu.image];
   }, [contextMenu.image, images, selectedImages]);
+  const deleteTargetCount = contextMenu.image && selectedImages.has(contextMenu.image.id)
+    ? selectedImages.size
+    : contextMenu.image ? 1 : 0;
 
   const handleAddToExistingCollection = useCallback(async (collection: SmartCollection) => {
     const targetImages = getContextTargetImages();
@@ -2806,8 +2809,8 @@ const ImageGrid: React.FC<ImageGridProps> = ({
               <ContextMenuButton
                 onClick={handleDeleteFromContextMenu}
                 icon={<Trash2 className="w-4 h-4" />}
-                label={getContextTargetImages().length > 1
-                  ? `Delete Selected (${getContextTargetImages().length})`
+                label={deleteTargetCount > 1
+                  ? `Delete Selected (${deleteTargetCount})`
                   : 'Delete'}
               />
             </>

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ComfyUI Workspace Thumbnails**: Single-clicking a thumbnail now opens it in the workspace inspector, while double-clicking or pressing Enter opens the full image viewer according to the configured inline or detached viewer setting without returning to the Library grid.
 - **Detached Viewer Deletion**: Deleting the current image now advances to the next available image without closing, flashing, or reopening the detached viewer window.
+- **Image Grid Deletion**: Added a Delete action to the image grid context menu, applying to the clicked image or the current multi-selection.
 - **Light Mode Image Preview**: The preview title, file name, and metadata section headings now remain readable against the preview panel when using Light Mode.
 
 ## [0.19.1] - [2026-08-26]


### PR DESCRIPTION
## Summary
- add Delete to the Image Grid context menu
- delete only the clicked image when it is outside the current selection
- delete the full selection when right-clicking a selected image
- update both changelog files

## Validation
- npm test -- --run __tests__/ImageGrid.contextMenu.test.tsx (28 passed)
- git diff --check