### PR TITLE
feat: improve license delivery email

### DIFF
--- a/packages/license-server/__tests__/resendClient.test.ts
+++ b/packages/license-server/__tests__/resendClient.test.ts
@@ -4,8 +4,10 @@ import { ResendDeliveryClient } from '../src/resendClient.js';
 
 describe('ResendDeliveryClient', () => {
   it('invokes fetch with the global receiver required by Cloudflare Workers', async () => {
-    const fetchImpl = function (this: unknown) {
+    let sentBody: Record<string, unknown> | undefined;
+    const fetchImpl = function (this: unknown, _url: string | URL | Request, init?: RequestInit) {
       expect(this).toBe(globalThis);
+      sentBody = JSON.parse(String(init?.body));
       return Promise.resolve(new Response(JSON.stringify({ id: 'email_1' }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -26,5 +28,27 @@ describe('ResendDeliveryClient', () => {
     });
 
     expect(result).toEqual({ ok: true, messageId: 'email_1' });
+    expect(sentBody?.text).toBe([
+      'Hi there!',
+      '',
+      'Thank you for your purchase and for supporting the project!',
+      '',
+      'Your license is ready to use. Just open Image MetaHub, go to Settings → License, enter the email below and the key, and the app will activate immediately.',
+      '',
+      'Email: buyer@example.com',
+      'License: IMH2-TEST',
+      '',
+      'If you have a moment, I’d really appreciate it if you could fill out this short survey: https://forms.gle/HY8eysnEB2uS9bsS6. Hearing directly from you helps me a lot in making the app better for everyone!',
+      '',
+      'If you have any issues activating the license, please let me know!',
+      '',
+      'Best regards,',
+      'Lucas',
+    ].join('\n'));
+    expect(sentBody?.html).toContain('<p>Hi there!</p>');
+    expect(sentBody?.html).toContain('<strong>Email:</strong> buyer@example.com<br>');
+    expect(sentBody?.html).toContain('<strong>License:</strong> <code>IMH2-TEST</code>');
+    expect(sentBody?.html).toContain('<a href="https://forms.gle/HY8eysnEB2uS9bsS6">');
+    expect(sentBody?.html).toContain('<p>Best regards,<br>Lucas</p>');
   });
 });

--- a/packages/license-server/src/resendClient.js
+++ b/packages/license-server/src/resendClient.js
@@ -7,15 +7,6 @@ const escapeHtml = (value) => String(value)
   .replace(/"/g, '&quot;')
   .replace(/'/g, '&#039;');
 
-const planLabel = (plan) => ({ lifetime: 'Lifetime', monthly: 'Monthly', annual: 'Annual' }[plan] || 'Pro');
-
-function formatExpiration(expiresAt) {
-  if (!expiresAt) return 'No expiration';
-  return new Intl.DateTimeFormat('en-US', {
-    year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC',
-  }).format(new Date(expiresAt));
-}
-
 export class ResendDeliveryClient {
   constructor({ apiKey, from, replyTo = null, fetchImpl = globalThis.fetch }) {
     this.apiKey = apiKey;
@@ -24,24 +15,33 @@ export class ResendDeliveryClient {
     this.fetchImpl = fetchImpl;
   }
 
-  async sendLicense({ outboxId, email, licenseKey, plan, expiresAt }) {
-    const label = planLabel(plan);
-    const validity = formatExpiration(expiresAt);
+  async sendLicense({ outboxId, email, licenseKey }) {
     const text = [
-      'Thank you for supporting Image MetaHub.',
+      'Hi there!',
       '',
-      `Plan: ${label}`,
-      `Validity: ${validity}`,
-      `License key: ${licenseKey}`,
+      'Thank you for your purchase and for supporting the project!',
       '',
-      'Activate it in Image MetaHub using this email address and the license key above.',
+      'Your license is ready to use. Just open Image MetaHub, go to Settings → License, enter the email below and the key, and the app will activate immediately.',
+      '',
+      `Email: ${email}`,
+      `License: ${licenseKey}`,
+      '',
+      'If you have a moment, I’d really appreciate it if you could fill out this short survey: https://forms.gle/HY8eysnEB2uS9bsS6. Hearing directly from you helps me a lot in making the app better for everyone!',
+      '',
+      'If you have any issues activating the license, please let me know!',
+      '',
+      'Best regards,',
+      'Lucas',
     ].join('\n');
     const html = [
-      '<p>Thank you for supporting Image MetaHub.</p>',
-      `<p><strong>Plan:</strong> ${escapeHtml(label)}<br>`,
-      `<strong>Validity:</strong> ${escapeHtml(validity)}</p>`,
-      `<p><strong>License key:</strong><br><code>${escapeHtml(licenseKey)}</code></p>`,
-      '<p>Activate it in Image MetaHub using this email address and the license key above.</p>',
+      '<p>Hi there!</p>',
+      '<p>Thank you for your purchase and for supporting the project!</p>',
+      '<p>Your license is ready to use. Just open Image MetaHub, go to Settings → License, enter the email below and the key, and the app will activate immediately.</p>',
+      `<p><strong>Email:</strong> ${escapeHtml(email)}<br>`,
+      `<strong>License:</strong> <code>${escapeHtml(licenseKey)}</code></p>`,
+      '<p>If you have a moment, I’d really appreciate it if you could fill out this short survey: <a href="https://forms.gle/HY8eysnEB2uS9bsS6">https://forms.gle/HY8eysnEB2uS9bsS6</a>. Hearing directly from you helps me a lot in making the app better for everyone!</p>',
+      '<p>If you have any issues activating the license, please let me know!</p>',
+      '<p>Best regards,<br>Lucas</p>',
     ].join('');
     const body = {
       from: this.from,


### PR DESCRIPTION
## Summary
- replace the automatic license-delivery email with a clearer activation walkthrough
- include the customer email and license key in both plain-text and HTML versions
- add properly separated paragraphs, a clickable feedback survey link, and a support closing
- extend the regression test to verify the rendered message content

## Verification
- `npx vitest run packages/license-server/__tests__` — 49 tests passed
- production deployment preflight, dry-run, D1 migration check, and entitlement smoke test passed
- Worker health check returned HTTP 200; rollback was not triggered

## Production
- deployed commit: `bc572ec`
- Worker version: `a418df6a-59f2-4b15-88c7-8df51cbb511d`
- deploy run: https://github.com/LuqP2/Image-MetaHub/actions/runs/33091189733