### PR TITLE
Fix viewer zoom controls

### DIFF
--- a/__tests__/useSettingsStore.imageViewer.test.ts
+++ b/__tests__/useSettingsStore.imageViewer.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { sanitizeImageViewerMode, useSettingsStore } from '../store/useSettingsStore';
+import {
+  sanitizeImageViewerDefaultZoom,
+  sanitizeImageViewerMode,
+  useSettingsStore,
+} from '../store/useSettingsStore';
 
 describe('image viewer preference', () => {
   beforeEach(() => useSettingsStore.getState().resetState());
@@ -17,5 +21,14 @@ describe('image viewer preference', () => {
     expect(useSettingsStore.getState().imageViewerMode).toBe('detached');
     useSettingsStore.getState().setImageViewerMode('invalid' as never);
     expect(useSettingsStore.getState().imageViewerMode).toBe('detached');
+  });
+
+  it('defaults image zoom to fit and stores 1:1 as the alternative', () => {
+    expect(sanitizeImageViewerDefaultZoom(undefined)).toBe('fit');
+    expect(useSettingsStore.getState().imageViewerDefaultZoom).toBe('fit');
+    useSettingsStore.getState().setImageViewerDefaultZoom('actual');
+    expect(useSettingsStore.getState().imageViewerDefaultZoom).toBe('actual');
+    useSettingsStore.getState().setImageViewerDefaultZoom('invalid' as never);
+    expect(useSettingsStore.getState().imageViewerDefaultZoom).toBe('fit');
   });
 });

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1017,6 +1017,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const slideshowIntervalSeconds = useSettingsStore((state) => state.slideshowIntervalSeconds);
   const slideshowShowFilename = useSettingsStore((state) => state.slideshowShowFilename);
   const autoPlayMedia = useSettingsStore((state) => state.autoPlayMedia);
+  const imageViewerDefaultZoom = useSettingsStore((state) => state.imageViewerDefaultZoom);
   // A running slideshow and a repeat-all/shuffle chain both imply continuous playback, so they
   // start the media regardless of the auto-play preference.
   const shouldAutoPlayMedia = autoPlayMedia || isChainedPlayback || (isSlideshowMode && isSlideshowPlaying);
