### PR TITLE
Fix Krea2 grounded encode prompt extraction

### DIFF
--- a/__tests__/cacheParserVersionConsistency.test.ts
+++ b/__tests__/cacheParserVersionConsistency.test.ts
@@ -4,10 +4,10 @@ import { describe, expect, it } from 'vitest';
 import { PARSER_VERSION } from '../services/cacheManager';
 
 describe('cache parser version consistency', () => {
-  it('uses the shared v11 parser version in both renderer and Electron', () => {
+  it('uses the shared v12 parser version in both renderer and Electron', () => {
     const electronSource = fs.readFileSync(path.resolve(process.cwd(), 'electron.mjs'), 'utf8');
 
-    expect(PARSER_VERSION).toBe(11);
+    expect(PARSER_VERSION).toBe(12);
     expect(electronSource).toContain("import { PARSER_VERSION } from './utils/parserVersion.js';");
     expect(electronSource).not.toMatch(/const PARSER_VERSION\s*=/);
   });

--- a/__tests__/comfyui-parser.test.ts
+++ b/__tests__/comfyui-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseComfyUIMetadataEnhanced, resolveModel3DLineageFromGraph, resolvePromptFromGraph, resolveWorkflowFactsFromGraph } from '../services/parsers/comfyUIParser';
+import { resolvePromptFromGraph as resolveEnginePromptFromGraph } from '../packages/metadata-engine/src/parsers/comfyUIParser';
 import { parseImageMetadata } from '../services/parsers/metadataParserFactory';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -46,6 +47,45 @@ describe('ComfyUI Parser - Prompt Sources', () => {
 
     expect(result.prompt).toBe('Visualize a long, eel-like mutant lizard with overlapping plates of translucent skin. Place it in a fossilized ocean desert where waves are frozen into glassy dunes.');
     expect(result._telemetry.unknown_nodes_count).toBe(0);
+  });
+
+  it('extracts positive and negative prompts from Krea2 Edit grounded encodes', () => {
+    const workflow = {
+      nodes: [
+        { id: 53, type: 'KSampler', widgets_values: [42, 'fixed', 10, 1, 'euler', 'simple', 1] },
+        { id: 84, type: 'Krea2EditGroundedEncode', widgets_values: ['Change her outfit to a red raincoat.', 768, ''] },
+        { id: 85, type: 'Krea2EditGroundedEncode', widgets_values: ['avoid artifacts', 768, ''] },
+      ],
+    };
+    const prompt = {
+      '53': {
+        class_type: 'KSampler',
+        inputs: {
+          seed: 42,
+          steps: 10,
+          cfg: 1,
+          sampler_name: 'euler',
+          scheduler: 'simple',
+          positive: ['84', 0],
+          negative: ['85', 0],
+        },
+      },
+      '84': {
+        class_type: 'Krea2EditGroundedEncode',
+        inputs: { prompt: 'Change her outfit to a red raincoat.', grounding_px: 768 },
+      },
+      '85': {
+        class_type: 'Krea2EditGroundedEncode',
+        inputs: { prompt: 'avoid artifacts', grounding_px: 768 },
+      },
+    };
+
+    for (const resolveGraph of [resolvePromptFromGraph, resolveEnginePromptFromGraph]) {
+      const result = resolveGraph(workflow, prompt);
+      expect(result.prompt).toBe('Change her outfit to a red raincoat.');
+      expect(result.negativePrompt).toBe('avoid artifacts');
+      expect(result._telemetry.unknown_nodes_count).toBe(0);
+    }
   });
 
   describe('Krea2 conditional prompt routing', () => {

--- a/packages/metadata-engine/src/parsers/comfyui/nodeRegistry.ts
+++ b/packages/metadata-engine/src/parsers/comfyui/nodeRegistry.ts
@@ -36,6 +36,23 @@ function resolveFirstTextInput(
   return null;
 }
 
+function extractKrea2GroundedPrompt(
+  node: ParserNode,
+  state: any,
+  graph: any,
+  traverse: any,
+): string | null {
+  const promptInput = node.inputs?.prompt;
+  if (Array.isArray(promptInput)) {
+    const resolved = traverse(promptInput, state, graph, []);
+    if (typeof resolved === 'string') return resolved;
+  }
+  if (typeof promptInput === 'string') return promptInput;
+
+  const widgetPrompt = node.widgets_values?.[0];
+  return typeof widgetPrompt === 'string' ? widgetPrompt : null;
+}
+
 function extractRgthreePowerLoras(node: ParserNode): string[] {
   const loras: string[] = [];
   const addLora = (value: unknown) => {
@@ -330,6 +347,24 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
       }
     },
     widget_order: ['text']
+  },
+  Krea2EditGroundedEncode: {
+    category: 'CONDITIONING',
+    roles: ['SOURCE'],
+    inputs: {
+      clip: { type: 'CLIP' },
+      prompt: { type: 'STRING' },
+      image: { type: 'IMAGE' },
+      image_b: { type: 'IMAGE' },
+      grounding_px: { type: 'INT' },
+      system_prompt: { type: 'STRING' },
+    },
+    outputs: { CONDITIONING: { type: 'CONDITIONING' } },
+    param_mapping: {
+      prompt: { source: 'custom_extractor', extractor: extractKrea2GroundedPrompt },
+      negativePrompt: { source: 'custom_extractor', extractor: extractKrea2GroundedPrompt },
+    },
+    widget_order: ['prompt', 'grounding_px', 'system_prompt'],
   },
   'StylePromptEncoder2 //ZImagePowerNodes': {
     category: 'CONDITIONING',

--- a/services/parsers/comfyui/nodeRegistry.ts
+++ b/services/parsers/comfyui/nodeRegistry.ts
@@ -36,6 +36,23 @@ function resolveFirstTextInput(
   return null;
 }
 
+function extractKrea2GroundedPrompt(
+  node: ParserNode,
+  state: any,
+  graph: any,
+  traverse: any,
+): string | null {
+  const promptInput = node.inputs?.prompt;
+  if (Array.isArray(promptInput)) {
+    const resolved = traverse(promptInput, state, graph, []);
+    if (typeof resolved === 'string') return resolved;
+  }
+  if (typeof promptInput === 'string') return promptInput;
+
+  const widgetPrompt = node.widgets_values?.[0];
+  return typeof widgetPrompt === 'string' ? widgetPrompt : null;
+}
+
 function extractRgthreePowerLoras(node: ParserNode): string[] {
   const loras: string[] = [];
   const addLora = (value: unknown) => {
@@ -332,6 +349,24 @@ export const NodeRegistry: Record<string, NodeDefinition> = {
       }
     },
     widget_order: ['text']
+  },
+  Krea2EditGroundedEncode: {
+    category: 'CONDITIONING',
+    roles: ['SOURCE'],
+    inputs: {
+      clip: { type: 'CLIP' },
+      prompt: { type: 'STRING' },
+      image: { type: 'IMAGE' },
+      image_b: { type: 'IMAGE' },
+      grounding_px: { type: 'INT' },
+      system_prompt: { type: 'STRING' },
+    },
+    outputs: { CONDITIONING: { type: 'CONDITIONING' } },
+    param_mapping: {
+      prompt: { source: 'custom_extractor', extractor: extractKrea2GroundedPrompt },
+      negativePrompt: { source: 'custom_extractor', extractor: extractKrea2GroundedPrompt },
+    },
+    widget_order: ['prompt', 'grounding_px', 'system_prompt'],
   },
   'StylePromptEncoder2 //ZImagePowerNodes': {
     category: 'CONDITIONING',

--- a/utils/parserVersion.js
+++ b/utils/parserVersion.js
@@ -1,4 +1,4 @@
 // Shared by the Electron main process and renderer cache manager. Keep this
 // value monotonic whenever parser output changes so a newer cache is never
 // rejected by another process from the same build.
-export const PARSER_VERSION = 11;
+export const PARSER_VERSION = 12;


### PR DESCRIPTION
## Summary
- recognize `Krea2EditGroundedEncode` as a ComfyUI conditioning source
- extract positive and negative text from its `prompt` input, including linked prompt inputs and workflow widget fallback
- keep the app parser and standalone metadata engine registries aligned
- bump the shared parser cache version so previously indexed Krea2 images are reparsed
- add regression coverage based on the official Krea2 Edit workflow shape

## Validation
- `npx vitest run __tests__/comfyui-parser.test.ts __tests__/cacheParserVersionConsistency.test.ts` — 2 files and 48 tests passed
- `git diff --check`

## Scope
- parser cache version bumped from 11 to 12 because parser output changed
- no unrelated changelog changes included

Fixes #548