### PR TITLE
fix: stop repeated cache invalidation and startup churn

### DIFF
--- a/__tests__/cacheParserVersionConsistency.test.ts
+++ b/__tests__/cacheParserVersionConsistency.test.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PARSER_VERSION } from '../services/cacheManager';
+
+describe('cache parser version consistency', () => {
+  it('uses the shared v11 parser version in both renderer and Electron', () => {
+    const electronSource = fs.readFileSync(path.resolve(process.cwd(), 'electron.mjs'), 'utf8');
+
+    expect(PARSER_VERSION).toBe(11);
+    expect(electronSource).toContain("import { PARSER_VERSION } from './utils/parserVersion.js';");
+    expect(electronSource).not.toMatch(/const PARSER_VERSION\s*=/);
+  });
+});

--- a/__tests__/thumbnailManager.retry.test.ts
+++ b/__tests__/thumbnailManager.retry.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IndexedImage } from '../types';
+
+const cacheMocks = vi.hoisted(() => ({
+  getCachedThumbnail: vi.fn().mockResolvedValue(null),
+  cacheThumbnail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/cacheManager', () => ({
+  default: {
+    getCachedThumbnail: cacheMocks.getCachedThumbnail,
+    cacheThumbnail: cacheMocks.cacheThumbnail,
+  },
+}));
+
+import { thumbnailManager } from '../services/thumbnailManager';
+
+describe('thumbnailManager retry cooldown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-30T21:00:00-03:00'));
+    cacheMocks.getCachedThumbnail.mockClear();
+    cacheMocks.cacheThumbnail.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries a transient failure after the cooldown without retrying every viewport request', async () => {
+    const getFile = vi.fn().mockRejectedValue(new Error('Temporary file access failure'));
+    const image = {
+      id: 'dir-1::transient-thumbnail.png',
+      name: 'transient-thumbnail.png',
+      lastModified: 123,
+      handle: { getFile } as unknown as FileSystemFileHandle,
+      metadata: {},
+      metadataString: '',
+      models: [],
+      loras: [],
+      directoryId: 'dir-1',
+    } as IndexedImage;
+
+    await thumbnailManager.ensureThumbnail(image);
+    await Promise.resolve();
+    expect(getFile).toHaveBeenCalledTimes(1);
+
+    await thumbnailManager.ensureThumbnail(image);
+    expect(getFile).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await thumbnailManager.ensureThumbnail(image);
+    await Promise.resolve();
+
+    expect(getFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/thumbnailManager.retry.test.ts
+++ b/__tests__/thumbnailManager.retry.test.ts
@@ -40,6 +40,7 @@ describe('thumbnailManager retry cooldown', () => {
       loras: [],
       directoryId: 'dir-1',
     } as IndexedImage;
+    const unsubscribe = thumbnailManager.subscribe(image.id, () => undefined);
 
     await thumbnailManager.ensureThumbnail(image);
     await Promise.resolve();
@@ -49,9 +50,9 @@ describe('thumbnailManager retry cooldown', () => {
     expect(getFile).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(30_000);
-    await thumbnailManager.ensureThumbnail(image);
     await Promise.resolve();
 
     expect(getFile).toHaveBeenCalledTimes(2);
+    unsubscribe();
   });
 });

--- a/__tests__/useImageStore.filters.test.ts
+++ b/__tests__/useImageStore.filters.test.ts
@@ -561,6 +561,31 @@ describe('useImageStore tri-state filters', () => {
     expect(storedTarget?.rating).toBe(4);
   });
 
