### PR TITLE
Fix viewer zoom defaults and ComfyUI navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1990,7 +1990,12 @@ export default function App() {
     }
 
     if (modal.navigationSource === 'comfyui') {
-      return modal.navigationImageIds.filter((imageId) => Boolean(getImageByIdFromStore(imageId)));
+      const workspaceImageIds = comfyUIWorkspaceNavigationImageIds ?? modal.navigationImageIds;
+      return sortImagesNewestFirst(
+        workspaceImageIds
+          .map((imageId) => getImageByIdFromStore(imageId))
+          .filter((candidate): candidate is IndexedImage => Boolean(candidate))
+      ).map((image) => image.id);
     }
 
     if (modal.navigationSource === 'find-similar') {
@@ -1998,7 +2003,7 @@ export default function App() {
     }
 
     return modal.navigationImageIds.filter((imageId) => imageLookup.has(imageId));
-  }, [activeScopeNavigationImageIds, filteredNavigationImageIds, getImageByIdFromStore, imageLookup]);
+  }, [activeScopeNavigationImageIds, comfyUIWorkspaceNavigationImageIds, filteredNavigationImageIds, getImageByIdFromStore, imageLookup]);
 
   const resolveModalNavigationIndex = useCallback((
     modal: OpenImageModalState,
@@ -3091,13 +3096,48 @@ export default function App() {
   }, []);
   const handleComfyUIWorkspaceViewFullMetadata = useCallback((image: IndexedImage) => {
     setComfyUIWorkspaceImageId(image.id);
+    const navigationImageIds = comfyUIWorkspaceNavigationImages.length > 0
+      ? comfyUIWorkspaceNavigationImages.map((candidate) => candidate.id)
+      : [image.id];
     const existing = openImageModals.find((modal) => modal.imageId === image.id);
     if (existing) {
+      setOpenImageModals((current) =>
+        current.map((modal) =>
+          modal.modalId === existing.modalId
+            ? { ...modal, navigationImageIds, navigationSource: 'comfyui' }
+            : modal
+        )
+      );
       handleActivateImageModal(existing.modalId);
       return;
     }
+
+    const modalId = `image-modal-${Date.now()}-${image.id}`;
+    setOpenImageModals((current) => {
+      const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;
+      const host = resolveViewerHost();
+      return [
+        ...current,
+        {
+          sessionId: modalId,
+          modalId,
+          imageId: image.id,
+          navigationImageIds,
+          navigationSource: 'comfyui',
+          host,
+          nativeStatus: host === 'detached' ? 'pending' : undefined,
+          zIndex: highestZIndex + 1,
+          initialWindowOffset: current.length * 28,
+          isMinimized: false,
+          diagnosticsFlowId: beginModalOpenFlow(image.id, 'comfyui-workspace'),
+        },
+      ];
+    });
+
+    setActiveImageModalId(modalId);
+    suppressSelectedImageModalOpenRef.current = image.id;
     setSelectedImage(image);
-  }, [handleActivateImageModal, openImageModals, setSelectedImage]);
+  }, [beginModalOpenFlow, comfyUIWorkspaceNavigationImages, handleActivateImageModal, openImageModals, resolveViewerHost, setSelectedImage]);
   const handleComfyUIWorkspaceNavigate = useCallback((direction: 'next' | 'previous') => {
     if (comfyUIWorkspaceCurrentIndex === -1) {
       return;

--- a/App.tsx
+++ b/App.tsx
@@ -566,6 +566,7 @@ export default function App() {
   const [isSaveFilteredCollectionModalOpen, setIsSaveFilteredCollectionModalOpen] = useState(false);
   const [openImageModals, setOpenImageModals] = useState<OpenImageModalState[]>([]);
   const [activeImageModalId, setActiveImageModalId] = useState<string | null>(null);
+  const comfyUIWorkspaceModalIdRef = useRef<string | null>(null);
   const [findSimilarState, setFindSimilarState] = useState<FindSimilarState | null>(null);
   const [findSimilarGridFilter, setFindSimilarGridFilter] = useState<FindSimilarGridFilterState | null>(null);
   const [modelPromptPickerState, setModelPromptPickerState] = useState<{
@@ -1990,12 +1991,7 @@ export default function App() {
     }
 
     if (modal.navigationSource === 'comfyui') {
-      const workspaceImageIds = comfyUIWorkspaceNavigationImageIds ?? modal.navigationImageIds;
-      return sortImagesNewestFirst(
-        workspaceImageIds
-          .map((imageId) => getImageByIdFromStore(imageId))
-          .filter((candidate): candidate is IndexedImage => Boolean(candidate))
-      ).map((image) => image.id);
+      return modal.navigationImageIds.filter((imageId) => Boolean(getImageByIdFromStore(imageId)));
     }
 
     if (modal.navigationSource === 'find-similar') {
@@ -2003,7 +1999,7 @@ export default function App() {
     }
 
     return modal.navigationImageIds.filter((imageId) => imageLookup.has(imageId));
-  }, [activeScopeNavigationImageIds, comfyUIWorkspaceNavigationImageIds, filteredNavigationImageIds, getImageByIdFromStore, imageLookup]);
+  }, [activeScopeNavigationImageIds, filteredNavigationImageIds, getImageByIdFromStore, imageLookup]);
 
   const resolveModalNavigationIndex = useCallback((
     modal: OpenImageModalState,
@@ -2575,6 +2571,7 @@ export default function App() {
   useEffect(() => {
     if (libraryView !== 'comfyui') {
       setComfyUIWorkspaceNavigationImageIds(null);
+      comfyUIWorkspaceModalIdRef.current = null;
       return;
     }
 
@@ -3069,6 +3066,29 @@ export default function App() {
 
     return sortImagesNewestFirst(nextImages);
   }, [comfyUIWorkspaceImage, comfyUIWorkspaceNavigationImageIds, imageLookup]);
+  useEffect(() => {
+    if (libraryView !== 'comfyui' || !comfyUIWorkspaceModalIdRef.current) {
+      return;
+    }
+
+    const modalId = comfyUIWorkspaceModalIdRef.current;
+    const navigationImageIds = comfyUIWorkspaceNavigationImages.map((image) => image.id);
+    setOpenImageModals((current) => {
+      const targetModal = current.find((modal) => modal.modalId === modalId);
+      if (
+        !targetModal ||
+        targetModal.navigationSource !== 'comfyui' ||
+        !navigationImageIds.includes(targetModal.imageId) ||
+        areStringArraysEqual(targetModal.navigationImageIds, navigationImageIds)
+      ) {
+        return current;
+      }
+
+      return current.map((modal) =>
+        modal.modalId === modalId ? { ...modal, navigationImageIds } : modal
+      );
+    });
+  }, [comfyUIWorkspaceNavigationImages, libraryView]);
   const comfyUIWorkspaceCurrentIndex = useMemo(() => {
     if (!comfyUIWorkspaceImage) {
       return -1;
@@ -3101,6 +3121,7 @@ export default function App() {
       : [image.id];
     const existing = openImageModals.find((modal) => modal.imageId === image.id);
     if (existing) {
+      comfyUIWorkspaceModalIdRef.current = existing.modalId;
       setOpenImageModals((current) =>
         current.map((modal) =>
           modal.modalId === existing.modalId
@@ -3113,6 +3134,7 @@ export default function App() {
     }
 
     const modalId = `image-modal-${Date.now()}-${image.id}`;
+    comfyUIWorkspaceModalIdRef.current = modalId;
     setOpenImageModals((current) => {
       const highestZIndex = current.length > 0 ? Math.max(...current.map((modal) => modal.zIndex)) : 59;
       const host = resolveViewerHost();

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2715,10 +2715,12 @@ const ImageModal: React.FC<ImageModalProps> = ({
     slideshowTimeoutRef.current = null;
   }, []);
 
+  const showImagePreviewWhileLoading = !isPlayableMedia && imageViewerDefaultZoom !== 'actual';
+
   useEffect(() => {
     let isMounted = true;
     const hasPreview = !isPlayableMedia && Boolean(preferredThumbnailUrl);
-    const showPreviewWhileLoading = imageViewerDefaultZoom !== 'actual' && hasPreview;
+    const showPreviewWhileLoading = showImagePreviewWhileLoading && hasPreview;
     const sourceLoadStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
 
     if (warmFullImageUrl) {
@@ -2790,7 +2792,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     // warmFullImageUrl is read from the closure on purpose. It is computed in the same render as
     // the image id change, so the run that matters already sees the right value; adding it here
     // would re-run the whole load when a later prefetch flips warmth for the image on screen.
-  }, [diagnosticsFlowId, liveImage.id, liveImage.handle, liveImage.thumbnailHandle, liveImage.name, liveImage.lastModified, directoryPath, preferredThumbnailUrl, imageViewerDefaultZoom, isPlayableMedia, isVideo]);
+  }, [diagnosticsFlowId, liveImage.id, liveImage.handle, liveImage.thumbnailHandle, liveImage.name, liveImage.lastModified, directoryPath, preferredThumbnailUrl, showImagePreviewWhileLoading, isPlayableMedia, isVideo]);
 
   // Decoded bitmaps are worth tens of megabytes, so they only stay alive while a modal is open.
   useEffect(() => {

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -2717,7 +2717,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   useEffect(() => {
     let isMounted = true;
-    const hasPreview = imageViewerDefaultZoom !== 'actual' && Boolean(preferredThumbnailUrl);
+    const hasPreview = !isPlayableMedia && Boolean(preferredThumbnailUrl);
+    const showPreviewWhileLoading = imageViewerDefaultZoom !== 'actual' && hasPreview;
     const sourceLoadStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
 
     if (warmFullImageUrl) {
@@ -2727,7 +2728,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
       setIsFullImageSourceReady(true);
     } else {
       setIsFullImageSourceReady(false);
-      setImageUrl(isPlayableMedia || !hasPreview ? null : preferredThumbnailUrl);
+      setImageUrl(isPlayableMedia || !showPreviewWhileLoading ? null : preferredThumbnailUrl);
     }
 
     const loadImage = async () => {
@@ -2737,9 +2738,13 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
       if (!directoryPath && window.electronAPI && !electronAbsoluteMediaPath) {
         console.error('Cannot load image: directoryPath is undefined');
-        if (isMounted && !hasPreview) {
-          setImageUrl(null);
-          alert('Failed to load image: Directory path is not available.');
+        if (isMounted) {
+          if (hasPreview) {
+            setImageUrl(preferredThumbnailUrl);
+          } else {
+            setImageUrl(null);
+            alert('Failed to load image: Directory path is not available.');
+          }
         }
         return;
       }
@@ -2766,9 +2771,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
           // The warm branch above marks the source ready before this confirms it, so a failure
           // here has to take that back: otherwise export and editing stay enabled over nothing.
           setIsFullImageSourceReady(false);
-          if (!hasPreview) {
-            setImageUrl(null);
-          }
+          setImageUrl(hasPreview ? preferredThumbnailUrl : null);
         }
       } finally {
         recordPerformanceDuration('modal.full-source-load', (typeof performance !== 'undefined' ? performance.now() : Date.now()) - sourceLoadStartedAt, {

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1019,6 +1019,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const slideshowShowFilename = useSettingsStore((state) => state.slideshowShowFilename);
   const autoPlayMedia = useSettingsStore((state) => state.autoPlayMedia);
   const imageViewerDefaultZoom = useSettingsStore((state) => state.imageViewerDefaultZoom);
+  const setImageViewerDefaultZoom = useSettingsStore((state) => state.setImageViewerDefaultZoom);
   // A running slideshow and a repeat-all/shuffle chain both imply continuous playback, so they
   // start the media regardless of the auto-play preference.
   const shouldAutoPlayMedia = autoPlayMedia || isChainedPlayback || (isSlideshowMode && isSlideshowPlaying);
@@ -1078,7 +1079,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   }, [enableAnimations, isMinimized, modalId, zIndex]);
 
   const [zoom, setZoom] = useState(1);
-  const [viewerZoomMode, setViewerZoomMode] = useState<ViewerZoomMode>('fit');
+  const [viewerZoomMode, setViewerZoomMode] = useState<ViewerZoomMode>(() => imageViewerDefaultZoom);
   const [windowZoomFactor, setWindowZoomFactor] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
@@ -1283,6 +1284,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
     ? editedPreviewUrl
     : (warmFullImageUrl ?? imageUrl);
 
+  useLayoutEffect(() => {
+    setDisplayedImageNaturalSize(null);
+  }, [displayedImageUrl]);
+
   useEffect(() => {
     let isMounted = true;
     setExternalMediaPath(null);
@@ -1385,7 +1390,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
     setImageEditRecipe(DEFAULT_IMAGE_EDIT_RECIPE);
     setImageEditorTab('adjust');
     setImageEditSourceDimensions(null);
-    setDisplayedImageNaturalSize(null);
     setCropImageBounds(null);
     setEditedPreviewUrl(null);
     setIsRenderingEditedPreview(false);
@@ -2139,7 +2143,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     openBatchExport();
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setZoom(1);
     setViewerZoomMode(imageViewerDefaultZoom);
     setPan({ x: 0, y: 0 });
@@ -2157,7 +2161,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     setPan({ x: 0, y: 0 });
   }, [image.id, isSlideshowMode]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setZoom(1);
     setViewerZoomMode(isSlideshowMode ? 'fit' : imageViewerDefaultZoom);
     setPan({ x: 0, y: 0 });
@@ -2205,11 +2209,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
       return;
     }
 
-    const frameId = window.requestAnimationFrame(() => {
-      setZoom(getActualSizeZoom());
-    });
-
-    return () => window.cancelAnimationFrame(frameId);
+    setZoom(getActualSizeZoom());
   }, [getActualSizeZoom, viewerZoomMode, windowZoomFactor]);
 
   const handleWheel = useCallback((e: WheelEvent) => {
@@ -2406,6 +2406,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   };
 
   const handleFitToScreen = () => {
+    setImageViewerDefaultZoom('fit');
     setViewerZoomMode('fit');
     setZoom(1);
     setPan({ x: 0, y: 0 });
@@ -2413,6 +2414,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   const handleActualSize = () => {
     const nextZoom = getActualSizeZoom();
+    setImageViewerDefaultZoom('actual');
     setViewerZoomMode('actual');
     setZoom(nextZoom);
     if (Math.abs(nextZoom - 1) < 0.01) {
@@ -2715,7 +2717,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
 
   useEffect(() => {
     let isMounted = true;
-    const hasPreview = Boolean(preferredThumbnailUrl);
+    const hasPreview = imageViewerDefaultZoom !== 'actual' && Boolean(preferredThumbnailUrl);
     const sourceLoadStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
 
     if (warmFullImageUrl) {
@@ -2725,7 +2727,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
       setIsFullImageSourceReady(true);
     } else {
       setIsFullImageSourceReady(false);
-      setImageUrl(isPlayableMedia ? null : (preferredThumbnailUrl ?? null));
+      setImageUrl(isPlayableMedia || !hasPreview ? null : preferredThumbnailUrl);
     }
 
     const loadImage = async () => {
@@ -2785,7 +2787,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     // warmFullImageUrl is read from the closure on purpose. It is computed in the same render as
     // the image id change, so the run that matters already sees the right value; adding it here
     // would re-run the whole load when a later prefetch flips warmth for the image on screen.
-  }, [diagnosticsFlowId, liveImage.id, liveImage.handle, liveImage.thumbnailHandle, liveImage.name, liveImage.lastModified, directoryPath, preferredThumbnailUrl, isPlayableMedia, isVideo]);
+  }, [diagnosticsFlowId, liveImage.id, liveImage.handle, liveImage.thumbnailHandle, liveImage.name, liveImage.lastModified, directoryPath, preferredThumbnailUrl, imageViewerDefaultZoom, isPlayableMedia, isVideo]);
 
   // Decoded bitmaps are worth tens of megabytes, so they only stay alive while a modal is open.
   useEffect(() => {
@@ -3767,7 +3769,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   onDragStart={handleDragStart}
                   style={{
                     transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
-                    transition: isDragging ? 'none' : 'transform 0.1s ease-out',
+                    transition: isDragging || viewerZoomMode !== 'manual' ? 'none' : 'transform 0.1s ease-out',
+                    opacity: viewerZoomMode === 'actual' && (
+                      !displayedImageNaturalSize || Math.abs(zoom - actualSizeZoom) >= 0.05
+                    ) ? 0 : 1,
                   }}
                   title={hasImageEditChanges && editedPreviewUrl ? 'Hold to compare with the original image' : undefined}
                   draggable={canDragExternally && zoom === 1}


### PR DESCRIPTION
## Summary
- open images directly at 1:1 without rendering an intermediate Fit frame
- make the ImageModal Fit and 1:1 buttons update the same persisted default used by Settings
- keep ComfyUI Workspace modal navigation newest-first and independent from the Grid sort order
- update open ComfyUI navigation when newly indexed images arrive while preserving the current image

## Validation
- manually confirmed the corrected 1:1 opening behavior
- git diff --check