### PR TITLE
Provenance repository foundation

### DIFF
--- a/__tests__/provenanceRepository.test.ts
+++ b/__tests__/provenanceRepository.test.ts
@@ -120,6 +120,31 @@ describe('AssetProvenanceRepository production contract', () => {
     repository.close();
   });
 
+  it('normalizes filesystem timestamps while preserving opaque location whitespace', async () => {
+    const databasePath = resolveProvenanceCatalogPath(await temporaryUserData());
+    const repository = new AssetProvenanceRepository({ databasePath });
+    repository.open();
+
+    const created = repository.createAssetWithRevisionAndLocation(initialRecord({
+      relativePath: ' images/original.png ',
+      contentModifiedMs: 1_788_000_000_000.875,
+    }));
+    expect(created).toMatchObject({
+      revisions: [{ contentModifiedMs: 1_788_000_000_000 }],
+      locations: [{ relativePath: ' images/original.png ' }],
+    });
+
+    expect(repository.relocateLocation(initialRecord().locationId as string, {
+      rootId: 'library-root',
+      relativePath: ' renamed/original.png ',
+    })).toMatchObject({ relativePath: ' renamed/original.png ' });
+    expect(() => repository.relocateLocation(initialRecord().locationId as string, {
+      rootId: 'library-root',
+      relativePath: '   ',
+    })).toThrowError(expect.objectContaining({ code: 'PROVENANCE_INVALID_INPUT' }));
+    repository.close();
+  });
+
   it('migrates v1 to v2 transactionally, preserves records and retries after rollback', async () => {
     const databasePath = resolveProvenanceCatalogPath(await temporaryUserData());
     let repository = new AssetProvenanceRepository({

--- a/__tests__/provenanceRepository.test.ts
+++ b/__tests__/provenanceRepository.test.ts
@@ -1,0 +1,275 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resetUserDataContents } from '../electron/cacheReset.mjs';
+import {
+  AssetProvenanceRepository,
+  PROVENANCE_SCHEMA_VERSION,
+  ProvenanceRepositoryLifecycle,
+  resolveProvenanceCatalogPath,
+} from '../electron/provenanceRepository.mjs';
+
+const temporaryDirectories: string[] = [];
+const sha = (character: string) => character.repeat(64);
+
+async function temporaryUserData() {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-provenance-repository-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function initialRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    assetId: '11111111-1111-4111-8111-111111111111',
+    revisionId: '22222222-2222-4222-8222-222222222222',
+    locationId: '33333333-3333-4333-8333-333333333333',
+    rootId: 'library-root',
+    relativePath: 'images/original.png',
+    byteSize: 1024,
+    mimeType: 'image/png',
+    width: 512,
+    height: 512,
+    contentModifiedMs: 1_788_000_000_000,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+describe('AssetProvenanceRepository production contract', () => {
+  it('persists stable assets, immutable revisions, locations and lifecycle states across restart', async () => {
+    const userDataPath = await temporaryUserData();
+    const databasePath = resolveProvenanceCatalogPath(userDataPath);
+    let repository = new AssetProvenanceRepository({
+      databasePath,
+      now: () => new Date('2026-09-06T12:00:00.000Z'),
+    });
+    expect(repository.open()).toMatchObject({ state: 'ready', schemaVersion: PROVENANCE_SCHEMA_VERSION });
+
+    const created = repository.createAssetWithRevisionAndLocation(initialRecord());
+    expect(created).toMatchObject({
+      assetId: initialRecord().assetId,
+      state: 'active',
+      revisions: [{ revisionId: initialRecord().revisionId, hashState: 'pending', sha256: null }],
+      locations: [{ locationId: initialRecord().locationId, state: 'present' }],
+    });
+    expect(() => JSON.stringify(created)).not.toThrow();
+    expect(() => repository.createAssetWithRevisionAndLocation(initialRecord({ assetId: 'path-based-id' })))
+      .toThrowError(expect.objectContaining({ code: 'PROVENANCE_INVALID_INPUT' }));
+
+    repository.completeRevisionHash(initialRecord().revisionId as string, { sha256: sha('a') });
+    expect(() => repository.completeRevisionHash(initialRecord().revisionId as string, { sha256: sha('b') }))
+      .toThrowError(expect.objectContaining({ code: 'PROVENANCE_REVISION_IMMUTABLE' }));
+    const duplicateBytes = repository.createAssetWithRevisionAndLocation(initialRecord({
+      assetId: 'bbbbbbbb-bbbb-4bbb-abbb-bbbbbbbbbbbb',
+      revisionId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      locationId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      relativePath: 'images/duplicate-bytes.png',
+      sha256: sha('a'),
+    }));
+    expect(duplicateBytes.assetId).not.toBe(created.assetId);
+
+    expect(repository.relocateLocation(initialRecord().locationId as string, {
+      rootId: 'library-root',
+      relativePath: 'renamed/original.png',
+    })).toMatchObject({
+      locationId: initialRecord().locationId,
+      relativePath: 'renamed/original.png',
+    });
+    repository.markLocationMissing(initialRecord().locationId as string);
+    expect(repository.getAsset(initialRecord().assetId as string)?.state).toBe('missing');
+
+    const secondRevisionId = '44444444-4444-4444-8444-444444444444';
+    repository.addRevision(initialRecord().assetId as string, {
+      revisionId: secondRevisionId,
+      locationId: initialRecord().locationId,
+      byteSize: 2048,
+      sha256: sha('c'),
+      mimeType: 'image/png',
+    });
+    expect(repository.getAsset(initialRecord().assetId as string)).toMatchObject({
+      state: 'active',
+      locations: [{ revisionId: secondRevisionId, state: 'present' }],
+    });
+    repository.close();
+
+    repository = new AssetProvenanceRepository({ databasePath });
+    repository.open();
+    expect(repository.getAsset(initialRecord().assetId as string)).toMatchObject({
+      state: 'active',
+      revisions: [{ revisionId: initialRecord().revisionId }, { revisionId: secondRevisionId }],
+      locations: [{ relativePath: 'renamed/original.png', revisionId: secondRevisionId }],
+    });
+    expect(repository.markAssetDeleted(initialRecord().assetId as string)).toMatchObject({
+      state: 'deleted',
+      locations: [{ state: 'removed' }],
+    });
+    expect(() => repository.addRevision(initialRecord().assetId as string, { byteSize: 1 }))
+      .toThrowError(expect.objectContaining({ code: 'PROVENANCE_ASSET_DELETED' }));
+    expect(repository.createAssetWithRevisionAndLocation(initialRecord({
+      assetId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+      revisionId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      locationId: '12121212-1212-4121-8121-121212121212',
+      relativePath: 'renamed/original.png',
+    }))).toMatchObject({ state: 'active' });
+    repository.close();
+  });
+
+  it('migrates v1 to v2 transactionally, preserves records and retries after rollback', async () => {
+    const databasePath = resolveProvenanceCatalogPath(await temporaryUserData());
+    let repository = new AssetProvenanceRepository({
+      databasePath,
+      now: () => new Date('2026-09-06T12:00:00.000Z'),
+    });
+    repository.open({ targetSchemaVersion: 1 });
+    repository.database.prepare('INSERT INTO assets VALUES (?, ?, ?, ?)').run('legacy-asset', 'active', 'now', 'now');
+    repository.database.prepare(`
+      INSERT INTO asset_revisions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run('legacy-revision', 'legacy-asset', sha('d'), 'available', 1, 'image/png', null, null, null, 'now', 'now');
+    repository.close();
+
+    repository = new AssetProvenanceRepository({ databasePath });
+    expect(() => repository.open({ failMigrationVersion: 2 }))
+      .toThrowError(expect.objectContaining({ code: 'PROVENANCE_MIGRATION_FAILED' }));
+
+    repository = new AssetProvenanceRepository({ databasePath });
+    repository.open({ targetSchemaVersion: 1 });
+    expect(repository.getStatus().schemaVersion).toBe(1);
+    expect(repository.database.prepare("SELECT name FROM sqlite_master WHERE name = 'asset_locations'").get()).toBeUndefined();
+    expect(repository.database.prepare('SELECT asset_id FROM assets WHERE asset_id = ?').get('legacy-asset'))
+      .toEqual({ asset_id: 'legacy-asset' });
+    repository.close();
+
+    repository = new AssetProvenanceRepository({ databasePath });
+    repository.open();
+    repository.applyMigrations();
+    expect(repository.getStatus().schemaVersion).toBe(2);
+    expect(repository.getAsset('legacy-asset')).toMatchObject({
+      assetId: 'legacy-asset',
+      revisions: [{ revisionId: 'legacy-revision' }],
+      locations: [],
+    });
+    repository.close();
+  });
+
+  it('creates a verified checkpointed backup and keeps the live writer usable', async () => {
+    const userDataPath = await temporaryUserData();
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath, logger: { error: vi.fn() } });
+    expect(lifecycle.initialize()).toMatchObject({ available: true });
+    lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation(initialRecord({ sha256: sha('e') })));
+
+    const liveReader = new AssetProvenanceRepository({ databasePath: resolveProvenanceCatalogPath(userDataPath), readOnly: true });
+    liveReader.open();
+    liveReader.database.exec('BEGIN');
+    expect(liveReader.getAsset(initialRecord().assetId as string)).not.toBeNull();
+
+    lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation(initialRecord({
+      assetId: '55555555-5555-4555-8555-555555555555',
+      revisionId: '66666666-6666-4666-8666-666666666666',
+      locationId: '77777777-7777-4777-8777-777777777777',
+      relativePath: 'images/before-backup.png',
+      sha256: sha('f'),
+    })));
+
+    const backupPath = path.join(userDataPath, 'backups', 'provenance.sqlite');
+    expect(lifecycle.createBackup(backupPath)).toMatchObject({ path: backupPath, schemaVersion: 2, created: true });
+    liveReader.database.exec('COMMIT');
+    liveReader.close();
+    lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation(initialRecord({
+      assetId: '88888888-8888-4888-8888-888888888888',
+      revisionId: '99999999-9999-4999-8999-999999999999',
+      locationId: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
+      relativePath: 'images/after-backup.png',
+      sha256: sha('a'),
+    })));
+
+    const backup = new AssetProvenanceRepository({ databasePath: backupPath, readOnly: true });
+    backup.open();
+    expect(backup.getAsset(initialRecord().assetId as string)).not.toBeNull();
+    expect(backup.getAsset('55555555-5555-4555-8555-555555555555')).not.toBeNull();
+    expect(backup.getAsset('88888888-8888-4888-8888-888888888888')).toBeNull();
+    backup.close();
+    expect(lifecycle.run((repository) => repository.getAsset('88888888-8888-4888-8888-888888888888'))).not.toBeNull();
+    lifecycle.close();
+  });
+
+  it('reopens the live database when backup copying fails', async () => {
+    const userDataPath = await temporaryUserData();
+    const lifecycle = new ProvenanceRepositoryLifecycle({
+      userDataPath,
+      logger: { error: vi.fn() },
+      repositoryOptions: { backupDatabase: () => { throw new Error('synthetic backup failure'); } },
+    });
+    lifecycle.initialize();
+    lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation(initialRecord()));
+
+    expect(() => lifecycle.createBackup(path.join(userDataPath, 'backup.sqlite')))
+      .toThrowError(expect.objectContaining({ code: 'PROVENANCE_BACKUP_FAILED' }));
+    expect(lifecycle.run((repository) => repository.getAsset(initialRecord().assetId as string))).not.toBeNull();
+    lifecycle.close();
+  });
+});
+
+describe('provenance repository lifecycle and cache independence', () => {
+  it('preserves the live catalog while cache reset removes disposable entries', async () => {
+    const userDataPath = await temporaryUserData();
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath, logger: { error: vi.fn() } });
+    lifecycle.initialize();
+    lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation(initialRecord()));
+    await fs.writeFile(path.join(userDataPath, 'disposable-cache.json'), '{}', 'utf8');
+
+    await resetUserDataContents({ userDataDir: userDataPath });
+    await expect(fs.stat(path.join(userDataPath, 'disposable-cache.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(lifecycle.run((repository) => repository.getAsset(initialRecord().assetId as string))).not.toBeNull();
+    lifecycle.close();
+
+    const reopened = new ProvenanceRepositoryLifecycle({ userDataPath, logger: { error: vi.fn() } });
+    expect(reopened.initialize()).toMatchObject({ available: true, schemaVersion: 2 });
+    expect(reopened.run((repository) => repository.getAsset(initialRecord().assetId as string))).not.toBeNull();
+    reopened.close();
+  });
+
+  it('reports an unavailable catalog without replacing corrupt data or throwing from startup', async () => {
+    const userDataPath = await temporaryUserData();
+    const databasePath = resolveProvenanceCatalogPath(userDataPath);
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const original = Buffer.from('existing data that is not a SQLite database');
+    await fs.writeFile(databasePath, original);
+    const logger = { error: vi.fn() };
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath, logger });
+
+    expect(() => lifecycle.initialize()).not.toThrow();
+    expect(lifecycle.getStatus()).toMatchObject({
+      state: 'unavailable',
+      available: false,
+      error: { code: 'PROVENANCE_OPEN_FAILED' },
+    });
+    expect(await fs.readFile(databasePath)).toEqual(original);
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(() => lifecycle.run(() => null)).toThrowError(expect.objectContaining({ code: 'PROVENANCE_UNAVAILABLE' }));
+  });
+
+  it('preserves a newer incompatible catalog and its records', async () => {
+    const userDataPath = await temporaryUserData();
+    const databasePath = resolveProvenanceCatalogPath(userDataPath);
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const database = new DatabaseSync(databasePath);
+    database.exec('CREATE TABLE future_records (value TEXT NOT NULL); INSERT INTO future_records VALUES (\'keep-me\'); PRAGMA user_version = 99;');
+    database.close();
+
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath, logger: { error: vi.fn() } });
+    expect(lifecycle.initialize()).toMatchObject({
+      available: false,
+      error: { code: 'PROVENANCE_SCHEMA_INCOMPATIBLE' },
+    });
+    const verification = new DatabaseSync(databasePath, { readOnly: true });
+    expect(verification.prepare('SELECT value FROM future_records').get()).toEqual({ value: 'keep-me' });
+    expect(verification.prepare('PRAGMA user_version').get()).toEqual({ user_version: 99 });
+    verification.close();
+  });
+});

--- a/docs/provenance-repository-foundation.md
+++ b/docs/provenance-repository-foundation.md
@@ -1,0 +1,37 @@
+# Provenance repository foundation
+
+## Purpose and ownership
+
+The provenance catalog is durable application data stored at `<userData>/provenance/catalog.sqlite`. It is independent from parser and thumbnail caches. Clearing cache must preserve the entire top-level `provenance` directory.
+
+The Electron main process owns the only writable `AssetProvenanceRepository`. It opens the database, enables foreign keys and WAL, applies migrations transactionally, coordinates backups, and closes the connection before application exit. No renderer IPC or library-indexing integration is part of this foundation.
+
+`node:sqlite` stays private to `electron/provenanceRepository.mjs`. Callers receive plain serializable objects. A catalog open or migration failure is reported by `ProvenanceRepositoryLifecycle` as an unavailable status and does not reject application startup, delete the database, or recreate it.
+
+## Identity contract
+
+- An **asset** is a logical library item with a stable UUID. Its state is `active`, `missing`, or `deleted`.
+- A **revision** is one observed byte version of an asset with its own UUID. Revisions are not merged when SHA-256 values match. A hash can be `pending`, `available`, or `failed`; once available, it cannot be replaced with a different hash.
+- A **location** has its own UUID and points to the revision currently observed at an opaque root ID plus relative path. Its state is `present`, `missing`, or `removed`.
+- A known rename or move updates the existing location and preserves its ID. An overwrite creates a revision and advances the location. Explicit deletion keeps the asset and revision records and marks locations removed.
+- Copy and Save As will create a new asset when library integration is added. Their relationship belongs in the later provenance-edge schema.
+
+Only present locations are unique by root and relative path. Missing or removed records keep history without preventing a newly observed asset from occupying the same path. The future indexer adapter owns root identity and relative-path normalization.
+
+The repository supports creating an asset with its first revision and location, adding a revision, completing a hash, relocating or marking a location missing, marking an asset deleted, and loading the serialized aggregate. The indexing integration will call these operations in the next PR.
+
+## Schema and migrations
+
+Schema v1 introduces `assets`, `asset_revisions`, and the migration ledger. Schema v2 introduces `asset_locations` and lookup indexes. The hash index is deliberately non-unique because identical bytes do not prove logical identity.
+
+Each migration runs in `BEGIN IMMEDIATE` and updates both the migration ledger and `PRAGMA user_version` in the same transaction. A failed migration rolls back without advancing the version. A database newer than the supported schema is left in place and reported as incompatible.
+
+## Backup and recovery
+
+`createBackup` runs through the writer-owned repository. It uses SQLite `VACUUM INTO` to create a consistent snapshot at a unique temporary destination, verifies schema and `PRAGMA integrity_check`, and atomically renames the verified copy. The destination must not already exist. This remains correct when a separate read-only connection holds an older WAL snapshot.
+
+If snapshot creation or validation fails, the incomplete temporary file is discarded and the live writer remains open. The original database is never replaced. Directly copying an active database and its sidecars is not a supported backup procedure.
+
+## Current boundary
+
+This PR installs an empty durable catalog and its lifecycle. It does not read the image library, hash files, migrate annotations, create provenance edges or audit events, expose MCP/IPC, or change the Provenance Summary UI. Linux and macOS packaged validation remain adoption gates inherited from the feasibility spike.

--- a/electron.mjs
+++ b/electron.mjs
@@ -42,6 +42,7 @@ import { createLicenseManager } from './electron/licenseManager.mjs';
 import { licenseClientConfig } from './electron/licenseClientConfig.generated.mjs';
 import { resolveLicenseRuntimeConfig } from './electron/licenseRuntimeConfig.mjs';
 import { resetUserDataContents } from './electron/cacheReset.mjs';
+import { ProvenanceRepositoryLifecycle } from './electron/provenanceRepository.mjs';
 import { openAuthorizedCacheDirectory } from './electron/cacheDirectory.mjs';
 import { appendEmbeddingSegmentAtOffset } from './electron/embeddingSegmentFile.mjs';
 import { hashFileSha256 } from './electron/fileFingerprint.mjs';
@@ -604,6 +605,7 @@ async function readMediaMetadataWithFfprobe(filePath) {
 
 let mainWindow;
 let licenseManager;
+let provenanceRepositoryLifecycle;
 const detachedImageViewerWindows = new Map();
 const detachedImageViewerSnapshots = new Map();
 const detachedImageViewerRequestResolvers = new Map();
@@ -2944,6 +2946,11 @@ app.whenReady().then(async () => {
   registerMediaProtocol();
   registerThumbnailProtocol();
   registerModelProtocol();
+
+  provenanceRepositoryLifecycle = new ProvenanceRepositoryLifecycle({
+    userDataPath: app.getPath('userData'),
+  });
+  provenanceRepositoryLifecycle.initialize();
 
   const licenseRuntimeConfig = resolveLicenseRuntimeConfig({
     isPackaged: app.isPackaged,
@@ -7440,6 +7447,7 @@ app.on('before-quit', () => {
   // Stop all file watchers before quitting
   fileWatcher.stopAllWatchers();
   licenseManager?.dispose?.();
+  provenanceRepositoryLifecycle?.close();
 });
 
 app.on('activate', () => {

--- a/electron/cacheReset.mjs
+++ b/electron/cacheReset.mjs
@@ -1,11 +1,13 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { PROVENANCE_DIRECTORY_NAME } from './provenancePaths.mjs';
 
 export async function resetUserDataContents({ userDataDir, preservedFileNames = new Set() }) {
+  const protectedEntries = new Set([PROVENANCE_DIRECTORY_NAME, ...preservedFileNames]);
   try {
     const files = await fs.readdir(userDataDir);
     for (const file of files) {
-      if (preservedFileNames.has(file)) continue;
+      if (protectedEntries.has(file)) continue;
       const filePath = path.join(userDataDir, file);
       const stat = await fs.stat(filePath);
       if (stat.isDirectory()) {

--- a/electron/provenancePaths.mjs
+++ b/electron/provenancePaths.mjs
@@ -1,0 +1,8 @@
+import path from 'node:path';
+
+export const PROVENANCE_DIRECTORY_NAME = 'provenance';
+export const PROVENANCE_DATABASE_NAME = 'catalog.sqlite';
+
+export function resolveProvenanceCatalogPath(userDataPath) {
+  return path.join(userDataPath, PROVENANCE_DIRECTORY_NAME, PROVENANCE_DATABASE_NAME);
+}

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -29,7 +29,19 @@ function assertNonBlank(value, name) {
   if (typeof value !== 'string' || !value.trim()) {
     throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', `${name} must be a non-empty string.`);
   }
-  return value.trim();
+  return value;
+}
+
+function normalizeOptionalTimestamp(value, name) {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', `${name} must be a non-negative, finite timestamp.`);
+  }
+  const normalized = Math.trunc(value);
+  if (!Number.isSafeInteger(normalized)) {
+    throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', `${name} must be a non-negative, finite timestamp.`);
+  }
+  return normalized;
 }
 
 function assertUuid(value, name) {
@@ -444,6 +456,7 @@ export class AssetProvenanceRepository {
   }
 
   #insertRevision({ assetId, revisionId, sha256, hashState, byteSize, mimeType = null, width = null, height = null, contentModifiedMs = null, observedAt = null, timestamp }) {
+    const normalizedContentModifiedMs = normalizeOptionalTimestamp(contentModifiedMs, 'contentModifiedMs');
     this.database.prepare(`
       INSERT INTO asset_revisions (
         revision_id, asset_id, sha256, hash_state, byte_size, mime_type,
@@ -451,7 +464,7 @@ export class AssetProvenanceRepository {
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       revisionId, assetId, sha256, hashState, byteSize, mimeType,
-      width, height, contentModifiedMs, observedAt || timestamp, timestamp,
+      width, height, normalizedContentModifiedMs, observedAt || timestamp, timestamp,
     );
   }
 

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -1,0 +1,531 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { DatabaseSync } from 'node:sqlite';
+import {
+  PROVENANCE_DATABASE_NAME,
+  PROVENANCE_DIRECTORY_NAME,
+  resolveProvenanceCatalogPath,
+} from './provenancePaths.mjs';
+
+export { PROVENANCE_DATABASE_NAME, PROVENANCE_DIRECTORY_NAME, resolveProvenanceCatalogPath };
+export const PROVENANCE_SCHEMA_VERSION = 2;
+
+export const ASSET_STATES = Object.freeze(['active', 'missing', 'deleted']);
+export const LOCATION_STATES = Object.freeze(['present', 'missing', 'removed']);
+export const REVISION_HASH_STATES = Object.freeze(['pending', 'available', 'failed']);
+
+const HASH_STATE_SET = new Set(REVISION_HASH_STATES);
+
+export class ProvenanceRepositoryError extends Error {
+  constructor(code, message, cause = null) {
+    super(message, cause ? { cause } : undefined);
+    this.name = 'ProvenanceRepositoryError';
+    this.code = code;
+  }
+}
+
+function assertNonBlank(value, name) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', `${name} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function assertUuid(value, name) {
+  const normalized = assertNonBlank(value, name).toLowerCase();
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(normalized)) {
+    throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', `${name} must be a UUID.`);
+  }
+  return normalized;
+}
+
+function normalizeHash(hash, hashState) {
+  if (!HASH_STATE_SET.has(hashState)) {
+    throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', `Unsupported revision hash state: ${hashState}.`);
+  }
+  const normalized = typeof hash === 'string' && hash.trim() ? hash.trim().toLowerCase() : null;
+  if (hashState === 'available' && !/^[a-f0-9]{64}$/.test(normalized || '')) {
+    throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', 'An available revision hash must be a 64-character SHA-256 value.');
+  }
+  if (hashState !== 'available' && normalized !== null) {
+    throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', `Revision hash must be null while its state is ${hashState}.`);
+  }
+  return normalized;
+}
+
+function readSchemaVersion(database) {
+  return Number(database.prepare('PRAGMA user_version').get().user_version || 0);
+}
+
+function migrationOne(database) {
+  database.exec(`
+    CREATE TABLE provenance_schema_migrations (
+      version INTEGER PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    ) STRICT;
+
+    CREATE TABLE assets (
+      asset_id TEXT PRIMARY KEY,
+      state TEXT NOT NULL CHECK (state IN ('active', 'missing', 'deleted')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    ) STRICT;
+
+    CREATE TABLE asset_revisions (
+      revision_id TEXT PRIMARY KEY,
+      asset_id TEXT NOT NULL,
+      sha256 TEXT,
+      hash_state TEXT NOT NULL CHECK (hash_state IN ('pending', 'available', 'failed')),
+      byte_size INTEGER NOT NULL CHECK (byte_size >= 0),
+      mime_type TEXT,
+      width INTEGER CHECK (width IS NULL OR width > 0),
+      height INTEGER CHECK (height IS NULL OR height > 0),
+      content_modified_ms INTEGER,
+      observed_at TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (asset_id) REFERENCES assets(asset_id) ON DELETE RESTRICT,
+      UNIQUE (asset_id, revision_id),
+      CHECK (
+        (hash_state = 'available' AND sha256 IS NOT NULL AND length(sha256) = 64)
+        OR (hash_state != 'available' AND sha256 IS NULL)
+      )
+    ) STRICT;
+
+    CREATE INDEX asset_revisions_asset_id_idx ON asset_revisions(asset_id);
+    CREATE INDEX asset_revisions_sha256_idx ON asset_revisions(sha256) WHERE sha256 IS NOT NULL;
+  `);
+}
+
+function migrationTwo(database) {
+  database.exec(`
+    CREATE TABLE asset_locations (
+      location_id TEXT PRIMARY KEY,
+      asset_id TEXT NOT NULL,
+      revision_id TEXT NOT NULL,
+      root_id TEXT NOT NULL,
+      relative_path TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN ('present', 'missing', 'removed')),
+      first_observed_at TEXT NOT NULL,
+      last_observed_at TEXT NOT NULL,
+      missing_at TEXT,
+      FOREIGN KEY (asset_id) REFERENCES assets(asset_id) ON DELETE RESTRICT,
+      FOREIGN KEY (asset_id, revision_id) REFERENCES asset_revisions(asset_id, revision_id) ON DELETE RESTRICT
+    ) STRICT;
+
+    CREATE INDEX asset_locations_asset_id_idx ON asset_locations(asset_id);
+    CREATE INDEX asset_locations_revision_id_idx ON asset_locations(revision_id);
+    CREATE UNIQUE INDEX asset_locations_present_path_idx
+      ON asset_locations(root_id, relative_path) WHERE state = 'present';
+  `);
+}
+
+const MIGRATIONS = new Map([[1, migrationOne], [2, migrationTwo]]);
+
+function serializeAsset(row) {
+  return row ? {
+    assetId: row.asset_id,
+    state: row.state,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  } : null;
+}
+
+function serializeRevision(row) {
+  return row ? {
+    revisionId: row.revision_id,
+    assetId: row.asset_id,
+    sha256: row.sha256,
+    hashState: row.hash_state,
+    byteSize: Number(row.byte_size),
+    mimeType: row.mime_type,
+    width: row.width === null ? null : Number(row.width),
+    height: row.height === null ? null : Number(row.height),
+    contentModifiedMs: row.content_modified_ms === null ? null : Number(row.content_modified_ms),
+    observedAt: row.observed_at,
+    createdAt: row.created_at,
+  } : null;
+}
+
+function serializeLocation(row) {
+  return row ? {
+    locationId: row.location_id,
+    assetId: row.asset_id,
+    revisionId: row.revision_id,
+    rootId: row.root_id,
+    relativePath: row.relative_path,
+    state: row.state,
+    firstObservedAt: row.first_observed_at,
+    lastObservedAt: row.last_observed_at,
+    missingAt: row.missing_at,
+  } : null;
+}
+
+function runTransaction(database, operation) {
+  database.exec('BEGIN IMMEDIATE');
+  try {
+    const result = operation();
+    database.exec('COMMIT');
+    return result;
+  } catch (error) {
+    try { database.exec('ROLLBACK'); } catch { /* preserve the original failure */ }
+    throw error;
+  }
+}
+
+export class AssetProvenanceRepository {
+  constructor({
+    databasePath,
+    readOnly = false,
+    busyTimeoutMs = 1_000,
+    randomUUID = () => crypto.randomUUID(),
+    now = () => new Date(),
+    backupDatabase = (database, destination) => database.prepare('VACUUM INTO ?').run(destination),
+  }) {
+    this.databasePath = databasePath;
+    this.readOnly = readOnly;
+    this.busyTimeoutMs = busyTimeoutMs;
+    this.randomUUID = randomUUID;
+    this.now = now;
+    this.backupDatabase = backupDatabase;
+    this.database = null;
+  }
+
+  open({ failMigrationVersion = null, targetSchemaVersion = PROVENANCE_SCHEMA_VERSION } = {}) {
+    if (this.database) return this.getStatus();
+    if (this.readOnly && !fs.existsSync(this.databasePath)) {
+      throw new ProvenanceRepositoryError('PROVENANCE_CATALOG_NOT_FOUND', `Provenance catalog does not exist at ${this.databasePath}.`);
+    }
+    try {
+      if (!this.readOnly) fs.mkdirSync(path.dirname(this.databasePath), { recursive: true });
+      this.database = new DatabaseSync(this.databasePath, { readOnly: this.readOnly });
+      this.database.exec(`PRAGMA busy_timeout = ${Math.max(0, Math.trunc(this.busyTimeoutMs))}`);
+      this.database.exec('PRAGMA foreign_keys = ON');
+      if (this.readOnly) {
+        const version = readSchemaVersion(this.database);
+        if (version !== PROVENANCE_SCHEMA_VERSION) {
+          throw new ProvenanceRepositoryError(
+            'PROVENANCE_SCHEMA_INCOMPATIBLE',
+            `Provenance catalog schema ${version} is incompatible with expected schema ${PROVENANCE_SCHEMA_VERSION}.`,
+          );
+        }
+      } else {
+        const journalMode = this.database.prepare('PRAGMA journal_mode = WAL').get().journal_mode;
+        if (String(journalMode).toLowerCase() !== 'wal') {
+          throw new ProvenanceRepositoryError('PROVENANCE_WAL_UNAVAILABLE', `SQLite selected journal mode ${journalMode} instead of WAL.`);
+        }
+        this.database.exec('PRAGMA synchronous = NORMAL');
+        this.applyMigrations({ failMigrationVersion, targetSchemaVersion });
+      }
+      return this.getStatus();
+    } catch (error) {
+      this.close();
+      if (error instanceof ProvenanceRepositoryError) throw error;
+      throw new ProvenanceRepositoryError('PROVENANCE_OPEN_FAILED', `Could not open provenance catalog at ${this.databasePath}.`, error);
+    }
+  }
+
+  applyMigrations({ failMigrationVersion = null, targetSchemaVersion = PROVENANCE_SCHEMA_VERSION } = {}) {
+    this.#requireWritable();
+    let currentVersion = readSchemaVersion(this.database);
+    if (!Number.isInteger(targetSchemaVersion) || targetSchemaVersion < 0 || targetSchemaVersion > PROVENANCE_SCHEMA_VERSION) {
+      throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', `Unsupported target schema version ${targetSchemaVersion}.`);
+    }
+    if (currentVersion > targetSchemaVersion) {
+      throw new ProvenanceRepositoryError(
+        'PROVENANCE_SCHEMA_INCOMPATIBLE',
+        `Provenance catalog schema ${currentVersion} is newer than supported schema ${targetSchemaVersion}.`,
+      );
+    }
+    while (currentVersion < targetSchemaVersion) {
+      const nextVersion = currentVersion + 1;
+      const migration = MIGRATIONS.get(nextVersion);
+      if (!migration) throw new ProvenanceRepositoryError('PROVENANCE_MIGRATION_MISSING', `Migration ${nextVersion} is not defined.`);
+      try {
+        runTransaction(this.database, () => {
+          migration(this.database);
+          if (failMigrationVersion === nextVersion) throw new Error(`Injected migration ${nextVersion} failure.`);
+          const appliedAt = this.now().toISOString();
+          this.database.prepare('INSERT INTO provenance_schema_migrations (version, applied_at) VALUES (?, ?)').run(nextVersion, appliedAt);
+          this.database.exec(`PRAGMA user_version = ${nextVersion}`);
+        });
+      } catch (error) {
+        throw new ProvenanceRepositoryError('PROVENANCE_MIGRATION_FAILED', `Migration to schema ${nextVersion} failed.`, error);
+      }
+      currentVersion = nextVersion;
+    }
+    return currentVersion;
+  }
+
+  getStatus() {
+    const open = Boolean(this.database);
+    return {
+      state: open ? (this.readOnly ? 'ready-read-only' : 'ready') : 'closed',
+      available: open,
+      readOnly: this.readOnly,
+      databasePath: this.databasePath,
+      schemaVersion: open ? readSchemaVersion(this.database) : null,
+    };
+  }
+
+  createAssetWithRevisionAndLocation(input) {
+    this.#requireWritable();
+    const assetId = assertUuid(input.assetId || this.randomUUID(), 'assetId');
+    const revisionId = assertUuid(input.revisionId || this.randomUUID(), 'revisionId');
+    const locationId = assertUuid(input.locationId || this.randomUUID(), 'locationId');
+    const rootId = assertNonBlank(input.rootId, 'rootId');
+    const relativePath = assertNonBlank(input.relativePath, 'relativePath');
+    const hashState = input.hashState || (input.sha256 ? 'available' : 'pending');
+    const sha256 = normalizeHash(input.sha256, hashState);
+    const byteSize = Number(input.byteSize);
+    if (!Number.isSafeInteger(byteSize) || byteSize < 0) {
+      throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', 'byteSize must be a non-negative safe integer.');
+    }
+    const timestamp = this.now().toISOString();
+    runTransaction(this.database, () => {
+      this.database.prepare('INSERT INTO assets VALUES (?, ?, ?, ?)').run(assetId, 'active', timestamp, timestamp);
+      this.#insertRevision({ ...input, assetId, revisionId, sha256, hashState, byteSize, timestamp });
+      this.database.prepare(`
+        INSERT INTO asset_locations (
+          location_id, asset_id, revision_id, root_id, relative_path, state,
+          first_observed_at, last_observed_at, missing_at
+        ) VALUES (?, ?, ?, ?, ?, 'present', ?, ?, NULL)
+      `).run(locationId, assetId, revisionId, rootId, relativePath, timestamp, timestamp);
+    });
+    return this.getAsset(assetId);
+  }
+
+  addRevision(assetId, input) {
+    this.#requireWritable();
+    const existingAsset = this.#requireAsset(assetId);
+    if (existingAsset.state === 'deleted') {
+      throw new ProvenanceRepositoryError('PROVENANCE_ASSET_DELETED', `Asset ${assetId} is deleted.`);
+    }
+    const revisionId = assertUuid(input.revisionId || this.randomUUID(), 'revisionId');
+    const hashState = input.hashState || (input.sha256 ? 'available' : 'pending');
+    const sha256 = normalizeHash(input.sha256, hashState);
+    const byteSize = Number(input.byteSize);
+    if (!Number.isSafeInteger(byteSize) || byteSize < 0) {
+      throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', 'byteSize must be a non-negative safe integer.');
+    }
+    const timestamp = this.now().toISOString();
+    runTransaction(this.database, () => {
+      this.#insertRevision({ ...input, assetId, revisionId, sha256, hashState, byteSize, timestamp });
+      if (input.locationId) {
+        const result = this.database.prepare(`
+          UPDATE asset_locations
+          SET revision_id = ?, state = 'present', last_observed_at = ?, missing_at = NULL
+          WHERE location_id = ? AND asset_id = ? AND state != 'removed'
+        `).run(revisionId, timestamp, input.locationId, assetId);
+        if (Number(result.changes) !== 1) {
+          throw new ProvenanceRepositoryError('PROVENANCE_LOCATION_NOT_FOUND', `Active location ${input.locationId} was not found for asset ${assetId}.`);
+        }
+      }
+      this.database.prepare(`UPDATE assets SET state = CASE WHEN ? THEN 'active' ELSE state END, updated_at = ? WHERE asset_id = ?`)
+        .run(input.locationId ? 1 : 0, timestamp, assetId);
+    });
+    return serializeRevision(this.database.prepare('SELECT * FROM asset_revisions WHERE revision_id = ?').get(revisionId));
+  }
+
+  completeRevisionHash(revisionId, { sha256, state = 'available' }) {
+    this.#requireWritable();
+    const normalizedHash = normalizeHash(sha256, state);
+    const revision = this.database.prepare('SELECT * FROM asset_revisions WHERE revision_id = ?').get(revisionId);
+    if (!revision) throw new ProvenanceRepositoryError('PROVENANCE_REVISION_NOT_FOUND', `Revision ${revisionId} was not found.`);
+    if (revision.hash_state === 'available' && revision.sha256 !== normalizedHash) {
+      throw new ProvenanceRepositoryError('PROVENANCE_REVISION_IMMUTABLE', `Revision ${revisionId} already has a different SHA-256 value.`);
+    }
+    this.database.prepare('UPDATE asset_revisions SET sha256 = ?, hash_state = ? WHERE revision_id = ?').run(normalizedHash, state, revisionId);
+    return serializeRevision(this.database.prepare('SELECT * FROM asset_revisions WHERE revision_id = ?').get(revisionId));
+  }
+
+  relocateLocation(locationId, { rootId, relativePath }) {
+    this.#requireWritable();
+    const timestamp = this.now().toISOString();
+    return runTransaction(this.database, () => {
+      const result = this.database.prepare(`
+        UPDATE asset_locations
+        SET root_id = ?, relative_path = ?, state = 'present', last_observed_at = ?, missing_at = NULL
+        WHERE location_id = ? AND state != 'removed'
+      `).run(assertNonBlank(rootId, 'rootId'), assertNonBlank(relativePath, 'relativePath'), timestamp, locationId);
+      if (Number(result.changes) !== 1) throw new ProvenanceRepositoryError('PROVENANCE_LOCATION_NOT_FOUND', `Active location ${locationId} was not found.`);
+      const location = this.database.prepare('SELECT * FROM asset_locations WHERE location_id = ?').get(locationId);
+      this.database.prepare(`UPDATE assets SET state = 'active', updated_at = ? WHERE asset_id = ?`).run(timestamp, location.asset_id);
+      return serializeLocation(location);
+    });
+  }
+
+  markLocationMissing(locationId) {
+    this.#requireWritable();
+    const timestamp = this.now().toISOString();
+    return runTransaction(this.database, () => {
+      const location = this.database.prepare('SELECT * FROM asset_locations WHERE location_id = ?').get(locationId);
+      if (!location || location.state === 'removed') {
+        throw new ProvenanceRepositoryError('PROVENANCE_LOCATION_NOT_FOUND', `Active location ${locationId} was not found.`);
+      }
+      this.database.prepare(`
+        UPDATE asset_locations SET state = 'missing', last_observed_at = ?, missing_at = ? WHERE location_id = ?
+      `).run(timestamp, timestamp, locationId);
+      const presentCount = Number(this.database.prepare(`
+        SELECT COUNT(*) AS count FROM asset_locations WHERE asset_id = ? AND state = 'present'
+      `).get(location.asset_id).count);
+      this.database.prepare(`UPDATE assets SET state = ?, updated_at = ? WHERE asset_id = ?`).run(presentCount ? 'active' : 'missing', timestamp, location.asset_id);
+      return serializeLocation(this.database.prepare('SELECT * FROM asset_locations WHERE location_id = ?').get(locationId));
+    });
+  }
+
+  markAssetDeleted(assetId) {
+    this.#requireWritable();
+    this.#requireAsset(assetId);
+    const timestamp = this.now().toISOString();
+    runTransaction(this.database, () => {
+      this.database.prepare(`UPDATE assets SET state = 'deleted', updated_at = ? WHERE asset_id = ?`).run(timestamp, assetId);
+      this.database.prepare(`
+        UPDATE asset_locations SET state = 'removed', last_observed_at = ?, missing_at = COALESCE(missing_at, ?)
+        WHERE asset_id = ?
+      `).run(timestamp, timestamp, assetId);
+    });
+    return this.getAsset(assetId);
+  }
+
+  getAsset(assetId) {
+    this.#requireOpen();
+    const asset = serializeAsset(this.database.prepare('SELECT * FROM assets WHERE asset_id = ?').get(assetId));
+    if (!asset) return null;
+    return {
+      ...asset,
+      revisions: this.database.prepare('SELECT * FROM asset_revisions WHERE asset_id = ? ORDER BY created_at, revision_id').all(assetId).map(serializeRevision),
+      locations: this.database.prepare('SELECT * FROM asset_locations WHERE asset_id = ? ORDER BY first_observed_at, location_id').all(assetId).map(serializeLocation),
+    };
+  }
+
+  createBackup(destinationPath) {
+    this.#requireWritable();
+    const resolvedDestination = path.resolve(destinationPath);
+    if (resolvedDestination === path.resolve(this.databasePath)) {
+      throw new ProvenanceRepositoryError('PROVENANCE_BACKUP_INVALID_TARGET', 'Backup destination must differ from the live catalog.');
+    }
+    if (fs.existsSync(resolvedDestination)) {
+      throw new ProvenanceRepositoryError('PROVENANCE_BACKUP_EXISTS', `Backup destination already exists at ${resolvedDestination}.`);
+    }
+    try {
+      fs.mkdirSync(path.dirname(resolvedDestination), { recursive: true });
+    } catch (error) {
+      throw new ProvenanceRepositoryError('PROVENANCE_BACKUP_FAILED', `Could not prepare backup directory for ${resolvedDestination}.`, error);
+    }
+    const temporaryPath = `${resolvedDestination}.${this.randomUUID()}.tmp`;
+    let backupCreated = false;
+    try {
+      this.backupDatabase(this.database, temporaryPath);
+      const verification = new DatabaseSync(temporaryPath, { readOnly: true });
+      try {
+        const integrity = verification.prepare('PRAGMA integrity_check').get().integrity_check;
+        const version = readSchemaVersion(verification);
+        if (integrity !== 'ok' || version !== PROVENANCE_SCHEMA_VERSION) {
+          throw new ProvenanceRepositoryError('PROVENANCE_BACKUP_INVALID', `Backup verification failed with integrity ${integrity} and schema ${version}.`);
+        }
+      } finally {
+        verification.close();
+      }
+      fs.renameSync(temporaryPath, resolvedDestination);
+      backupCreated = true;
+    } catch (error) {
+      if (error instanceof ProvenanceRepositoryError) throw error;
+      throw new ProvenanceRepositoryError('PROVENANCE_BACKUP_FAILED', `Could not create provenance backup at ${resolvedDestination}.`, error);
+    } finally {
+      try { fs.unlinkSync(temporaryPath); } catch { /* best-effort cleanup of an incomplete snapshot */ }
+    }
+    return { path: resolvedDestination, schemaVersion: PROVENANCE_SCHEMA_VERSION, created: backupCreated };
+  }
+
+  close() {
+    if (!this.database) return;
+    try { this.database.close(); } finally { this.database = null; }
+  }
+
+  #insertRevision({ assetId, revisionId, sha256, hashState, byteSize, mimeType = null, width = null, height = null, contentModifiedMs = null, observedAt = null, timestamp }) {
+    this.database.prepare(`
+      INSERT INTO asset_revisions (
+        revision_id, asset_id, sha256, hash_state, byte_size, mime_type,
+        width, height, content_modified_ms, observed_at, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      revisionId, assetId, sha256, hashState, byteSize, mimeType,
+      width, height, contentModifiedMs, observedAt || timestamp, timestamp,
+    );
+  }
+
+  #requireAsset(assetId) {
+    const asset = this.database.prepare('SELECT * FROM assets WHERE asset_id = ?').get(assetId);
+    if (!asset) throw new ProvenanceRepositoryError('PROVENANCE_ASSET_NOT_FOUND', `Asset ${assetId} was not found.`);
+    return asset;
+  }
+
+  #requireOpen() {
+    if (!this.database) throw new ProvenanceRepositoryError('PROVENANCE_REPOSITORY_CLOSED', 'Provenance repository is closed.');
+  }
+
+  #requireWritable() {
+    this.#requireOpen();
+    if (this.readOnly) throw new ProvenanceRepositoryError('PROVENANCE_READ_ONLY', 'Provenance repository is read-only.');
+  }
+
+}
+
+export class ProvenanceRepositoryLifecycle {
+  constructor({ userDataPath, logger = console, repositoryOptions = {} }) {
+    this.databasePath = resolveProvenanceCatalogPath(userDataPath);
+    this.logger = logger;
+    this.repositoryOptions = repositoryOptions;
+    this.repository = null;
+    this.status = {
+      state: 'not-initialized',
+      available: false,
+      databasePath: this.databasePath,
+      schemaVersion: null,
+      error: null,
+    };
+  }
+
+  initialize() {
+    if (this.repository) return this.getStatus();
+    try {
+      const repository = new AssetProvenanceRepository({ databasePath: this.databasePath, ...this.repositoryOptions });
+      const repositoryStatus = repository.open();
+      this.repository = repository;
+      this.status = { ...repositoryStatus, error: null };
+    } catch (error) {
+      this.repository = null;
+      this.status = {
+        state: 'unavailable',
+        available: false,
+        databasePath: this.databasePath,
+        schemaVersion: null,
+        error: { code: error?.code || 'PROVENANCE_INITIALIZATION_FAILED', message: error?.message || String(error) },
+      };
+      this.logger.error('Provenance catalog is unavailable; the library will continue without it.', error);
+    }
+    return this.getStatus();
+  }
+
+  run(operation) {
+    if (!this.repository) {
+      throw new ProvenanceRepositoryError('PROVENANCE_UNAVAILABLE', 'Provenance repository is unavailable.');
+    }
+    return operation(this.repository);
+  }
+
+  createBackup(destinationPath) {
+    return this.run((repository) => repository.createBackup(destinationPath));
+  }
+
+  getStatus() {
+    return JSON.parse(JSON.stringify(this.status));
+  }
+
+  close() {
+    this.repository?.close();
+    this.repository = null;
+    this.status = { ...this.status, state: 'closed', available: false };
+  }
+}


### PR DESCRIPTION
## Summary

Image MetaHub now creates and owns a durable provenance catalog independently from disposable parser caches. The Electron main process opens and migrates the SQLite repository, preserves it during cache reset, closes it during shutdown, and lets the rest of the app continue if the catalog is unavailable.

The repository defines the production contracts for stable assets, immutable revisions, and locations. It supports pending/available/failed hashes, explicit lifecycle states, transactional migrations, serializable reads, and writer-coordinated verified backups through `VACUUM INTO`.

## Validation

- `npx vitest run __tests__/provenanceRepository.test.ts __tests__/licenseCacheReset.test.ts` — 9 tests passed
- targeted ESLint for the new repository, paths, cache reset, and tests
- `npm run build`

Library indexing, annotation migration, provenance edges, audit history, IPC/MCP, and UI integration remain follow-up work.