+  it('defers enrichment merges until startup directory refresh finishes', () => {
+    const original = createImage({
+      id: 'dir-1::refreshing.png',
+      name: 'refreshing.png',
+      prompt: 'catalog metadata',
+    });
+
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      directories: [directory],
+      images: [original],
+      filteredImages: [original],
+      sortOrder: 'asc',
+    });
+
+    useImageStore.getState().setDirectoryRefreshing(directory.id, true);
+    useImageStore.getState().mergeImages([{ ...original, prompt: 'enriched metadata' }]);
+
+    expect(useImageStore.getState().images[0].prompt).toBe('catalog metadata');
+
+    useImageStore.getState().setDirectoryRefreshing(directory.id, false);
+
+    expect(useImageStore.getState().images[0].prompt).toBe('enriched metadata');
+  });
+
   it('ignores queued images and merges from removed directories', () => {
     useImageStore.getState().resetState();
     useImageStore.setState({

--- a/__tests__/useImageStore.filters.test.ts
+++ b/__tests__/useImageStore.filters.test.ts
@@ -588,6 +588,44 @@ describe('useImageStore tri-state filters', () => {
     expect(useImageStore.getState().images[0].prompt).toBe('enriched metadata');
   });
 
+  it('only defers merge updates that belong to the refreshing directory', () => {
+    const refreshingImage = createImage({
+      id: 'dir-1::refreshing.png',
+      name: 'refreshing.png',
+      prompt: 'old refreshing metadata',
+    });
+    const editedImage = createImage({
+      id: 'dir-2::edited.png',
+      name: 'edited.png',
+      directoryId: 'dir-2',
+      prompt: 'old edited metadata',
+    });
+
+    useImageStore.getState().resetState();
+    useImageStore.setState({
+      directories: [directory, secondDirectory],
+      images: [refreshingImage, editedImage],
+      filteredImages: [refreshingImage, editedImage],
+      sortOrder: 'asc',
+    });
+
+    useImageStore.getState().setDirectoryRefreshing(directory.id, true);
+    useImageStore.getState().mergeImages([
+      { ...refreshingImage, prompt: 'new refreshing metadata' },
+      { ...editedImage, prompt: 'new edited metadata' },
+    ]);
+
+    expect(useImageStore.getState().images.find((image) => image.id === refreshingImage.id)?.prompt)
+      .toBe('old refreshing metadata');
+    expect(useImageStore.getState().images.find((image) => image.id === editedImage.id)?.prompt)
+      .toBe('new edited metadata');
+
+    useImageStore.getState().setDirectoryRefreshing(directory.id, false);
+
+    expect(useImageStore.getState().images.find((image) => image.id === refreshingImage.id)?.prompt)
+      .toBe('new refreshing metadata');
+  });
+
   it('ignores queued images and merges from removed directories', () => {
     useImageStore.getState().resetState();
     useImageStore.setState({

--- a/__tests__/useImageStore.filters.test.ts
+++ b/__tests__/useImageStore.filters.test.ts
@@ -562,7 +562,7 @@ describe('useImageStore tri-state filters', () => {
   });
 
   it('defers enrichment merges until startup directory refresh finishes', () => {
-    const original = createImage({
+    const catalogImage = createImage({
       id: 'dir-1::refreshing.png',
       name: 'refreshing.png',
       prompt: 'catalog metadata',
@@ -571,18 +571,20 @@ describe('useImageStore tri-state filters', () => {
     useImageStore.getState().resetState();
     useImageStore.setState({
       directories: [directory],
-      images: [original],
-      filteredImages: [original],
+      images: [],
+      filteredImages: [],
       sortOrder: 'asc',
     });
 
     useImageStore.getState().setDirectoryRefreshing(directory.id, true);
-    useImageStore.getState().mergeImages([{ ...original, prompt: 'enriched metadata' }]);
+    useImageStore.getState().addImages([catalogImage]);
+    useImageStore.getState().mergeImages([{ ...catalogImage, prompt: 'enriched metadata' }]);
 
-    expect(useImageStore.getState().images[0].prompt).toBe('catalog metadata');
+    expect(useImageStore.getState().images).toEqual([]);
 
     useImageStore.getState().setDirectoryRefreshing(directory.id, false);
 
+    expect(useImageStore.getState().images).toHaveLength(1);
     expect(useImageStore.getState().images[0].prompt).toBe('enriched metadata');
   });
 

--- a/electron.mjs
+++ b/electron.mjs
@@ -28,6 +28,7 @@ import {
   isSupportedMediaFileName,
 } from './utils/mediaTypes.js';
 import { normalizeBirthtimeMs, resolveFileSortDate } from './utils/fileTimestamps.js';
+import { PARSER_VERSION } from './utils/parserVersion.js';
 import { copyFilePreservingTimestamps } from './utils/fileCopy.mjs';
 import { readBasicMp4Metadata } from './utils/mp4Metadata.mjs';
 import {
@@ -134,10 +135,6 @@ app.commandLine.appendSwitch('js-flags', '--max-old-space-size=4096');
 if (!gpuMitigationEnabled) {
   app.commandLine.appendSwitch('enable-unsafe-webgpu');
 }
-
-// Parser version - increment when parser logic changes
-// This ensures cache is invalidated when parsing rules change
-const PARSER_VERSION = 11; // v11: Index 3D models and bounded GLB/GLTF/sidecar metadata
 
 const logMainPerf = (event, details = {}) => {
   console.log('[main:perf]', { event, ...details });

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -6,12 +6,9 @@ import {
   type ThumbnailGenerateToCacheRequest,
 } from '../types';
 import { isUsableTimestamp } from '../utils/fileTimestamps.js';
+import { PARSER_VERSION } from '../utils/parserVersion.js';
 
-/**
- * Parser version - increment when parser logic changes significantly
- * This ensures cache is invalidated when parsing rules change
- */
-export const PARSER_VERSION = 10; // v10: Parse AVIF XMP/EXIF metadata and compact Image MetaHub extensions
+export { PARSER_VERSION };
 
 // Simplified metadata structure for the JSON cache
 export interface CacheImageMetadata {

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -2934,8 +2934,6 @@ export async function processFiles(
     const resultsBatch: IndexedImage[] = [];
     const touchedChunks = new Set<number>();
     const DIRTY_CHUNK_FLUSH_THRESHOLD = 12;
-    const DIRTY_FLUSH_INTERVAL_MS = 350;
-    let lastFlushTime = performance.now();
     const canWriteCache = Boolean(cacheWriter);
     const DEFER_CACHE_FLUSH_THRESHOLD = 5000;
     const deferCacheFlush = canWriteCache && totalEnrichment >= DEFER_CACHE_FLUSH_THRESHOLD;
@@ -3085,14 +3083,11 @@ export async function processFiles(
         detail: { depth: queueLength - phaseBStats.processed }
       });
 
-      const now = performance.now();
       if (
         resultsBatch.length >= enrichmentBatchSize ||
-        (canWriteCache && !deferCacheFlush && touchedChunks.size >= DIRTY_CHUNK_FLUSH_THRESHOLD) ||
-        now - lastFlushTime >= DIRTY_FLUSH_INTERVAL_MS
+        (canWriteCache && !deferCacheFlush && touchedChunks.size >= DIRTY_CHUNK_FLUSH_THRESHOLD)
       ) {
         await commitBatch();
-        lastFlushTime = now;
       }
 
       return merged;

--- a/services/thumbnailManager.ts
+++ b/services/thumbnailManager.ts
@@ -191,6 +191,11 @@ class ThumbnailManager {
   private activeUrls = new Map<string, string>();
   private runtimeState = new Map<string, RuntimeThumbnailState>();
   private failureState = new Map<string, ThumbnailFailureState>();
+  private retryTimers = new Map<string, {
+    lastModified: number;
+    retryAt: number;
+    timer: ReturnType<typeof setTimeout>;
+  }>();
   private resolvedStateCache = new Map<string, {
     lastModified: number;
     thumbnailUrl: string | null;
@@ -235,6 +240,7 @@ class ThumbnailManager {
       currentListeners.delete(listener);
       if (currentListeners.size === 0) {
         this.listeners.delete(imageId);
+        this.clearRetryTimer(imageId);
       }
     };
   }
@@ -525,7 +531,11 @@ class ThumbnailManager {
     // Avoid retry storms while still allowing transient file, IPC and cache
     // failures to recover. Repeated failures back off to a bounded five-minute
     // cooldown; a changed file version retries immediately.
-    if (this.isFailureCoolingDown(image)) {
+    const retryDelayMs = this.getFailureRetryDelay(image);
+    if (retryDelayMs !== null) {
+      if (priority === 'high') {
+        this.scheduleRetry(image, retryDelayMs);
+      }
       return;
     }
 
@@ -593,8 +603,15 @@ class ThumbnailManager {
   ): Promise<IndexedImage[]> {
     const candidates = this.dedupeImages(images)
       .filter((image) => {
-        return !this.isFailureCoolingDown(image) &&
-          !this.hasReadyThumbnail(image) &&
+        const retryDelayMs = this.getFailureRetryDelay(image);
+        if (retryDelayMs !== null) {
+          if (detail.priority !== 'overscan') {
+            this.scheduleRetry(image, retryDelayMs);
+          }
+          return false;
+        }
+
+        return !this.hasReadyThumbnail(image) &&
           !isAudioAsset(image) &&
           !isModel3DAsset(image);
       })
@@ -711,21 +728,23 @@ class ThumbnailManager {
     return runtimeState;
   }
 
-  private isFailureCoolingDown(image: IndexedImage): boolean {
+  private getFailureRetryDelay(image: IndexedImage): number | null {
     const failure = this.failureState.get(image.id);
     if (!failure) {
-      return false;
+      return null;
     }
 
     if (failure.lastModified !== image.lastModified) {
       this.failureState.delete(image.id);
-      return false;
+      this.clearRetryTimer(image.id);
+      return null;
     }
 
-    return Date.now() < failure.retryAfter;
+    const remainingMs = failure.retryAfter - Date.now();
+    return remainingMs > 0 ? remainingMs : null;
   }
 
-  private recordFailure(image: IndexedImage): void {
+  private recordFailure(image: IndexedImage): number {
     const current = this.failureState.get(image.id);
     const failures = current?.lastModified === image.lastModified
       ? current.failures + 1
@@ -740,6 +759,57 @@ class ThumbnailManager {
       failures,
       retryAfter: Date.now() + delayMs,
     });
+
+    return delayMs;
+  }
+
+  private scheduleRetry(image: IndexedImage, delayMs: number): void {
+    if (!this.listeners.has(image.id)) {
+      return;
+    }
+
+    const retryAt = Date.now() + Math.max(0, delayMs);
+    const existing = this.retryTimers.get(image.id);
+    if (
+      existing?.lastModified === image.lastModified &&
+      existing.retryAt <= retryAt
+    ) {
+      return;
+    }
+
+    this.clearRetryTimer(image.id);
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(image.id);
+      const failure = this.failureState.get(image.id);
+      if (
+        !failure ||
+        failure.lastModified !== image.lastModified ||
+        !this.listeners.has(image.id)
+      ) {
+        return;
+      }
+
+      void this.ensureThumbnail(image, 'high', { markLoading: false }).catch(() => {
+        // A subsequent failure records a longer cooldown and schedules the next
+        // retry while the thumbnail still has an active UI consumer.
+      });
+    }, Math.max(0, retryAt - Date.now()));
+
+    this.retryTimers.set(image.id, {
+      lastModified: image.lastModified,
+      retryAt,
+      timer,
+    });
+  }
+
+  private clearRetryTimer(imageId: string): void {
+    const existing = this.retryTimers.get(imageId);
+    if (!existing) {
+      return;
+    }
+
+    clearTimeout(existing.timer);
+    this.retryTimers.delete(imageId);
   }
 
   private setRuntimeState(
@@ -762,6 +832,7 @@ class ThumbnailManager {
 
     if (payload.thumbnailStatus === 'ready') {
       this.failureState.delete(image.id);
+      this.clearRetryTimer(image.id);
     }
 
     if (
@@ -1006,7 +1077,8 @@ class ThumbnailManager {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown thumbnail error';
       if (!this.isStale(image.id, token)) {
-        this.recordFailure(image);
+        const retryDelayMs = this.recordFailure(image);
+        this.scheduleRetry(image, retryDelayMs);
       }
       setSafe({ thumbnailStatus: 'error', thumbnailError: message });
     }

--- a/services/thumbnailManager.ts
+++ b/services/thumbnailManager.ts
@@ -17,6 +17,8 @@ const MAX_CONCURRENT_HIGH_PRIORITY_THUMBNAILS = 3;
 const MAX_CONCURRENT_BACKGROUND_THUMBNAILS = 1;
 const MAX_ACTIVE_THUMBNAIL_URLS = 200;
 const MAX_RENDERER_VIDEO_THUMBNAIL_BYTES = 80 * 1024 * 1024;
+const THUMBNAIL_RETRY_BASE_DELAY_MS = 30_000;
+const THUMBNAIL_RETRY_MAX_DELAY_MS = 5 * 60_000;
 
 type ElectronFileHandle = FileSystemFileHandle & { _filePath?: string };
 
@@ -25,6 +27,12 @@ type RuntimeThumbnailState = {
   thumbnailUrl: string | null;
   thumbnailStatus: ThumbnailStatus;
   thumbnailError: string | null;
+};
+
+type ThumbnailFailureState = {
+  lastModified: number;
+  failures: number;
+  retryAfter: number;
 };
 
 type ThumbnailJob = {
@@ -182,6 +190,7 @@ class ThumbnailManager {
   private inflight = new Map<string, Promise<void>>();
   private activeUrls = new Map<string, string>();
   private runtimeState = new Map<string, RuntimeThumbnailState>();
+  private failureState = new Map<string, ThumbnailFailureState>();
   private resolvedStateCache = new Map<string, {
     lastModified: number;
     thumbnailUrl: string | null;
@@ -513,15 +522,10 @@ class ThumbnailManager {
       return;
     }
 
-    // A decode failure is stable for this exact file version. Without this
-    // guard, every viewport change queues the same broken image again, causing
-    // repeated full-file reads, decode attempts and console/error storms while
-    // scrolling. A changed lastModified value invalidates the runtime state and
-    // allows a fresh attempt.
-    if (
-      activeState?.thumbnailStatus === 'error' ||
-      (!activeState && image.thumbnailStatus === 'error')
-    ) {
+    // Avoid retry storms while still allowing transient file, IPC and cache
+    // failures to recover. Repeated failures back off to a bounded five-minute
+    // cooldown; a changed file version retries immediately.
+    if (this.isFailureCoolingDown(image)) {
       return;
     }
 
@@ -589,9 +593,7 @@ class ThumbnailManager {
   ): Promise<IndexedImage[]> {
     const candidates = this.dedupeImages(images)
       .filter((image) => {
-        const activeState = this.getActiveRuntimeState(image);
-        const thumbnailStatus = activeState?.thumbnailStatus ?? image.thumbnailStatus;
-        return thumbnailStatus !== 'error' &&
+        return !this.isFailureCoolingDown(image) &&
           !this.hasReadyThumbnail(image) &&
           !isAudioAsset(image) &&
           !isModel3DAsset(image);
@@ -709,6 +711,37 @@ class ThumbnailManager {
     return runtimeState;
   }
 
+  private isFailureCoolingDown(image: IndexedImage): boolean {
+    const failure = this.failureState.get(image.id);
+    if (!failure) {
+      return false;
+    }
+
+    if (failure.lastModified !== image.lastModified) {
+      this.failureState.delete(image.id);
+      return false;
+    }
+
+    return Date.now() < failure.retryAfter;
+  }
+
+  private recordFailure(image: IndexedImage): void {
+    const current = this.failureState.get(image.id);
+    const failures = current?.lastModified === image.lastModified
+      ? current.failures + 1
+      : 1;
+    const delayMs = Math.min(
+      THUMBNAIL_RETRY_BASE_DELAY_MS * (2 ** Math.min(failures - 1, 4)),
+      THUMBNAIL_RETRY_MAX_DELAY_MS
+    );
+
+    this.failureState.set(image.id, {
+      lastModified: image.lastModified,
+      failures,
+      retryAfter: Date.now() + delayMs,
+    });
+  }
+
   private setRuntimeState(
     image: IndexedImage,
     payload: {
@@ -726,6 +759,10 @@ class ThumbnailManager {
         ? 'Failed to load thumbnail'
         : currentState?.thumbnailError ?? image.thumbnailError ?? null),
     };
+
+    if (payload.thumbnailStatus === 'ready') {
+      this.failureState.delete(image.id);
+    }
 
     if (
       currentState &&
@@ -968,6 +1005,9 @@ class ThumbnailManager {
       setSafe({ thumbnailStatus: 'ready', thumbnailUrl: url, thumbnailError: null });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown thumbnail error';
+      if (!this.isStale(image.id, token)) {
+        this.recordFailure(image);
+      }
       setSafe({ thumbnailStatus: 'error', thumbnailError: message });
     }
   }

--- a/services/thumbnailManager.ts
+++ b/services/thumbnailManager.ts
@@ -513,6 +513,18 @@ class ThumbnailManager {
       return;
     }
 
+    // A decode failure is stable for this exact file version. Without this
+    // guard, every viewport change queues the same broken image again, causing
+    // repeated full-file reads, decode attempts and console/error storms while
+    // scrolling. A changed lastModified value invalidates the runtime state and
+    // allows a fresh attempt.
+    if (
+      activeState?.thumbnailStatus === 'error' ||
+      (!activeState && image.thumbnailStatus === 'error')
+    ) {
+      return;
+    }
+
     if (!activeState && image.thumbnailStatus === 'ready' && image.thumbnailUrl) {
       return;
     }
@@ -576,7 +588,14 @@ class ThumbnailManager {
     detail: { priority: 'visible' | 'overscan' | 'single' }
   ): Promise<IndexedImage[]> {
     const candidates = this.dedupeImages(images)
-      .filter((image) => !this.hasReadyThumbnail(image) && !isAudioAsset(image) && !isModel3DAsset(image))
+      .filter((image) => {
+        const activeState = this.getActiveRuntimeState(image);
+        const thumbnailStatus = activeState?.thumbnailStatus ?? image.thumbnailStatus;
+        return thumbnailStatus !== 'error' &&
+          !this.hasReadyThumbnail(image) &&
+          !isAudioAsset(image) &&
+          !isModel3DAsset(image);
+      })
       .map((image) => getThumbnailCacheCandidate(image));
 
     if (candidates.length === 0) {

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -3923,25 +3923,44 @@ export const useImageStore = create<ImageState>((set, get) => {
 
             const state = get();
             const isIndexing = state.indexingState === 'indexing';
-            const isRefreshingDirectory = state.refreshingDirectories.size > 0;
-            if (isIndexing || isRefreshingDirectory) {
+            if (isIndexing) {
                 pendingMergeQueue.push(...updatedImages);
-                // Startup reconciliation already has a catalog the user can browse.
-                // Keep its enrichment replacements out of React until the directory
-                // refresh completes; otherwise tiny Phase B batches repeatedly rebuild
-                // a large virtualized library while the user is trying to scroll it.
-                if (!isRefreshingDirectory) {
-                    scheduleMergeFlush();
-                }
+                scheduleMergeFlush();
                 return;
             }
 
+            let updatesToApply = updatedImages;
+            if (state.refreshingDirectories.size > 0) {
+                const deferredUpdates: IndexedImage[] = [];
+                const immediateUpdates: IndexedImage[] = [];
+                for (const image of updatedImages) {
+                    if (image.directoryId && state.refreshingDirectories.has(image.directoryId)) {
+                        deferredUpdates.push(image);
+                    } else {
+                        immediateUpdates.push(image);
+                    }
+                }
+
+                // Startup reconciliation already has a catalog the user can browse.
+                // Keep only that directory's enrichment replacements out of React;
+                // edits and saves in other directories must remain immediately visible.
+                if (deferredUpdates.length > 0) {
+                    pendingMergeQueue.push(...deferredUpdates);
+                }
+                if (immediateUpdates.length === 0) {
+                    return;
+                }
+                updatesToApply = immediateUpdates;
+            }
+
             flushPendingImages(true);
-        flushPendingMerges();
-            set(state => _updateStateIncremental(state, { updated: updatedImages }));
+            if (get().refreshingDirectories.size === 0) {
+                flushPendingMerges();
+            }
+            set(state => _updateStateIncremental(state, { updated: updatesToApply }));
 
             if (get().isAnnotationsLoaded) {
-                void get().importMetadataTags(updatedImages);
+                void get().importMetadataTags(updatesToApply);
             }
             maybeQueueLineageBuild(700);
         },

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -5768,6 +5768,11 @@ export const useImageStore = create<ImageState>((set, get) => {
                 return { refreshingDirectories: next };
             });
             if (!isRefreshing && get().refreshingDirectories.size === 0) {
+                // Catalog additions and their Phase B enrichment updates can both
+                // finish before the normal 100 ms add timer on a small refresh.
+                // Make the catalog records visible before applying replacements so
+                // an unmatched merge cannot be discarded for the current session.
+                flushPendingImages(true);
                 flushPendingMerges();
             }
         },

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -3921,10 +3921,18 @@ export const useImageStore = create<ImageState>((set, get) => {
                 return;
             }
 
-            const isIndexing = get().indexingState === 'indexing';
-            if (isIndexing) {
+            const state = get();
+            const isIndexing = state.indexingState === 'indexing';
+            const isRefreshingDirectory = state.refreshingDirectories.size > 0;
+            if (isIndexing || isRefreshingDirectory) {
                 pendingMergeQueue.push(...updatedImages);
-                scheduleMergeFlush();
+                // Startup reconciliation already has a catalog the user can browse.
+                // Keep its enrichment replacements out of React until the directory
+                // refresh completes; otherwise tiny Phase B batches repeatedly rebuild
+                // a large virtualized library while the user is trying to scroll it.
+                if (!isRefreshingDirectory) {
+                    scheduleMergeFlush();
+                }
                 return;
             }
 
@@ -5759,6 +5767,9 @@ export const useImageStore = create<ImageState>((set, get) => {
                 }
                 return { refreshingDirectories: next };
             });
+            if (!isRefreshing && get().refreshingDirectories.size === 0) {
+                flushPendingMerges();
+            }
         },
 
         toggleImageSelection: (imageId) => {

--- a/utils/parserVersion.js
+++ b/utils/parserVersion.js
@@ -1,0 +1,4 @@
+// Shared by the Electron main process and renderer cache manager. Keep this
+// value monotonic whenever parser output changes so a newer cache is never
+// rejected by another process from the same build.
+export const PARSER_VERSION = 11;


### PR DESCRIPTION
## Summary

- use one shared parser cache version (`11`) in Electron and the renderer, so a cache written by the current build is accepted on the next launch instead of triggering a full reindex every time
- preserve the configured Phase B enrichment batch size and defer renderer merges until startup directory refresh completes, avoiding hundreds of large-library recomputations during startup
- stop retrying stable thumbnail decode failures on every viewport change; a changed file timestamp still permits a fresh attempt
- add regression coverage for parser-version consistency and deferred startup merges

## Why this fixes the reported behavior

The current build writes cache files with parser version 11 in the Electron process, while the renderer expects version 10. The renderer therefore logs `Expected 10, got 11`, invalidates the valid cache, and reindexes the directory on every launch. The extra batching and thumbnail guards prevent the same startup/scroll workload from overwhelming the renderer while enrichment completes or a file cannot be decoded.

## Validation

- `node --check electron.mjs`
- `vitest run __tests__/cacheParserVersionConsistency.test.ts __tests__/useImageStore.filters.test.ts __tests__/clusterCacheManager.smart-cache.test.ts __tests__/fileIndexer.png-truncation.test.ts __tests__/fileIndexer.webp-truncation.test.ts __tests__/fileIndexer.comfyui-exif-priority.test.ts` (41 passed)
- `git diff --check`

## Manual acceptance gate

- launch the packaged app with an existing large v11 cache and confirm the parser-version mismatch no longer appears
- confirm startup no longer performs a full reindex and scrolling remains responsive during enrichment
- confirm an undecodable image does not generate repeated thumbnail errors while scrolling