### PR TITLE
Fix macOS viewer and Krea2 prompt routing

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -145,6 +145,26 @@ jobs:
           echo "macOS build completed!"
           ls -la dist-electron/
 
+      - name: Smoke test packaged detached viewer
+        run: |
+          SMOKE_IMAGE="$RUNNER_TEMP/imh-detached-viewer-smoke.png"
+          SMOKE_LOG="$RUNNER_TEMP/imh-detached-viewer-smoke.log"
+          node -e "require('fs').writeFileSync(process.argv[1], Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64'))" "$SMOKE_IMAGE"
+
+          if [[ "$(uname -m)" == "arm64" ]]; then
+            APP_PATH="dist-electron/mac-arm64/Image MetaHub.app"
+          else
+            APP_PATH="dist-electron/mac/Image MetaHub.app"
+          fi
+
+          if ! GITHUB_ACTIONS=true IMH_PACKAGED_DETACHED_VIEWER_SMOKE_IMAGE="$SMOKE_IMAGE" "$APP_PATH/Contents/MacOS/Image MetaHub" > "$SMOKE_LOG" 2>&1; then
+            cat "$SMOKE_LOG"
+            exit 1
+          fi
+
+          cat "$SMOKE_LOG"
+          grep -F "[packaged-detached-viewer-smoke] renderer-ready" "$SMOKE_LOG"
+
       - name: Upload macOS app as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -95,6 +95,42 @@ describe('ComfyUI Parser - Prompt Sources', () => {
       expect(result.prompt).toBe(`${fixture.expectedPrompt}, darkbrush`);
     });
 
