### PR TITLE
chore: automate WinGet update submissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,6 +100,43 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  submit-winget:
+    name: Submit WinGet update
+    needs: build-windows
+    if: github.repository == 'LuqP2/Image-MetaHub' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download WinGetCreate
+        shell: pwsh
+        run: |
+          Invoke-WebRequest `
+            -Uri "https://github.com/microsoft/winget-create/releases/download/v1.12.13.0/wingetcreate.exe" `
+            -OutFile "wingetcreate.exe"
+
+          $actualHash = (Get-FileHash .\wingetcreate.exe -Algorithm SHA256).Hash
+          $expectedHash = "24042BD37915805615E6CF969AC57C6439124C3FE85823327F5F3FB24BD9FFEA"
+
+          if ($actualHash -ne $expectedHash) {
+            throw "WinGetCreate integrity check failed."
+          }
+
+      - name: Submit WinGet manifest
+        shell: pwsh
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+        run: |
+          $version = "${{ github.ref_name }}" -replace '^v', ''
+          $installerUrl = "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/ImageMetaHub-Setup-$version.exe"
+          $installerSpec = "$installerUrl|x64|user"
+
+          .\wingetcreate.exe update LuqP2.ImageMetaHub `
+            --version $version `
+            --urls $installerSpec `
+            --submit
+
   build-macos:
     name: Build macOS
     runs-on: macos-latest


### PR DESCRIPTION
## Summary

- submit a WinGet update PR after the Windows release is published for `v*` tags
- restrict submission to the official `LuqP2/Image-MetaHub` repository so forks skip the job
- pin WinGetCreate v1.12.13.0 and verify its SHA-256 before execution
- explicitly match the NSIS installer as `x64|user` because automatic detection identifies the bootstrapper as x86

## Validation

- `actionlint .github/workflows/publish.yml`
- executed WinGetCreate locally against the published `v0.19.2` installer without `--submit`
- generated all three manifests successfully
- `winget validate` passed on the generated manifest
- confirmed generated architecture `x64`, scope `user`, and installer SHA-256

## Operational note

The workflow uses the repository secret `WINGET_CREATE_GITHUB_TOKEN`. The end-to-end `--submit` path is intentionally not exercised locally because it would create a duplicate external PR.