@@ -2137,11 +2138,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   useEffect(() => {
     setZoom(1);
-    setViewerZoomMode('fit');
+    setViewerZoomMode(imageViewerDefaultZoom);
     setPan({ x: 0, y: 0 });
     setSlideshowVideoDuration(null);
     revealMediaOverlay();
-  }, [image.id, revealMediaOverlay]);
+  }, [image.id, imageViewerDefaultZoom, revealMediaOverlay]);
 
   useEffect(() => {
     if (!isSlideshowMode) {
@@ -2155,11 +2156,11 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   useEffect(() => {
     setZoom(1);
-    setViewerZoomMode('fit');
+    setViewerZoomMode(isSlideshowMode ? 'fit' : imageViewerDefaultZoom);
     setPan({ x: 0, y: 0 });
     setIsMediaOverlayVisible(false);
     clearMediaOverlayHideTimer();
-  }, [clearMediaOverlayHideTimer, isFullscreen]);
+  }, [clearMediaOverlayHideTimer, imageViewerDefaultZoom, isFullscreen, isSlideshowMode]);
 
   useEffect(() => {
     const applyWindowZoomFactor = (nextZoomFactor: number) => {
@@ -2211,7 +2212,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const handleWheel = useCallback((e: WheelEvent) => {
     e.preventDefault();
 
-    const delta = e.deltaY * -0.01;
+    const delta = Math.max(-0.1, Math.min(0.1, e.deltaY * -0.001));
     const newZoom = Math.min(Math.max(minViewerZoom, zoom + delta), maxViewerZoom);
 
     setViewerZoomMode('manual');

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2212,7 +2212,13 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const handleWheel = useCallback((e: WheelEvent) => {
     e.preventDefault();
 
-    const delta = Math.max(-0.1, Math.min(0.1, e.deltaY * -0.001));
+    const deltaModeScale = e.deltaMode === WheelEvent.DOM_DELTA_LINE
+      ? 40
+      : e.deltaMode === WheelEvent.DOM_DELTA_PAGE
+        ? Math.max(window.innerHeight, 800)
+        : 1;
+    const normalizedDeltaY = e.deltaY * deltaModeScale;
+    const delta = Math.max(-0.1, Math.min(0.1, normalizedDeltaY * -0.001));
     const newZoom = Math.min(Math.max(minViewerZoom, zoom + delta), maxViewerZoom);
 
     setViewerZoomMode('manual');

--- a/components/settings/ViewerSettingsPanel.tsx
+++ b/components/settings/ViewerSettingsPanel.tsx
@@ -36,6 +36,8 @@ export const ViewerSettingsPanel: React.FC = () => {
   const setSlideshowShowFilename = useSettingsStore((state) => state.setSlideshowShowFilename);
   const imageViewerMode = useSettingsStore((state) => state.imageViewerMode);
   const setImageViewerMode = useSettingsStore((state) => state.setImageViewerMode);
+  const imageViewerDefaultZoom = useSettingsStore((state) => state.imageViewerDefaultZoom);
+  const setImageViewerDefaultZoom = useSettingsStore((state) => state.setImageViewerDefaultZoom);
   const isDesktop = typeof window !== 'undefined' && Boolean(window.electronAPI);
 
   return (
@@ -50,6 +52,19 @@ export const ViewerSettingsPanel: React.FC = () => {
               onChange={(checked) => setImageViewerMode(checked ? 'detached' : 'inline')}
               disabled={!isDesktop}
             />
+          }
+        />
+        <SettingRow
+          label="Default image zoom"
+          control={
+            <select
+              value={imageViewerDefaultZoom}
+              onChange={(event) => setImageViewerDefaultZoom(event.target.value as 'fit' | 'actual')}
+              className="rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+            >
+              <option value="fit">Fit</option>
+              <option value="actual">1:1</option>
+            </select>
           }
         />
         <SettingRow

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -111,9 +111,13 @@ export const sanitizeSlideshowIntervalSeconds = (value: number): number => {
 
 export type VideoRepeatMode = 'off' | 'one' | 'all';
 export type ImageViewerMode = 'detached' | 'inline';
+export type ImageViewerDefaultZoom = 'fit' | 'actual';
 
 export const sanitizeImageViewerMode = (value: unknown): ImageViewerMode =>
   value === 'inline' || value === 'detached' ? value : 'detached';
+
+export const sanitizeImageViewerDefaultZoom = (value: unknown): ImageViewerDefaultZoom =>
+  value === 'actual' ? 'actual' : 'fit';
 
 const VALID_VIDEO_REPEAT_MODES: VideoRepeatMode[] = ['off', 'one', 'all'];
 const isValidVideoRepeatMode = (value: unknown): value is VideoRepeatMode =>
@@ -196,6 +200,8 @@ interface SettingsState {
   videoShuffle: boolean;
   /** Desktop viewer host. Web builds always resolve this preference to inline. */
   imageViewerMode: ImageViewerMode;
+  /** Zoom mode applied whenever an image opens in the viewer. */
+  imageViewerDefaultZoom: ImageViewerDefaultZoom;
   creatorAttributionToken: string | null;
   creatorAttributionUpdatedAt: number | null;
 
@@ -258,6 +264,7 @@ interface SettingsState {
   setVideoRepeatMode: (value: VideoRepeatMode) => void;
   setVideoShuffle: (value: boolean) => void;
   setImageViewerMode: (value: ImageViewerMode) => void;
+  setImageViewerDefaultZoom: (value: ImageViewerDefaultZoom) => void;
   setCreatorAttributionToken: (token: string | null) => void;
   setA1111Enabled: (value: boolean) => void;
   setA1111ServerUrl: (url: string) => void;
@@ -324,6 +331,7 @@ export const useSettingsStore = create<SettingsState>()(
       videoRepeatMode: readLegacyVideoRepeatMode(),
       videoShuffle: false,
       imageViewerMode: 'detached',
+      imageViewerDefaultZoom: 'fit',
       creatorAttributionToken: null,
       creatorAttributionUpdatedAt: null,
 
@@ -400,6 +408,7 @@ export const useSettingsStore = create<SettingsState>()(
         set({ videoRepeatMode: isValidVideoRepeatMode(value) ? value : 'off' }),
       setVideoShuffle: (value) => set({ videoShuffle: !!value }),
       setImageViewerMode: (value) => set({ imageViewerMode: sanitizeImageViewerMode(value) }),
+      setImageViewerDefaultZoom: (value) => set({ imageViewerDefaultZoom: sanitizeImageViewerDefaultZoom(value) }),
       setCreatorAttributionToken: (token) => {
         const normalizedToken = typeof token === 'string' ? token.trim() : '';
         set({
@@ -487,6 +496,7 @@ export const useSettingsStore = create<SettingsState>()(
         videoRepeatMode: 'off',
         videoShuffle: false,
         imageViewerMode: 'detached',
+        imageViewerDefaultZoom: 'fit',
         creatorAttributionToken: null,
         creatorAttributionUpdatedAt: null,
         a1111Enabled: true,
@@ -607,6 +617,10 @@ export const useSettingsStore = create<SettingsState>()(
 
         if (state && !isValidVideoRepeatMode(state.videoRepeatMode)) {
           state.videoRepeatMode = 'off';
+        }
+
+        if (state) {
+          state.imageViewerDefaultZoom = sanitizeImageViewerDefaultZoom(state.imageViewerDefaultZoom);
         }
 
         if (state && typeof state.videoShuffle !== 'boolean') {


### PR DESCRIPTION
## Summary
- make mouse-wheel zoom changes more granular
- add a persistent Fit / 1:1 default image zoom preference
- keep slideshow images fitted to the viewport

## Validation
- git diff --check
- Targeted Vitest could not start in this environment because Node ran out of memory during Vitest initialization.