+    it('collects LoRAs only from the executed switch branch', () => {
+      const fixture = loadKreaFixture();
+      fixture.workflow.nodes.push(
+        { id: 56, type: 'UNETLoader', widgets_values: ['base.safetensors', 'default'] },
+        { id: 60, type: 'LoraLoaderModelOnly', widgets_values: ['active-a.safetensors', 0.8] },
+        { id: 62, type: 'LoraLoaderModelOnly', widgets_values: ['inactive-b.safetensors', 0.9] },
+        { id: 66, type: 'ComfySwitchNode', widgets_values: [false] },
+      );
+      fixture.prompt['56'] = {
+        class_type: 'UNETLoader',
+        inputs: { unet_name: 'base.safetensors', weight_dtype: 'default' },
+      };
+      fixture.prompt['60'] = {
+        class_type: 'LoraLoaderModelOnly',
+        inputs: { lora_name: 'active-a.safetensors', strength_model: 0.8, model: ['56', 0] },
+      };
+      fixture.prompt['62'] = {
+        class_type: 'LoraLoaderModelOnly',
+        inputs: { lora_name: 'inactive-b.safetensors', strength_model: 0.9, model: ['56', 0] },
+      };
+      fixture.prompt['66'] = {
+        class_type: 'ComfySwitchNode',
+        inputs: { switch: ['67', 0], on_false: ['60', 0], on_true: ['62', 0] },
+      };
+      fixture.prompt['72'].inputs.model = ['66', 0];
+
+      const falseBranch = resolvePromptFromGraph(fixture.workflow, fixture.prompt);
+      expect(falseBranch.lora).toContain('active-a.safetensors');
+      expect(falseBranch.lora).not.toContain('inactive-b.safetensors');
+
+      fixture.prompt['67'].inputs.value = true;
+      const trueBranch = resolvePromptFromGraph(fixture.workflow, fixture.prompt);
+      expect(trueBranch.lora).toContain('inactive-b.safetensors');
+      expect(trueBranch.lora).not.toContain('active-a.safetensors');
+    });
+
     it('uses the source prompt when the runtime-only TextGenerate branch is active', () => {
       const fixture = loadKreaFixture();
       fixture.prompt['68'].inputs.value = true;

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -48,6 +48,79 @@ describe('ComfyUI Parser - Prompt Sources', () => {
     expect(result._telemetry.unknown_nodes_count).toBe(0);
   });
 
+  describe('Krea2 conditional prompt routing', () => {
+    const loadKreaFixture = () => loadFixture('krea2-switch-routing.json');
+
+    it('uses the executed false branch instead of a stale CLIP widget', () => {
+      const fixture = loadKreaFixture();
+      const result = resolvePromptFromGraph(fixture.workflow, fixture.prompt);
+
+      expect(result.prompt).toBe(fixture.expectedPrompt);
+      expect(result.prompt).not.toBe(fixture.staleWidgetPrompt);
+      expect(result.seed).toBe(4242);
+    });
+
+    it('passes through RBG conditioning without using its seed or target vibe', () => {
+      const fixture = loadKreaFixture();
+      fixture.workflow.nodes.push(
+        { id: 74, type: 'RBG_Smart_Seed_Variance', widgets_values: ['Balanced', 50, 999999] },
+        { id: 75, type: 'CLIPTextEncode', widgets_values: ['unrelated target vibe'] },
+      );
+      fixture.prompt['72'].inputs.positive = ['74', 0];
+      fixture.prompt['74'] = {
+        class_type: 'RBG_Smart_Seed_Variance',
+        inputs: {
+          seed: 999999,
+          conditioning: ['73', 0],
+          target_vibe: ['75', 0],
+        },
+      };
+      fixture.prompt['75'] = {
+        class_type: 'CLIPTextEncode',
+        inputs: { text: 'unrelated target vibe' },
+      };
+
+      const result = resolvePromptFromGraph(fixture.workflow, fixture.prompt);
+
+      expect(result.prompt).toBe(fixture.expectedPrompt);
+      expect(result.seed).toBe(4242);
+    });
+
+    it('supports direct boolean controls and the true LoRA concatenation branch', () => {
+      const fixture = loadKreaFixture();
+      fixture.prompt['70'].inputs.switch = true;
+
+      const result = resolvePromptFromGraph(fixture.workflow, fixture.prompt);
+
+      expect(result.prompt).toBe(`${fixture.expectedPrompt}, darkbrush`);
+    });
+
+    it('uses the source prompt when the runtime-only TextGenerate branch is active', () => {
+      const fixture = loadKreaFixture();
+      fixture.prompt['68'].inputs.value = true;
+
+      const result = resolvePromptFromGraph(fixture.workflow, fixture.prompt);
+
+      expect(result.prompt).toBe(fixture.expectedPrompt);
+      expect(result.prompt).not.toBe(fixture.staleWidgetPrompt);
+    });
+
+    it('preserves an explicit manual prompt over graph recovery', async () => {
+      const fixture = loadKreaFixture();
+      const result = await parseImageMetadata({
+        imagemetahub_data: {
+          generator: 'ComfyUI',
+          prompt: 'Curated manual prompt',
+          metadata_sources: { prompt: 'manual_override' },
+          workflow: fixture.workflow,
+          prompt_api: fixture.prompt,
+        },
+      } as any);
+
+      expect(result?.prompt).toBe('Curated manual prompt');
+    });
+  });
+
   it('preserves empty runtime prompt values over stale workflow text', () => {
     const workflow = {
       nodes: [

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -131,6 +131,35 @@ describe('ComfyUI Parser - Prompt Sources', () => {
       expect(trueBranch.lora).not.toContain('active-a.safetensors');
     });
 
+    it('does not restore an inactive LoRA when the executed branch has none', () => {
+      const fixture = loadKreaFixture();
+      fixture.workflow.nodes.push(
+        { id: 56, type: 'UNETLoader', widgets_values: ['base.safetensors', 'default'] },
+        { id: 62, type: 'LoraLoaderModelOnly', widgets_values: ['inactive.safetensors', 0.9] },
+        { id: 66, type: 'ComfySwitchNode', widgets_values: [false] },
+      );
+      fixture.prompt['56'] = {
+        class_type: 'UNETLoader',
+        inputs: { unet_name: 'base.safetensors', weight_dtype: 'default' },
+      };
+      fixture.prompt['62'] = {
+        class_type: 'LoraLoaderModelOnly',
+        inputs: { lora_name: 'inactive.safetensors', strength_model: 0.9, model: ['56', 0] },
+      };
+      fixture.prompt['66'] = {
+        class_type: 'ComfySwitchNode',
+        inputs: { switch: ['67', 0], on_false: ['56', 0], on_true: ['62', 0] },
+      };
+      fixture.prompt['72'].inputs.model = ['66', 0];
+
+      const noLoraBranch = resolvePromptFromGraph(fixture.workflow, fixture.prompt);
+      expect(noLoraBranch.lora).not.toContain('inactive.safetensors');
+
+      fixture.prompt['67'].inputs.value = true;
+      const loraBranch = resolvePromptFromGraph(fixture.workflow, fixture.prompt);
+      expect(loraBranch.lora).toContain('inactive.safetensors');
+    });
+
     it('uses the source prompt when the runtime-only TextGenerate branch is active', () => {
       const fixture = loadKreaFixture();
       fixture.prompt['68'].inputs.value = true;

--- a/__tests__/detachedViewerHotfix.test.ts
+++ b/__tests__/detachedViewerHotfix.test.ts
@@ -1,18 +1,32 @@
 import { describe, expect, it } from 'vitest';
-import { fileURLToPath } from 'url';
 
-import { buildDetachedViewerUrl } from '../utils/detachedViewerUrl.mjs';
+import { buildDetachedViewerLoadTarget } from '../utils/detachedViewerUrl.mjs';
 import { resolveNavigationAfterDeletion } from '../utils/viewerNavigation';
 
 describe('detached viewer hotfix helpers', () => {
-  it('builds a file URL for packaged macOS paths with spaces and Unicode', () => {
+  it('loads packaged macOS paths with spaces and Unicode through loadFile', () => {
     const indexPath = '/Applications/Image MetaHub á.app/Contents/Resources/app.asar/dist/index.html';
-    const url = buildDetachedViewerUrl(indexPath, 'session 1');
+    const target = buildDetachedViewerLoadTarget(indexPath, 'session 1');
 
-    expect(url.protocol).toBe('file:');
-    expect(fileURLToPath(url)).toBe(indexPath);
-    expect(url.searchParams.get('window')).toBe('image-modal');
-    expect(url.searchParams.get('sessionId')).toBe('session 1');
+    expect(target).toEqual({
+      method: 'file',
+      filePath: indexPath,
+      options: {
+        query: {
+          window: 'image-modal',
+          sessionId: 'session 1',
+        },
+      },
+    });
+  });
+
+  it('keeps loadURL for the development server', () => {
+    const target = buildDetachedViewerLoadTarget('/unused/index.html', 'session 1', true);
+
+    expect(target.method).toBe('url');
+    expect(new URL(target.url).origin).toBe('http://localhost:5173');
+    expect(new URL(target.url).searchParams.get('window')).toBe('image-modal');
+    expect(new URL(target.url).searchParams.get('sessionId')).toBe('session 1');
   });
 
   it('keeps the next item, then falls back to the previous item', () => {

--- a/__tests__/fixtures/comfyui/krea2-switch-routing.json
+++ b/__tests__/fixtures/comfyui/krea2-switch-routing.json
@@ -1,0 +1,50 @@
+{
+  "expectedPrompt": "A concrete bunker at dusk",
+  "staleWidgetPrompt": "A martini glass with ink doodles",
+  "workflow": {
+    "nodes": [
+      { "id": 61, "type": "TextGenerate", "widgets_values": ["", 512] },
+      { "id": 64, "type": "PreviewAny", "widgets_values": [] },
+      { "id": 65, "type": "ComfySwitchNode", "widgets_values": [false] },
+      { "id": 67, "type": "PrimitiveBoolean", "widgets_values": [false] },
+      { "id": 68, "type": "PrimitiveBoolean", "widgets_values": [false] },
+      { "id": 69, "type": "StringConcatenate", "widgets_values": ["", "darkbrush", ", "] },
+      { "id": 70, "type": "ComfySwitchNode", "widgets_values": [false] },
+      { "id": 71, "type": "PrimitiveStringMultiline", "widgets_values": ["A concrete bunker at dusk"] },
+      { "id": 72, "type": "KSampler", "widgets_values": [4242, "fixed", 8, 1, "euler", "simple", 1] },
+      { "id": 73, "type": "CLIPTextEncode", "widgets_values": ["A martini glass with ink doodles"] }
+    ]
+  },
+  "prompt": {
+    "61": { "class_type": "TextGenerate", "inputs": { "prompt": ["71", 0] } },
+    "64": { "class_type": "PreviewAny", "inputs": { "source": ["65", 0] } },
+    "65": {
+      "class_type": "ComfySwitchNode",
+      "inputs": { "switch": ["68", 0], "on_false": ["71", 0], "on_true": ["61", 0] }
+    },
+    "67": { "class_type": "PrimitiveBoolean", "inputs": { "value": false } },
+    "68": { "class_type": "PrimitiveBoolean", "inputs": { "value": false } },
+    "69": {
+      "class_type": "StringConcatenate",
+      "inputs": { "string_a": ["64", 0], "string_b": "darkbrush", "delimiter": ", " }
+    },
+    "70": {
+      "class_type": "ComfySwitchNode",
+      "inputs": { "switch": ["67", 0], "on_false": ["64", 0], "on_true": ["69", 0] }
+    },
+    "71": { "class_type": "PrimitiveStringMultiline", "inputs": { "value": "A concrete bunker at dusk" } },
+    "72": {
+      "class_type": "KSampler",
+      "inputs": {
+        "seed": 4242,
+        "steps": 8,
+        "cfg": 1,
+        "sampler_name": "euler",
+        "scheduler": "simple",
+        "denoise": 1,
+        "positive": ["73", 0]
+      }
+    },
+    "73": { "class_type": "CLIPTextEncode", "inputs": { "text": ["70", 0] } }
+  }
+}

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -552,6 +552,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
           {isModel3D ? (
             <div className="h-80 w-full overflow-hidden rounded-lg">
               <Model3DViewer
+                key={activeImage.id}
                 image={activeImage}
                 directoryPath={activeImageDirectoryPath}
                 compact

--- a/electron.mjs
+++ b/electron.mjs
@@ -79,6 +79,12 @@ const permanentDeleteGrants = createPermanentDeleteGrantStore({
 
 // Simple development check
 const isDev = !app.isPackaged;
+const PACKAGED_DETACHED_VIEWER_SMOKE_SESSION_ID = 'packaged-detached-viewer-smoke';
+const packagedDetachedViewerSmokeImagePath = app.isPackaged
+  && process.env.GITHUB_ACTIONS === 'true'
+  && typeof process.env.IMH_PACKAGED_DETACHED_VIEWER_SMOKE_IMAGE === 'string'
+  ? process.env.IMH_PACKAGED_DETACHED_VIEWER_SMOKE_IMAGE.trim()
+  : '';
 const gpuMitigationEnabled = process.env.IMH_DISABLE_GPU === '1' || process.env.IMH_DISABLE_GPU === 'true';
 const mediaSafeModeEnabled = process.platform === 'darwin' && (process.env.IMH_MEDIA_SAFE_MODE === '1' || process.env.IMH_MEDIA_SAFE_MODE === 'true');
 const audioDiagnosticModeEnabled = process.platform === 'darwin' && (process.env.IMH_AUDIO_DIAGNOSTIC_MODE === '1' || process.env.IMH_AUDIO_DIAGNOSTIC_MODE === 'true');
@@ -603,6 +609,7 @@ let licenseManager;
 const detachedImageViewerWindows = new Map();
 const detachedImageViewerSnapshots = new Map();
 const detachedImageViewerRequestResolvers = new Map();
+let packagedDetachedViewerSmokeReadyResolver = null;
 let comfyUIView = null;
 let comfyUIViewConfiguredUrl = '';
 let comfyUIViewState = {
@@ -2562,6 +2569,12 @@ async function createDetachedImageViewer(sessionId, snapshot) {
   viewerWindow.setMenu(null);
   viewerWindow.__imageViewerCascadeSlot = cascadeSlot;
   const viewerWindowId = viewerWindow.id;
+  if (sessionId === PACKAGED_DETACHED_VIEWER_SMOKE_SESSION_ID) {
+    viewerWindow.once('show', () => {
+      packagedDetachedViewerSmokeReadyResolver?.();
+      packagedDetachedViewerSmokeReadyResolver = null;
+    });
+  }
 
   const viewerIndexPath = path.join(__dirname, 'dist', 'index.html');
   const viewerUrl = buildDetachedViewerUrl(
@@ -2644,6 +2657,75 @@ async function createDetachedImageViewer(sessionId, snapshot) {
     detachedImageViewerSnapshots.delete(sessionId);
     if (!viewerWindow.isDestroyed()) viewerWindow.destroy();
     return { success: false, error: error?.message || 'Failed to load detached viewer.' };
+  }
+}
+
+async function runPackagedDetachedViewerSmokeTest() {
+  if (!packagedDetachedViewerSmokeImagePath) return;
+
+  let timeoutId;
+  try {
+    const imagePath = path.resolve(packagedDetachedViewerSmokeImagePath);
+    const imageStats = await fs.stat(imagePath);
+    if (!imageStats.isFile()) {
+      throw new Error(`Smoke image is not a file: ${imagePath}`);
+    }
+
+    const directoryPath = path.dirname(imagePath);
+    const imageName = path.basename(imagePath);
+    const readyPromise = new Promise((resolve, reject) => {
+      packagedDetachedViewerSmokeReadyResolver = resolve;
+      timeoutId = setTimeout(() => reject(new Error('Detached viewer did not become visible after its renderer-ready handshake.')), 20000);
+    });
+    const snapshot = {
+      sessionId: PACKAGED_DETACHED_VIEWER_SMOKE_SESSION_ID,
+      revision: 1,
+      image: {
+        id: imagePath,
+        name: imageName,
+        metadata: { normalizedMetadata: {} },
+        metadataString: '',
+        lastModified: imageStats.mtimeMs,
+        models: [],
+        loras: [],
+        scheduler: '',
+        directoryId: directoryPath,
+        fileSize: imageStats.size,
+        fileType: 'image/png',
+      },
+      previousImage: null,
+      nextImage: null,
+      currentIndex: 0,
+      totalImages: 1,
+      directoryPath,
+      isIndexing: false,
+      startSlideshow: false,
+      closeOnSlideshowExit: false,
+      recentTags: [],
+      comparisonCount: 0,
+      comparisonImages: [],
+      collections: [],
+      selectedImageIds: [],
+    };
+
+    const openResult = await createDetachedImageViewer(PACKAGED_DETACHED_VIEWER_SMOKE_SESSION_ID, snapshot);
+    if (!openResult.success) {
+      throw new Error(openResult.error || 'Failed to open detached viewer.');
+    }
+
+    await readyPromise;
+    console.log('[packaged-detached-viewer-smoke] renderer-ready');
+    closeAllDetachedImageViewers();
+    if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
+    app.exit(0);
+  } catch (error) {
+    console.error('[packaged-detached-viewer-smoke] failed:', error);
+    closeAllDetachedImageViewers();
+    if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
+    app.exit(1);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    packagedDetachedViewerSmokeReadyResolver = null;
   }
 }
 
@@ -2938,6 +3020,7 @@ app.whenReady().then(async () => {
   setupFileOperationHandlers();
   
   await createWindow(startupDirectory);
+  await runPackagedDetachedViewerSmokeTest();
 });
 
 function setupLicenseHandlers() {

--- a/electron.mjs
+++ b/electron.mjs
@@ -49,7 +49,7 @@ import {
   requestPermanentDeleteConfirmation,
 } from './electron/permanentDeletePolicy.mjs';
 import { resolvePortableRuntime } from './utils/portableRuntime.mjs';
-import { buildDetachedViewerUrl } from './utils/detachedViewerUrl.mjs';
+import { buildDetachedViewerLoadTarget, buildDetachedViewerUrl } from './utils/detachedViewerUrl.mjs';
 import {
   buildEmbeddingModelDownloadUrl,
   validateEmbeddingModelId,
@@ -2563,11 +2563,13 @@ async function createDetachedImageViewer(sessionId, snapshot) {
   viewerWindow.__imageViewerCascadeSlot = cascadeSlot;
   const viewerWindowId = viewerWindow.id;
 
+  const viewerIndexPath = path.join(__dirname, 'dist', 'index.html');
   const viewerUrl = buildDetachedViewerUrl(
-    path.join(__dirname, 'dist', 'index.html'),
+    viewerIndexPath,
     sessionId,
     isDev,
   );
+  const viewerLoadTarget = buildDetachedViewerLoadTarget(viewerIndexPath, sessionId, isDev);
   configureDetachedViewerNavigationHandlers(viewerWindow, viewerUrl);
 
   detachedImageViewerWindows.set(sessionId, viewerWindow);
@@ -2631,7 +2633,11 @@ async function createDetachedImageViewer(sessionId, snapshot) {
   });
 
   try {
-    await viewerWindow.loadURL(viewerUrl.toString());
+    if (viewerLoadTarget.method === 'url') {
+      await viewerWindow.loadURL(viewerLoadTarget.url);
+    } else {
+      await viewerWindow.loadFile(viewerLoadTarget.filePath, viewerLoadTarget.options);
+    }
     return { success: true };
   } catch (error) {
     detachedImageViewerWindows.delete(sessionId);

--- a/packages/metadata-engine/src/parsers/comfyUIParser.ts
+++ b/packages/metadata-engine/src/parsers/comfyUIParser.ts
@@ -827,17 +827,18 @@ export function resolvePromptFromGraph(workflow: any, prompt: any): Record<strin
     results.controlnets = modifiers.controlnets;
   }
   if (modifiers.loras.length > 0) {
-    // Merge with existing lora array from resolveAll
-    const existingLoras = results.lora || [];
-    results.loras = modifiers.loras; // Detailed lora info
-    const loraNameSet = new Set<string>();
-    for (let i = 0; i < existingLoras.length; i++) {
-      loraNameSet.add(existingLoras[i]);
-    }
-    for (let i = 0; i < modifiers.loras.length; i++) {
-      loraNameSet.add(modifiers.loras[i].name);
-    }
-    results.lora = Array.from(loraNameSet); // Backward compatibility
+    const resolvedLoras = Array.isArray(results.lora) ? results.lora : [];
+    const resolvedLoraNames = new Set(resolvedLoras.map((name: unknown) => String(name)));
+    // resolveAll follows executed routing. Keep the graph-wide modifier scan only
+    // as a fallback for legacy nodes that the traversal engine cannot resolve.
+    const activeModifiers = resolvedLoraNames.size > 0
+      ? modifiers.loras.filter((lora) => resolvedLoraNames.has(String(lora.name)))
+      : modifiers.loras;
+
+    results.loras = activeModifiers;
+    results.lora = resolvedLoraNames.size > 0
+      ? Array.from(resolvedLoraNames)
+      : activeModifiers.map((lora) => lora.name);
   }
   if (modifiers.vaes.length > 0) {
     results.vaes = modifiers.vaes;

--- a/packages/metadata-engine/src/parsers/comfyUIParser.ts
+++ b/packages/metadata-engine/src/parsers/comfyUIParser.ts
@@ -1,4 +1,4 @@
-import { resolveAll, resolveFacts } from './comfyui/traversalEngine';
+import { collectActiveNodeIds, resolveAll, resolveFacts } from './comfyui/traversalEngine';
 import { NodeRegistry } from './comfyui/nodeRegistry';
 import type { ParserNode, WorkflowFacts, GenerationType, ImageLineage, SourceImageReference } from './comfyui/types';
 
@@ -300,7 +300,7 @@ function extractAdvancedModel(node: ParserNode | null, graph: Graph): string | n
 /**
  * Extract ControlNet, LoRA, and VAE with weights and parameters
  */
-function extractAdvancedModifiers(graph: Graph): {
+function extractAdvancedModifiers(graph: Graph, activeLoraNodeIds: ReadonlySet<string>): {
   controlnets: Array<{ name: string; weight?: number; module?: string; applied_to?: string }>;
   loras: Array<{ name: string; weight?: number }>;
   vaes: Array<{ name: string }>;
@@ -386,7 +386,7 @@ function extractAdvancedModifiers(graph: Graph): {
     }
     
     // LoRA detection
-    if (classType.includes('lora')) {
+    if (classType.includes('lora') && activeLoraNodeIds.has(nodeId)) {
       if (node.class_type === 'Power Lora Loader (rgthree)') {
         addRgthreePowerLoras(node);
       } else {
@@ -822,7 +822,8 @@ export function resolvePromptFromGraph(workflow: any, prompt: any): Record<strin
   }
   
   // Extract modifiers (ControlNet, LoRA, VAE)
-  const modifiers = extractAdvancedModifiers(graph);
+  const activeNodeIds = collectActiveNodeIds({ startNode: terminalNode, graph });
+  const modifiers = extractAdvancedModifiers(graph, activeNodeIds);
   if (modifiers.controlnets.length > 0) {
     results.controlnets = modifiers.controlnets;
   }

--- a/packages/metadata-engine/src/parsers/comfyui/nodeRegistry.ts
+++ b/packages/metadata-engine/src/parsers/comfyui/nodeRegistry.ts
@@ -561,6 +561,24 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     pass_through_rules: [{ from_input: 'trigger_words', to_output: 'filtered_trigger_words' }],
     widget_order: ['group_mode', 'default_active', 'allow_strength_adjustment', 'toggle_trigger_words', 'orinalMessage']
   },
+  ComfySwitchNode: {
+    category: 'ROUTING',
+    roles: ['ROUTING'],
+    inputs: {
+      switch: { type: 'BOOLEAN' },
+      on_false: { type: 'ANY' },
+      on_true: { type: 'ANY' },
+    },
+    outputs: { output: { type: 'ANY' } },
+    conditional_routing: {
+      control_input: 'switch',
+      routes: {
+        false: 'on_false',
+        true: 'on_true',
+      },
+    },
+    widget_order: ['switch'],
+  },
   ImpactSwitch: {
     category: 'ROUTING', roles: ['ROUTING'],
     inputs: { select: { type: 'INT' }, input1: { type: 'ANY' }, input2: { type: 'ANY' } },
@@ -569,6 +587,17 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
         control_input: 'select',
         dynamic_input_prefix: 'input'
     }
+  },
+  RBG_Smart_Seed_Variance: {
+    category: 'CONDITIONING',
+    roles: ['PASS_THROUGH'],
+    inputs: { conditioning: { type: 'CONDITIONING' } },
+    outputs: { conditioning: { type: 'CONDITIONING' } },
+    param_mapping: {
+      prompt: { source: 'trace', input: 'conditioning' },
+      negativePrompt: { source: 'trace', input: 'conditioning' },
+    },
+    pass_through_rules: [{ from_input: 'conditioning', to_output: 'conditioning' }],
   },
 
   // --- IO NODES ---
@@ -621,6 +650,58 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
       negativePrompt: { source: 'input', key: 'value' },
     },
     widget_order: ['value']
+  },
+  PrimitiveBoolean: {
+    category: 'UTILS',
+    roles: ['SOURCE'],
+    inputs: { value: { type: 'BOOLEAN' } },
+    outputs: { BOOLEAN: { type: 'BOOLEAN' } },
+    widget_order: ['value'],
+  },
+  PreviewAny: {
+    category: 'UTILS',
+    roles: ['PASS_THROUGH'],
+    inputs: { source: { type: 'ANY' } },
+    outputs: { STRING: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'input', key: 'source' },
+      negativePrompt: { source: 'input', key: 'source' },
+    },
+    pass_through_rules: [{ from_input: 'source', to_output: 'STRING' }],
+  },
+  StringConcatenate: {
+    category: 'UTILS',
+    roles: ['TRANSFORM'],
+    inputs: {
+      string_a: { type: 'STRING' },
+      string_b: { type: 'STRING' },
+      delimiter: { type: 'STRING' },
+    },
+    outputs: { STRING: { type: 'STRING' } },
+    param_mapping: {
+      prompt: {
+        source: 'custom_extractor',
+        extractor: (node, state, graph, traverse) =>
+          extractors.concatTextExtractor(node, state, graph, traverse, ['string_a', 'string_b']),
+      },
+      negativePrompt: {
+        source: 'custom_extractor',
+        extractor: (node, state, graph, traverse) =>
+          extractors.concatTextExtractor(node, state, graph, traverse, ['string_a', 'string_b']),
+      },
+    },
+    widget_order: ['string_a', 'string_b', 'delimiter'],
+  },
+  TextGenerate: {
+    category: 'UTILS',
+    roles: ['PASS_THROUGH'],
+    inputs: { prompt: { type: 'STRING' } },
+    outputs: { generated_text: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'input', key: 'prompt' },
+      negativePrompt: { source: 'input', key: 'prompt' },
+    },
+    pass_through_rules: [{ from_input: 'prompt', to_output: 'generated_text' }],
   },
   Ideogram4PromptBuilderKJ: {
     category: 'UTILS',

--- a/packages/metadata-engine/src/parsers/comfyui/traversalEngine.ts
+++ b/packages/metadata-engine/src/parsers/comfyui/traversalEngine.ts
@@ -105,6 +105,29 @@ function getTraversableInputLinks(
   return links;
 }
 
+export function collectActiveNodeIds(args: { startNode: ParserNode, graph: Graph }): Set<string> {
+  const activeNodeIds = new Set<string>();
+  const routingState = createInitialState('lora');
+
+  const visit = (currentNode: ParserNode | null | undefined) => {
+    if (!currentNode || activeNodeIds.has(currentNode.id)) return;
+    if (currentNode.mode === 2 || currentNode.mode === 4) return;
+
+    activeNodeIds.add(currentNode.id);
+    for (const inputLink of getTraversableInputLinks(currentNode, routingState, args.graph)) {
+      const [sourceNodeId] = inputLink;
+      let nextNode = args.graph[sourceNodeId];
+      if (!nextNode && sourceNodeId.includes(':')) {
+        nextNode = args.graph[sourceNodeId.split(':')[0]];
+      }
+      visit(nextNode);
+    }
+  };
+
+  visit(args.startNode);
+  return activeNodeIds;
+}
+
 // Helper para criar o estado inicial da travessia
 function createInitialState(param: ComfyTraversableParam): TraversalState {
     let expectedType: ComfyNodeDataType = 'ANY';

--- a/packages/metadata-engine/src/parsers/comfyui/traversalEngine.ts
+++ b/packages/metadata-engine/src/parsers/comfyui/traversalEngine.ts
@@ -10,6 +10,60 @@ interface TraversalState {
   visitedLinks: Set<string>;
 }
 
+function readScalarControlValue(node: ParserNode | null | undefined): unknown {
+  if (!node) return undefined;
+
+  for (const key of ['value', 'select', 'int']) {
+    const value = node.inputs?.[key];
+    if (value !== undefined && !Array.isArray(value)) {
+      return value;
+    }
+  }
+
+  const nodeDef = NodeRegistry[node.class_type];
+  const preferredWidgetIndex = nodeDef?.widget_order?.findIndex((key) =>
+    key === 'value' || key === 'select' || key === 'int'
+  ) ?? -1;
+  if (preferredWidgetIndex >= 0 && node.widgets_values?.[preferredWidgetIndex] !== undefined) {
+    return node.widgets_values[preferredWidgetIndex];
+  }
+
+  const namedWidget = node.widgets_values?.find((widget) =>
+    widget && typeof widget === 'object' && ['value', 'select', 'int'].includes(widget.name)
+  );
+  if (namedWidget && typeof namedWidget === 'object') {
+    return namedWidget.value;
+  }
+
+  return undefined;
+}
+
+function resolveRoutingControlValue(
+  currentNode: ParserNode,
+  controlInputName: string,
+  state: TraversalState,
+  graph: Graph,
+): unknown {
+  const controlInput = currentNode.inputs?.[controlInputName];
+
+  if (Array.isArray(controlInput)) {
+    const controlNode = graph[String(controlInput[0])];
+    const scalarValue = readScalarControlValue(controlNode);
+    if (scalarValue !== undefined) {
+      return scalarValue;
+    }
+
+    const controlState = { ...createInitialState('steps'), visitedLinks: state.visitedLinks };
+    return traverseFromLink(controlInput as NodeLink, controlState, graph, []);
+  }
+
+  if (controlInput !== undefined) {
+    return controlInput;
+  }
+
+  return readScalarControlValue(currentNode);
+}
+
 // Helper para criar o estado inicial da travessia
 function createInitialState(param: ComfyTraversableParam): TraversalState {
     let expectedType: ComfyNodeDataType = 'ANY';
@@ -70,23 +124,23 @@ function traverse(
   // 3. Roteamento Dinâmico (Problema do "Switch")
   if (nodeDef.roles.includes('ROUTING') && nodeDef.conditional_routing) {
     const controlInputName = nodeDef.conditional_routing.control_input;
-    let controlValue: any = null;
-    
-    // Tenta resolver o valor de controle, que pode ser um widget ou um link
-    const controlLink = currentNode.inputs[controlInputName];
-    if (controlLink && Array.isArray(controlLink)) {
-      const controlState = { ...createInitialState('steps'), visitedLinks: state.visitedLinks }; // 'steps' -> INT
-      controlValue = traverseFromLink(controlLink as NodeLink, controlState, graph, []);
-    } else {
-        const widgetValue = currentNode.widgets_values?.find(w => typeof w === 'object' ? w.name === controlInputName : false) ?? currentNode.widgets_values?.[0];
-        controlValue = typeof widgetValue === 'object' ? widgetValue.value : widgetValue;
-    }
+    const controlValue = resolveRoutingControlValue(currentNode, controlInputName, state, graph);
 
     if (controlValue != null) {
-      const dynamicInputName = `${nodeDef.conditional_routing.dynamic_input_prefix}${controlValue}`;
+      const routeKey = String(controlValue).toLowerCase();
+      const dynamicInputName = nodeDef.conditional_routing.routes?.[routeKey]
+        ?? (nodeDef.conditional_routing.dynamic_input_prefix
+          ? `${nodeDef.conditional_routing.dynamic_input_prefix}${controlValue}`
+          : undefined);
+      if (!dynamicInputName) {
+        return state.targetParam === 'lora' ? accumulator : null;
+      }
       const targetLink = currentNode.inputs[dynamicInputName];
       if (targetLink && Array.isArray(targetLink)) {
         return traverseFromLink(targetLink as NodeLink, state, graph, accumulator);
+      }
+      if (targetLink !== undefined) {
+        return targetLink;
       }
     }
     return state.targetParam === 'lora' ? accumulator : null; // Rota dinâmica não encontrada

--- a/packages/metadata-engine/src/parsers/comfyui/traversalEngine.ts
+++ b/packages/metadata-engine/src/parsers/comfyui/traversalEngine.ts
@@ -64,6 +64,47 @@ function resolveRoutingControlValue(
   return readScalarControlValue(currentNode);
 }
 
+function resolveConditionalRouteInputName(
+  currentNode: ParserNode,
+  state: TraversalState,
+  graph: Graph,
+): string | undefined {
+  const routingRule = NodeRegistry[currentNode.class_type]?.conditional_routing;
+  if (!routingRule) return undefined;
+
+  const controlValue = resolveRoutingControlValue(currentNode, routingRule.control_input, state, graph);
+  if (controlValue == null) return undefined;
+
+  const routeKey = String(controlValue).toLowerCase();
+  return routingRule.routes?.[routeKey]
+    ?? (routingRule.dynamic_input_prefix
+      ? `${routingRule.dynamic_input_prefix}${controlValue}`
+      : undefined);
+}
+
+function getTraversableInputLinks(
+  currentNode: ParserNode,
+  state: TraversalState,
+  graph: Graph,
+): NodeLink[] {
+  const nodeDef = NodeRegistry[currentNode.class_type];
+  if (nodeDef?.roles.includes('ROUTING') && nodeDef.conditional_routing) {
+    const selectedInputName = resolveConditionalRouteInputName(currentNode, state, graph);
+    const selectedInput = selectedInputName ? currentNode.inputs[selectedInputName] : undefined;
+    return Array.isArray(selectedInput) && selectedInput.length === 2
+      ? [selectedInput as NodeLink]
+      : [];
+  }
+
+  const links: NodeLink[] = [];
+  for (const input of Object.values(currentNode.inputs)) {
+    if (Array.isArray(input) && input.length === 2) {
+      links.push(input as NodeLink);
+    }
+  }
+  return links;
+}
+
 // Helper para criar o estado inicial da travessia
 function createInitialState(param: ComfyTraversableParam): TraversalState {
     let expectedType: ComfyNodeDataType = 'ANY';
@@ -123,19 +164,9 @@ function traverse(
 
   // 3. Roteamento Dinâmico (Problema do "Switch")
   if (nodeDef.roles.includes('ROUTING') && nodeDef.conditional_routing) {
-    const controlInputName = nodeDef.conditional_routing.control_input;
-    const controlValue = resolveRoutingControlValue(currentNode, controlInputName, state, graph);
-
-    if (controlValue != null) {
-      const routeKey = String(controlValue).toLowerCase();
-      const dynamicInputName = nodeDef.conditional_routing.routes?.[routeKey]
-        ?? (nodeDef.conditional_routing.dynamic_input_prefix
-          ? `${nodeDef.conditional_routing.dynamic_input_prefix}${controlValue}`
-          : undefined);
-      if (!dynamicInputName) {
-        return state.targetParam === 'lora' ? accumulator : null;
-      }
-      const targetLink = currentNode.inputs[dynamicInputName];
+    const selectedInputName = resolveConditionalRouteInputName(currentNode, state, graph);
+    if (selectedInputName) {
+      const targetLink = currentNode.inputs[selectedInputName];
       if (targetLink && Array.isArray(targetLink)) {
         return traverseFromLink(targetLink as NodeLink, state, graph, accumulator);
       }
@@ -310,14 +341,11 @@ function collectValuesRecursive(
     }
 
     // 3. Continua a exploração para todos os caminhos possíveis
-    for (const inputName in currentNode.inputs) {
-        const inputLink = currentNode.inputs[inputName];
-        if (inputLink && Array.isArray(inputLink)) {
-            const [sourceNodeId] = inputLink;
-            const nextNode = graph[sourceNodeId];
-            if (nextNode) {
-                collectValuesRecursive(nextNode, state, graph, values, visited);
-            }
+    for (const inputLink of getTraversableInputLinks(currentNode, state, graph)) {
+        const [sourceNodeId] = inputLink;
+        const nextNode = graph[sourceNodeId];
+        if (nextNode) {
+            collectValuesRecursive(nextNode, state, graph, values, visited);
         }
     }
 }
@@ -390,22 +418,19 @@ export function resolve(args: { startNode: ParserNode, param: ComfyTraversablePa
             }
 
             // Continua explorando inputs
-            for (const inputName in currentNode.inputs) {
-                const inputLink = currentNode.inputs[inputName];
-                if (Array.isArray(inputLink) && inputLink.length === 2) {
-                    const [sourceNodeId] = inputLink;
-                    let nextNode = args.graph[sourceNodeId];
+            for (const inputLink of getTraversableInputLinks(currentNode, initialState, args.graph)) {
+                const [sourceNodeId] = inputLink;
+                let nextNode = args.graph[sourceNodeId];
 
-                    // Suporte para grouped nodes: keep exact prefixed ids (for example "98:17")
-                    // when present, and only fall back to the parent node if the exact child is absent.
-                    if (!nextNode && sourceNodeId.includes(':')) {
-                        const parentId = sourceNodeId.split(':')[0];
-                        nextNode = args.graph[parentId];
-                    }
+                // Suporte para grouped nodes: keep exact prefixed ids (for example "98:17")
+                // when present, and only fall back to the parent node if the exact child is absent.
+                if (!nextNode && sourceNodeId.includes(':')) {
+                    const parentId = sourceNodeId.split(':')[0];
+                    nextNode = args.graph[parentId];
+                }
 
-                    if (nextNode) {
-                        collectValues(nextNode);
-                    }
+                if (nextNode) {
+                    collectValues(nextNode);
                 }
             }
         };
@@ -431,6 +456,7 @@ function checkIfParamNeedsAccumulation(startNode: ParserNode | null, param: Comf
 
     // Check if any node in the graph has this param with accumulate: true
     const visited = new Set<string>();
+    const accumulationState = createInitialState(param);
 
     const check = (currentNode: ParserNode | null | undefined): boolean => {
         if (!currentNode) return false;
@@ -446,22 +472,19 @@ function checkIfParamNeedsAccumulation(startNode: ParserNode | null, param: Comf
         }
 
         // Check connected nodes
-        for (const inputName in currentNode.inputs) {
-            const inputLink = currentNode.inputs[inputName];
-            if (Array.isArray(inputLink) && inputLink.length === 2) {
-                const [sourceNodeId] = inputLink;
-                let nextNode = graph[sourceNodeId];
+        for (const inputLink of getTraversableInputLinks(currentNode, accumulationState, graph)) {
+            const [sourceNodeId] = inputLink;
+            let nextNode = graph[sourceNodeId];
 
-                // Keep exact prefixed ids (for example "98:17") when present, and only
-                // fall back to the parent node if the exact child is absent.
-                if (!nextNode && sourceNodeId.includes(':')) {
-                    const parentId = sourceNodeId.split(':')[0];
-                    nextNode = graph[parentId];
-                }
+            // Keep exact prefixed ids (for example "98:17") when present, and only
+            // fall back to the parent node if the exact child is absent.
+            if (!nextNode && sourceNodeId.includes(':')) {
+                const parentId = sourceNodeId.split(':')[0];
+                nextNode = graph[parentId];
+            }
 
-                if (nextNode && check(nextNode)) {
-                    return true;
-                }
+            if (nextNode && check(nextNode)) {
+                return true;
             }
         }
 

--- a/packages/metadata-engine/src/parsers/comfyui/types.ts
+++ b/packages/metadata-engine/src/parsers/comfyui/types.ts
@@ -9,7 +9,7 @@ export interface ParserNode {
 export type ComfyNodeDataType =
   | 'MODEL' | 'CONDITIONING' | 'LATENT' | 'IMAGE' | 'VAE' | 'CLIP' | 'INT'
   | 'FLOAT' | 'STRING' | 'CONTROL_NET' | 'GUIDER' | 'SAMPLER' | 'SCHEDULER'
-  | 'SIGMAS' | 'NOISE' | 'UPSCALE_MODEL' | 'MASK' | 'ANY' | 'LORA_STACK' | 'SDXL_TUPLE';
+  | 'SIGMAS' | 'NOISE' | 'UPSCALE_MODEL' | 'MASK' | 'BOOLEAN' | 'ANY' | 'LORA_STACK' | 'SDXL_TUPLE';
 
 export type ComfyTraversableParam =
   | 'prompt' | 'negativePrompt' | 'seed' | 'steps' | 'cfg' | 'width' | 'height'
@@ -33,7 +33,8 @@ export type NodeBehavior = 'SOURCE' | 'SINK' | 'TRANSFORM' | 'PASS_THROUGH' | 'R
 
 export interface ConditionalRoutingRule {
   control_input: string;
-  dynamic_input_prefix: string;
+  dynamic_input_prefix?: string;
+  routes?: Record<string, string>;
 }
 
 export interface NodeDefinition {

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -918,17 +918,18 @@ export function resolvePromptFromGraph(workflow: any, prompt: any): Record<strin
     results.controlnets = modifiers.controlnets;
   }
   if (modifiers.loras.length > 0) {
-    // Merge with existing lora array from resolveAll
-    const existingLoras = results.lora || [];
-    results.loras = modifiers.loras; // Detailed lora info
-    const loraNameSet = new Set<string>();
-    for (let i = 0; i < existingLoras.length; i++) {
-      loraNameSet.add(existingLoras[i]);
-    }
-    for (let i = 0; i < modifiers.loras.length; i++) {
-      loraNameSet.add(modifiers.loras[i].name);
-    }
-    results.lora = Array.from(loraNameSet); // Backward compatibility
+    const resolvedLoras = Array.isArray(results.lora) ? results.lora : [];
+    const resolvedLoraNames = new Set(resolvedLoras.map((name: unknown) => String(name)));
+    // resolveAll follows executed routing. Keep the graph-wide modifier scan only
+    // as a fallback for legacy nodes that the traversal engine cannot resolve.
+    const activeModifiers = resolvedLoraNames.size > 0
+      ? modifiers.loras.filter((lora) => resolvedLoraNames.has(String(lora.name)))
+      : modifiers.loras;
+
+    results.loras = activeModifiers;
+    results.lora = resolvedLoraNames.size > 0
+      ? Array.from(resolvedLoraNames)
+      : activeModifiers.map((lora) => lora.name);
   }
   if (modifiers.vaes.length > 0) {
     results.vaes = modifiers.vaes;

--- a/services/parsers/comfyUIParser.ts
+++ b/services/parsers/comfyUIParser.ts
@@ -1,4 +1,4 @@
-import { resolveAll, resolveFacts } from './comfyui/traversalEngine';
+import { collectActiveNodeIds, resolveAll, resolveFacts } from './comfyui/traversalEngine';
 import { NodeRegistry } from './comfyui/nodeRegistry';
 import type { ParserNode, WorkflowFacts } from './comfyui/types';
 import type { GenerationType, ImageLineage, SourceImageReference } from '../../types';
@@ -315,7 +315,7 @@ function extractAdvancedModel(node: ParserNode | null, graph: Graph): string | n
 /**
  * Extract ControlNet, LoRA, and VAE with weights and parameters
  */
-function extractAdvancedModifiers(graph: Graph): {
+function extractAdvancedModifiers(graph: Graph, activeLoraNodeIds: ReadonlySet<string>): {
   controlnets: Array<{ name: string; weight?: number; module?: string; applied_to?: string }>;
   loras: Array<{ name: string; weight?: number }>;
   vaes: Array<{ name: string }>;
@@ -401,7 +401,7 @@ function extractAdvancedModifiers(graph: Graph): {
     }
     
     // LoRA detection
-    if (classType.includes('lora')) {
+    if (classType.includes('lora') && activeLoraNodeIds.has(nodeId)) {
       if (node.class_type === 'Power Lora Loader (rgthree)') {
         addRgthreePowerLoras(node);
       } else {
@@ -913,7 +913,8 @@ export function resolvePromptFromGraph(workflow: any, prompt: any): Record<strin
   }
   
   // Extract modifiers (ControlNet, LoRA, VAE)
-  const modifiers = extractAdvancedModifiers(graph);
+  const activeNodeIds = collectActiveNodeIds({ startNode: terminalNode, graph });
+  const modifiers = extractAdvancedModifiers(graph, activeNodeIds);
   if (modifiers.controlnets.length > 0) {
     results.controlnets = modifiers.controlnets;
   }

--- a/services/parsers/comfyui/nodeRegistry.ts
+++ b/services/parsers/comfyui/nodeRegistry.ts
@@ -563,6 +563,24 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
     pass_through_rules: [{ from_input: 'trigger_words', to_output: 'filtered_trigger_words' }],
     widget_order: ['group_mode', 'default_active', 'allow_strength_adjustment', 'toggle_trigger_words', 'orinalMessage']
   },
+  ComfySwitchNode: {
+    category: 'ROUTING',
+    roles: ['ROUTING'],
+    inputs: {
+      switch: { type: 'BOOLEAN' },
+      on_false: { type: 'ANY' },
+      on_true: { type: 'ANY' },
+    },
+    outputs: { output: { type: 'ANY' } },
+    conditional_routing: {
+      control_input: 'switch',
+      routes: {
+        false: 'on_false',
+        true: 'on_true',
+      },
+    },
+    widget_order: ['switch'],
+  },
   ImpactSwitch: {
     category: 'ROUTING', roles: ['ROUTING'],
     inputs: { select: { type: 'INT' }, input1: { type: 'ANY' }, input2: { type: 'ANY' } },
@@ -571,6 +589,17 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
         control_input: 'select',
         dynamic_input_prefix: 'input'
     }
+  },
+  RBG_Smart_Seed_Variance: {
+    category: 'CONDITIONING',
+    roles: ['PASS_THROUGH'],
+    inputs: { conditioning: { type: 'CONDITIONING' } },
+    outputs: { conditioning: { type: 'CONDITIONING' } },
+    param_mapping: {
+      prompt: { source: 'trace', input: 'conditioning' },
+      negativePrompt: { source: 'trace', input: 'conditioning' },
+    },
+    pass_through_rules: [{ from_input: 'conditioning', to_output: 'conditioning' }],
   },
 
   // --- IO NODES ---
@@ -623,6 +652,58 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
       negativePrompt: { source: 'input', key: 'value' },
     },
     widget_order: ['value']
+  },
+  PrimitiveBoolean: {
+    category: 'UTILS',
+    roles: ['SOURCE'],
+    inputs: { value: { type: 'BOOLEAN' } },
+    outputs: { BOOLEAN: { type: 'BOOLEAN' } },
+    widget_order: ['value'],
+  },
+  PreviewAny: {
+    category: 'UTILS',
+    roles: ['PASS_THROUGH'],
+    inputs: { source: { type: 'ANY' } },
+    outputs: { STRING: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'input', key: 'source' },
+      negativePrompt: { source: 'input', key: 'source' },
+    },
+    pass_through_rules: [{ from_input: 'source', to_output: 'STRING' }],
+  },
+  StringConcatenate: {
+    category: 'UTILS',
+    roles: ['TRANSFORM'],
+    inputs: {
+      string_a: { type: 'STRING' },
+      string_b: { type: 'STRING' },
+      delimiter: { type: 'STRING' },
+    },
+    outputs: { STRING: { type: 'STRING' } },
+    param_mapping: {
+      prompt: {
+        source: 'custom_extractor',
+        extractor: (node, state, graph, traverse) =>
+          extractors.concatTextExtractor(node, state, graph, traverse, ['string_a', 'string_b']),
+      },
+      negativePrompt: {
+        source: 'custom_extractor',
+        extractor: (node, state, graph, traverse) =>
+          extractors.concatTextExtractor(node, state, graph, traverse, ['string_a', 'string_b']),
+      },
+    },
+    widget_order: ['string_a', 'string_b', 'delimiter'],
+  },
+  TextGenerate: {
+    category: 'UTILS',
+    roles: ['PASS_THROUGH'],
+    inputs: { prompt: { type: 'STRING' } },
+    outputs: { generated_text: { type: 'STRING' } },
+    param_mapping: {
+      prompt: { source: 'input', key: 'prompt' },
+      negativePrompt: { source: 'input', key: 'prompt' },
+    },
+    pass_through_rules: [{ from_input: 'prompt', to_output: 'generated_text' }],
   },
   Ideogram4PromptBuilderKJ: {
     category: 'UTILS',

--- a/services/parsers/comfyui/traversalEngine.ts
+++ b/services/parsers/comfyui/traversalEngine.ts
@@ -105,6 +105,29 @@ function getTraversableInputLinks(
   return links;
 }
 
+export function collectActiveNodeIds(args: { startNode: ParserNode, graph: Graph }): Set<string> {
+  const activeNodeIds = new Set<string>();
+  const routingState = createInitialState('lora');
+
+  const visit = (currentNode: ParserNode | null | undefined) => {
+    if (!currentNode || activeNodeIds.has(currentNode.id)) return;
+    if (currentNode.mode === 2 || currentNode.mode === 4) return;
+
+    activeNodeIds.add(currentNode.id);
+    for (const inputLink of getTraversableInputLinks(currentNode, routingState, args.graph)) {
+      const [sourceNodeId] = inputLink;
+      let nextNode = args.graph[sourceNodeId];
+      if (!nextNode && sourceNodeId.includes(':')) {
+        nextNode = args.graph[sourceNodeId.split(':')[0]];
+      }
+      visit(nextNode);
+    }
+  };
+
+  visit(args.startNode);
+  return activeNodeIds;
+}
+
 // Helper para criar o estado inicial da travessia
 function createInitialState(param: ComfyTraversableParam): TraversalState {
     let expectedType: ComfyNodeDataType = 'ANY';

--- a/services/parsers/comfyui/traversalEngine.ts
+++ b/services/parsers/comfyui/traversalEngine.ts
@@ -10,6 +10,60 @@ interface TraversalState {
   visitedLinks: Set<string>;
 }
 
+function readScalarControlValue(node: ParserNode | null | undefined): unknown {
+  if (!node) return undefined;
+
+  for (const key of ['value', 'select', 'int']) {
+    const value = node.inputs?.[key];
+    if (value !== undefined && !Array.isArray(value)) {
+      return value;
+    }
+  }
+
+  const nodeDef = NodeRegistry[node.class_type];
+  const preferredWidgetIndex = nodeDef?.widget_order?.findIndex((key) =>
+    key === 'value' || key === 'select' || key === 'int'
+  ) ?? -1;
+  if (preferredWidgetIndex >= 0 && node.widgets_values?.[preferredWidgetIndex] !== undefined) {
+    return node.widgets_values[preferredWidgetIndex];
+  }
+
+  const namedWidget = node.widgets_values?.find((widget) =>
+    widget && typeof widget === 'object' && ['value', 'select', 'int'].includes(widget.name)
+  );
+  if (namedWidget && typeof namedWidget === 'object') {
+    return namedWidget.value;
+  }
+
+  return undefined;
+}
+
+function resolveRoutingControlValue(
+  currentNode: ParserNode,
+  controlInputName: string,
+  state: TraversalState,
+  graph: Graph,
+): unknown {
+  const controlInput = currentNode.inputs?.[controlInputName];
+
+  if (Array.isArray(controlInput)) {
+    const controlNode = graph[String(controlInput[0])];
+    const scalarValue = readScalarControlValue(controlNode);
+    if (scalarValue !== undefined) {
+      return scalarValue;
+    }
+
+    const controlState = { ...createInitialState('steps'), visitedLinks: state.visitedLinks };
+    return traverseFromLink(controlInput as NodeLink, controlState, graph, []);
+  }
+
+  if (controlInput !== undefined) {
+    return controlInput;
+  }
+
+  return readScalarControlValue(currentNode);
+}
+
 // Helper para criar o estado inicial da travessia
 function createInitialState(param: ComfyTraversableParam): TraversalState {
     let expectedType: ComfyNodeDataType = 'ANY';
@@ -70,23 +124,23 @@ function traverse(
   // 3. Roteamento Dinâmico (Problema do "Switch")
   if (nodeDef.roles.includes('ROUTING') && nodeDef.conditional_routing) {
     const controlInputName = nodeDef.conditional_routing.control_input;
-    let controlValue: any = null;
-    
-    // Tenta resolver o valor de controle, que pode ser um widget ou um link
-    const controlLink = currentNode.inputs[controlInputName];
-    if (controlLink && Array.isArray(controlLink)) {
-      const controlState = { ...createInitialState('steps'), visitedLinks: state.visitedLinks }; // 'steps' -> INT
-      controlValue = traverseFromLink(controlLink as NodeLink, controlState, graph, []);
-    } else {
-        const widgetValue = currentNode.widgets_values?.find(w => typeof w === 'object' ? w.name === controlInputName : false) ?? currentNode.widgets_values?.[0];
-        controlValue = typeof widgetValue === 'object' ? widgetValue.value : widgetValue;
-    }
+    const controlValue = resolveRoutingControlValue(currentNode, controlInputName, state, graph);
 
     if (controlValue != null) {
-      const dynamicInputName = `${nodeDef.conditional_routing.dynamic_input_prefix}${controlValue}`;
+      const routeKey = String(controlValue).toLowerCase();
+      const dynamicInputName = nodeDef.conditional_routing.routes?.[routeKey]
+        ?? (nodeDef.conditional_routing.dynamic_input_prefix
+          ? `${nodeDef.conditional_routing.dynamic_input_prefix}${controlValue}`
+          : undefined);
+      if (!dynamicInputName) {
+        return state.targetParam === 'lora' ? accumulator : null;
+      }
       const targetLink = currentNode.inputs[dynamicInputName];
       if (targetLink && Array.isArray(targetLink)) {
         return traverseFromLink(targetLink as NodeLink, state, graph, accumulator);
+      }
+      if (targetLink !== undefined) {
+        return targetLink;
       }
     }
     return state.targetParam === 'lora' ? accumulator : null; // Rota dinâmica não encontrada

--- a/services/parsers/comfyui/traversalEngine.ts
+++ b/services/parsers/comfyui/traversalEngine.ts
@@ -64,6 +64,47 @@ function resolveRoutingControlValue(
   return readScalarControlValue(currentNode);
 }
 
+function resolveConditionalRouteInputName(
+  currentNode: ParserNode,
+  state: TraversalState,
+  graph: Graph,
+): string | undefined {
+  const routingRule = NodeRegistry[currentNode.class_type]?.conditional_routing;
+  if (!routingRule) return undefined;
+
+  const controlValue = resolveRoutingControlValue(currentNode, routingRule.control_input, state, graph);
+  if (controlValue == null) return undefined;
+
+  const routeKey = String(controlValue).toLowerCase();
+  return routingRule.routes?.[routeKey]
+    ?? (routingRule.dynamic_input_prefix
+      ? `${routingRule.dynamic_input_prefix}${controlValue}`
+      : undefined);
+}
+
+function getTraversableInputLinks(
+  currentNode: ParserNode,
+  state: TraversalState,
+  graph: Graph,
+): NodeLink[] {
+  const nodeDef = NodeRegistry[currentNode.class_type];
+  if (nodeDef?.roles.includes('ROUTING') && nodeDef.conditional_routing) {
+    const selectedInputName = resolveConditionalRouteInputName(currentNode, state, graph);
+    const selectedInput = selectedInputName ? currentNode.inputs[selectedInputName] : undefined;
+    return Array.isArray(selectedInput) && selectedInput.length === 2
+      ? [selectedInput as NodeLink]
+      : [];
+  }
+
+  const links: NodeLink[] = [];
+  for (const input of Object.values(currentNode.inputs)) {
+    if (Array.isArray(input) && input.length === 2) {
+      links.push(input as NodeLink);
+    }
+  }
+  return links;
+}
+
 // Helper para criar o estado inicial da travessia
 function createInitialState(param: ComfyTraversableParam): TraversalState {
     let expectedType: ComfyNodeDataType = 'ANY';
@@ -123,19 +164,9 @@ function traverse(
 
   // 3. Roteamento Dinâmico (Problema do "Switch")
   if (nodeDef.roles.includes('ROUTING') && nodeDef.conditional_routing) {
-    const controlInputName = nodeDef.conditional_routing.control_input;
-    const controlValue = resolveRoutingControlValue(currentNode, controlInputName, state, graph);
-
-    if (controlValue != null) {
-      const routeKey = String(controlValue).toLowerCase();
-      const dynamicInputName = nodeDef.conditional_routing.routes?.[routeKey]
-        ?? (nodeDef.conditional_routing.dynamic_input_prefix
-          ? `${nodeDef.conditional_routing.dynamic_input_prefix}${controlValue}`
-          : undefined);
-      if (!dynamicInputName) {
-        return state.targetParam === 'lora' ? accumulator : null;
-      }
-      const targetLink = currentNode.inputs[dynamicInputName];
+    const selectedInputName = resolveConditionalRouteInputName(currentNode, state, graph);
+    if (selectedInputName) {
+      const targetLink = currentNode.inputs[selectedInputName];
       if (targetLink && Array.isArray(targetLink)) {
         return traverseFromLink(targetLink as NodeLink, state, graph, accumulator);
       }
@@ -310,14 +341,11 @@ function collectValuesRecursive(
     }
 
     // 3. Continua a exploração para todos os caminhos possíveis
-    for (const inputName in currentNode.inputs) {
-        const inputLink = currentNode.inputs[inputName];
-        if (inputLink && Array.isArray(inputLink)) {
-            const [sourceNodeId] = inputLink;
-            const nextNode = graph[sourceNodeId];
-            if (nextNode) {
-                collectValuesRecursive(nextNode, state, graph, values, visited);
-            }
+    for (const inputLink of getTraversableInputLinks(currentNode, state, graph)) {
+        const [sourceNodeId] = inputLink;
+        const nextNode = graph[sourceNodeId];
+        if (nextNode) {
+            collectValuesRecursive(nextNode, state, graph, values, visited);
         }
     }
 }
@@ -390,22 +418,19 @@ export function resolve(args: { startNode: ParserNode, param: ComfyTraversablePa
             }
 
             // Continua explorando inputs
-            for (const inputName in currentNode.inputs) {
-                const inputLink = currentNode.inputs[inputName];
-                if (Array.isArray(inputLink) && inputLink.length === 2) {
-                    const [sourceNodeId] = inputLink;
-                    let nextNode = args.graph[sourceNodeId];
+            for (const inputLink of getTraversableInputLinks(currentNode, initialState, args.graph)) {
+                const [sourceNodeId] = inputLink;
+                let nextNode = args.graph[sourceNodeId];
 
-                    // Suporte para grouped nodes: keep exact prefixed ids (for example "98:17")
-                    // when present, and only fall back to the parent node if the exact child is absent.
-                    if (!nextNode && sourceNodeId.includes(':')) {
-                        const parentId = sourceNodeId.split(':')[0];
-                        nextNode = args.graph[parentId];
-                    }
+                // Suporte para grouped nodes: keep exact prefixed ids (for example "98:17")
+                // when present, and only fall back to the parent node if the exact child is absent.
+                if (!nextNode && sourceNodeId.includes(':')) {
+                    const parentId = sourceNodeId.split(':')[0];
+                    nextNode = args.graph[parentId];
+                }
 
-                    if (nextNode) {
-                        collectValues(nextNode);
-                    }
+                if (nextNode) {
+                    collectValues(nextNode);
                 }
             }
         };
@@ -431,6 +456,7 @@ function checkIfParamNeedsAccumulation(startNode: ParserNode | null, param: Comf
 
     // Check if any node in the graph has this param with accumulate: true
     const visited = new Set<string>();
+    const accumulationState = createInitialState(param);
 
     const check = (currentNode: ParserNode | null | undefined): boolean => {
         if (!currentNode) return false;
@@ -446,22 +472,19 @@ function checkIfParamNeedsAccumulation(startNode: ParserNode | null, param: Comf
         }
 
         // Check connected nodes
-        for (const inputName in currentNode.inputs) {
-            const inputLink = currentNode.inputs[inputName];
-            if (Array.isArray(inputLink) && inputLink.length === 2) {
-                const [sourceNodeId] = inputLink;
-                let nextNode = graph[sourceNodeId];
+        for (const inputLink of getTraversableInputLinks(currentNode, accumulationState, graph)) {
+            const [sourceNodeId] = inputLink;
+            let nextNode = graph[sourceNodeId];
 
-                // Keep exact prefixed ids (for example "98:17") when present, and only
-                // fall back to the parent node if the exact child is absent.
-                if (!nextNode && sourceNodeId.includes(':')) {
-                    const parentId = sourceNodeId.split(':')[0];
-                    nextNode = graph[parentId];
-                }
+            // Keep exact prefixed ids (for example "98:17") when present, and only
+            // fall back to the parent node if the exact child is absent.
+            if (!nextNode && sourceNodeId.includes(':')) {
+                const parentId = sourceNodeId.split(':')[0];
+                nextNode = graph[parentId];
+            }
 
-                if (nextNode && check(nextNode)) {
-                    return true;
-                }
+            if (nextNode && check(nextNode)) {
+                return true;
             }
         }
 

--- a/utils/detachedViewerUrl.mjs
+++ b/utils/detachedViewerUrl.mjs
@@ -8,3 +8,23 @@ export function buildDetachedViewerUrl(indexPath, sessionId, isDev = false) {
   url.searchParams.set('sessionId', sessionId);
   return url;
 }
+
+export function buildDetachedViewerLoadTarget(indexPath, sessionId, isDev = false) {
+  const query = {
+    window: 'image-modal',
+    sessionId,
+  };
+
+  if (isDev) {
+    return {
+      method: 'url',
+      url: buildDetachedViewerUrl(indexPath, sessionId, true).toString(),
+    };
+  }
+
+  return {
+    method: 'file',
+    filePath: indexPath,
+    options: { query },
+  };
+}


### PR DESCRIPTION
## Summary
- load the packaged detached viewer with `BrowserWindow.loadFile` while keeping `loadURL` for development
- remount the 3D preview renderer when the selected model changes
- resolve Krea2 boolean switches from the executable ComfyUI graph and pass through RBG conditioning without taking its seed or target vibe
- keep LoRA accumulation on the executed switch branch, including the detailed modifier fallback
- keep manual metadata and the legacy Krea2 `False` recovery behavior intact
- add a macOS packaged-app smoke that opens the detached viewer and requires its renderer-ready handshake

## Validation
- `npx vitest run __tests__/comfyui-parser.test.ts __tests__/detachedViewerHotfix.test.ts packages/metadata-engine/src/parsers/index.test.ts packages/metadata-engine/src/parsers/automatic1111Parser.test.ts __tests__/mp4Metadata.test.ts __tests__/fileCopy.test.ts __tests__/contextMenuFileActions.test.tsx`
- 7 test files passed, 69 tests passed
- added false/true switch regressions covering a LoRA on each branch and an executed branch with no LoRA
- validated against the four reporter-provided Krea2 samples: Native/IMH, with and without RBG; the private samples are not committed
- macOS packaged build and detached-viewer smoke passed for commit `62add19`: https://github.com/LuqP2/Image-MetaHub/actions/runs/33390005491
- CI test, lint, and build passed for the latest commit `6ac86b0`

## Scope
- no `PARSER_VERSION` bump
- no MetaHub Save Node changes
- MP3 support and feature request #540 remain out of scope

## macOS validation status
- automated: the PR commit was packaged with `electron-builder --mac`; the generated arm64 `.app` launched, opened the detached viewer through `loadFile`, completed the preload/IPC renderer-ready handshake, became visible, and uploaded the DMG artifacts
- manual visual/behavioral acceptance remains when a macOS host is available: open real image and 3D files, switch 3D A -> B -> A, check for renderer exit code 6, and verify the startup empty-state flash

Refs #539, #528, #518, #517