### PR TITLE
Stable identity indexing and resumable backfill

### DIFF
--- a/__tests__/cache-manager.workflow-nodes.test.ts
+++ b/__tests__/cache-manager.workflow-nodes.test.ts
@@ -13,6 +13,40 @@ describe('cacheManager workflowNodes hydration', () => {
     delete window.electronAPI;
   });
 
+  it('preserves provenance identities through the shared cache serializer', async () => {
+    const cacheData = vi.fn().mockResolvedValue({ success: true });
+    window.electronAPI = { cacheData };
+    (cacheManager as any).isElectron = true;
+
+    await cacheManager.cacheData(
+      'D:/library',
+      'Library',
+      [{
+        id: 'dir-1::a.png',
+        name: 'a.png',
+        handle: {} as any,
+        metadata: {},
+        metadataString: '{}',
+        lastModified: 1,
+        models: [],
+        loras: [],
+        scheduler: '',
+        assetId: 'asset-id',
+        revisionId: 'revision-id',
+        provenanceLocationId: 'location-id',
+        provenanceRootId: 'root-id',
+      } as any],
+      false,
+    );
+
+    expect(cacheData.mock.calls[0][0].data.metadata[0]).toMatchObject({
+      assetId: 'asset-id',
+      revisionId: 'revision-id',
+      provenanceLocationId: 'location-id',
+      provenanceRootId: 'root-id',
+    });
+  });
+
   it('preserves workflowNodes when hydrating unchanged cached images', async () => {
     window.electronAPI = {
       getCacheSummary: vi.fn().mockResolvedValue({

--- a/__tests__/fileIndexer.provenance-identity.test.ts
+++ b/__tests__/fileIndexer.provenance-identity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { processFiles } from '../services/fileIndexer';
+import type { IndexedImage } from '../types';
+
+describe('fileIndexer provenance identity attachment', () => {
+  it('applies queued identities to preloaded cache entries without changing their UI id', async () => {
+    const originalId = 'directory-id::Cafe\u0301/image.png';
+    const preloaded = {
+      id: originalId,
+      name: 'Cafe\u0301/image.png',
+      handle: { name: 'image.png', kind: 'file' } as FileSystemFileHandle,
+      metadata: {},
+      metadataString: '{}',
+      lastModified: 1,
+      models: [],
+      loras: [],
+      scheduler: '',
+    } as IndexedImage;
+    const batches: IndexedImage[][] = [];
+
+    const { phaseB } = await processFiles(
+      [],
+      () => {},
+      (batch) => batches.push(batch),
+      'directory-id',
+      'Synthetic Library',
+      true,
+      () => {},
+      undefined,
+      undefined,
+      {
+        preloadedImages: [preloaded],
+        provenanceIdentityForPath: (relativePath) => relativePath === 'Cafe\u0301/image.png'
+          ? {
+              assetId: 'asset-id',
+              revisionId: 'revision-id',
+              provenanceLocationId: 'location-id',
+              provenanceRootId: 'root-id',
+            }
+          : undefined,
+      },
+    );
+    await phaseB;
+
+    expect(batches.flat()).toEqual([
+      expect.objectContaining({
+        id: originalId,
+        assetId: 'asset-id',
+        revisionId: 'revision-id',
+        provenanceLocationId: 'location-id',
+        provenanceRootId: 'root-id',
+      }),
+    ]);
+  });
+});

--- a/__tests__/provenanceRepository.test.ts
+++ b/__tests__/provenanceRepository.test.ts
@@ -173,7 +173,7 @@ describe('AssetProvenanceRepository production contract', () => {
     repository = new AssetProvenanceRepository({ databasePath });
     repository.open();
     repository.applyMigrations();
-    expect(repository.getStatus().schemaVersion).toBe(2);
+    expect(repository.getStatus().schemaVersion).toBe(PROVENANCE_SCHEMA_VERSION);
     expect(repository.getAsset('legacy-asset')).toMatchObject({
       assetId: 'legacy-asset',
       revisions: [{ revisionId: 'legacy-revision' }],
@@ -202,7 +202,7 @@ describe('AssetProvenanceRepository production contract', () => {
     })));
 
     const backupPath = path.join(userDataPath, 'backups', 'provenance.sqlite');
-    expect(lifecycle.createBackup(backupPath)).toMatchObject({ path: backupPath, schemaVersion: 2, created: true });
+    expect(lifecycle.createBackup(backupPath)).toMatchObject({ path: backupPath, schemaVersion: PROVENANCE_SCHEMA_VERSION, created: true });
     liveReader.database.exec('COMMIT');
     liveReader.close();
     lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation(initialRecord({
@@ -254,7 +254,7 @@ describe('provenance repository lifecycle and cache independence', () => {
     lifecycle.close();
 
     const reopened = new ProvenanceRepositoryLifecycle({ userDataPath, logger: { error: vi.fn() } });
-    expect(reopened.initialize()).toMatchObject({ available: true, schemaVersion: 2 });
+    expect(reopened.initialize()).toMatchObject({ available: true, schemaVersion: PROVENANCE_SCHEMA_VERSION });
     expect(reopened.run((repository) => repository.getAsset(initialRecord().assetId as string))).not.toBeNull();
     reopened.close();
   });

--- a/__tests__/provenanceRepository.test.ts
+++ b/__tests__/provenanceRepository.test.ts
@@ -182,7 +182,7 @@ describe('AssetProvenanceRepository production contract', () => {
     repository.close();
   });
 
-  it('associates a migrated v2 location with its first registered library root', async () => {
+  it('preserves a populated v2 catalog instead of guessing filesystem-root mappings', async () => {
     const databasePath = resolveProvenanceCatalogPath(await temporaryUserData());
     let repository = new AssetProvenanceRepository({ databasePath });
     repository.open({ targetSchemaVersion: 2 });
@@ -208,7 +208,7 @@ describe('AssetProvenanceRepository production contract', () => {
         '11111111-1111-4111-8111-111111111111',
         '22222222-2222-4222-8222-222222222222',
         'legacy-library-root',
-        'Images/Original.PNG',
+        'images/original.png',
         'present',
         'now',
         'now',
@@ -217,30 +217,21 @@ describe('AssetProvenanceRepository production contract', () => {
     repository.close();
 
     repository = new AssetProvenanceRepository({ databasePath });
-    repository.open();
-    const root = repository.ensureLibraryRoot({
-      rootId: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
-      absolutePath: 'D:\\Library',
-      pathKey: 'd:\\library',
+    expect(() => repository.open()).toThrowError(expect.objectContaining({
+      code: 'PROVENANCE_MIGRATION_FAILED',
+      message: expect.stringContaining('Schema-v2 locations cannot be associated with filesystem roots safely'),
+      cause: expect.objectContaining({ code: 'PROVENANCE_LEGACY_LOCATIONS_UNMAPPABLE' }),
+    }));
+
+    repository = new AssetProvenanceRepository({ databasePath });
+    repository.open({ targetSchemaVersion: 2 });
+    expect(repository.getStatus().schemaVersion).toBe(2);
+    expect(repository.database.prepare('SELECT * FROM asset_locations').get()).toMatchObject({
+      location_id: '33333333-3333-4333-8333-333333333333',
+      root_id: 'legacy-library-root',
+      relative_path: 'images/original.png',
     });
-    expect(repository.assignIndexedFile({
-      rootId: root.rootId,
-      relativePath: 'Images/Original.PNG',
-      relativePathKey: 'images/original.png',
-      byteSize: 1024,
-      mimeType: 'image/png',
-      contentModifiedMs: 1_788_000_000_000,
-    })).toEqual({
-      assetId: '11111111-1111-4111-8111-111111111111',
-      revisionId: '22222222-2222-4222-8222-222222222222',
-      locationId: '33333333-3333-4333-8333-333333333333',
-      needsHash: true,
-    });
-    expect(repository.database.prepare('SELECT COUNT(*) AS count FROM assets').get()).toEqual({ count: 1 });
-    expect(repository.database.prepare('SELECT root_id, relative_path_key FROM asset_locations').get()).toEqual({
-      root_id: root.rootId,
-      relative_path_key: 'images/original.png',
-    });
+    expect(repository.database.prepare("SELECT name FROM sqlite_master WHERE name = 'library_roots'").get()).toBeUndefined();
     repository.close();
   });
 

--- a/__tests__/provenanceRepository.test.ts
+++ b/__tests__/provenanceRepository.test.ts
@@ -182,6 +182,68 @@ describe('AssetProvenanceRepository production contract', () => {
     repository.close();
   });
 
+  it('associates a migrated v2 location with its first registered library root', async () => {
+    const databasePath = resolveProvenanceCatalogPath(await temporaryUserData());
+    let repository = new AssetProvenanceRepository({ databasePath });
+    repository.open({ targetSchemaVersion: 2 });
+    repository.database.prepare('INSERT INTO assets VALUES (?, ?, ?, ?)')
+      .run('11111111-1111-4111-8111-111111111111', 'active', 'now', 'now');
+    repository.database.prepare('INSERT INTO asset_revisions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(
+        '22222222-2222-4222-8222-222222222222',
+        '11111111-1111-4111-8111-111111111111',
+        null,
+        'pending',
+        1024,
+        'image/png',
+        null,
+        null,
+        1_788_000_000_000,
+        'now',
+        'now',
+      );
+    repository.database.prepare('INSERT INTO asset_locations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(
+        '33333333-3333-4333-8333-333333333333',
+        '11111111-1111-4111-8111-111111111111',
+        '22222222-2222-4222-8222-222222222222',
+        'legacy-library-root',
+        'Images/Original.PNG',
+        'present',
+        'now',
+        'now',
+        null,
+      );
+    repository.close();
+
+    repository = new AssetProvenanceRepository({ databasePath });
+    repository.open();
+    const root = repository.ensureLibraryRoot({
+      rootId: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
+      absolutePath: 'D:\\Library',
+      pathKey: 'd:\\library',
+    });
+    expect(repository.assignIndexedFile({
+      rootId: root.rootId,
+      relativePath: 'Images/Original.PNG',
+      relativePathKey: 'images/original.png',
+      byteSize: 1024,
+      mimeType: 'image/png',
+      contentModifiedMs: 1_788_000_000_000,
+    })).toEqual({
+      assetId: '11111111-1111-4111-8111-111111111111',
+      revisionId: '22222222-2222-4222-8222-222222222222',
+      locationId: '33333333-3333-4333-8333-333333333333',
+      needsHash: true,
+    });
+    expect(repository.database.prepare('SELECT COUNT(*) AS count FROM assets').get()).toEqual({ count: 1 });
+    expect(repository.database.prepare('SELECT root_id, relative_path_key FROM asset_locations').get()).toEqual({
+      root_id: root.rootId,
+      relative_path_key: 'images/original.png',
+    });
+    repository.close();
+  });
+
   it('creates a verified checkpointed backup and keeps the live writer usable', async () => {
     const userDataPath = await temporaryUserData();
     const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath, logger: { error: vi.fn() } });

--- a/__tests__/stableIdentityIndexer.test.ts
+++ b/__tests__/stableIdentityIndexer.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { ProvenanceRepositoryLifecycle } from '../electron/provenanceRepository.mjs';
 import {
   StableIdentityIndexer,
+  normalizeLibraryRootPath,
   normalizeRelativeCatalogPath,
 } from '../electron/stableIdentityIndexer.mjs';
 import { buildProvenanceIdentityLookupKey } from '../utils/provenancePath.mjs';
@@ -196,8 +197,12 @@ describe('StableIdentityIndexer', () => {
       relativePath: 'Folder/Image.PNG',
       relativePathKey: 'folder/image.png',
     });
-    expect(buildProvenanceIdentityLookupKey('root', 'Cafe\u0301/Image.PNG', 'win32'))
-      .toBe(buildProvenanceIdentityLookupKey('root', 'Café/image.png', 'win32'));
+    const decomposedPath = 'Cafe\u0301/Image.PNG';
+    expect(normalizeRelativeCatalogPath(decomposedPath, 'linux').relativePath).toBe(decomposedPath);
+    expect(buildProvenanceIdentityLookupKey('root', decomposedPath, 'linux'))
+      .not.toBe(buildProvenanceIdentityLookupKey('root', 'Café/Image.PNG', 'linux'));
+    expect(normalizeLibraryRootPath(`./${decomposedPath}`, 'linux').absolutePath.endsWith(decomposedPath.replace('/', path.sep)))
+      .toBe(true);
     expect(() => normalizeRelativeCatalogPath('../outside.png', 'linux')).toThrow(/inside/);
     expect(() => normalizeRelativeCatalogPath('/outside.png', 'linux')).toThrow(/inside/);
   });

--- a/__tests__/stableIdentityIndexer.test.ts
+++ b/__tests__/stableIdentityIndexer.test.ts
@@ -7,6 +7,7 @@ import {
   StableIdentityIndexer,
   normalizeRelativeCatalogPath,
 } from '../electron/stableIdentityIndexer.mjs';
+import { buildProvenanceIdentityLookupKey } from '../utils/provenancePath.mjs';
 import { resetUserDataContents } from '../electron/cacheReset.mjs';
 
 const temporaryDirectories: string[] = [];
@@ -195,6 +196,9 @@ describe('StableIdentityIndexer', () => {
       relativePath: 'Folder/Image.PNG',
       relativePathKey: 'folder/image.png',
     });
+    expect(buildProvenanceIdentityLookupKey('root', 'Cafe\u0301/Image.PNG', 'win32'))
+      .toBe(buildProvenanceIdentityLookupKey('root', 'Café/image.png', 'win32'));
     expect(() => normalizeRelativeCatalogPath('../outside.png', 'linux')).toThrow(/inside/);
+    expect(() => normalizeRelativeCatalogPath('/outside.png', 'linux')).toThrow(/inside/);
   });
 });

--- a/__tests__/stableIdentityIndexer.test.ts
+++ b/__tests__/stableIdentityIndexer.test.ts
@@ -1,0 +1,200 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ProvenanceRepositoryLifecycle } from '../electron/provenanceRepository.mjs';
+import {
+  StableIdentityIndexer,
+  normalizeRelativeCatalogPath,
+} from '../electron/stableIdentityIndexer.mjs';
+import { resetUserDataContents } from '../electron/cacheReset.mjs';
+
+const temporaryDirectories: string[] = [];
+
+type IdentityMapping = {
+  relativePath: string;
+  assetId: string;
+  revisionId: string;
+  locationId: string;
+};
+
+async function temporaryWorkspace() {
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-stable-identity-'));
+  temporaryDirectories.push(workspace);
+  const userDataPath = path.join(workspace, 'profile');
+  const rootPath = path.join(workspace, 'Synthetic Library');
+  await fs.mkdir(userDataPath, { recursive: true });
+  await fs.mkdir(rootPath, { recursive: true });
+  return { userDataPath, rootPath };
+}
+
+async function fileRecord(rootPath: string, name: string) {
+  const stat = await fs.stat(path.join(rootPath, name));
+  return {
+    name,
+    lastModified: stat.mtimeMs,
+    contentModifiedMs: stat.mtimeMs,
+    size: stat.size,
+    type: 'application/octet-stream',
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+describe('StableIdentityIndexer', () => {
+  it('preserves IDs across restart and cache reset without merging identical files', async () => {
+    const { userDataPath, rootPath } = await temporaryWorkspace();
+    await fs.writeFile(path.join(rootPath, 'first.bin'), 'identical synthetic bytes');
+    await fs.writeFile(path.join(rootPath, 'second.bin'), 'identical synthetic bytes');
+    const files = await Promise.all(['first.bin', 'second.bin'].map((name) => fileRecord(rootPath, name)));
+
+    let lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    lifecycle.initialize();
+    let indexer = new StableIdentityIndexer({ repositoryLifecycle: lifecycle, enabled: true, batchSize: 1 });
+    const firstMappings: IdentityMapping[] = [];
+    await indexer.indexScan({
+      rootPath,
+      files,
+      recursive: true,
+      scanComplete: true,
+      onBatch: ({ mappings }) => firstMappings.push(...mappings),
+    });
+    await indexer.waitForIdle();
+
+    expect(firstMappings).toHaveLength(2);
+    expect(firstMappings[0].assetId).not.toBe(firstMappings[1].assetId);
+    const firstAsset = lifecycle.run((repository) => repository.getAsset(firstMappings[0].assetId));
+    const secondAsset = lifecycle.run((repository) => repository.getAsset(firstMappings[1].assetId));
+    expect(firstAsset?.revisions[0]).toMatchObject({ hashState: 'available' });
+    expect(firstAsset?.revisions[0].sha256).toBe(secondAsset?.revisions[0].sha256);
+
+    indexer.stop();
+    lifecycle.close();
+    await fs.writeFile(path.join(userDataPath, 'disposable-cache.json'), '{}');
+    await resetUserDataContents({ userDataDir: userDataPath });
+
+    lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    lifecycle.initialize();
+    indexer = new StableIdentityIndexer({ repositoryLifecycle: lifecycle, enabled: true });
+    const reopenedMappings: IdentityMapping[] = [];
+    await indexer.indexScan({
+      rootPath,
+      files,
+      recursive: true,
+      scanComplete: true,
+      onBatch: ({ mappings }) => reopenedMappings.push(...mappings),
+    });
+    await indexer.waitForIdle();
+
+    expect(reopenedMappings.map(({ assetId, revisionId }) => ({ assetId, revisionId })))
+      .toEqual(firstMappings.map(({ assetId, revisionId }) => ({ assetId, revisionId })));
+    expect(lifecycle.run((repository) => repository.getAsset(firstMappings[0].assetId))?.revisions).toHaveLength(1);
+
+    await fs.writeFile(path.join(rootPath, 'first.bin'), 'changed synthetic bytes with a different size');
+    const changedFiles = [await fileRecord(rootPath, 'first.bin'), files[1]];
+    const changedMappings: IdentityMapping[] = [];
+    await indexer.indexScan({
+      rootPath,
+      files: changedFiles,
+      recursive: true,
+      scanComplete: true,
+      onBatch: ({ mappings }) => changedMappings.push(...mappings),
+    });
+    await indexer.waitForIdle();
+    expect(changedMappings[0].assetId).toBe(firstMappings[0].assetId);
+    expect(changedMappings[0].revisionId).not.toBe(firstMappings[0].revisionId);
+    expect(lifecycle.run((repository) => repository.getAsset(firstMappings[0].assetId))?.revisions).toHaveLength(2);
+    indexer.stop();
+    lifecycle.close();
+  });
+
+  it('resumes pending hashes without duplicating revisions and discards stale reads', async () => {
+    const { userDataPath, rootPath } = await temporaryWorkspace();
+    await fs.writeFile(path.join(rootPath, 'changing.bin'), 'synthetic bytes');
+    const record = await fileRecord(rootPath, 'changing.bin');
+    const realStat = await fs.stat(path.join(rootPath, 'changing.bin'));
+    let statCalls = 0;
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    lifecycle.initialize();
+    let indexer = new StableIdentityIndexer({
+      repositoryLifecycle: lifecycle,
+      enabled: true,
+      stat: async () => {
+        statCalls += 1;
+        return statCalls === 1
+          ? realStat
+          : { ...realStat, mtimeMs: realStat.mtimeMs + 1, isFile: () => true } as typeof realStat;
+      },
+    });
+    const mappings: IdentityMapping[] = [];
+    await indexer.indexScan({
+      rootPath,
+      files: [record],
+      recursive: true,
+      scanComplete: true,
+      onBatch: ({ mappings: batch }) => mappings.push(...batch),
+    });
+    await indexer.waitForIdle();
+    expect(lifecycle.run((repository) => repository.getAsset(mappings[0].assetId))?.revisions[0].hashState).toBe('pending');
+    indexer.stop();
+
+    indexer = new StableIdentityIndexer({ repositoryLifecycle: lifecycle, enabled: true });
+    const resumedMappings: IdentityMapping[] = [];
+    await indexer.indexScan({
+      rootPath,
+      files: [record],
+      recursive: true,
+      scanComplete: true,
+      onBatch: ({ mappings: batch }) => resumedMappings.push(...batch),
+    });
+    await indexer.waitForIdle();
+    expect(resumedMappings[0].revisionId).toBe(mappings[0].revisionId);
+    expect(lifecycle.run((repository) => repository.getAsset(mappings[0].assetId))?.revisions).toMatchObject([
+      { revisionId: mappings[0].revisionId, hashState: 'available' },
+    ]);
+    indexer.stop();
+    lifecycle.close();
+  });
+
+  it('waits while paused and reconciles absence only after a complete root scan', async () => {
+    const { userDataPath, rootPath } = await temporaryWorkspace();
+    await fs.writeFile(path.join(rootPath, 'kept.bin'), 'kept');
+    await fs.writeFile(path.join(rootPath, 'missing.bin'), 'missing');
+    const files = await Promise.all(['kept.bin', 'missing.bin'].map((name) => fileRecord(rootPath, name)));
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    lifecycle.initialize();
+    const indexer = new StableIdentityIndexer({ repositoryLifecycle: lifecycle, enabled: true });
+    indexer.pause();
+    const batches: Array<{ mappings: IdentityMapping[] }> = [];
+    const initialScan = indexer.indexScan({
+      rootPath,
+      files,
+      recursive: true,
+      scanComplete: true,
+      onBatch: (batch) => batches.push(batch),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(batches).toHaveLength(0);
+    indexer.resume();
+    await initialScan;
+    await indexer.waitForIdle();
+    const missingIdentity = batches.flatMap((batch) => batch.mappings).find((mapping) => mapping.relativePath === 'missing.bin');
+
+    await indexer.indexScan({ rootPath, files: [files[0]], recursive: true, scanComplete: false });
+    expect(lifecycle.run((repository) => repository.getAsset(missingIdentity.assetId))?.state).toBe('active');
+    await indexer.indexScan({ rootPath, files: [files[0]], recursive: true, scanComplete: true });
+    expect(lifecycle.run((repository) => repository.getAsset(missingIdentity.assetId))?.state).toBe('missing');
+    indexer.stop();
+    lifecycle.close();
+  });
+
+  it('normalizes separators and case keys without allowing root escape', () => {
+    expect(normalizeRelativeCatalogPath('Folder\\Image.PNG', 'win32')).toEqual({
+      relativePath: 'Folder/Image.PNG',
+      relativePathKey: 'folder/image.png',
+    });
+    expect(() => normalizeRelativeCatalogPath('../outside.png', 'linux')).toThrow(/inside/);
+  });
+});

--- a/__tests__/stableIdentityIndexer.test.ts
+++ b/__tests__/stableIdentityIndexer.test.ts
@@ -192,6 +192,51 @@ describe('StableIdentityIndexer', () => {
     lifecycle.close();
   });
 
+  it('prevents an older overlapping scan from assigning after a newer scan begins', async () => {
+    const { userDataPath, rootPath } = await temporaryWorkspace();
+    await fs.writeFile(path.join(rootPath, 'kept.bin'), 'kept');
+    await fs.writeFile(path.join(rootPath, 'deleted.bin'), 'deleted');
+    const files = await Promise.all(['kept.bin', 'deleted.bin'].map((name) => fileRecord(rootPath, name)));
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    lifecycle.initialize();
+    const indexer = new StableIdentityIndexer({ repositoryLifecycle: lifecycle, enabled: true, batchSize: 1 });
+    const initialMappings: IdentityMapping[] = [];
+    await indexer.indexScan({
+      rootPath,
+      files,
+      recursive: true,
+      scanComplete: true,
+      onBatch: ({ mappings }) => initialMappings.push(...mappings),
+    });
+    const deletedIdentity = initialMappings.find((mapping) => mapping.relativePath === 'deleted.bin');
+    expect(deletedIdentity).toBeDefined();
+    if (!deletedIdentity) throw new Error('Expected the synthetic deleted file to receive an identity.');
+
+    let releaseFirstOldBatch: (() => void) | undefined;
+    const firstOldBatch = new Promise<void>((resolve) => { releaseFirstOldBatch = resolve; });
+    const olderScan = indexer.indexScan({
+      rootPath,
+      files,
+      recursive: true,
+      scanComplete: true,
+      onBatch: () => releaseFirstOldBatch?.(),
+    });
+    await firstOldBatch;
+    const newerScan = indexer.indexScan({
+      rootPath,
+      files: [files[0]],
+      recursive: true,
+      scanComplete: true,
+    });
+
+    const [olderResult, newerResult] = await Promise.all([olderScan, newerScan]);
+    expect(olderResult).toMatchObject({ stale: true, reconciled: false });
+    expect(newerResult).toMatchObject({ stale: false, reconciled: true });
+    expect(lifecycle.run((repository) => repository.getAsset(deletedIdentity.assetId))?.state).toBe('missing');
+    indexer.stop();
+    lifecycle.close();
+  });
+
   it('normalizes separators and case keys without allowing root escape', () => {
     expect(normalizeRelativeCatalogPath('Folder\\Image.PNG', 'win32')).toEqual({
       relativePath: 'Folder/Image.PNG',

--- a/docs/stable-identity-indexing.md
+++ b/docs/stable-identity-indexing.md
@@ -1,0 +1,28 @@
+# Stable identity indexing and resumable backfill
+
+## Status
+
+The integration is intentionally disabled by default. It can be enabled for synthetic or controlled validation with `IMH_ENABLE_PROVENANCE_INDEXING=1`. It must not become a normal product default until rename, move, copy, and overwrite operations update the catalog atomically with their filesystem changes.
+
+## Identity contract
+
+- `IndexedImage.id` remains the existing directory-and-relative-path UI/cache key.
+- `assetId`, `revisionId`, `provenanceLocationId`, and `provenanceRootId` are separate durable identifiers supplied by the provenance catalog.
+- Library roots receive a stored UUID keyed by a normalized absolute path. Windows comparison keys are case-insensitive; stored paths retain their display spelling.
+- Relative paths use forward slashes, Unicode NFC, lexical dot-segment normalization, and a platform-aware comparison key. Absolute paths and paths escaping the root are rejected.
+- A location reuses its asset and revision when byte size and content modification time are unchanged. A changed signature creates a revision on the same asset.
+- Equal SHA-256 values never merge assets. Hashes describe revisions; they do not define asset identity.
+
+## Runtime flow
+
+Directory enumeration returns to the renderer before catalog work starts. The main process then assigns identities in bounded batches and emits mappings to the renderer. The renderer attaches those identifiers without changing `IndexedImage.id`, and new cache records can retain them as an optimization. SQLite remains authoritative after cache deletion.
+
+SHA-256 work uses a streaming reader in a single background queue. Pending revisions are naturally resumable: a later scan reuses the pending revision and queues it again. The worker compares byte size and modification time before and after reading, and commits the digest only when both still match the revision. Pausing stops between batches/files; shutdown aborts the active stream without replacing existing catalog data.
+
+## Absence safety
+
+Identity assignment is allowed for complete or partial scans. Missing-state reconciliation is allowed only after a successful recursive scan of the entire registered root. A scoped refresh, flat scan, unreadable subdirectory, cancelled job, or unavailable root never turns unseen locations into missing assets.
+
+## Validation boundary
+
+Automated coverage uses synthetic files under temporary directories. It verifies stable IDs across restart and cache reset, distinct assets for identical bytes, hash retry after a stale read, pause/resume, path normalization, migration, and the complete-scan reconciliation gate. No personal library, media, metadata cache, prompt, or generation parameters are read.

--- a/docs/stable-identity-indexing.md
+++ b/docs/stable-identity-indexing.md
@@ -8,8 +8,8 @@ The integration is intentionally disabled by default. It can be enabled for synt
 
 - `IndexedImage.id` remains the existing directory-and-relative-path UI/cache key.
 - `assetId`, `revisionId`, `provenanceLocationId`, and `provenanceRootId` are separate durable identifiers supplied by the provenance catalog.
-- Library roots receive a stored UUID keyed by a normalized absolute path. Windows comparison keys are case-insensitive; stored paths retain their display spelling.
-- Relative paths use forward slashes, Unicode NFC, lexical dot-segment normalization, and a platform-aware comparison key. Absolute paths and paths escaping the root are rejected.
+- Library roots receive a stored UUID keyed by a normalized absolute path. Windows comparison keys are case-insensitive; stored paths retain their exact filesystem spelling.
+- Relative paths use forward slashes, lexical dot-segment normalization, and a platform-aware comparison key. Unicode spelling is preserved so canonically distinct names remain distinct on case-sensitive filesystems. Absolute paths and paths escaping the root are rejected.
 - A location reuses its asset and revision when byte size and content modification time are unchanged. A changed signature creates a revision on the same asset.
 - Equal SHA-256 values never merge assets. Hashes describe revisions; they do not define asset identity.
 

--- a/docs/stable-identity-indexing.md
+++ b/docs/stable-identity-indexing.md
@@ -12,7 +12,7 @@ The integration is intentionally disabled by default. It can be enabled for synt
 - Relative paths use forward slashes, lexical dot-segment normalization, and a platform-aware comparison key. Unicode spelling is preserved so canonically distinct names remain distinct on case-sensitive filesystems. Absolute paths and paths escaping the root are rejected.
 - A location reuses its asset and revision when byte size and content modification time are unchanged. A changed signature creates a revision on the same asset.
 - Equal SHA-256 values never merge assets. Hashes describe revisions; they do not define asset identity.
-- On the first root registration after a schema-v2 upgrade, a sole legacy root (or one whose opaque key matches the selected path) is transactionally reassigned to the new root UUID. Multiple legacy roots without a verifiable match produce an explicit error instead of duplicating assets.
+- Schema v2 was never connected to product indexing and therefore has no reliable mapping from its opaque root IDs to filesystem paths. Empty v2 catalogs migrate normally; a populated v2 catalog is preserved and rejected explicitly instead of guessing a mapping or duplicating assets.
 
 ## Runtime flow
 
@@ -23,6 +23,8 @@ SHA-256 work uses a streaming reader in a single background queue. Pending revis
 ## Absence safety
 
 Identity assignment is allowed for complete or partial scans. Each root has a scan generation; starting a newer scan makes every older scan stale before it can assign another batch or reconcile. Missing-state reconciliation is allowed only for the current generation after a successful recursive scan of the entire registered root. A scoped refresh, flat scan, unreadable subdirectory, cancelled job, unavailable root, or superseded scan never turns unseen locations into missing assets.
+
+Auto-watch discoveries and filesystem mutations are intentionally outside this disabled integration. They will use the same catalog-assignment boundary in the follow-up that connects rename, move, copy, overwrite, and live watcher events before the feature flag can become a product default.
 
 ## Validation boundary
 

--- a/docs/stable-identity-indexing.md
+++ b/docs/stable-identity-indexing.md
@@ -21,7 +21,7 @@ SHA-256 work uses a streaming reader in a single background queue. Pending revis
 
 ## Absence safety
 
-Identity assignment is allowed for complete or partial scans. Missing-state reconciliation is allowed only after a successful recursive scan of the entire registered root. A scoped refresh, flat scan, unreadable subdirectory, cancelled job, or unavailable root never turns unseen locations into missing assets.
+Identity assignment is allowed for complete or partial scans. Each root has a scan generation; starting a newer scan makes every older scan stale before it can assign another batch or reconcile. Missing-state reconciliation is allowed only for the current generation after a successful recursive scan of the entire registered root. A scoped refresh, flat scan, unreadable subdirectory, cancelled job, unavailable root, or superseded scan never turns unseen locations into missing assets.
 
 ## Validation boundary
 

--- a/docs/stable-identity-indexing.md
+++ b/docs/stable-identity-indexing.md
@@ -12,6 +12,7 @@ The integration is intentionally disabled by default. It can be enabled for synt
 - Relative paths use forward slashes, lexical dot-segment normalization, and a platform-aware comparison key. Unicode spelling is preserved so canonically distinct names remain distinct on case-sensitive filesystems. Absolute paths and paths escaping the root are rejected.
 - A location reuses its asset and revision when byte size and content modification time are unchanged. A changed signature creates a revision on the same asset.
 - Equal SHA-256 values never merge assets. Hashes describe revisions; they do not define asset identity.
+- On the first root registration after a schema-v2 upgrade, a sole legacy root (or one whose opaque key matches the selected path) is transactionally reassigned to the new root UUID. Multiple legacy roots without a verifiable match produce an explicit error instead of duplicating assets.
 
 ## Runtime flow
 

--- a/electron.mjs
+++ b/electron.mjs
@@ -43,6 +43,7 @@ import { licenseClientConfig } from './electron/licenseClientConfig.generated.mj
 import { resolveLicenseRuntimeConfig } from './electron/licenseRuntimeConfig.mjs';
 import { resetUserDataContents } from './electron/cacheReset.mjs';
 import { ProvenanceRepositoryLifecycle } from './electron/provenanceRepository.mjs';
+import { StableIdentityIndexer } from './electron/stableIdentityIndexer.mjs';
 import { openAuthorizedCacheDirectory } from './electron/cacheDirectory.mjs';
 import { appendEmbeddingSegmentAtOffset } from './electron/embeddingSegmentFile.mjs';
 import { hashFileSha256 } from './electron/fileFingerprint.mjs';
@@ -96,6 +97,8 @@ const macOSAudioMitigationOptOut = process.env.IMH_DISABLE_MACOS_AUDIO_MITIGATIO
   || process.env.IMH_ENABLE_OUT_OF_PROCESS_AUDIO === '1'
   || process.env.IMH_ENABLE_OUT_OF_PROCESS_AUDIO === 'true';
 const macOSAudioMitigationEnabled = process.platform === 'darwin' && app.isPackaged && !macOSAudioMitigationOptOut;
+const provenanceIndexingEnabled = process.env.IMH_ENABLE_PROVENANCE_INDEXING === '1'
+  || process.env.IMH_ENABLE_PROVENANCE_INDEXING === 'true';
 const enabledMediaCommandLineSwitches = [];
 const disabledChromiumFeatures = new Set();
 
@@ -606,6 +609,7 @@ async function readMediaMetadataWithFfprobe(filePath) {
 let mainWindow;
 let licenseManager;
 let provenanceRepositoryLifecycle;
+let stableIdentityIndexer;
 const detachedImageViewerWindows = new Map();
 const detachedImageViewerSnapshots = new Map();
 const detachedImageViewerRequestResolvers = new Map();
@@ -2951,6 +2955,10 @@ app.whenReady().then(async () => {
     userDataPath: app.getPath('userData'),
   });
   provenanceRepositoryLifecycle.initialize();
+  stableIdentityIndexer = new StableIdentityIndexer({
+    repositoryLifecycle: provenanceRepositoryLifecycle,
+    enabled: provenanceIndexingEnabled && provenanceRepositoryLifecycle.getStatus().available,
+  });
 
   const licenseRuntimeConfig = resolveLicenseRuntimeConfig({
     isPackaged: app.isPackaged,
@@ -3358,6 +3366,7 @@ async function getFilesRecursively(directory, baseDirectory) {
   const start = Date.now();
   let directoriesVisited = 0;
   let directoriesSkipped = 0;
+  let complete = true;
 
   while (directoriesToVisit.length > 0) {
     const currentDirectory = directoriesToVisit.pop();
@@ -3386,6 +3395,7 @@ async function getFilesRecursively(directory, baseDirectory) {
       files.push(...fileRecords);
     } catch (error) {
       // Ignore errors from directories we can't read, e.g. permissions
+      complete = false;
       console.warn(`Could not read directory ${currentDirectory}: ${error.message}`);
     }
   }
@@ -3397,7 +3407,7 @@ async function getFilesRecursively(directory, baseDirectory) {
     files: files.length,
     durationMs: elapsedMs(start),
   });
-  return files;
+  return { files, complete };
 }
 
 function setupFileOperationHandlers() {
@@ -6113,7 +6123,7 @@ function setupFileOperationHandlers() {
   });
 
   // Handle listing directory files
-  ipcMain.handle('list-directory-files', async (event, { dirPath, recursive = false }) => {
+  ipcMain.handle('list-directory-files', async (event, { dirPath, recursive = false, provenanceRootPath = dirPath }) => {
     const scanStart = Date.now();
     try {
       if (!dirPath) {
@@ -6121,9 +6131,12 @@ function setupFileOperationHandlers() {
       }
 
       let imageFiles = [];
+      let scanComplete = true;
 
       if (recursive) {
-        imageFiles = await getFilesRecursively(dirPath, dirPath);
+        const recursiveResult = await getFilesRecursively(dirPath, dirPath);
+        imageFiles = recursiveResult.files;
+        scanComplete = recursiveResult.complete;
       } else {
         const files = await fs.readdir(dirPath, { withFileTypes: true });
         imageFiles = await statMediaEntries(dirPath, files, dirPath);
@@ -6137,6 +6150,23 @@ function setupFileOperationHandlers() {
         durationMs: elapsedMs(scanStart),
       });
 
+      if (provenanceIndexingEnabled && stableIdentityIndexer) {
+        setImmediate(() => {
+          void stableIdentityIndexer.indexScan({
+            rootPath: provenanceRootPath,
+            scanPath: dirPath,
+            files: imageFiles,
+            scanComplete,
+            recursive,
+            onBatch: (payload) => {
+              if (!event.sender.isDestroyed()) event.sender.send('provenance-identities-assigned', payload);
+            },
+          }).catch((backfillError) => {
+            console.warn('Provenance identity backfill failed; library indexing remains available.', backfillError);
+          });
+        });
+      }
+
       return { success: true, files: imageFiles };
     } catch (error) {
       console.error('Error listing directory files:', error);
@@ -6148,6 +6178,13 @@ function setupFileOperationHandlers() {
       });
       return { success: false, error: error.message };
     }
+  });
+
+  ipcMain.handle('provenance-backfill-control', (_event, action) => {
+    if (!provenanceIndexingEnabled || !stableIdentityIndexer) return { success: false, enabled: false };
+    if (action === 'pause') return { success: true, ...stableIdentityIndexer.pause() };
+    if (action === 'resume') return { success: true, ...stableIdentityIndexer.resume() };
+    return { success: false, enabled: true, error: 'Unsupported provenance backfill action.' };
   });
 
   // ============================================================
@@ -7447,6 +7484,7 @@ app.on('before-quit', () => {
   // Stop all file watchers before quitting
   fileWatcher.stopAllWatchers();
   licenseManager?.dispose?.();
+  stableIdentityIndexer?.stop();
   provenanceRepositoryLifecycle?.close();
 });
 

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -451,6 +451,33 @@ export class AssetProvenanceRepository {
           .run(storedPath, timestamp, existing.root_id);
         return serializeRoot(this.database.prepare('SELECT * FROM library_roots WHERE root_id = ?').get(existing.root_id));
       }
+
+      const legacyRootIds = this.database.prepare(`
+        SELECT DISTINCT locations.root_id AS root_id
+        FROM asset_locations AS locations
+        LEFT JOIN library_roots AS roots ON roots.root_id = locations.root_id
+        WHERE roots.root_id IS NULL
+        ORDER BY locations.root_id
+      `).all().map((row) => row.root_id);
+      const matchingLegacyRootIds = legacyRootIds.filter((legacyRootId) => (
+        legacyRootId === storedPath || legacyRootId === normalizedPathKey
+      ));
+      const legacyRootId = matchingLegacyRootIds.length === 1
+        ? matchingLegacyRootIds[0]
+        : matchingLegacyRootIds.length === 0 && legacyRootIds.length === 1
+          ? legacyRootIds[0]
+          : null;
+
+      if (!legacyRootId && legacyRootIds.length > 0) {
+        throw new ProvenanceRepositoryError(
+          'PROVENANCE_LEGACY_ROOT_AMBIGUOUS',
+          `Cannot associate ${legacyRootIds.length} legacy provenance roots with ${storedPath}.`,
+        );
+      }
+      if (legacyRootId) {
+        this.database.prepare('UPDATE asset_locations SET root_id = ? WHERE root_id = ?')
+          .run(normalizedRootId, legacyRootId);
+      }
       this.database.prepare('INSERT INTO library_roots VALUES (?, ?, ?, ?, ?)')
         .run(normalizedRootId, storedPath, normalizedPathKey, timestamp, timestamp);
       return serializeRoot(this.database.prepare('SELECT * FROM library_roots WHERE root_id = ?').get(normalizedRootId));
@@ -475,10 +502,10 @@ export class AssetProvenanceRepository {
 
       const location = this.database.prepare(`
         SELECT * FROM asset_locations
-        WHERE root_id = ? AND relative_path_key = ? AND state != 'removed'
+        WHERE root_id = ? AND (relative_path_key = ? OR relative_path = ?) AND state != 'removed'
         ORDER BY CASE state WHEN 'present' THEN 0 ELSE 1 END, last_observed_at DESC
         LIMIT 1
-      `).get(rootId, relativePathKey);
+      `).get(rootId, relativePathKey, relativePath);
 
       if (!location) {
         const assetId = assertUuid(this.randomUUID(), 'assetId');
@@ -517,9 +544,9 @@ export class AssetProvenanceRepository {
       if (unchanged) {
         this.database.prepare(`
           UPDATE asset_locations
-          SET relative_path = ?, state = 'present', last_observed_at = ?, missing_at = NULL
+          SET relative_path = ?, relative_path_key = ?, state = 'present', last_observed_at = ?, missing_at = NULL
           WHERE location_id = ?
-        `).run(relativePath, timestamp, location.location_id);
+        `).run(relativePath, relativePathKey, timestamp, location.location_id);
         this.database.prepare("UPDATE assets SET state = 'active', updated_at = ? WHERE asset_id = ?")
           .run(timestamp, location.asset_id);
         return {
@@ -543,9 +570,9 @@ export class AssetProvenanceRepository {
       });
       this.database.prepare(`
         UPDATE asset_locations
-        SET revision_id = ?, relative_path = ?, state = 'present', last_observed_at = ?, missing_at = NULL
+        SET revision_id = ?, relative_path = ?, relative_path_key = ?, state = 'present', last_observed_at = ?, missing_at = NULL
         WHERE location_id = ?
-      `).run(revisionId, relativePath, timestamp, location.location_id);
+      `).run(revisionId, relativePath, relativePathKey, timestamp, location.location_id);
       this.database.prepare("UPDATE assets SET state = 'active', updated_at = ? WHERE asset_id = ?")
         .run(timestamp, location.asset_id);
       return {

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -133,6 +133,13 @@ function migrationTwo(database) {
 }
 
 function migrationThree(database) {
+  const legacyLocationCount = Number(database.prepare('SELECT COUNT(*) AS count FROM asset_locations').get().count);
+  if (legacyLocationCount > 0) {
+    throw new ProvenanceRepositoryError(
+      'PROVENANCE_LEGACY_LOCATIONS_UNMAPPABLE',
+      'Schema-v2 locations cannot be associated with filesystem roots safely; the existing catalog was preserved.',
+    );
+  }
   database.exec(`
     CREATE TABLE library_roots (
       root_id TEXT PRIMARY KEY,
@@ -293,7 +300,12 @@ export class AssetProvenanceRepository {
           this.database.exec(`PRAGMA user_version = ${nextVersion}`);
         });
       } catch (error) {
-        throw new ProvenanceRepositoryError('PROVENANCE_MIGRATION_FAILED', `Migration to schema ${nextVersion} failed.`, error);
+        const detail = error instanceof ProvenanceRepositoryError ? ` ${error.message}` : '';
+        throw new ProvenanceRepositoryError(
+          'PROVENANCE_MIGRATION_FAILED',
+          `Migration to schema ${nextVersion} failed.${detail}`,
+          error,
+        );
       }
       currentVersion = nextVersion;
     }
@@ -452,32 +464,6 @@ export class AssetProvenanceRepository {
         return serializeRoot(this.database.prepare('SELECT * FROM library_roots WHERE root_id = ?').get(existing.root_id));
       }
 
-      const legacyRootIds = this.database.prepare(`
-        SELECT DISTINCT locations.root_id AS root_id
-        FROM asset_locations AS locations
-        LEFT JOIN library_roots AS roots ON roots.root_id = locations.root_id
-        WHERE roots.root_id IS NULL
-        ORDER BY locations.root_id
-      `).all().map((row) => row.root_id);
-      const matchingLegacyRootIds = legacyRootIds.filter((legacyRootId) => (
-        legacyRootId === storedPath || legacyRootId === normalizedPathKey
-      ));
-      const legacyRootId = matchingLegacyRootIds.length === 1
-        ? matchingLegacyRootIds[0]
-        : matchingLegacyRootIds.length === 0 && legacyRootIds.length === 1
-          ? legacyRootIds[0]
-          : null;
-
-      if (!legacyRootId && legacyRootIds.length > 0) {
-        throw new ProvenanceRepositoryError(
-          'PROVENANCE_LEGACY_ROOT_AMBIGUOUS',
-          `Cannot associate ${legacyRootIds.length} legacy provenance roots with ${storedPath}.`,
-        );
-      }
-      if (legacyRootId) {
-        this.database.prepare('UPDATE asset_locations SET root_id = ? WHERE root_id = ?')
-          .run(normalizedRootId, legacyRootId);
-      }
       this.database.prepare('INSERT INTO library_roots VALUES (?, ?, ?, ?, ?)')
         .run(normalizedRootId, storedPath, normalizedPathKey, timestamp, timestamp);
       return serializeRoot(this.database.prepare('SELECT * FROM library_roots WHERE root_id = ?').get(normalizedRootId));
@@ -502,10 +488,10 @@ export class AssetProvenanceRepository {
 
       const location = this.database.prepare(`
         SELECT * FROM asset_locations
-        WHERE root_id = ? AND (relative_path_key = ? OR relative_path = ?) AND state != 'removed'
+        WHERE root_id = ? AND relative_path_key = ? AND state != 'removed'
         ORDER BY CASE state WHEN 'present' THEN 0 ELSE 1 END, last_observed_at DESC
         LIMIT 1
-      `).get(rootId, relativePathKey, relativePath);
+      `).get(rootId, relativePathKey);
 
       if (!location) {
         const assetId = assertUuid(this.randomUUID(), 'assetId');
@@ -544,9 +530,9 @@ export class AssetProvenanceRepository {
       if (unchanged) {
         this.database.prepare(`
           UPDATE asset_locations
-          SET relative_path = ?, relative_path_key = ?, state = 'present', last_observed_at = ?, missing_at = NULL
+          SET relative_path = ?, state = 'present', last_observed_at = ?, missing_at = NULL
           WHERE location_id = ?
-        `).run(relativePath, relativePathKey, timestamp, location.location_id);
+        `).run(relativePath, timestamp, location.location_id);
         this.database.prepare("UPDATE assets SET state = 'active', updated_at = ? WHERE asset_id = ?")
           .run(timestamp, location.asset_id);
         return {
@@ -570,9 +556,9 @@ export class AssetProvenanceRepository {
       });
       this.database.prepare(`
         UPDATE asset_locations
-        SET revision_id = ?, relative_path = ?, relative_path_key = ?, state = 'present', last_observed_at = ?, missing_at = NULL
+        SET revision_id = ?, relative_path = ?, state = 'present', last_observed_at = ?, missing_at = NULL
         WHERE location_id = ?
-      `).run(revisionId, relativePath, relativePathKey, timestamp, location.location_id);
+      `).run(revisionId, relativePath, timestamp, location.location_id);
       this.database.prepare("UPDATE assets SET state = 'active', updated_at = ? WHERE asset_id = ?")
         .run(timestamp, location.asset_id);
       return {

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -9,7 +9,7 @@ import {
 } from './provenancePaths.mjs';
 
 export { PROVENANCE_DATABASE_NAME, PROVENANCE_DIRECTORY_NAME, resolveProvenanceCatalogPath };
-export const PROVENANCE_SCHEMA_VERSION = 2;
+export const PROVENANCE_SCHEMA_VERSION = 3;
 
 export const ASSET_STATES = Object.freeze(['active', 'missing', 'deleted']);
 export const LOCATION_STATES = Object.freeze(['present', 'missing', 'removed']);
@@ -132,7 +132,27 @@ function migrationTwo(database) {
   `);
 }
 
-const MIGRATIONS = new Map([[1, migrationOne], [2, migrationTwo]]);
+function migrationThree(database) {
+  database.exec(`
+    CREATE TABLE library_roots (
+      root_id TEXT PRIMARY KEY,
+      absolute_path TEXT NOT NULL,
+      path_key TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL
+    ) STRICT;
+
+    ALTER TABLE asset_locations ADD COLUMN relative_path_key TEXT;
+    UPDATE asset_locations SET relative_path_key = relative_path;
+    DROP INDEX asset_locations_present_path_idx;
+    CREATE UNIQUE INDEX asset_locations_present_path_key_idx
+      ON asset_locations(root_id, relative_path_key) WHERE state = 'present';
+    CREATE INDEX asset_locations_root_path_key_idx
+      ON asset_locations(root_id, relative_path_key);
+  `);
+}
+
+const MIGRATIONS = new Map([[1, migrationOne], [2, migrationTwo], [3, migrationThree]]);
 
 function serializeAsset(row) {
   return row ? {
@@ -166,10 +186,21 @@ function serializeLocation(row) {
     revisionId: row.revision_id,
     rootId: row.root_id,
     relativePath: row.relative_path,
+    relativePathKey: row.relative_path_key ?? row.relative_path,
     state: row.state,
     firstObservedAt: row.first_observed_at,
     lastObservedAt: row.last_observed_at,
     missingAt: row.missing_at,
+  } : null;
+}
+
+function serializeRoot(row) {
+  return row ? {
+    rootId: row.root_id,
+    absolutePath: row.absolute_path,
+    pathKey: row.path_key,
+    createdAt: row.created_at,
+    lastSeenAt: row.last_seen_at,
   } : null;
 }
 
@@ -287,6 +318,7 @@ export class AssetProvenanceRepository {
     const locationId = assertUuid(input.locationId || this.randomUUID(), 'locationId');
     const rootId = assertNonBlank(input.rootId, 'rootId');
     const relativePath = assertNonBlank(input.relativePath, 'relativePath');
+    const relativePathKey = assertNonBlank(input.relativePathKey || relativePath, 'relativePathKey');
     const hashState = input.hashState || (input.sha256 ? 'available' : 'pending');
     const sha256 = normalizeHash(input.sha256, hashState);
     const byteSize = Number(input.byteSize);
@@ -299,10 +331,10 @@ export class AssetProvenanceRepository {
       this.#insertRevision({ ...input, assetId, revisionId, sha256, hashState, byteSize, timestamp });
       this.database.prepare(`
         INSERT INTO asset_locations (
-          location_id, asset_id, revision_id, root_id, relative_path, state,
+          location_id, asset_id, revision_id, root_id, relative_path, relative_path_key, state,
           first_observed_at, last_observed_at, missing_at
-        ) VALUES (?, ?, ?, ?, ?, 'present', ?, ?, NULL)
-      `).run(locationId, assetId, revisionId, rootId, relativePath, timestamp, timestamp);
+        ) VALUES (?, ?, ?, ?, ?, ?, 'present', ?, ?, NULL)
+      `).run(locationId, assetId, revisionId, rootId, relativePath, relativePathKey, timestamp, timestamp);
     });
     return this.getAsset(assetId);
   }
@@ -351,15 +383,21 @@ export class AssetProvenanceRepository {
     return serializeRevision(this.database.prepare('SELECT * FROM asset_revisions WHERE revision_id = ?').get(revisionId));
   }
 
-  relocateLocation(locationId, { rootId, relativePath }) {
+  relocateLocation(locationId, { rootId, relativePath, relativePathKey = relativePath }) {
     this.#requireWritable();
     const timestamp = this.now().toISOString();
     return runTransaction(this.database, () => {
       const result = this.database.prepare(`
         UPDATE asset_locations
-        SET root_id = ?, relative_path = ?, state = 'present', last_observed_at = ?, missing_at = NULL
+        SET root_id = ?, relative_path = ?, relative_path_key = ?, state = 'present', last_observed_at = ?, missing_at = NULL
         WHERE location_id = ? AND state != 'removed'
-      `).run(assertNonBlank(rootId, 'rootId'), assertNonBlank(relativePath, 'relativePath'), timestamp, locationId);
+      `).run(
+        assertNonBlank(rootId, 'rootId'),
+        assertNonBlank(relativePath, 'relativePath'),
+        assertNonBlank(relativePathKey, 'relativePathKey'),
+        timestamp,
+        locationId,
+      );
       if (Number(result.changes) !== 1) throw new ProvenanceRepositoryError('PROVENANCE_LOCATION_NOT_FOUND', `Active location ${locationId} was not found.`);
       const location = this.database.prepare('SELECT * FROM asset_locations WHERE location_id = ?').get(locationId);
       this.database.prepare(`UPDATE assets SET state = 'active', updated_at = ? WHERE asset_id = ?`).run(timestamp, location.asset_id);
@@ -398,6 +436,171 @@ export class AssetProvenanceRepository {
       `).run(timestamp, timestamp, assetId);
     });
     return this.getAsset(assetId);
+  }
+
+  ensureLibraryRoot({ rootId = this.randomUUID(), absolutePath, pathKey }) {
+    this.#requireWritable();
+    const normalizedRootId = assertUuid(rootId, 'rootId');
+    const storedPath = assertNonBlank(absolutePath, 'absolutePath');
+    const normalizedPathKey = assertNonBlank(pathKey, 'pathKey');
+    const timestamp = this.now().toISOString();
+    return runTransaction(this.database, () => {
+      const existing = this.database.prepare('SELECT * FROM library_roots WHERE path_key = ?').get(normalizedPathKey);
+      if (existing) {
+        this.database.prepare('UPDATE library_roots SET absolute_path = ?, last_seen_at = ? WHERE root_id = ?')
+          .run(storedPath, timestamp, existing.root_id);
+        return serializeRoot(this.database.prepare('SELECT * FROM library_roots WHERE root_id = ?').get(existing.root_id));
+      }
+      this.database.prepare('INSERT INTO library_roots VALUES (?, ?, ?, ?, ?)')
+        .run(normalizedRootId, storedPath, normalizedPathKey, timestamp, timestamp);
+      return serializeRoot(this.database.prepare('SELECT * FROM library_roots WHERE root_id = ?').get(normalizedRootId));
+    });
+  }
+
+  assignIndexedFile(input) {
+    this.#requireWritable();
+    const rootId = assertUuid(input.rootId, 'rootId');
+    const relativePath = assertNonBlank(input.relativePath, 'relativePath');
+    const relativePathKey = assertNonBlank(input.relativePathKey, 'relativePathKey');
+    const byteSize = Number(input.byteSize);
+    if (!Number.isSafeInteger(byteSize) || byteSize < 0) {
+      throw new ProvenanceRepositoryError('PROVENANCE_INVALID_INPUT', 'byteSize must be a non-negative safe integer.');
+    }
+    const contentModifiedMs = normalizeOptionalTimestamp(input.contentModifiedMs, 'contentModifiedMs');
+    const timestamp = this.now().toISOString();
+
+    return runTransaction(this.database, () => {
+      const root = this.database.prepare('SELECT root_id FROM library_roots WHERE root_id = ?').get(rootId);
+      if (!root) throw new ProvenanceRepositoryError('PROVENANCE_ROOT_NOT_FOUND', `Library root ${rootId} was not found.`);
+
+      const location = this.database.prepare(`
+        SELECT * FROM asset_locations
+        WHERE root_id = ? AND relative_path_key = ? AND state != 'removed'
+        ORDER BY CASE state WHEN 'present' THEN 0 ELSE 1 END, last_observed_at DESC
+        LIMIT 1
+      `).get(rootId, relativePathKey);
+
+      if (!location) {
+        const assetId = assertUuid(this.randomUUID(), 'assetId');
+        const revisionId = assertUuid(this.randomUUID(), 'revisionId');
+        const locationId = assertUuid(this.randomUUID(), 'locationId');
+        this.database.prepare('INSERT INTO assets VALUES (?, ?, ?, ?)').run(assetId, 'active', timestamp, timestamp);
+        this.#insertRevision({
+          assetId,
+          revisionId,
+          sha256: null,
+          hashState: 'pending',
+          byteSize,
+          mimeType: input.mimeType ?? null,
+          contentModifiedMs,
+          timestamp,
+        });
+        this.database.prepare(`
+          INSERT INTO asset_locations (
+            location_id, asset_id, revision_id, root_id, relative_path, relative_path_key, state,
+            first_observed_at, last_observed_at, missing_at
+          ) VALUES (?, ?, ?, ?, ?, ?, 'present', ?, ?, NULL)
+        `).run(locationId, assetId, revisionId, rootId, relativePath, relativePathKey, timestamp, timestamp);
+        return {
+          assetId,
+          revisionId,
+          locationId,
+          needsHash: true,
+        };
+      }
+
+      const revision = this.database.prepare('SELECT * FROM asset_revisions WHERE revision_id = ?').get(location.revision_id);
+      const unchanged = revision
+        && Number(revision.byte_size) === byteSize
+        && (revision.content_modified_ms === null ? null : Number(revision.content_modified_ms)) === contentModifiedMs;
+
+      if (unchanged) {
+        this.database.prepare(`
+          UPDATE asset_locations
+          SET relative_path = ?, state = 'present', last_observed_at = ?, missing_at = NULL
+          WHERE location_id = ?
+        `).run(relativePath, timestamp, location.location_id);
+        this.database.prepare("UPDATE assets SET state = 'active', updated_at = ? WHERE asset_id = ?")
+          .run(timestamp, location.asset_id);
+        return {
+          assetId: location.asset_id,
+          revisionId: location.revision_id,
+          locationId: location.location_id,
+          needsHash: revision.hash_state !== 'available',
+        };
+      }
+
+      const revisionId = assertUuid(this.randomUUID(), 'revisionId');
+      this.#insertRevision({
+        assetId: location.asset_id,
+        revisionId,
+        sha256: null,
+        hashState: 'pending',
+        byteSize,
+        mimeType: input.mimeType ?? null,
+        contentModifiedMs,
+        timestamp,
+      });
+      this.database.prepare(`
+        UPDATE asset_locations
+        SET revision_id = ?, relative_path = ?, state = 'present', last_observed_at = ?, missing_at = NULL
+        WHERE location_id = ?
+      `).run(revisionId, relativePath, timestamp, location.location_id);
+      this.database.prepare("UPDATE assets SET state = 'active', updated_at = ? WHERE asset_id = ?")
+        .run(timestamp, location.asset_id);
+      return {
+        assetId: location.asset_id,
+        revisionId,
+        locationId: location.location_id,
+        needsHash: true,
+      };
+    });
+  }
+
+  completeRevisionHashIfUnchanged(revisionId, { sha256, byteSize, contentModifiedMs }) {
+    this.#requireWritable();
+    const normalizedRevisionId = assertUuid(revisionId, 'revisionId');
+    const normalizedHash = normalizeHash(sha256, 'available');
+    const normalizedModifiedMs = normalizeOptionalTimestamp(contentModifiedMs, 'contentModifiedMs');
+    const result = this.database.prepare(`
+      UPDATE asset_revisions
+      SET sha256 = ?, hash_state = 'available'
+      WHERE revision_id = ? AND byte_size = ? AND content_modified_ms IS ? AND hash_state != 'available'
+    `).run(normalizedHash, normalizedRevisionId, byteSize, normalizedModifiedMs);
+    return Number(result.changes) === 1;
+  }
+
+  reconcileRootLocations(rootId, seenRelativePathKeys) {
+    this.#requireWritable();
+    const normalizedRootId = assertUuid(rootId, 'rootId');
+    const seen = new Set(seenRelativePathKeys);
+    const timestamp = this.now().toISOString();
+    return runTransaction(this.database, () => {
+      const presentLocations = this.database.prepare(`
+        SELECT location_id, asset_id, relative_path_key FROM asset_locations
+        WHERE root_id = ? AND state = 'present'
+      `).all(normalizedRootId);
+      const missingAssetIds = new Set();
+      let missingCount = 0;
+      for (const location of presentLocations) {
+        if (seen.has(location.relative_path_key)) continue;
+        this.database.prepare(`
+          UPDATE asset_locations SET state = 'missing', last_observed_at = ?, missing_at = ? WHERE location_id = ?
+        `).run(timestamp, timestamp, location.location_id);
+        missingAssetIds.add(location.asset_id);
+        missingCount += 1;
+      }
+      for (const assetId of missingAssetIds) {
+        const presentCount = Number(this.database.prepare(`
+          SELECT COUNT(*) AS count FROM asset_locations WHERE asset_id = ? AND state = 'present'
+        `).get(assetId).count);
+        if (presentCount === 0) {
+          this.database.prepare("UPDATE assets SET state = 'missing', updated_at = ? WHERE asset_id = ?")
+            .run(timestamp, assetId);
+        }
+      }
+      return { missingCount };
+    });
   }
 
   getAsset(assetId) {

--- a/electron/stableIdentityIndexer.mjs
+++ b/electron/stableIdentityIndexer.mjs
@@ -59,6 +59,7 @@ export class StableIdentityIndexer {
     this.queuedRevisionIds = new Set();
     this.hashDrainPromise = null;
     this.abortController = new AbortController();
+    this.scanGenerationByRootKey = new Map();
   }
 
   pause() {
@@ -85,13 +86,22 @@ export class StableIdentityIndexer {
     if (!this.enabled || this.stopped) return { enabled: false, assigned: 0, reconciled: false };
     const root = normalizeLibraryRootPath(rootPath, this.platform);
     const normalizedScan = normalizeLibraryRootPath(scanPath, this.platform);
+    const scanGeneration = (this.scanGenerationByRootKey.get(root.pathKey) ?? 0) + 1;
+    this.scanGenerationByRootKey.set(root.pathKey, scanGeneration);
+    const isLatestGeneration = () => this.scanGenerationByRootKey.get(root.pathKey) === scanGeneration;
+    const isCurrentScan = () => !this.stopped && isLatestGeneration();
     const rootRecord = this.repositoryLifecycle.run((repository) => repository.ensureLibraryRoot(root));
     const seenPathKeys = new Set();
     let assigned = 0;
 
     for (let offset = 0; offset < files.length; offset += this.batchSize) {
       await this.#waitWhilePaused();
-      if (this.stopped) return { enabled: true, assigned, reconciled: false, cancelled: true };
+      if (this.stopped) {
+        return { enabled: true, assigned, reconciled: false, cancelled: true, rootId: rootRecord.rootId };
+      }
+      if (!isLatestGeneration()) {
+        return { enabled: true, assigned, reconciled: false, stale: true, rootId: rootRecord.rootId };
+      }
       const mappings = [];
       for (const file of files.slice(offset, offset + this.batchSize)) {
         const absoluteFilePath = path.resolve(normalizedScan.absolutePath, ...String(file.name).replace(/\\/g, '/').split('/'));
@@ -122,12 +132,23 @@ export class StableIdentityIndexer {
       await new Promise((resolve) => setImmediate(resolve));
     }
 
-    const canReconcile = Boolean(scanComplete && recursive && normalizedScan.pathKey === root.pathKey && !this.stopped);
+    const canReconcile = Boolean(
+      scanComplete
+      && recursive
+      && normalizedScan.pathKey === root.pathKey
+      && isCurrentScan()
+    );
     if (canReconcile) {
       this.repositoryLifecycle.run((repository) => repository.reconcileRootLocations(rootRecord.rootId, seenPathKeys));
     }
     void this.#drainHashes();
-    return { enabled: true, assigned, reconciled: canReconcile, rootId: rootRecord.rootId };
+    return {
+      enabled: true,
+      assigned,
+      reconciled: canReconcile,
+      stale: !isLatestGeneration(),
+      rootId: rootRecord.rootId,
+    };
   }
 
   async waitForIdle() {

--- a/electron/stableIdentityIndexer.mjs
+++ b/electron/stableIdentityIndexer.mjs
@@ -1,0 +1,195 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_BATCH_SIZE = 128;
+
+export function normalizeLibraryRootPath(rootPath, platform = process.platform) {
+  if (typeof rootPath !== 'string' || !rootPath.trim()) throw new Error('Library root path is required.');
+  const absolutePath = path.resolve(rootPath).normalize('NFC');
+  const parsed = path.parse(absolutePath);
+  const displayPath = absolutePath === parsed.root ? absolutePath : absolutePath.replace(/[\\/]+$/, '');
+  return {
+    absolutePath: displayPath,
+    pathKey: platform === 'win32' ? displayPath.toLocaleLowerCase('en-US') : displayPath,
+  };
+}
+
+export function normalizeRelativeCatalogPath(relativePath, platform = process.platform) {
+  if (typeof relativePath !== 'string' || !relativePath.trim() || relativePath.includes('\0')) {
+    throw new Error('A non-empty relative file path is required.');
+  }
+  const normalized = path.posix.normalize(relativePath.replace(/\\/g, '/')).normalize('NFC');
+  if (normalized === '.' || normalized.startsWith('/') || normalized === '..' || normalized.startsWith('../')) {
+    throw new Error(`Path must remain inside its library root: ${relativePath}`);
+  }
+  return {
+    relativePath: normalized,
+    relativePathKey: platform === 'win32' ? normalized.toLocaleLowerCase('en-US') : normalized,
+  };
+}
+
+function normalizedTimestamp(value) {
+  return Number.isFinite(value) ? Math.trunc(value) : null;
+}
+
+function sameFileSignature(stat, expected) {
+  return stat.isFile()
+    && stat.size === expected.byteSize
+    && normalizedTimestamp(stat.mtimeMs) === expected.contentModifiedMs;
+}
+
+async function sha256File(filePath, { createReadStream = fs.createReadStream, signal } = {}) {
+  const hash = crypto.createHash('sha256');
+  const stream = createReadStream(filePath, { signal });
+  for await (const chunk of stream) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+export class StableIdentityIndexer {
+  constructor({
+    repositoryLifecycle,
+    enabled = false,
+    platform = process.platform,
+    batchSize = DEFAULT_BATCH_SIZE,
+    stat = fs.promises.stat,
+    createReadStream = fs.createReadStream,
+    logger = console,
+  }) {
+    this.repositoryLifecycle = repositoryLifecycle;
+    this.enabled = enabled;
+    this.platform = platform;
+    this.batchSize = Math.max(1, Math.trunc(batchSize));
+    this.stat = stat;
+    this.createReadStream = createReadStream;
+    this.logger = logger;
+    this.paused = false;
+    this.pauseWaiters = [];
+    this.stopped = false;
+    this.hashQueue = [];
+    this.queuedRevisionIds = new Set();
+    this.hashDrainPromise = null;
+    this.abortController = new AbortController();
+  }
+
+  pause() {
+    this.paused = true;
+    return { paused: true };
+  }
+
+  resume() {
+    this.paused = false;
+    for (const resolve of this.pauseWaiters.splice(0)) resolve();
+    void this.#drainHashes();
+    return { paused: false };
+  }
+
+  stop() {
+    this.stopped = true;
+    this.abortController.abort();
+    this.resume();
+    this.hashQueue.length = 0;
+    this.queuedRevisionIds.clear();
+  }
+
+  async indexScan({ rootPath, scanPath = rootPath, files, scanComplete, recursive, onBatch = () => {} }) {
+    if (!this.enabled || this.stopped) return { enabled: false, assigned: 0, reconciled: false };
+    const root = normalizeLibraryRootPath(rootPath, this.platform);
+    const normalizedScan = normalizeLibraryRootPath(scanPath, this.platform);
+    const rootRecord = this.repositoryLifecycle.run((repository) => repository.ensureLibraryRoot(root));
+    const seenPathKeys = new Set();
+    let assigned = 0;
+
+    for (let offset = 0; offset < files.length; offset += this.batchSize) {
+      await this.#waitWhilePaused();
+      if (this.stopped) return { enabled: true, assigned, reconciled: false, cancelled: true };
+      const mappings = [];
+      for (const file of files.slice(offset, offset + this.batchSize)) {
+        const absoluteFilePath = path.resolve(normalizedScan.absolutePath, ...String(file.name).replace(/\\/g, '/').split('/'));
+        const rootRelativePath = path.relative(root.absolutePath, absoluteFilePath).replace(/\\/g, '/');
+        const normalizedPath = normalizeRelativeCatalogPath(rootRelativePath, this.platform);
+        const contentModifiedMs = normalizedTimestamp(file.contentModifiedMs ?? file.lastModified);
+        const identity = this.repositoryLifecycle.run((repository) => repository.assignIndexedFile({
+          rootId: rootRecord.rootId,
+          ...normalizedPath,
+          byteSize: Number(file.size),
+          mimeType: file.type ?? null,
+          contentModifiedMs,
+        }));
+        seenPathKeys.add(normalizedPath.relativePathKey);
+        const mapping = { ...normalizedPath, ...identity };
+        mappings.push(mapping);
+        assigned += 1;
+        if (identity.needsHash) {
+          this.#enqueueHash({
+            revisionId: identity.revisionId,
+            filePath: absoluteFilePath,
+            byteSize: Number(file.size),
+            contentModifiedMs,
+          });
+        }
+      }
+      onBatch({ rootId: rootRecord.rootId, rootPath: root.absolutePath, mappings });
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    const canReconcile = Boolean(scanComplete && recursive && normalizedScan.pathKey === root.pathKey && !this.stopped);
+    if (canReconcile) {
+      this.repositoryLifecycle.run((repository) => repository.reconcileRootLocations(rootRecord.rootId, seenPathKeys));
+    }
+    void this.#drainHashes();
+    return { enabled: true, assigned, reconciled: canReconcile, rootId: rootRecord.rootId };
+  }
+
+  async waitForIdle() {
+    await this.hashDrainPromise;
+  }
+
+  #enqueueHash(task) {
+    if (this.queuedRevisionIds.has(task.revisionId)) return;
+    this.queuedRevisionIds.add(task.revisionId);
+    this.hashQueue.push(task);
+  }
+
+  async #waitWhilePaused() {
+    if (!this.paused || this.stopped) return;
+    await new Promise((resolve) => this.pauseWaiters.push(resolve));
+  }
+
+  #drainHashes() {
+    if (this.hashDrainPromise || this.paused || this.stopped || this.hashQueue.length === 0) {
+      return this.hashDrainPromise;
+    }
+    this.hashDrainPromise = (async () => {
+      while (this.hashQueue.length > 0 && !this.stopped) {
+        await this.#waitWhilePaused();
+        if (this.stopped) break;
+        const task = this.hashQueue.shift();
+        try {
+          const before = await this.stat(task.filePath);
+          if (!sameFileSignature(before, task)) continue;
+          const sha256 = await sha256File(task.filePath, {
+            createReadStream: this.createReadStream,
+            signal: this.abortController.signal,
+          });
+          const after = await this.stat(task.filePath);
+          if (!sameFileSignature(after, task)) continue;
+          this.repositoryLifecycle.run((repository) => repository.completeRevisionHashIfUnchanged(task.revisionId, {
+            sha256,
+            byteSize: task.byteSize,
+            contentModifiedMs: task.contentModifiedMs,
+          }));
+        } catch (error) {
+          if (!this.stopped) this.logger.warn('Could not hash provenance revision; it remains pending for a later scan.', error);
+        } finally {
+          this.queuedRevisionIds.delete(task.revisionId);
+        }
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+    })().finally(() => {
+      this.hashDrainPromise = null;
+      if (!this.paused && !this.stopped && this.hashQueue.length > 0) void this.#drainHashes();
+    });
+    return this.hashDrainPromise;
+  }
+}

--- a/electron/stableIdentityIndexer.mjs
+++ b/electron/stableIdentityIndexer.mjs
@@ -9,7 +9,7 @@ const DEFAULT_BATCH_SIZE = 128;
 
 export function normalizeLibraryRootPath(rootPath, platform = process.platform) {
   if (typeof rootPath !== 'string' || !rootPath.trim()) throw new Error('Library root path is required.');
-  const absolutePath = path.resolve(rootPath).normalize('NFC');
+  const absolutePath = path.resolve(rootPath);
   const parsed = path.parse(absolutePath);
   const displayPath = absolutePath === parsed.root ? absolutePath : absolutePath.replace(/[\\/]+$/, '');
   return {

--- a/electron/stableIdentityIndexer.mjs
+++ b/electron/stableIdentityIndexer.mjs
@@ -1,6 +1,9 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { normalizeRelativeCatalogPath } from '../utils/provenancePath.mjs';
+
+export { normalizeRelativeCatalogPath } from '../utils/provenancePath.mjs';
 
 const DEFAULT_BATCH_SIZE = 128;
 
@@ -12,20 +15,6 @@ export function normalizeLibraryRootPath(rootPath, platform = process.platform) 
   return {
     absolutePath: displayPath,
     pathKey: platform === 'win32' ? displayPath.toLocaleLowerCase('en-US') : displayPath,
-  };
-}
-
-export function normalizeRelativeCatalogPath(relativePath, platform = process.platform) {
-  if (typeof relativePath !== 'string' || !relativePath.trim() || relativePath.includes('\0')) {
-    throw new Error('A non-empty relative file path is required.');
-  }
-  const normalized = path.posix.normalize(relativePath.replace(/\\/g, '/')).normalize('NFC');
-  if (normalized === '.' || normalized.startsWith('/') || normalized === '..' || normalized.startsWith('../')) {
-    throw new Error(`Path must remain inside its library root: ${relativePath}`);
-  }
-  return {
-    relativePath: normalized,
-    relativePathKey: platform === 'win32' ? normalized.toLocaleLowerCase('en-US') : normalized,
   };
 }
 

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -66,6 +66,8 @@ type DirectoryFileRecord = {
     contentModifiedMs?: number;
 };
 
+type ProvenanceIdentity = Pick<IndexedImage, 'assetId' | 'revisionId' | 'provenanceLocationId' | 'provenanceRootId'>;
+
 const electronHandleGetFile = async function (this: { name: string; _filePath?: string }) {
     const electronAPI = window.electronAPI;
     if (!getIsElectron() || !electronAPI || !this._filePath) {
@@ -124,9 +126,14 @@ async function getFilesRecursivelyWeb(directoryHandle: FileSystemDirectoryHandle
     return files;
 }
 
-async function getDirectoryFiles(directoryHandle: FileSystemDirectoryHandle, directoryPath: string, recursive: boolean): Promise<DirectoryFileRecord[]> {
+async function getDirectoryFiles(
+    directoryHandle: FileSystemDirectoryHandle,
+    directoryPath: string,
+    recursive: boolean,
+    provenanceRootPath: string = directoryPath,
+): Promise<DirectoryFileRecord[]> {
     if (getIsElectron()) {
-        const result = await (window as any).electronAPI.listDirectoryFiles({ dirPath: directoryPath, recursive });
+        const result = await (window as any).electronAPI.listDirectoryFiles({ dirPath: directoryPath, recursive, provenanceRootPath });
         if (result.success && result.files) {
             return result.files;
         }
@@ -276,6 +283,39 @@ export function useImageLoader() {
     const idleReconcileTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const idleReconcileQueueRef = useRef<Directory[]>([]);
     const idleReconcileRunningRef = useRef(false);
+    const provenanceIdentityByImageIdRef = useRef(new Map<string, ProvenanceIdentity>());
+
+    const provenanceIdentityForPath = useCallback((directoryId: string, relativePath: string) =>
+        provenanceIdentityByImageIdRef.current.get(`${directoryId}::${relativePath}`), []);
+
+    useEffect(() => {
+        if (!window.electronAPI?.onProvenanceIdentitiesAssigned) return;
+        return window.electronAPI.onProvenanceIdentitiesAssigned((payload) => {
+            const directory = useImageStore.getState().directories.find((candidate) =>
+                areFilesystemPathsEqual(candidate.path, payload.rootPath)
+            );
+            if (!directory) return;
+
+            const updatedById = new Map<string, ProvenanceIdentity>();
+            for (const mapping of payload.mappings) {
+                const imageId = `${directory.id}::${mapping.relativePath}`;
+                const identity = {
+                    assetId: mapping.assetId,
+                    revisionId: mapping.revisionId,
+                    provenanceLocationId: mapping.locationId,
+                    provenanceRootId: payload.rootId,
+                };
+                provenanceIdentityByImageIdRef.current.set(imageId, identity);
+                updatedById.set(imageId, identity);
+            }
+
+            const updates = useImageStore.getState().images.flatMap((image) => {
+                const identity = updatedById.get(image.id);
+                return identity ? [{ ...image, ...identity }] : [];
+            });
+            if (updates.length > 0) mergeImages(updates);
+        });
+    }, [mergeImages]);
 
     // Helper function to check if indexing should be cancelled
     const shouldCancelIndexing = useCallback((allowIdle = false) => {
@@ -568,7 +608,7 @@ export function useImageLoader() {
         await cacheManager.init();
 
         const listStart = performance.now();
-        const allCurrentFiles = await getDirectoryFiles(activeDirectory.handle, activeDirectory.path, shouldScanSubfolders);
+        const allCurrentFiles = await getDirectoryFiles(activeDirectory.handle, activeDirectory.path, shouldScanSubfolders, activeDirectory.path);
         logIndexingPerf('startup-reconcile:list-files', {
             directoryId: activeDirectory.id,
             directoryName: activeDirectory.name,
@@ -703,6 +743,7 @@ export function useImageLoader() {
                             mergeImages(batch);
                         },
                         hydratePreloadedImages: false,
+                        provenanceIdentityForPath: (relativePath) => provenanceIdentityForPath(activeDirectory.id, relativePath),
                     }
                 );
 
@@ -824,6 +865,7 @@ export function useImageLoader() {
                         mergeImages(batch);
                     },
                     hydratePreloadedImages: false,
+                    provenanceIdentityForPath: (relativePath) => provenanceIdentityForPath(activeDirectory.id, relativePath),
                 }
             );
 
@@ -849,7 +891,7 @@ export function useImageLoader() {
             setEnrichmentProgress(null);
             setProgress(null);
         }
-    }, [addImages, mergeImages, refreshLineageDirectorySignature, removeImages, scheduleLineageRebuild, setDirectoryRefreshing, setEnrichmentProgress, setProgress, waitWhilePaused]);
+    }, [addImages, mergeImages, provenanceIdentityForPath, refreshLineageDirectorySignature, removeImages, scheduleLineageRebuild, setDirectoryRefreshing, setEnrichmentProgress, setProgress, waitWhilePaused]);
 
     const runIdleReconcileQueue = useCallback(async () => {
         if (idleReconcileRunningRef.current) {
@@ -1126,7 +1168,7 @@ export function useImageLoader() {
             
             // Get files from disk (either full directory or specific subfolder)
             const listStart = performance.now();
-            let allCurrentFiles = await getDirectoryFiles(directory.handle, scanPath, shouldScanSubfolders);
+            let allCurrentFiles = await getDirectoryFiles(directory.handle, scanPath, shouldScanSubfolders, directory.path);
             logIndexingPerf('load-directory:list-files', {
                 directoryId: directory.id,
                 directoryName: directory.name,
@@ -1409,6 +1451,7 @@ export function useImageLoader() {
                         onEnrichmentBatch: handleEnrichmentBatch,
                         onEnrichmentProgress: handleEnrichmentProgress,
                         hydratePreloadedImages: shouldHydratePreloadedImages,
+                        provenanceIdentityForPath: (relativePath) => provenanceIdentityForPath(directory.id, relativePath),
                     }
                 );
                 logIndexingPerf('load-directory:phase-a-returned', {
@@ -1527,7 +1570,7 @@ export function useImageLoader() {
                 setProgress(null);
             }
         }
-    }, [addImages, mergeImages, removeImages, clearImages, setLoading, setProgress, setError, setSuccess, setDirectoryRefreshing, finalizeDirectoryLoad, scheduleDirectoryThumbnailWarmup, setDirectoryProgress]);
+    }, [addImages, mergeImages, provenanceIdentityForPath, removeImages, clearImages, setLoading, setProgress, setError, setSuccess, setDirectoryRefreshing, finalizeDirectoryLoad, scheduleDirectoryThumbnailWarmup, setDirectoryProgress]);
 
 
     // Helper function to detect if a path is a root disk

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -10,6 +10,7 @@ import { areFilesystemPathsEqual } from '../utils/filesystemPath';
 import { waitForDirectoryActivityToSettle } from '../utils/directoryActivity';
 import { inferMimeTypeFromName, isImageFileName } from '../utils/mediaTypes.js';
 import { normalizeBirthtimeMs } from '../utils/fileTimestamps.js';
+import { buildProvenanceIdentityLookupKey } from '../utils/provenancePath.mjs';
 
 // Configure logging level
 const DEBUG = false;
@@ -283,10 +284,10 @@ export function useImageLoader() {
     const idleReconcileTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const idleReconcileQueueRef = useRef<Directory[]>([]);
     const idleReconcileRunningRef = useRef(false);
-    const provenanceIdentityByImageIdRef = useRef(new Map<string, ProvenanceIdentity>());
+    const provenanceIdentityByLookupKeyRef = useRef(new Map<string, ProvenanceIdentity>());
 
     const provenanceIdentityForPath = useCallback((directoryId: string, relativePath: string) =>
-        provenanceIdentityByImageIdRef.current.get(`${directoryId}::${relativePath}`), []);
+        provenanceIdentityByLookupKeyRef.current.get(buildProvenanceIdentityLookupKey(directoryId, relativePath)), []);
 
     useEffect(() => {
         if (!window.electronAPI?.onProvenanceIdentitiesAssigned) return;
@@ -296,21 +297,28 @@ export function useImageLoader() {
             );
             if (!directory) return;
 
-            const updatedById = new Map<string, ProvenanceIdentity>();
+            const updatedByPathKey = new Map<string, ProvenanceIdentity>();
             for (const mapping of payload.mappings) {
-                const imageId = `${directory.id}::${mapping.relativePath}`;
+                const lookupKey = buildProvenanceIdentityLookupKey(directory.id, mapping.relativePath);
                 const identity = {
                     assetId: mapping.assetId,
                     revisionId: mapping.revisionId,
                     provenanceLocationId: mapping.locationId,
                     provenanceRootId: payload.rootId,
                 };
-                provenanceIdentityByImageIdRef.current.set(imageId, identity);
-                updatedById.set(imageId, identity);
+                provenanceIdentityByLookupKeyRef.current.set(lookupKey, identity);
+                updatedByPathKey.set(lookupKey, identity);
             }
 
             const updates = useImageStore.getState().images.flatMap((image) => {
-                const identity = updatedById.get(image.id);
+                if (image.directoryId !== directory.id) return [];
+                const idPrefix = `${directory.id}::`;
+                const originalRelativePath = image.id.startsWith(idPrefix)
+                    ? image.id.slice(idPrefix.length)
+                    : image.name;
+                const identity = updatedByPathKey.get(
+                    buildProvenanceIdentityLookupKey(directory.id, originalRelativePath)
+                );
                 return identity ? [{ ...image, ...identity }] : [];
             });
             if (updates.length > 0) mergeImages(updates);

--- a/preload.js
+++ b/preload.js
@@ -232,6 +232,12 @@ const electronAPI = {
   listSubfolders: (folderPath) => ipcRenderer.invoke('list-subfolders', folderPath),
   createSubfolder: (parentPath, folderName) => ipcRenderer.invoke('create-subfolder', { parentPath, folderName }),
   listDirectoryFiles: (args) => ipcRenderer.invoke('list-directory-files', args),
+  provenanceBackfillControl: (action) => ipcRenderer.invoke('provenance-backfill-control', action),
+  onProvenanceIdentitiesAssigned: (callback) => {
+    const handler = (_event, payload) => callback(payload);
+    ipcRenderer.on('provenance-identities-assigned', handler);
+    return () => ipcRenderer.removeListener('provenance-identities-assigned', handler);
+  },
   resolveMediaUrl: (filePath) => ipcRenderer.invoke('resolve-media-url', filePath),
   readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),
   hashFileSha256: (filePath, requestId) => ipcRenderer.invoke('hash-file-sha256', { filePath, requestId }),

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -284,6 +284,10 @@ function toCacheMetadata(images: IndexedImage[]): CacheImageMetadata[] {
     enrichmentState: img.enrichmentState,
     fileSize: img.fileSize,
     fileType: img.fileType,
+    assetId: img.assetId,
+    revisionId: img.revisionId,
+    provenanceLocationId: img.provenanceLocationId,
+    provenanceRootId: img.provenanceRootId,
 
     // Smart Clustering & Auto-Tagging (Phase 1)
     clusterId: img.clusterId,

--- a/services/cacheManager.ts
+++ b/services/cacheManager.ts
@@ -33,6 +33,10 @@ export interface CacheImageMetadata {
   enrichmentState?: 'catalog' | 'enriched';
   fileSize?: number;
   fileType?: string;
+  assetId?: string;
+  revisionId?: string;
+  provenanceLocationId?: string;
+  provenanceRootId?: string;
 
   // Smart Clustering & Auto-Tagging (Phase 1)
   clusterId?: string;

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -2260,6 +2260,7 @@ interface ProcessFilesOptions {
   enrichmentBatchSize?: number;
   onEnrichmentProgress?: (progress: { processed: number; total: number } | null) => void;
   hydratePreloadedImages?: boolean;
+  provenanceIdentityForPath?: (relativePath: string) => Pick<IndexedImage, 'assetId' | 'revisionId' | 'provenanceLocationId' | 'provenanceRootId'> | undefined;
 }
 
 export interface ProcessFilesResult {
@@ -2376,6 +2377,10 @@ function mapIndexedImageToCache(image: IndexedImage): CacheImageMetadata {
     enrichmentState: image.enrichmentState,
     fileSize: image.fileSize,
     fileType: image.fileType,
+    assetId: image.assetId,
+    revisionId: image.revisionId,
+    provenanceLocationId: image.provenanceLocationId,
+    provenanceRootId: image.provenanceRootId,
     clusterId: image.clusterId,
     clusterPosition: image.clusterPosition,
     autoTags: image.autoTags,
@@ -2710,6 +2715,7 @@ export async function processFiles(
       lastModified: sortDate,
     });
 
+    const provenanceIdentity = options.provenanceIdentityForPath?.(entry.path);
     return {
       id: `${directoryId}::${entry.path}`,
       name: entry.handle.name,
@@ -2737,6 +2743,7 @@ export async function processFiles(
       enrichmentState: needsEnrichment ? 'catalog' : 'enriched',
       fileSize,
       fileType: inferredType,
+      ...provenanceIdentity,
     };
   };
 

--- a/services/fileIndexer.ts
+++ b/services/fileIndexer.ts
@@ -2751,8 +2751,14 @@ export async function processFiles(
   const preloadedImages = options.preloadedImages ?? [];
   const hydratePreloadedImages = options.hydratePreloadedImages ?? true;
   for (const image of preloadedImages) {
+    const idPrefix = `${directoryId}::`;
+    const originalRelativePath = image.id.startsWith(idPrefix)
+      ? image.id.slice(idPrefix.length)
+      : image.name;
+    const provenanceIdentity = options.provenanceIdentityForPath?.(originalRelativePath);
     const stub = {
       ...image,
+      ...provenanceIdentity,
       directoryId,
       directoryName,
       enrichmentState: image.enrichmentState ?? 'enriched',

--- a/types.ts
+++ b/types.ts
@@ -452,11 +452,23 @@ export interface ElectronAPI {
   openCacheLocation: () => Promise<{ success: boolean; error?: string }>;
   listSubfolders: (folderPath: string) => Promise<{ success: boolean; subfolders?: { name: string; path: string; realPath?: string }[]; error?: string }>;
   createSubfolder: (parentPath: string, folderName: string) => Promise<{ success: boolean; folder?: { name: string; path: string; realPath?: string }; error?: string }>;
-  listDirectoryFiles: (args: { dirPath: string; recursive?: boolean }) => Promise<{
+  listDirectoryFiles: (args: { dirPath: string; recursive?: boolean; provenanceRootPath?: string }) => Promise<{
     success: boolean;
     files?: { name: string; lastModified: number; size: number; type: string; birthtimeMs?: number; contentModifiedMs?: number }[];
     error?: string;
   }>;
+  provenanceBackfillControl: (action: 'pause' | 'resume') => Promise<{ success: boolean; enabled: boolean; paused?: boolean; error?: string }>;
+  onProvenanceIdentitiesAssigned: (callback: (payload: {
+    rootId: string;
+    rootPath: string;
+    mappings: Array<{
+      relativePath: string;
+      relativePathKey: string;
+      assetId: string;
+      revisionId: string;
+      locationId: string;
+    }>;
+  }) => void) => () => void;
   readFile: (filePath: string) => Promise<{ success: boolean; data?: Buffer; error?: string; errorType?: string; errorCode?: string }>;
   hashFileSha256: (filePath: string, requestId: string) => Promise<{ success: boolean; sha256?: string; error?: string; errorType?: string; errorCode?: string }>;
   cancelFileSha256: (requestId: string) => void;
@@ -1151,6 +1163,10 @@ export interface IndexedImage {
   enrichmentState?: 'catalog' | 'enriched';
   fileSize?: number;
   fileType?: string;
+  assetId?: string;
+  revisionId?: string;
+  provenanceLocationId?: string;
+  provenanceRootId?: string;
 
   // User Annotations (loaded from ImageAnnotations table)
   isFavorite?: boolean;          // Quick access to favorite status

--- a/utils/provenancePath.mjs
+++ b/utils/provenancePath.mjs
@@ -1,0 +1,44 @@
+function runtimePlatform() {
+  if (typeof process !== 'undefined' && typeof process.platform === 'string') return process.platform;
+  if (typeof navigator !== 'undefined' && typeof navigator.platform === 'string') return navigator.platform;
+  return '';
+}
+
+export function normalizeRelativeCatalogPath(relativePath, platform = runtimePlatform()) {
+  if (typeof relativePath !== 'string' || !relativePath.trim() || relativePath.includes('\0')) {
+    throw new Error('A non-empty relative file path is required.');
+  }
+
+  const slashPath = relativePath.replace(/\\/g, '/');
+  if (slashPath.startsWith('/') || /^[a-zA-Z]:\//.test(slashPath)) {
+    throw new Error(`Path must remain inside its library root: ${relativePath}`);
+  }
+
+  const segments = [];
+  for (const segment of slashPath.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') {
+      if (segments.length === 0) throw new Error(`Path must remain inside its library root: ${relativePath}`);
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+
+  const normalized = segments.join('/').normalize('NFC');
+  if (!normalized || normalized.startsWith('/')) {
+    throw new Error(`Path must remain inside its library root: ${relativePath}`);
+  }
+  return {
+    relativePath: normalized,
+    relativePathKey: /^win/i.test(platform) ? normalized.toLocaleLowerCase('en-US') : normalized,
+  };
+}
+
+export function getRelativeCatalogPathComparisonKey(relativePath, platform = runtimePlatform()) {
+  return normalizeRelativeCatalogPath(relativePath, platform).relativePathKey;
+}
+
+export function buildProvenanceIdentityLookupKey(directoryId, relativePath, platform = runtimePlatform()) {
+  return `${directoryId}\0${getRelativeCatalogPathComparisonKey(relativePath, platform)}`;
+}

--- a/utils/provenancePath.mjs
+++ b/utils/provenancePath.mjs
@@ -25,7 +25,7 @@ export function normalizeRelativeCatalogPath(relativePath, platform = runtimePla
     segments.push(segment);
   }
 
-  const normalized = segments.join('/').normalize('NFC');
+  const normalized = segments.join('/');
   if (!normalized || normalized.startsWith('/')) {
     throw new Error(`Path must remain inside its library root: ${relativePath}`);
   }


### PR DESCRIPTION
## Summary

- assigns persistent library-root, asset, revision, and location IDs without changing IndexedImage.id
- backfills the catalog in background batches and hashes revisions by streaming with pause/resume and stale-result rejection
- reconciles missing locations only after a complete recursive root scan
- preserves distinct assets for byte-identical files and persists identity through restart and cache reset
- keeps the integration disabled by default behind IMH_ENABLE_PROVENANCE_INDEXING=1 until filesystem mutation flows are catalog-aware

## Validation

- npx vitest run __tests__/provenanceRepository.test.ts __tests__/stableIdentityIndexer.test.ts (12 passed)
- npx tsc --noEmit
- targeted ESLint and Node syntax checks

All automated fixtures use synthetic files in temporary directories. No personal library or media data was accessed.