### PR TITLE
feat: migrate user data to stable asset identity

### DIFF
--- a/__tests__/helpers/fakeIndexedDb.ts
+++ b/__tests__/helpers/fakeIndexedDb.ts
@@ -1,0 +1,277 @@
+type FakeStoreState = {
+  keyPath: string;
+  records: Map<string, unknown>;
+  indexes: Map<string, { keyPath: string | string[]; options?: IDBIndexParameters }>;
+};
+
+type FakeDatabaseState = {
+  version: number;
+  stores: Map<string, FakeStoreState>;
+};
+
+type FakeTransaction = IDBTransaction & {
+  __requestStarted: () => void;
+  __requestFinished: () => void;
+  __whenComplete: (callback: () => void) => void;
+};
+
+const cloneValue = <T>(value: T): T => (
+  value == null ? value : structuredClone(value)
+);
+
+const createDomStringList = (values: () => string[]): DOMStringList => ({
+  contains: (name: string) => values().includes(name),
+  item: (index: number) => values()[index] ?? null,
+  get length() { return values().length; },
+  [Symbol.iterator]: function* iterator() { yield* values(); },
+} as unknown as DOMStringList);
+
+const makeRequest = <T>(): IDBRequest<T> & { result: T; error: DOMException | null; readyState: IDBRequestReadyState } => ({
+  result: undefined as T,
+  error: null,
+  source: null,
+  transaction: null,
+  readyState: 'pending',
+  onsuccess: null,
+  onerror: null,
+  addEventListener: () => undefined,
+  removeEventListener: () => undefined,
+  dispatchEvent: () => true,
+} as unknown as IDBRequest<T> & { result: T; error: DOMException | null; readyState: IDBRequestReadyState });
+
+function createTransaction(
+  state: FakeDatabaseState,
+  storeNames: string[] | null,
+  mode: IDBTransactionMode,
+): FakeTransaction {
+  let pending = 0;
+  let completed = false;
+  let completionScheduled = false;
+  const internalCompletionHandlers: Array<() => void> = [];
+  const allowed = storeNames ? new Set(storeNames) : null;
+  const transaction = {} as FakeTransaction;
+
+  const scheduleCompletion = () => {
+    if (completionScheduled || completed) return;
+    completionScheduled = true;
+    queueMicrotask(() => {
+      completionScheduled = false;
+      if (completed || pending !== 0) return;
+      completed = true;
+      transaction.oncomplete?.(new Event('complete'));
+      for (const handler of internalCompletionHandlers) handler();
+    });
+  };
+
+  Object.assign(transaction, {
+    db: undefined as unknown as IDBDatabase,
+    durability: 'default',
+    error: null,
+    mode,
+    objectStoreNames: createDomStringList(() => allowed ? [...allowed] : [...state.stores.keys()]),
+    onabort: null,
+    oncomplete: null,
+    onerror: null,
+    abort: () => {
+      if (completed) return;
+      completed = true;
+      transaction.onabort?.(new Event('abort'));
+    },
+    commit: () => scheduleCompletion(),
+    objectStore: (name: string) => {
+      if (allowed && !allowed.has(name)) throw new DOMException(`Store ${name} is outside the transaction scope.`, 'NotFoundError');
+      const store = state.stores.get(name);
+      if (!store) throw new DOMException(`Store ${name} does not exist.`, 'NotFoundError');
+      return createObjectStore(state, transaction, name);
+    },
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => true,
+    __requestStarted: () => {
+      if (completed) throw new DOMException('Transaction is inactive.', 'TransactionInactiveError');
+      pending += 1;
+    },
+    __requestFinished: () => {
+      pending -= 1;
+      scheduleCompletion();
+    },
+    __whenComplete: (callback: () => void) => internalCompletionHandlers.push(callback),
+  } as unknown as FakeTransaction);
+
+  scheduleCompletion();
+  return transaction;
+}
+
+function createObjectStore(
+  state: FakeDatabaseState,
+  transaction: FakeTransaction,
+  storeName: string,
+): IDBObjectStore {
+  const store = state.stores.get(storeName);
+  if (!store) throw new DOMException(`Store ${storeName} does not exist.`, 'NotFoundError');
+
+  const request = <T>(operation: () => T): IDBRequest<T> => {
+    transaction.__requestStarted();
+    const result = makeRequest<T>();
+    queueMicrotask(() => {
+      try {
+        result.result = cloneValue(operation());
+        result.readyState = 'done';
+        result.onsuccess?.(new Event('success'));
+      } catch (error) {
+        result.error = error instanceof DOMException
+          ? error
+          : new DOMException(error instanceof Error ? error.message : String(error), 'UnknownError');
+        result.readyState = 'done';
+        result.onerror?.(new Event('error'));
+      } finally {
+        transaction.__requestFinished();
+      }
+    });
+    return result;
+  };
+
+  const index = (indexName: string): IDBIndex => {
+    const definition = store.indexes.get(indexName);
+    if (!definition) throw new DOMException(`Index ${indexName} does not exist.`, 'NotFoundError');
+    return {
+      getAll: (query?: IDBValidKey | IDBKeyRange | null) => request(() => {
+        const exactQuery = query && typeof query === 'object' && '__only' in query
+          ? (query as IDBKeyRange & { __only: IDBValidKey }).__only
+          : query;
+        return [...store.records.values()].filter((value) => {
+          const indexed = (value as Record<string, unknown>)[definition.keyPath as string];
+          if (exactQuery == null) return true;
+          return definition.options?.multiEntry && Array.isArray(indexed)
+            ? indexed.includes(exactQuery)
+            : indexed === exactQuery;
+        });
+      }),
+    } as unknown as IDBIndex;
+  };
+
+  return {
+    keyPath: store.keyPath,
+    indexNames: createDomStringList(() => [...store.indexes.keys()]),
+    transaction,
+    createIndex: (name: string, keyPath: string | string[], options?: IDBIndexParameters) => {
+      store.indexes.set(name, { keyPath, options });
+      return index(name);
+    },
+    index,
+    get: (key: IDBValidKey | IDBKeyRange) => request(() => store.records.get(String(key))),
+    getAll: () => request(() => [...store.records.values()]),
+    getAllKeys: () => request(() => [...store.records.keys()]),
+    put: (value: unknown) => request(() => {
+      const key = String((value as Record<string, unknown>)[store.keyPath]);
+      store.records.set(key, cloneValue(value));
+      return key;
+    }),
+    delete: (key: IDBValidKey | IDBKeyRange) => request(() => {
+      store.records.delete(String(key));
+      return undefined;
+    }),
+    clear: () => request(() => {
+      store.records.clear();
+      return undefined;
+    }),
+  } as unknown as IDBObjectStore;
+}
+
+export function createFakeIndexedDb(): IDBFactory {
+  const databases = new Map<string, FakeDatabaseState>();
+
+  return {
+    open: (name: string, version?: number) => {
+      const request = makeRequest<IDBDatabase>() as IDBOpenDBRequest & ReturnType<typeof makeRequest<IDBDatabase>>;
+      request.onupgradeneeded = null;
+      request.onblocked = null;
+      queueMicrotask(() => {
+        const state = databases.get(name) ?? { version: 0, stores: new Map<string, FakeStoreState>() };
+        const requestedVersion = version ?? Math.max(1, state.version);
+        if (requestedVersion < state.version) {
+          request.error = new DOMException('Requested version is older than the current database.', 'VersionError');
+          request.readyState = 'done';
+          request.onerror?.(new Event('error'));
+          return;
+        }
+        databases.set(name, state);
+        let upgradeTransaction: FakeTransaction | null = null;
+        const database = {
+          name,
+          objectStoreNames: createDomStringList(() => [...state.stores.keys()]),
+          onabort: null,
+          onclose: null,
+          onerror: null,
+          onversionchange: null,
+          createObjectStore: (storeName: string, options?: IDBObjectStoreParameters) => {
+            if (state.stores.has(storeName)) throw new DOMException(`Store ${storeName} already exists.`, 'ConstraintError');
+            state.stores.set(storeName, {
+              keyPath: typeof options?.keyPath === 'string' ? options.keyPath : 'id',
+              records: new Map(),
+              indexes: new Map(),
+            });
+            if (!upgradeTransaction) throw new DOMException('No upgrade transaction is active.', 'InvalidStateError');
+            return createObjectStore(state, upgradeTransaction, storeName);
+          },
+          transaction: (storeNames: string | string[], mode: IDBTransactionMode = 'readonly') => {
+            const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+            const tx = createTransaction(state, names, mode);
+            tx.db = database as unknown as IDBDatabase;
+            return tx;
+          },
+          close: () => undefined,
+          get version() { return state.version; },
+          addEventListener: () => undefined,
+          removeEventListener: () => undefined,
+          dispatchEvent: () => true,
+        } as unknown as IDBDatabase;
+        request.result = database;
+
+        const succeed = () => {
+          request.transaction = null;
+          request.readyState = 'done';
+          request.onsuccess?.(new Event('success'));
+        };
+        if (requestedVersion > state.version) {
+          const oldVersion = state.version;
+          state.version = requestedVersion;
+          upgradeTransaction = createTransaction(state, null, 'versionchange');
+          upgradeTransaction.db = database;
+          request.transaction = upgradeTransaction;
+          request.onupgradeneeded?.({ oldVersion, newVersion: requestedVersion } as IDBVersionChangeEvent);
+          upgradeTransaction.__whenComplete(succeed);
+        } else {
+          succeed();
+        }
+      });
+      return request;
+    },
+    deleteDatabase: (name: string) => {
+      const request = makeRequest<undefined>() as IDBOpenDBRequest & ReturnType<typeof makeRequest<undefined>>;
+      request.onblocked = null;
+      request.onupgradeneeded = null;
+      queueMicrotask(() => {
+        databases.delete(name);
+        request.readyState = 'done';
+        request.onsuccess?.(new Event('success'));
+      });
+      return request;
+    },
+  } as unknown as IDBFactory;
+}
+
+export function installFakeIndexedDb(): void {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: createFakeIndexedDb(),
+    configurable: true,
+    writable: true,
+  });
+  if (typeof globalThis.IDBKeyRange === 'undefined') {
+    Object.defineProperty(globalThis, 'IDBKeyRange', {
+      value: { only: (value: IDBValidKey) => ({ __only: value }) },
+      configurable: true,
+      writable: true,
+    });
+  }
+}

--- a/__tests__/helpers/fakeIndexedDb.ts
+++ b/__tests__/helpers/fakeIndexedDb.ts
@@ -7,12 +7,14 @@ type FakeStoreState = {
 type FakeDatabaseState = {
   version: number;
   stores: Map<string, FakeStoreState>;
+  transactionTail?: Promise<void>;
 };
 
 type FakeTransaction = IDBTransaction & {
   __requestStarted: () => void;
   __requestFinished: () => void;
   __whenComplete: (callback: () => void) => void;
+  __enqueue: (callback: () => void) => void;
 };
 
 const cloneValue = <T>(value: T): T => (
@@ -50,14 +52,21 @@ function createTransaction(
   const internalCompletionHandlers: Array<() => void> = [];
   const allowed = storeNames ? new Set(storeNames) : null;
   const transaction = {} as FakeTransaction;
+  // Serialize database transactions, including connections opened by different
+  // callers. Real IndexedDB serializes overlapping read/write scopes.
+  const ready = state.transactionTail ?? Promise.resolve();
+  let release: () => void;
+  state.transactionTail = new Promise<void>((resolve) => { release = resolve; });
+  const enqueue = (callback: () => void) => { void ready.then(callback); };
 
   const scheduleCompletion = () => {
     if (completionScheduled || completed) return;
     completionScheduled = true;
-    queueMicrotask(() => {
+    enqueue(() => {
       completionScheduled = false;
       if (completed || pending !== 0) return;
       completed = true;
+      release();
       transaction.oncomplete?.(new Event('complete'));
       for (const handler of internalCompletionHandlers) handler();
     });
@@ -75,6 +84,7 @@ function createTransaction(
     abort: () => {
       if (completed) return;
       completed = true;
+      release();
       transaction.onabort?.(new Event('abort'));
     },
     commit: () => scheduleCompletion(),
@@ -96,6 +106,7 @@ function createTransaction(
       scheduleCompletion();
     },
     __whenComplete: (callback: () => void) => internalCompletionHandlers.push(callback),
+    __enqueue: enqueue,
   } as unknown as FakeTransaction);
 
   scheduleCompletion();
@@ -113,7 +124,7 @@ function createObjectStore(
   const request = <T>(operation: () => T): IDBRequest<T> => {
     transaction.__requestStarted();
     const result = makeRequest<T>();
-    queueMicrotask(() => {
+    transaction.__enqueue(() => {
       try {
         result.result = cloneValue(operation());
         result.readyState = 'done';

--- a/__tests__/legacyUserDataMigrationSource.test.ts
+++ b/__tests__/legacyUserDataMigrationSource.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearAllAnnotations, saveAnnotation } from '../services/imageAnnotationsStorage';
+import { commitLegacyUserDataPatch, readLegacyUserDataSnapshot } from '../services/legacyUserDataMigrationSource';
+
+describe('legacy user-data migration source', () => {
+  beforeEach(async () => {
+    await clearAllAnnotations();
+  });
+
+  it('commits source and retryable outbox together while preserving source timestamps and tombstones', async () => {
+    await saveAnnotation({
+      imageId: 'legacy-image',
+      isFavorite: false,
+      tags: ['old'],
+      addedAt: 10,
+      updatedAt: 20,
+    });
+
+    const first = await commitLegacyUserDataPatch(
+      'annotation',
+      'legacy-image',
+      { set: { isFavorite: true, updatedAt: 21 }, removeTags: ['old'], suppressTags: ['old'] },
+      '11111111-1111-4111-8111-111111111111',
+    );
+    expect(first).toMatchObject({
+      sourceVersion: 1,
+      tombstone: false,
+      payload: { isFavorite: true, tags: [], addedAt: 10, updatedAt: 21, suppressedMetadataTags: ['old'] },
+    });
+    expect(await readLegacyUserDataSnapshot('annotation', 'legacy-image')).toEqual(first);
+
+    const removed = await commitLegacyUserDataPatch(
+      'annotation',
+      'legacy-image',
+      { deleteRecord: true },
+      '22222222-2222-4222-8222-222222222222',
+    );
+    expect(removed).toMatchObject({ sourceVersion: 2, tombstone: true, payload: null });
+    expect(await readLegacyUserDataSnapshot('annotation', 'legacy-image')).toEqual(removed);
+  });
+});

--- a/__tests__/provenanceRepository.test.ts
+++ b/__tests__/provenanceRepository.test.ts
@@ -240,6 +240,16 @@ describe('AssetProvenanceRepository production contract', () => {
     const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath, logger: { error: vi.fn() } });
     expect(lifecycle.initialize()).toMatchObject({ available: true });
     lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation(initialRecord({ sha256: sha('e') })));
+    lifecycle.run((repository) => repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'backup-ui-id',
+      reference: {
+        assetId: initialRecord().assetId,
+        revisionId: initialRecord().revisionId,
+        locationId: initialRecord().locationId,
+      },
+      payload: { isFavorite: true, tags: ['backup'], rating: 5, addedAt: 10, updatedAt: 20 },
+      sourceVersion: 0,
+    }]));
 
     const liveReader = new AssetProvenanceRepository({ databasePath: resolveProvenanceCatalogPath(userDataPath), readOnly: true });
     liveReader.open();
@@ -271,6 +281,8 @@ describe('AssetProvenanceRepository production contract', () => {
     expect(backup.getAsset(initialRecord().assetId as string)).not.toBeNull();
     expect(backup.getAsset('55555555-5555-4555-8555-555555555555')).not.toBeNull();
     expect(backup.getAsset('88888888-8888-4888-8888-888888888888')).toBeNull();
+    expect(backup.captureAssetUserDataSnapshot(initialRecord().assetId as string, 30)[0]?.payload)
+      .toMatchObject({ isFavorite: true, tags: ['backup'], rating: 5, addedAt: 10 });
     backup.close();
     expect(lifecycle.run((repository) => repository.getAsset('88888888-8888-4888-8888-888888888888'))).not.toBeNull();
     lifecycle.close();
@@ -285,6 +297,16 @@ describe('AssetProvenanceRepository production contract', () => {
     });
     lifecycle.initialize();
     lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation(initialRecord()));
+    lifecycle.run((repository) => repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'reset-ui-id',
+      reference: {
+        assetId: initialRecord().assetId,
+        revisionId: initialRecord().revisionId,
+        locationId: initialRecord().locationId,
+      },
+      payload: { isFavorite: false, tags: [], addedAt: 10, updatedAt: 20 },
+      sourceVersion: 0,
+    }]));
 
     expect(() => lifecycle.createBackup(path.join(userDataPath, 'backup.sqlite')))
       .toThrowError(expect.objectContaining({ code: 'PROVENANCE_BACKUP_FAILED' }));
@@ -299,6 +321,16 @@ describe('provenance repository lifecycle and cache independence', () => {
     const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath, logger: { error: vi.fn() } });
     lifecycle.initialize();
     lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation(initialRecord()));
+    lifecycle.run((repository) => repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'reset-ui-id',
+      reference: {
+        assetId: initialRecord().assetId,
+        revisionId: initialRecord().revisionId,
+        locationId: initialRecord().locationId,
+      },
+      payload: { isFavorite: false, tags: [], addedAt: 10, updatedAt: 20 },
+      sourceVersion: 0,
+    }]));
     await fs.writeFile(path.join(userDataPath, 'disposable-cache.json'), '{}', 'utf8');
 
     await resetUserDataContents({ userDataDir: userDataPath });
@@ -309,6 +341,8 @@ describe('provenance repository lifecycle and cache independence', () => {
     const reopened = new ProvenanceRepositoryLifecycle({ userDataPath, logger: { error: vi.fn() } });
     expect(reopened.initialize()).toMatchObject({ available: true, schemaVersion: PROVENANCE_SCHEMA_VERSION });
     expect(reopened.run((repository) => repository.getAsset(initialRecord().assetId as string))).not.toBeNull();
+    expect(reopened.run((repository) => repository.captureAssetUserDataSnapshot(initialRecord().assetId as string, 30))[0]?.payload)
+      .toMatchObject({ isFavorite: false, tags: [], addedAt: 10 });
     reopened.close();
   });
 

--- a/__tests__/setupIndexedDb.ts
+++ b/__tests__/setupIndexedDb.ts
@@ -1,0 +1,3 @@
+import { installFakeIndexedDb } from './helpers/fakeIndexedDb';
+
+if (typeof globalThis.indexedDB === 'undefined') installFakeIndexedDb();

--- a/__tests__/smartCollections.storage.test.ts
+++ b/__tests__/smartCollections.storage.test.ts
@@ -218,7 +218,7 @@ describe('smart collection storage', () => {
     } = await import('../services/automationRulesStorage');
     const { PREFERENCES_DB_VERSION, PREFERENCES_STORE_NAMES } = await import('../services/preferencesDb');
 
-    expect(PREFERENCES_DB_VERSION).toBe(7);
+    expect(PREFERENCES_DB_VERSION).toBe(8);
     expect(PREFERENCES_STORE_NAMES.automationRules).toBe('automationRules');
 
     await saveAutomationRule({

--- a/__tests__/stableIdentityFileOperations.test.ts
+++ b/__tests__/stableIdentityFileOperations.test.ts
@@ -9,6 +9,7 @@ import { ProvenanceRepositoryLifecycle, resolveProvenanceCatalogPath } from '../
 import { StableIdentityIndexer } from '../electron/stableIdentityIndexer.mjs';
 import { StableIdentityFileOperationCoordinator } from '../electron/stableIdentityFileOperationCoordinator.mjs';
 import { runStableIdentityFileOperationsSmoke } from '../electron/stableIdentityFileOperationsSmoke.mjs';
+import { StableIdentityUserDataService } from '../electron/stableIdentityUserDataService.mjs';
 import { SUPPORTED_MEDIA_EXTENSIONS, inferMimeTypeFromName } from '../utils/mediaTypes.js';
 
 const temporaryDirectories: string[] = [];
@@ -207,6 +208,89 @@ describe('stable identity file-operation coordination', () => {
     expect(lifecycle.run((repository) => repository.getAsset(copy.assetId))?.revisions).toHaveLength(2);
     indexer.stop();
     lifecycle.close();
+  });
+
+  it('recovers a copied user-data snapshot after renderer loss without overwriting a later destination edit', async () => {
+    const { userDataPath, rootA, rootB } = await workspace();
+    const sourcePath = path.join(rootA, 'source-with-user-data.bin');
+    const destinationPath = path.join(rootB, 'copied-with-user-data.bin');
+    await fs.writeFile(sourcePath, 'copy recovery bytes');
+    const runtime = createRuntime(userDataPath, {
+      coordinator: { logger: { error: () => {}, warn: () => {} } },
+    });
+    const [source] = await registerRoot(runtime.indexer, rootA, ['source-with-user-data.bin']);
+    await registerRoot(runtime.indexer, rootB);
+    runtime.lifecycle.run((repository) => repository.syncLegacyUserDataBatch([
+      {
+        domain: 'annotation', legacyImageId: 'legacy-source',
+        payload: { isFavorite: true, tags: ['copied'], rating: 5, addedAt: 10, updatedAt: 20 },
+        sourceVersion: 0,
+      },
+      {
+        domain: 'shadow', legacyImageId: 'legacy-source',
+        payload: { prompt: '', resources: [], tags: [], notes: '', updatedAt: 20 },
+        sourceVersion: 0,
+      },
+    ]));
+
+    const repository = (runtime.lifecycle as any).repository;
+    const complete = repository.completeFileOperation.bind(repository);
+    let failOnce = true;
+    repository.completeFileOperation = (...args: unknown[]) => {
+      if (failOnce) {
+        failOnce = false;
+        throw new Error('synthetic lost renderer acknowledgement');
+      }
+      return complete(...args);
+    };
+    const copied = await runtime.coordinator.executeKnownOperation({
+      kind: 'copy',
+      sourcePath,
+      destinationPath,
+      userDataContext: { legacyImageId: 'legacy-source', copyUserData: true },
+      perform: () => fs.copyFile(sourcePath, destinationPath),
+    });
+    expect(copied.provenance).toMatchObject({ pending: true });
+    const [pending] = runtime.lifecycle.run((repo) => repo.listPendingFileOperations());
+    expect(pending.payload.userDataSnapshot).toHaveLength(2);
+    repository.completeFileOperation = complete;
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+
+    const reopened = createRuntime(userDataPath);
+    expect(await reopened.coordinator.initializeRecovery()).toMatchObject({ recovered: 1, pending: 0 });
+    const destinationRoot = reopened.lifecycle.run((repo) => (
+      repo.listLibraryRoots().find((entry) => entry.absolutePath === rootB)
+    ))!;
+    const destination = reopened.lifecycle.run((repo) => (
+      repo.getLocationByRootPath(destinationRoot.rootId, 'copied-with-user-data.bin')
+    ))!;
+    expect(destination.assetId).not.toBe(source.assetId);
+    const destinationReference = {
+      assetId: destination.assetId,
+      revisionId: destination.revisionId,
+      locationId: destination.locationId,
+    };
+    const [annotation, shadow] = reopened.lifecycle.run((repo) => repo.syncLegacyUserDataBatch([
+      { domain: 'annotation', legacyImageId: 'copy-ui-id', reference: destinationReference },
+      { domain: 'shadow', legacyImageId: 'copy-ui-id', reference: destinationReference },
+    ]));
+    expect(annotation.record?.payload).toMatchObject({ isFavorite: true, tags: ['copied'], rating: 5, addedAt: 10 });
+    expect(shadow.record?.payload).toMatchObject({ prompt: '', resources: [], tags: [], notes: '' });
+    expect(shadow.record?.payload.updatedAt).toBeGreaterThan(20);
+
+    const edited = reopened.lifecycle.run((repo) => repo.mutateAssetUserData({
+      domain: 'annotation', legacyImageId: 'copy-ui-id', reference: destinationReference,
+      expectedVersion: annotation.record.version,
+      patch: { set: { rating: 2, updatedAt: 30 } },
+    }));
+    reopened.lifecycle.run((repo) => repo.completeFileOperation(pending.operationId));
+    const afterRetry = reopened.lifecycle.run((repo) => repo.syncLegacyUserDataBatch([
+      { domain: 'annotation', legacyImageId: 'copy-ui-id', reference: destinationReference },
+    ]))[0].record;
+    expect(afterRetry).toMatchObject({ version: edited.version, payload: { rating: 2 } });
+    reopened.indexer.stop();
+    reopened.lifecycle.close();
   });
 
   it('aborts an unchanged failed overwrite and immediately releases the destination', async () => {
@@ -481,6 +565,12 @@ describe('stable identity file-operation coordination', () => {
     await Promise.all([fs.writeFile(modelPath, 'model'), fs.writeFile(sidecarPath, 'sidecar')]);
     const { lifecycle, indexer, coordinator } = createRuntime(userDataPath);
     const [model] = await registerRoot(indexer, rootA, ['cancelled-model.glb']);
+    lifecycle.run((repository) => repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'reused-path-ui-id',
+      reference: { assetId: model.assetId, revisionId: model.revisionId, locationId: model.locationId },
+      payload: { isFavorite: true, tags: ['historical'], addedAt: 10, updatedAt: 20 },
+      sourceVersion: 0,
+    }]));
 
     await expect(coordinator.executeKnownOperation({
       kind: 'delete',
@@ -503,9 +593,16 @@ describe('stable identity file-operation coordination', () => {
     await fs.writeFile(modelPath, 'replacement');
     await coordinator.observeWatcherFiles({ rootPath: rootA, files: [await record(rootA, 'cancelled-model.glb')] });
     const root = lifecycle.run((repository) => repository.listLibraryRoots()[0]);
-    expect(lifecycle.run((repository) => (
+    const replacement = lifecycle.run((repository) => (
       repository.getLocationByRootPath(root.rootId, 'cancelled-model.glb')
-    ))).toMatchObject({ state: 'present' });
+    ))!;
+    expect(replacement).toMatchObject({ state: 'present' });
+    expect(replacement.assetId).not.toBe(model.assetId);
+    const rebound = lifecycle.run((repository) => repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'reused-path-ui-id',
+      reference: { assetId: replacement.assetId, revisionId: replacement.revisionId, locationId: replacement.locationId },
+    }]))[0];
+    expect(rebound).toMatchObject({ status: 'ambiguous', record: null });
     indexer.stop();
     lifecycle.close();
   });
@@ -1317,6 +1414,49 @@ describe('stable identity file-operation coordination', () => {
     lifecycle.close();
   });
 
+  it('coordinates an explicit unmapped rename for an already-migrated flag-off profile without scanning or hashing', async () => {
+    const { userDataPath, rootA } = await workspace();
+    const sourcePath = path.join(rootA, 'unmapped-before-rename.bin');
+    const destinationPath = path.join(rootA, 'renamed-without-scan.bin');
+    await fs.writeFile(sourcePath, 'known operation bytes');
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    lifecycle.initialize();
+    lifecycle.run((repository) => {
+      repository.activateUserDataAuthority();
+      repository.syncLegacyUserDataBatch([{
+        domain: 'annotation', legacyImageId: 'legacy-unmapped',
+        payload: { isFavorite: true, tags: ['pending'], addedAt: 10, updatedAt: 20 },
+        sourceVersion: 0,
+      }]);
+    });
+    const indexer = new StableIdentityIndexer({ repositoryLifecycle: lifecycle, enabled: false });
+    const coordinator = new StableIdentityFileOperationCoordinator({ repositoryLifecycle: lifecycle, indexer, enabled: true });
+
+    const result = await coordinator.executeKnownOperation({
+      kind: 'rename',
+      sourcePath,
+      destinationPath,
+      userDataContext: {
+        legacyImageId: 'legacy-unmapped',
+        sourceRootPath: rootA,
+        destinationRootPath: rootA,
+      },
+      perform: () => fs.rename(sourcePath, destinationPath),
+    });
+    expect(result.provenance).toMatchObject({ enabled: true, available: true });
+    const root = lifecycle.run((repository) => repository.listLibraryRoots()[0]);
+    const renamed = lifecycle.run((repository) => repository.getLocationByRootPath(root.rootId, 'renamed-without-scan.bin'))!;
+    const record = lifecycle.run((repository) => repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'legacy-unmapped',
+      reference: { assetId: renamed.assetId, revisionId: renamed.revisionId, locationId: renamed.locationId },
+    }]))[0].record;
+    expect(record?.payload).toMatchObject({ isFavorite: true, tags: ['pending'] });
+    expect(lifecycle.run((repository) => repository.getAsset(renamed.assetId))?.revisions[0].hashState).toBe('pending');
+    await indexer.waitForIdle();
+    indexer.stop();
+    lifecycle.close();
+  });
+
   it('keeps the filesystem result when intent persistence is unavailable', async () => {
     const { userDataPath, rootA } = await workspace();
     const sourcePath = path.join(rootA, 'source.bin');
@@ -1358,12 +1498,36 @@ describe('stable identity file-operation coordination', () => {
     await expect(fs.stat(destinationPath)).resolves.toBeDefined();
   });
 
+  it('does not mutate the filesystem when stable user data requires an unavailable journal', async () => {
+    const { rootA } = await workspace();
+    const sourcePath = path.join(rootA, 'source-with-user-data.bin');
+    const destinationPath = path.join(rootA, 'renamed-with-user-data.bin');
+    await fs.writeFile(sourcePath, 'bytes');
+    const coordinator = new StableIdentityFileOperationCoordinator({
+      repositoryLifecycle: {
+        getStatus: () => ({ available: false, error: new Error('synthetic catalog unavailable') }),
+      },
+      indexer: { enabled: false },
+      enabled: true,
+    });
+
+    await expect(coordinator.executeKnownOperation({
+      kind: 'rename',
+      sourcePath,
+      destinationPath,
+      userDataContext: { legacyImageId: 'synthetic-ui-id' },
+      perform: () => fs.rename(sourcePath, destinationPath),
+    })).rejects.toThrow('synthetic catalog unavailable');
+    await expect(fs.stat(sourcePath)).resolves.toBeDefined();
+    await expect(fs.stat(destinationPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('stores the recovery journal outside disposable cache paths', async () => {
     const { userDataPath } = await workspace();
     const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
     lifecycle.initialize();
     expect(resolveProvenanceCatalogPath(userDataPath)).toContain(path.join('provenance', 'catalog.sqlite'));
-    expect(lifecycle.run((repository) => repository.getStatus().schemaVersion)).toBe(4);
+    expect(lifecycle.run((repository) => repository.getStatus().schemaVersion)).toBe(5);
     lifecycle.close();
   });
 
@@ -1374,10 +1538,19 @@ describe('stable identity file-operation coordination', () => {
       rootPath: rootA,
       userDataPath,
       repositoryLifecycle: lifecycle,
+      userDataService: (() => {
+        const service = new StableIdentityUserDataService({
+          repositoryLifecycle: lifecycle,
+          userDataPath,
+          migrationEnabled: true,
+        });
+        service.initialize();
+        return service;
+      })(),
       indexer,
       coordinator,
     });
-    expect(result).toMatchObject({ success: true, schemaVersion: 4, pendingOperations: 0 });
+    expect(result).toMatchObject({ success: true, schemaVersion: 5, pendingOperations: 0 });
     indexer.stop();
     lifecycle.close();
   });

--- a/__tests__/stableIdentityUserData.test.ts
+++ b/__tests__/stableIdentityUserData.test.ts
@@ -1,0 +1,211 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AssetProvenanceRepository, resolveProvenanceCatalogPath } from '../electron/provenanceRepository.mjs';
+
+const temporaryDirectories: string[] = [];
+const openRepositories: AssetProvenanceRepository[] = [];
+const ids = {
+  root: '99999999-9999-4999-8999-999999999999',
+  asset: '11111111-1111-4111-8111-111111111111',
+  revision: '22222222-2222-4222-8222-222222222222',
+  location: '33333333-3333-4333-8333-333333333333',
+  assetB: '44444444-4444-4444-8444-444444444444',
+  revisionB: '55555555-5555-4555-8555-555555555555',
+  locationB: '66666666-6666-4666-8666-666666666666',
+};
+
+async function createRepository() {
+  const userDataPath = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-stable-user-data-'));
+  temporaryDirectories.push(userDataPath);
+  const repository = new AssetProvenanceRepository({
+    databasePath: resolveProvenanceCatalogPath(userDataPath),
+    now: () => new Date('2026-09-07T12:00:00.000Z'),
+  });
+  repository.open();
+  openRepositories.push(repository);
+  repository.ensureLibraryRoot({ rootId: ids.root, absolutePath: path.join(userDataPath, 'library'), pathKey: 'synthetic-root' });
+  repository.createAssetWithRevisionAndLocation({
+    assetId: ids.asset,
+    revisionId: ids.revision,
+    locationId: ids.location,
+    rootId: ids.root,
+    relativePath: 'one.png',
+    relativePathKey: 'one.png',
+    byteSize: 10,
+  });
+  return repository;
+}
+
+const reference = {
+  assetId: ids.asset,
+  revisionId: ids.revision,
+  locationId: ids.location,
+};
+
+const annotation = (overrides: Record<string, unknown> = {}) => ({
+  isFavorite: false,
+  tags: [],
+  rating: 1,
+  addedAt: 10,
+  updatedAt: 20,
+  suppressedMetadataTags: [],
+  ...overrides,
+});
+
+afterEach(async () => {
+  for (const repository of openRepositories.splice(0)) repository.close();
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+describe('stable identity user-data repository', () => {
+  it('imports only through a trusted mapping while preserving false, zero and empty values', async () => {
+    const repository = await createRepository();
+    const pending = repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'unmapped', payload: annotation(), sourceVersion: 0,
+    }]);
+    expect(pending).toMatchObject([{ status: 'pending', record: null }]);
+
+    const [boundAnnotation, boundShadow] = repository.syncLegacyUserDataBatch([
+      { domain: 'annotation', legacyImageId: 'image-1', reference, payload: annotation(), sourceVersion: 0 },
+      {
+        domain: 'shadow', legacyImageId: 'image-1', reference,
+        payload: { prompt: '', seed: 0, resources: [], tags: [], notes: '', updatedAt: 20 }, sourceVersion: 0,
+      },
+    ]);
+    expect(boundAnnotation.record?.payload).toEqual(annotation());
+    expect(boundShadow.record?.payload).toEqual({ prompt: '', seed: 0, resources: [], tags: [], notes: '', updatedAt: 20 });
+    repository.close();
+  });
+
+  it('makes retry and lost acknowledgements idempotent without changing source timestamps', async () => {
+    const repository = await createRepository();
+    const entry = { domain: 'annotation', legacyImageId: 'image-1', reference, payload: annotation(), sourceVersion: 0 };
+    const first = repository.syncLegacyUserDataBatch([entry])[0].record;
+    const retry = repository.syncLegacyUserDataBatch([entry])[0].record;
+    expect(retry).toEqual(first);
+    expect(retry?.version).toBe(1);
+    expect(retry?.payload).toMatchObject({ addedAt: 10, updatedAt: 20 });
+    repository.close();
+  });
+
+  it('merges distinct-field edits from stale versions and rejects same-field lost updates', async () => {
+    const repository = await createRepository();
+    repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'image-1', reference, payload: annotation(), sourceVersion: 0,
+    }]);
+    repository.mutateAssetUserData({
+      domain: 'annotation', legacyImageId: 'image-1', reference, expectedVersion: 1,
+      patch: { set: { isFavorite: true, updatedAt: 21 } },
+    });
+    const rating = repository.mutateAssetUserData({
+      domain: 'annotation', legacyImageId: 'image-1', reference, expectedVersion: 1,
+      patch: { set: { rating: 5, updatedAt: 22 } },
+    });
+    expect(rating.payload).toMatchObject({ isFavorite: true, rating: 5 });
+    expect(() => repository.mutateAssetUserData({
+      domain: 'annotation', legacyImageId: 'image-1', reference, expectedVersion: 1,
+      patch: { set: { isFavorite: false, updatedAt: 23 } },
+    })).toThrowError(expect.objectContaining({
+      code: 'USER_DATA_CONFLICT',
+      details: { current: expect.objectContaining({ payload: expect.objectContaining({ isFavorite: true, rating: 5 }) }) },
+    }));
+    repository.close();
+  });
+
+  it('keeps tombstones authoritative over delayed legacy imports and metadata tag reimports', async () => {
+    const repository = await createRepository();
+    repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'image-1', reference, payload: annotation({ tags: ['embedded'] }), sourceVersion: 0,
+    }]);
+    const removedTag = repository.mutateAssetUserData({
+      domain: 'annotation', legacyImageId: 'image-1', reference, expectedVersion: 1,
+      patch: { removeTags: ['embedded'], suppressTags: ['embedded'], set: { updatedAt: 21 } },
+    });
+    const reimport = repository.mutateAssetUserData({
+      domain: 'annotation', legacyImageId: 'image-1', reference, expectedVersion: removedTag.version,
+      patch: { importTags: ['embedded'], set: { updatedAt: 22 } },
+    });
+    expect(reimport.payload).toMatchObject({ tags: [], suppressedMetadataTags: ['embedded'] });
+
+    const tombstone = repository.mutateAssetUserData({
+      domain: 'annotation', legacyImageId: 'image-1', reference, expectedVersion: reimport.version,
+      patch: { deleteRecord: true },
+    });
+    const delayed = repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'image-1', reference,
+      payload: annotation({ isFavorite: true, tags: ['embedded'] }), sourceVersion: 5,
+    }])[0].record;
+    expect(delayed).toEqual(tombstone);
+    expect(delayed?.tombstone).toBe(true);
+    repository.close();
+  });
+
+  it('serializes out-of-order legacy commits per field and finalizes each mutation once', async () => {
+    const repository = await createRepository();
+    repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'image-1', reference, payload: annotation(), sourceVersion: 0,
+    }]);
+    const earlierId = '77777777-7777-4777-8777-777777777777';
+    const laterId = '88888888-8888-4888-8888-888888888888';
+    repository.reserveLegacyUserDataMutation({
+      mutationId: earlierId, domain: 'annotation', legacyImageId: 'image-1',
+      patch: { set: { isFavorite: true, updatedAt: 21 } },
+    });
+    repository.reserveLegacyUserDataMutation({
+      mutationId: laterId, domain: 'annotation', legacyImageId: 'image-1',
+      patch: { addTags: ['later'], set: { updatedAt: 22 } },
+    });
+    repository.finalizeLegacyUserDataMutation({
+      mutationId: laterId, sourceVersion: 1, payload: annotation({ tags: ['later'], updatedAt: 22 }), tombstone: false,
+    });
+    const applied = repository.finalizeLegacyUserDataMutation({
+      mutationId: earlierId, sourceVersion: 2,
+      payload: annotation({ isFavorite: true, tags: ['later'], updatedAt: 21 }), tombstone: false,
+    });
+    expect(applied).toMatchObject({ state: 'applied', record: { payload: { isFavorite: true, tags: ['later'] } } });
+    const final = repository.syncLegacyUserDataBatch([{ domain: 'annotation', legacyImageId: 'image-1', reference }])[0].record;
+    expect(final?.payload).toMatchObject({ isFavorite: true, tags: ['later'], updatedAt: 22 });
+    const retry = repository.finalizeLegacyUserDataMutation({
+      mutationId: earlierId, sourceVersion: 2,
+      payload: annotation({ isFavorite: true, tags: ['later'], updatedAt: 21 }), tombstone: false,
+    });
+    expect(retry.state).toBe('applied');
+    repository.close();
+  });
+
+  it('marks a reused legacy path ambiguous instead of binding historical data to a new asset', async () => {
+    const repository = await createRepository();
+    repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'same-path', reference, payload: annotation({ isFavorite: true }), sourceVersion: 0,
+    }]);
+    repository.createAssetWithRevisionAndLocation({
+      assetId: ids.assetB, revisionId: ids.revisionB, locationId: ids.locationB,
+      rootId: ids.root, relativePath: 'two.png', relativePathKey: 'two.png', byteSize: 11,
+    });
+    const outcome = repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'same-path',
+      reference: { assetId: ids.assetB, revisionId: ids.revisionB, locationId: ids.locationB },
+    }])[0];
+    expect(outcome).toMatchObject({ status: 'ambiguous', record: null });
+    repository.close();
+  });
+
+  it('updates tags on historical assets without counting missing files in current-library facets', async () => {
+    const repository = await createRepository();
+    repository.syncLegacyUserDataBatch([{
+      domain: 'annotation', legacyImageId: 'image-1', reference,
+      payload: annotation({ tags: ['old-tag'] }), sourceVersion: 0,
+    }]);
+    repository.markLocationMissing(ids.location);
+
+    expect(repository.getUserDataTagCounts()).toEqual([]);
+    const changed = repository.mutateAnnotationTagGlobally({
+      action: 'rename', sourceTag: 'old-tag', targetTag: 'new-tag', updatedAt: 30,
+    });
+    expect(changed).toHaveLength(1);
+    expect(changed[0].payload).toMatchObject({ tags: ['new-tag'], suppressedMetadataTags: ['old-tag'] });
+    repository.close();
+  });
+});

--- a/__tests__/stableIdentityUserData.test.ts
+++ b/__tests__/stableIdentityUserData.test.ts
@@ -209,3 +209,49 @@ describe('stable identity user-data repository', () => {
     repository.close();
   });
 });
+
+
+it.each(['delete-first', 'edit-first'] as const)('rejects stale shadow mutations across whole-record deletion: %s', async (order) => {
+  const repository = await createRepository();
+  repository.syncLegacyUserDataBatch([{ domain: 'shadow', legacyImageId: 'one', reference, payload: { prompt: 'initial', updatedAt: 1 }, sourceVersion: 0 }]);
+  const deletion = { deleteRecord: true };
+  const edit = { set: { prompt: 'new', updatedAt: 2 } };
+  const first = repository.mutateAssetUserData({ domain: 'shadow', legacyImageId: 'one', reference, expectedVersion: 1, patch: order === 'delete-first' ? deletion : edit });
+  expect(() => repository.mutateAssetUserData({ domain: 'shadow', legacyImageId: 'one', reference, expectedVersion: 1, patch: order === 'delete-first' ? edit : deletion }))
+    .toThrowError(expect.objectContaining({ code: 'USER_DATA_CONFLICT' }));
+  expect(repository.syncLegacyUserDataBatch([{ domain: 'shadow', legacyImageId: 'one', reference }])[0].record).toEqual(first);
+  // An explicit retry using the confirmed current version remains valid.
+  expect(repository.mutateAssetUserData({ domain: 'shadow', legacyImageId: 'one', reference, expectedVersion: first.version, patch: order === 'delete-first' ? edit : deletion }).tombstone)
+    .toBe(order !== 'delete-first');
+});
+
+it.each(['before', 'after'] as const)('orders a pending source mutation reserved %s a global tag rename', async (order) => {
+  const repository = await createRepository();
+  repository.syncLegacyUserDataBatch([{ domain: 'annotation', legacyImageId: 'pending', payload: annotation({ tags: ['old'] }), sourceVersion: 0 }]);
+  const mutationId = '77777777-7777-4777-8777-777777777777';
+  const reserve = () => repository.reserveLegacyUserDataMutation({ mutationId, domain: 'annotation', legacyImageId: 'pending', patch: { unsuppressTags: ['old'], set: { tags: ['old'], updatedAt: 40 } } });
+  if (order === 'before') reserve();
+  repository.mutateAnnotationTagGlobally({ action: 'rename', sourceTag: 'old', targetTag: 'new', updatedAt: 30 });
+  if (order === 'after') reserve();
+  repository.finalizeLegacyUserDataMutation({ mutationId, sourceVersion: 1, payload: annotation({ tags: ['old'], updatedAt: 40 }), tombstone: false });
+  const pending = repository.syncLegacyUserDataBatch([{ domain: 'annotation', legacyImageId: 'pending' }])[0].pending;
+  const bound = repository.syncLegacyUserDataBatch([{ domain: 'annotation', legacyImageId: 'pending', reference }])[0].record;
+  expect(bound?.payload).toEqual(pending?.payload);
+  expect(bound?.payload?.tags).toEqual(order === 'before' ? ['new'] : ['old']);
+});
+
+
+it('keeps a global pending rename when a later source edit changes only favorite', async () => {
+  const repository = await createRepository();
+  repository.syncLegacyUserDataBatch([{ domain: 'annotation', legacyImageId: 'pending', payload: annotation({ tags: ['old'] }), sourceVersion: 0 }]);
+  repository.mutateAnnotationTagGlobally({ action: 'rename', sourceTag: 'old', targetTag: 'new', updatedAt: 30 });
+  const mutationId = '77777777-7777-4777-8777-777777777777';
+  repository.reserveLegacyUserDataMutation({ mutationId, domain: 'annotation', legacyImageId: 'pending', patch: { set: { isFavorite: true, updatedAt: 40 } } });
+  repository.finalizeLegacyUserDataMutation({ mutationId, sourceVersion: 1, payload: annotation({ isFavorite: true, tags: ['old'], updatedAt: 40 }), tombstone: false });
+  repository.close();
+  repository.open();
+  expect(repository.syncLegacyUserDataBatch([{ domain: 'annotation', legacyImageId: 'pending' }])[0].pending?.payload)
+    .toMatchObject({ isFavorite: true, tags: ['new'], updatedAt: 40 });
+  expect(repository.syncLegacyUserDataBatch([{ domain: 'annotation', legacyImageId: 'pending', reference }])[0].record?.payload)
+    .toMatchObject({ isFavorite: true, tags: ['new'], updatedAt: 40 });
+});

--- a/__tests__/stableIdentityUserDataService.test.ts
+++ b/__tests__/stableIdentityUserDataService.test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ProvenanceRepositoryLifecycle } from '../electron/provenanceRepository.mjs';
+import { AUTHORITY_MARKER_NAME, StableIdentityUserDataService } from '../electron/stableIdentityUserDataService.mjs';
+import { PROVENANCE_DIRECTORY_NAME } from '../electron/provenancePaths.mjs';
+
+const temporaryDirectories: string[] = [];
+
+async function profile() {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-user-data-authority-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+describe('stable user-data authority routing', () => {
+  it('leaves a new flag-off profile on legacy storage without creating migration state', async () => {
+    const userDataPath = await profile();
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    lifecycle.initialize();
+    const service = new StableIdentityUserDataService({ repositoryLifecycle: lifecycle, userDataPath, migrationEnabled: false });
+    expect(service.initialize()).toMatchObject({ authority: 'legacy', available: true, migrationEnabled: false });
+    await expect(fs.stat(path.join(userDataPath, PROVENANCE_DIRECTORY_NAME, AUTHORITY_MARKER_NAME)))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+    lifecycle.close();
+  });
+
+  it('keeps SQLite authoritative after explicit migration even when the flag is later off', async () => {
+    const userDataPath = await profile();
+    const firstLifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    firstLifecycle.initialize();
+    const activated = new StableIdentityUserDataService({
+      repositoryLifecycle: firstLifecycle, userDataPath, migrationEnabled: true,
+    });
+    expect(activated.initialize()).toMatchObject({ authority: 'sqlite', available: true, migrationEnabled: true });
+    await expect(fs.stat(path.join(userDataPath, PROVENANCE_DIRECTORY_NAME, AUTHORITY_MARKER_NAME))).resolves.toBeDefined();
+    firstLifecycle.close();
+
+    const reopenedLifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    reopenedLifecycle.initialize();
+    const reopened = new StableIdentityUserDataService({
+      repositoryLifecycle: reopenedLifecycle, userDataPath, migrationEnabled: false,
+    });
+    expect(reopened.initialize()).toMatchObject({
+      authority: 'sqlite', available: true, migrationEnabled: false, indexingEnabled: false,
+    });
+    reopenedLifecycle.close();
+  });
+
+  it('reports a migrated profile as unavailable instead of silently falling back to legacy data', async () => {
+    const userDataPath = await profile();
+    const markerDirectory = path.join(userDataPath, PROVENANCE_DIRECTORY_NAME);
+    await fs.mkdir(markerDirectory, { recursive: true });
+    await fs.writeFile(path.join(markerDirectory, AUTHORITY_MARKER_NAME), JSON.stringify({ authority: 'sqlite', version: 1 }));
+    const unavailableLifecycle = {
+      getStatus: () => ({ available: false, error: { code: 'SYNTHETIC', message: 'synthetic catalog failure' } }),
+    };
+    const service = new StableIdentityUserDataService({
+      repositoryLifecycle: unavailableLifecycle, userDataPath, migrationEnabled: false,
+    });
+    expect(service.initialize()).toEqual({
+      initialized: true,
+      authority: 'sqlite',
+      available: false,
+      migrationEnabled: false,
+      indexingEnabled: false,
+      legacyScanComplete: false,
+      legacyScanCompletedAt: null,
+      error: { code: 'SYNTHETIC', message: 'synthetic catalog failure' },
+    });
+    expect(() => service.getTagCounts()).toThrowError(expect.objectContaining({ code: 'USER_DATA_UNAVAILABLE' }));
+  });
+});

--- a/__tests__/userDataPersistenceAdapter.test.ts
+++ b/__tests__/userDataPersistenceAdapter.test.ts
@@ -1,0 +1,259 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { IndexedImage } from '../types';
+import { ProvenanceRepositoryLifecycle } from '../electron/provenanceRepository.mjs';
+import { StableIdentityUserDataService } from '../electron/stableIdentityUserDataService.mjs';
+import {
+  clearAllAnnotations,
+  saveAnnotation,
+  saveShadowMetadata,
+} from '../services/imageAnnotationsStorage';
+import {
+  __resetUserDataPersistenceAdapterForTests,
+  hydrateUserDataForImages,
+  loadAnnotationsForImages,
+  patchAnnotation,
+  patchShadowMetadata,
+  registerStableUserDataImages,
+} from '../services/userDataPersistenceAdapter';
+
+const temporaryDirectories: string[] = [];
+const lifecycles: ProvenanceRepositoryLifecycle[] = [];
+
+const image = (identity: {
+  imageId: string;
+  assetId: string;
+  revisionId: string;
+  locationId: string;
+}): IndexedImage => ({
+  id: identity.imageId,
+  name: 'synthetic.png',
+  directoryId: 'synthetic-root',
+  handle: {} as FileSystemFileHandle,
+  metadata: {} as IndexedImage['metadata'],
+  metadataString: '',
+  lastModified: 1,
+  models: [],
+  loras: [],
+  scheduler: '',
+  assetId: identity.assetId,
+  revisionId: identity.revisionId,
+  provenanceLocationId: identity.locationId,
+});
+
+async function stableBridge() {
+  const userDataPath = await fs.mkdtemp(path.join(os.tmpdir(), 'imh-user-data-adapter-'));
+  temporaryDirectories.push(userDataPath);
+  const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+  lifecycle.initialize();
+  lifecycles.push(lifecycle);
+  const ids = {
+    rootId: '99999999-9999-4999-8999-999999999999',
+    assetId: '11111111-1111-4111-8111-111111111111',
+    revisionId: '22222222-2222-4222-8222-222222222222',
+    locationId: '33333333-3333-4333-8333-333333333333',
+  };
+  lifecycle.run((repository) => {
+    repository.ensureLibraryRoot({ rootId: ids.rootId, absolutePath: path.join(userDataPath, 'library'), pathKey: 'library' });
+    repository.createAssetWithRevisionAndLocation({
+      assetId: ids.assetId,
+      revisionId: ids.revisionId,
+      locationId: ids.locationId,
+      rootId: ids.rootId,
+      relativePath: 'synthetic.png',
+      relativePathKey: 'synthetic.png',
+      byteSize: 10,
+    });
+  });
+  let rendererListener: ((payload: { records: any[] }) => void) | null = null;
+  const service = new StableIdentityUserDataService({
+    repositoryLifecycle: lifecycle,
+    userDataPath,
+    migrationEnabled: true,
+    publishChanges: (payload) => rendererListener?.(payload),
+  });
+  service.initialize();
+  const envelope = <T>(operation: () => T) => {
+    try { return { success: true, value: operation() }; }
+    catch (error: any) {
+      return { success: false, error: error?.message, code: error?.code, details: error?.details ?? null };
+    }
+  };
+  window.electronAPI = {
+    stableUserDataStatus: async () => service.getStatus(),
+    stableUserDataSync: async ({ entries }: any) => envelope(() => service.syncLegacyBatch(entries)),
+    stableUserDataMutate: async (input: any) => envelope(() => service.mutate(input)),
+    stableUserDataReserveLegacyMutation: async (input: any) => envelope(() => service.reserveLegacyMutation(input)),
+    stableUserDataFinalizeLegacyMutation: async (input: any) => envelope(() => service.finalizeLegacyMutation(input)),
+    stableUserDataCompleteLegacyScan: async () => envelope(() => service.completeLegacyScan()),
+    stableUserDataGlobalTagMutation: async (input: any) => envelope(() => service.mutateAnnotationTagGlobally(input)),
+    stableUserDataTagCounts: async () => envelope(() => service.getTagCounts()),
+    onStableUserDataChanged: (listener: typeof rendererListener) => {
+      rendererListener = listener;
+      return () => { rendererListener = null; };
+    },
+  } as any;
+  return { lifecycle, service, ids };
+}
+
+beforeEach(async () => {
+  __resetUserDataPersistenceAdapterForTests();
+  delete window.electronAPI;
+  await clearAllAnnotations();
+});
+
+afterEach(async () => {
+  __resetUserDataPersistenceAdapterForTests();
+  delete window.electronAPI;
+  for (const lifecycle of lifecycles.splice(0)) lifecycle.close();
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+describe('stable user-data persistence adapter', () => {
+  it('stages the complete readable legacy source before checkpointing the profile scan', async () => {
+    await saveAnnotation({
+      imageId: 'unmapped-legacy-id', isFavorite: false, tags: [], addedAt: 11, updatedAt: 12,
+    });
+    await saveShadowMetadata({
+      imageId: 'unmapped-legacy-id', prompt: '', resources: [], updatedAt: 13,
+    });
+    const { lifecycle, service, ids } = await stableBridge();
+
+    await hydrateUserDataForImages([image({ imageId: 'mapped-without-source', ...ids })]);
+
+    expect(service.getStatus()).toMatchObject({ legacyScanComplete: true });
+    const pending = lifecycle.run((repository) => repository.database.prepare(`
+      SELECT domain, legacy_image_id, payload_json, tombstone, state
+      FROM legacy_user_data_pending
+      WHERE legacy_image_id = ?
+      ORDER BY domain
+    `).all('unmapped-legacy-id'));
+    expect(pending).toHaveLength(2);
+    expect(pending.map((row: any) => ({
+      domain: row.domain,
+      payload: JSON.parse(row.payload_json),
+      tombstone: row.tombstone,
+      state: row.state,
+    }))).toEqual([
+      {
+        domain: 'annotation',
+        payload: { isFavorite: false, tags: [], addedAt: 11, updatedAt: 12 },
+        tombstone: 0,
+        state: 'pending',
+      },
+      {
+        domain: 'shadow',
+        payload: { prompt: '', resources: [], updatedAt: 13 },
+        tombstone: 0,
+        state: 'pending',
+      },
+    ]);
+
+    const indexedDb = globalThis.indexedDB;
+    Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true });
+    try {
+      const emptyAfterCheckpoint = await hydrateUserDataForImages([
+        image({ imageId: 'mapped-without-source-after-checkpoint', ...ids }),
+      ]);
+      expect(emptyAfterCheckpoint.annotations.size).toBe(0);
+      expect(emptyAfterCheckpoint.shadows.size).toBe(0);
+    } finally {
+      Object.defineProperty(globalThis, 'indexedDB', { value: indexedDb, configurable: true, writable: true });
+    }
+  });
+
+  it('migrates legacy data, preserves explicit values, survives UI-id rename, and rejects path reuse', async () => {
+    await saveAnnotation({
+      imageId: 'legacy-ui-id', isFavorite: true, tags: ['embedded'], rating: 4, addedAt: 10, updatedAt: 20,
+    });
+    await saveShadowMetadata({
+      imageId: 'legacy-ui-id', prompt: 'before', seed: 7, notes: 'before', updatedAt: 20,
+    });
+    const { lifecycle, ids } = await stableBridge();
+    const original = image({ imageId: 'legacy-ui-id', ...ids });
+    const hydrated = await hydrateUserDataForImages([original]);
+    expect(hydrated.annotations.get(original.id)).toMatchObject({
+      assetId: ids.assetId, isFavorite: true, tags: ['embedded'], rating: 4, addedAt: 10, updatedAt: 20,
+    });
+    expect(hydrated.shadows.get(original.id)).toMatchObject({ assetId: ids.assetId, prompt: 'before', seed: 7 });
+
+    const annotation = await patchAnnotation(original.id, {
+      set: { isFavorite: false },
+      remove: ['rating'],
+      removeTags: ['embedded'],
+      suppressTags: ['embedded'],
+    });
+    expect(annotation).toMatchObject({ isFavorite: false, tags: [], suppressedMetadataTags: ['embedded'] });
+    expect(annotation).not.toHaveProperty('rating');
+    expect((await patchAnnotation(original.id, { importTags: ['embedded'] }))?.tags).toEqual([]);
+    const shadow = await patchShadowMetadata(original, {
+      set: { prompt: '', seed: 0, resources: [], tags: [], notes: '' },
+    });
+    expect(shadow).toMatchObject({ prompt: '', seed: 0, resources: [], tags: [], notes: '' });
+
+    const renamed = image({ imageId: 'renamed-ui-id', ...ids });
+    const afterRename = await hydrateUserDataForImages([renamed]);
+    expect(afterRename.annotations.get(renamed.id)).toMatchObject({ isFavorite: false, tags: [] });
+    expect(afterRename.shadows.get(renamed.id)).toMatchObject({ prompt: '', seed: 0, resources: [], tags: [], notes: '' });
+
+    const indexedDb = globalThis.indexedDB;
+    Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true });
+    try {
+      const durableOnly = image({ imageId: 'durable-without-legacy-backend', ...ids });
+      const fromSqlite = await hydrateUserDataForImages([durableOnly]);
+      expect(fromSqlite.annotations.get(durableOnly.id)).toMatchObject({ isFavorite: false, tags: [] });
+      expect(fromSqlite.shadows.get(durableOnly.id)).toMatchObject({ prompt: '', seed: 0 });
+    } finally {
+      Object.defineProperty(globalThis, 'indexedDB', { value: indexedDb, configurable: true, writable: true });
+    }
+
+    const replacementIds = {
+      assetId: '44444444-4444-4444-8444-444444444444',
+      revisionId: '55555555-5555-4555-8555-555555555555',
+      locationId: '66666666-6666-4666-8666-666666666666',
+    };
+    lifecycle.run((repository) => repository.createAssetWithRevisionAndLocation({
+      ...replacementIds,
+      rootId: ids.rootId,
+      relativePath: 'replacement.png',
+      relativePathKey: 'replacement.png',
+      byteSize: 11,
+    }));
+    const reused = image({ imageId: 'legacy-ui-id', ...replacementIds });
+    registerStableUserDataImages([reused]);
+    const afterReuse = await hydrateUserDataForImages([reused]);
+    expect(afterReuse.annotations.has(reused.id)).toBe(false);
+    expect(afterReuse.shadows.has(reused.id)).toBe(false);
+  });
+
+  it('reports an unavailable migrated catalog instead of falling back to readable legacy data', async () => {
+    await saveAnnotation({
+      imageId: 'legacy-ui-id', isFavorite: true, tags: ['stale'], addedAt: 10, updatedAt: 20,
+    });
+    window.electronAPI = {
+      stableUserDataStatus: async () => ({
+        initialized: true,
+        authority: 'sqlite',
+        available: false,
+        migrationEnabled: false,
+        indexingEnabled: false,
+        error: { message: 'synthetic catalog unavailable' },
+      }),
+    } as any;
+    await expect(loadAnnotationsForImages([])).rejects.toThrow('synthetic catalog unavailable');
+  });
+
+  it('does not turn an unreadable, not-yet-migrated legacy record into a successful empty lookup', async () => {
+    const { ids } = await stableBridge();
+    const indexedDb = globalThis.indexedDB;
+    Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true });
+    try {
+      await expect(hydrateUserDataForImages([image({ imageId: 'not-yet-migrated', ...ids })]))
+        .rejects.toThrow('IndexedDB is unavailable');
+    } finally {
+      Object.defineProperty(globalThis, 'indexedDB', { value: indexedDb, configurable: true, writable: true });
+    }
+  });
+});

--- a/__tests__/userDataPersistenceAdapter.test.ts
+++ b/__tests__/userDataPersistenceAdapter.test.ts
@@ -257,3 +257,67 @@ describe('stable user-data persistence adapter', () => {
     }
   });
 });
+
+
+it('reads unmapped annotations and shadows from SQLite after checkpoint and opt-out', async () => {
+  await saveAnnotation({ imageId: 'pending-visible', isFavorite: true, tags: ['keep'], addedAt: 10, updatedAt: 20 });
+  await saveShadowMetadata({ imageId: 'pending-visible', prompt: '', seed: 0, updatedAt: 20 });
+  const { service } = await stableBridge();
+  const unmapped = image({ imageId: 'pending-visible', assetId: '', revisionId: '', locationId: '' });
+  await loadAnnotationsForImages([]);
+  service.migrationEnabled = false;
+  __resetUserDataPersistenceAdapterForTests();
+  const indexedDb = globalThis.indexedDB;
+  Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true });
+  try {
+    const hydrated = await hydrateUserDataForImages([unmapped]);
+    expect(hydrated.annotations.get(unmapped.id)).toMatchObject({ isFavorite: true, tags: ['keep'] });
+    expect(hydrated.shadows.get(unmapped.id)).toMatchObject({ prompt: '', seed: 0 });
+  } finally {
+    Object.defineProperty(globalThis, 'indexedDB', { value: indexedDb, configurable: true, writable: true });
+  }
+});
+
+it.each(['rename', 'remove'] as const)('keeps global tag %s on pending data through retries and mapping', async (action) => {
+  await saveAnnotation({ imageId: 'pending-tag', isFavorite: false, tags: ['old'], addedAt: 1, updatedAt: 2 });
+  const { lifecycle, ids } = await stableBridge();
+  const adapter = await import('../services/userDataPersistenceAdapter');
+  // The global operation itself must stage the legacy source before changing it.
+  await adapter.mutateAnnotationTagGlobally(action, 'old', action === 'rename' ? 'new' : undefined);
+  const expectedTags = action === 'rename' ? ['new'] : [];
+  const unmapped = image({ imageId: 'pending-tag', assetId: '', revisionId: '', locationId: '' });
+  expect((await hydrateUserDataForImages([unmapped])).annotations.get(unmapped.id)?.tags).toEqual(expectedTags);
+  lifecycle.run((repo) => repo.syncLegacyUserDataBatch([{
+    domain: 'annotation', legacyImageId: unmapped.id, payload: { isFavorite: false, tags: ['old'], addedAt: 1, updatedAt: 2 }, sourceVersion: 0,
+  }]));
+  const mapped = image({ imageId: unmapped.id, ...ids });
+  const hydrated = await hydrateUserDataForImages([mapped]);
+  expect(hydrated.annotations.get(mapped.id)).toMatchObject({ tags: expectedTags, suppressedMetadataTags: ['old'] });
+  expect((await patchAnnotation(mapped.id, { importTags: ['old'] }))?.tags).toEqual(expectedTags);
+});
+
+it('preserves simultaneous independent legacy patches and creates no migration outbox', async () => {
+  await saveAnnotation({ imageId: 'legacy-concurrent', isFavorite: false, tags: [], addedAt: 1, updatedAt: 2 });
+  await Promise.all([
+    patchAnnotation('legacy-concurrent', { set: { isFavorite: true } }),
+    patchAnnotation('legacy-concurrent', { addTags: ['keep'] }),
+    patchShadowMetadata('legacy-concurrent', { set: { prompt: 'keep' } }),
+    patchShadowMetadata('legacy-concurrent', { set: { seed: 0 } }),
+  ]);
+  const { getAnnotation, getShadowMetadata } = await import('../services/imageAnnotationsStorage');
+  const { readLegacyUserDataSnapshot } = await import('../services/legacyUserDataMigrationSource');
+  expect(await getAnnotation('legacy-concurrent')).toMatchObject({ isFavorite: true, tags: ['keep'] });
+  expect(await getShadowMetadata('legacy-concurrent')).toMatchObject({ prompt: 'keep', seed: 0 });
+  expect(await readLegacyUserDataSnapshot('annotation', 'legacy-concurrent')).toMatchObject({ sourceVersion: 0 });
+  expect(await readLegacyUserDataSnapshot('annotation', 'legacy-concurrent')).not.toHaveProperty('mutationId');
+});
+
+
+it('confirms the projected pending tags after a later favorite edit', async () => {
+  await saveAnnotation({ imageId: 'pending-edit', isFavorite: false, tags: ['old'], addedAt: 1, updatedAt: 2 });
+  await stableBridge();
+  const adapter = await import('../services/userDataPersistenceAdapter');
+  await adapter.mutateAnnotationTagGlobally('rename', 'old', 'new');
+  expect(await patchAnnotation('pending-edit', { set: { isFavorite: true } }))
+    .toMatchObject({ isFavorite: true, tags: ['new'], suppressedMetadataTags: ['old'] });
+});

--- a/components/BatchExportModal.tsx
+++ b/components/BatchExportModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Download, X } from 'lucide-react';
-import { getShadowMetadata } from '../services/imageAnnotationsStorage';
+import { getPersistedShadowMetadata } from '../services/userDataPersistenceAdapter';
 import { buildEffectiveMetadata } from '../utils/editableMetadata';
 import {
   type ExportFileDescriptor,
@@ -221,7 +221,7 @@ const BatchExportModal: React.FC<BatchExportModalProps> = ({
           return null;
         }
 
-        const shadowMetadata = applyShadowEdits ? await getShadowMetadata(image.id) : null;
+        const shadowMetadata = applyShadowEdits ? await getPersistedShadowMetadata(image) : null;
         const effectiveMetadata = metadataPolicy === 'metahub_standard'
           ? buildEffectiveMetadata(image.metadata?.normalizedMetadata, shadowMetadata)
           : null;

--- a/components/DetachedImageModalApp.tsx
+++ b/components/DetachedImageModalApp.tsx
@@ -112,27 +112,31 @@ const DetachedImageModalApp: React.FC = () => {
 
     useImageStore.setState({
       toggleFavorite: async (imageId: string) => {
+        const result = await sendCommand({ type: 'toggle-favorite', imageId });
+        if (!result.success) throw new Error(result.error || 'Favorite was not saved.');
         useImageStore.setState((state) => ({ images: state.images.map((entry) =>
           entry.id === imageId ? { ...entry, isFavorite: !entry.isFavorite } : entry) }));
-        await sendCommand({ type: 'toggle-favorite', imageId });
       },
       setImageRating: async (imageId: string, rating) => {
+        const result = await sendCommand({ type: 'set-rating', imageId, rating });
+        if (!result.success) throw new Error(result.error || 'Rating was not saved.');
         useImageStore.setState((state) => ({ images: state.images.map((entry) =>
           entry.id === imageId ? { ...entry, rating } : entry) }));
-        await sendCommand({ type: 'set-rating', imageId, rating });
       },
       addTagToImage: async (imageId: string, tag: string) => {
         const normalized = tag.trim().toLowerCase();
+        const result = await sendCommand({ type: 'add-tag', imageId, tag });
+        if (!result.success) throw new Error(result.error || 'Tag was not saved.');
         useImageStore.setState((state) => ({ images: state.images.map((entry) =>
           entry.id === imageId && normalized && !entry.tags?.includes(normalized)
             ? { ...entry, tags: [...(entry.tags || []), normalized] }
             : entry) }));
-        await sendCommand({ type: 'add-tag', imageId, tag });
       },
       removeTagFromImage: async (imageId: string, tag: string) => {
+        const result = await sendCommand({ type: 'remove-tag', imageId, tag });
+        if (!result.success) throw new Error(result.error || 'Tag removal was not saved.');
         useImageStore.setState((state) => ({ images: state.images.map((entry) =>
           entry.id === imageId ? { ...entry, tags: (entry.tags || []).filter((value) => value !== tag) } : entry) }));
-        await sendCommand({ type: 'remove-tag', imageId, tag });
       },
       removeAutoTagFromImage: (imageId: string, tag: string) => {
         useImageStore.setState((state) => ({ images: state.images.map((entry) =>

--- a/components/ImageEditorWorkspace.tsx
+++ b/components/ImageEditorWorkspace.tsx
@@ -60,6 +60,7 @@ import { getFileExtension } from '../utils/mediaTypes.js';
 import { indexImageFileAtPath, reparseIndexedImage } from '../services/fileIndexer';
 import cacheManager from '../services/cacheManager';
 import { useImageStore } from '../store/useImageStore';
+import { prepareUserDataForImages } from '../services/userDataPersistenceAdapter';
 
 interface ImageEditorWorkspaceProps {
   image: IndexedImage;
@@ -929,7 +930,19 @@ const ImageEditorWorkspace: React.FC<ImageEditorWorkspaceProps> = ({
       throw new Error('Saving edited images is only available in the desktop app.');
     }
     const outputBytes = await renderExportBytes();
-    const result = await window.electronAPI.writeFile(targetPath, outputBytes, { kind: mode });
+    if (mode === 'overwrite') {
+      try {
+        await prepareUserDataForImages([image]);
+      } catch (error) {
+        throw new Error(`The image was not overwritten because its local user data could not be staged safely: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    const result = await window.electronAPI.writeFile(targetPath, outputBytes, {
+      kind: mode,
+      ...(mode === 'overwrite'
+        ? { sourcePath: targetPath, userDataContext: { legacyImageId: image.id } }
+        : {}),
+    });
     if (!result.success) {
       throw new Error(result.error || 'Failed to write edited image.');
     }

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -48,7 +48,7 @@ import {
   renderEditedImageToPngBytes,
 } from '../services/imageEditingService';
 
-import { bulkSaveShadowMetadata } from '../services/imageAnnotationsStorage';
+import { prepareUserDataForImages, saveShadows } from '../services/userDataPersistenceAdapter';
 import { copyEditableMetadata, readEditableMetadataClipboard } from '../services/metadataClipboard';
 import { hasVerifiedTelemetry } from '../utils/telemetryDetection';
 import { getAvifCarrierConflicts } from '../utils/imageMetaHubAvifExtension.mjs';
@@ -1180,7 +1180,6 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const selectedNodes = useImageStore((state) => state.selectedNodes);
   const clusterNavigationContext = useImageStore((state) => state.clusterNavigationContext);
 
-  const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata, deleteMetadata: deleteShadowMetadata } = useShadowMetadata(image.id);
   const [isMetadataEditorOpen, setIsMetadataEditorOpen] = useState(false);
   const [isBatchExportModalOpen, setIsBatchExportModalOpen] = useState(false);
   const [showOriginal, setShowOriginal] = useState(false);
@@ -1192,6 +1191,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
     )
   );
   const liveImage = imageFromStore ?? image;
+  const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata, deleteMetadata: deleteShadowMetadata } = useShadowMetadata(liveImage);
   const thumbnail = useResolvedThumbnail(liveImage);
   const isVideo = isVideoFileName(image.name, image.fileType);
   const isAudio = isAudioFileName(image.name, image.fileType);
@@ -2530,7 +2530,19 @@ const ImageModal: React.FC<ImageModalProps> = ({
       sourceRawMetadata,
       imageEditOutputDimensions || undefined,
     );
-    const result = await window.electronAPI.writeFile(targetPath, outputBytes, { kind: mode });
+    if (mode === 'overwrite') {
+      try {
+        await prepareUserDataForImages([liveImage]);
+      } catch (error) {
+        throw new Error(`The image was not overwritten because its local user data could not be staged safely: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    const result = await window.electronAPI.writeFile(targetPath, outputBytes, {
+      kind: mode,
+      ...(mode === 'overwrite'
+        ? { sourcePath: targetPath, userDataContext: { legacyImageId: liveImage.id } }
+        : {}),
+    });
     if (!result.success) {
       throw new Error(result.error || 'Failed to write edited image.');
     }
@@ -4987,11 +4999,12 @@ const ImageModal: React.FC<ImageModalProps> = ({
           onSave={async (metadata) => { await saveShadowMetadata(metadata); }}
           onExportEditedCopy={openBatchExport}
           onApplyToSelected={exportSelectionIds.size > 1 ? async (metadata) => {
-            await bulkSaveShadowMetadata(Array.from(exportSelectionIds).map((imageId) => ({
+            const imagesById = new Map(allImages.map((candidate) => [candidate.id, candidate]));
+            await saveShadows(Array.from(exportSelectionIds).map((imageId) => ({
               ...metadata,
               imageId,
               updatedAt: Date.now(),
-            })));
+            })), imagesById);
           } : null}
           selectedImageCount={exportSelectionIds.size}
           onCopyEditableMetadata={(metadata) => {

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -28,7 +28,7 @@ import { isAudioFileName, isModel3DFileName, isVideoFileName } from '../utils/me
 import AudioPlayer from './AudioPlayer';
 import Model3DViewer from './Model3DViewer';
 import { useShadowMetadata } from '../hooks/useShadowMetadata';
-import { bulkSaveShadowMetadata } from '../services/imageAnnotationsStorage';
+import { saveShadows } from '../services/userDataPersistenceAdapter';
 import { copyEditableMetadata, readEditableMetadataClipboard } from '../services/metadataClipboard';
 import { buildEffectiveMetadata, getEditableMetadataFields } from '../utils/editableMetadata';
 import { MetadataEditorModal, type MetadataEditorDraft } from './MetadataEditorModal';
@@ -211,7 +211,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const { a1111Enabled, comfyUIEnabled, singleVisibleProvider } = useGenerationProviderAvailability();
 
   const activeImage = previewImageFromStore || previewImage;
-  const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata } = useShadowMetadata(activeImage?.id);
+  const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata } = useShadowMetadata(activeImage);
   const allImages = useImageStore((state) => state.images);
   const thumbnail = useResolvedThumbnail(activeImage);
   const isVideo = !!activeImage && isVideoFileName(activeImage.name, activeImage.fileType);
@@ -1207,11 +1207,12 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
         onSave={async (metadata) => { await saveShadowMetadata(metadata); }}
         onExportEditedCopy={openBatchExport}
         onApplyToSelected={exportSelectionIds.size > 1 ? async (metadata) => {
-          await bulkSaveShadowMetadata(Array.from(exportSelectionIds).map((imageId) => ({
+          const imagesById = new Map(allImages.map((candidate) => [candidate.id, candidate]));
+          await saveShadows(Array.from(exportSelectionIds).map((imageId) => ({
             ...metadata,
             imageId,
             updatedAt: Date.now(),
-          })));
+          })), imagesById);
         } : null}
         selectedImageCount={exportSelectionIds.size}
         onCopyEditableMetadata={(metadata) => {

--- a/docs/stable-identity-user-data-migration.md
+++ b/docs/stable-identity-user-data-migration.md
@@ -1,0 +1,72 @@
+# Stable identity user-data migration
+
+## Authority and data ownership
+
+`ImageAnnotations` (`isFavorite`, `tags`, `rating`, `addedAt`, and `updatedAt`) and `ShadowMetadata` overrides belong to the logical asset. `IndexedImage.id` remains the renderer/UI key; the persistence boundary resolves it to the catalog `assetId` and validates the supplied location and revision.
+
+The browser and a desktop profile that has never opted into stable identity continue to use IndexedDB only. Enabling `IMH_ENABLE_PROVENANCE_INDEXING` explicitly activates SQLite user-data authority for that profile. Once activated, SQLite remains authoritative even if indexing is later disabled; this does not restart scans or hashing. If that catalog is unavailable, persistence reports an error instead of reading stale legacy values.
+
+Legacy IndexedDB records are read without automatic database reset. Import is non-destructive and idempotent. The first activated-profile read stages every readable annotation, shadow, and migration outbox in bounded batches before recording the durable full-scan checkpoint. Each batch commits its payload and per-record pending/import state together; the profile checkpoint is written only after every batch is acknowledged. A record is bound only through a validated catalog location/asset/revision. Unmapped records remain pending in SQLite, and an old alias already bound to another asset is ambiguous rather than reassigned. Once the full scan is checkpointed, a missing SQLite row is authoritative absence and does not require IndexedDB to remain available.
+
+Annotations and shadows use record versions plus per-field versions. Renderer writes are semantic patches with an expected version: non-overlapping stale patches may rebase, while a stale patch to a field changed since its base version returns a conflict. Whole-record removal is a tombstone. Legacy writes made before a mapping is available receive a durable main-process sequence before their IndexedDB transaction and are finalized only after `transaction.oncomplete`; a later SQLite mutation therefore cannot be overwritten by an older import. Source timestamps are preserved, with migration time stored separately.
+
+Shadow metadata remains a set of local overrides, not byte history. Missing fields and explicit removals remain distinct, and valid `false`, zero, empty strings, and empty arrays are preserved. “Original” and “revert” continue to expose the current file metadata without the overlay.
+
+## API migration matrix
+
+| Flow/API | Previous source and consumers | Stable destination/behavior |
+| --- | --- | --- |
+| Load all / load one annotation | `loadAllAnnotations`, `getAnnotation`; image store, filters, counts | Adapter routes legacy profiles to IndexedDB; activated profiles hydrate validated assets from SQLite without double-counting aliases. |
+| Save annotation / favorite / rating | `saveAnnotation`, `bulkSaveAnnotations`; image store and detached viewer commands | Semantic main-process patches keyed by `assetId`; field-version conflict detection and confirmed broadcasts. |
+| Add/remove/bulk tags | Image-store annotation snapshots | Semantic tag patches; explicit removals suppress automatic re-import of the removed metadata tag. |
+| Automatic metadata-tag import | `importMetadataTags` union into IndexedDB | Idempotent import patch respecting suppression and SQLite authority. |
+| Global rename/clear/purge and counts | Iterate renderer annotation map plus manual-tag store | SQLite mutates current and historical asset annotations transactionally, while counts include only present assets; the manual-tag catalog and smart-collection rules remain IndexedDB entities. |
+| Delete annotation | `deleteAnnotation`, `bulkDeleteAnnotations` | Durable asset tombstone; legacy source is retained. |
+| Load/save/revert shadow | `useShadowMetadata`, metadata editors, preview and modal | Versioned SQLite override keyed by `assetId`; revert writes a tombstone so legacy data cannot return. |
+| Batch shadow apply | Metadata editors | Bounded per-asset patches; partial success updates only confirmed items. |
+| Batch export shadow read | `BatchExportModal` | Adapter reads the authoritative override for each validated image; effective/original composition is unchanged. |
+| Rename/move | `transferImagePersistence` copied then deleted legacy IDs | Same asset row; only the UI projection changes. The durable record is never copied or deleted. |
+| Transfer copy | Renderer callback before/after watcher | The existing filesystem journal captures one source snapshot and clones it once to the reserved destination asset. Retry never overwrites a later destination edit. |
+| Save As / folder export | Existing write/export coordinators | Existing policy is preserved; no general annotation/shadow clone is introduced. |
+| Overwrite | Existing write coordinator | Same asset, new byte revision, unchanged asset-owned user data. |
+
+## Recovery and activation boundary
+
+File-operation recovery reuses `provenance_operations`; no second filesystem coordinator is introduced. A transfer intent can bind pending legacy data before mutation and carries the source user-data snapshot needed to finish a copy after renderer exit. Missing library entries never delete durable rows, and a deleted asset retains its tombstoned or historical user data without exposing it to a new asset at the same path.
+
+The feature flag remains off by default. Directory/subtree rename, Linux/macOS packaged validation, and public activation remain separate gates. This phase does not add provenance edges, audit history, generation runs, C2PA, IPTC, MCP, parser changes, or UI redesign.
+
+## Acceptance evidence
+
+All automated fixtures use generated temporary profiles, SQLite catalogs, IndexedDB stores, and synthetic files. No personal library, real cache, sidecar, or generation-parameter payload was opened.
+
+| Acceptance area | Deterministic evidence |
+| --- | --- |
+| Valid, unmapped, and ambiguous legacy bindings | `stableIdentityUserData.test.ts`; `userDataPersistenceAdapter.test.ts` full-source staging and path-reuse cases. |
+| Retry, lost acknowledgement, and two-window serialization | Repository idempotency, main-process sequencing, finalized-outbox retry, and stale-version tests in `stableIdentityUserData.test.ts`; all windows share this transactional main boundary. |
+| Failure before commit, committed source without ACK, and restart | Fake IndexedDB transaction barriers in `legacyUserDataMigrationSource.test.ts`; journal recovery and reopen tests in `stableIdentityFileOperations.test.ts`. |
+| Edits/removals during import and delayed retry | Reserved/finalized sequence interleavings, annotation/shadow tombstones, and suppressed metadata-tag cases in the repository and adapter suites. |
+| Distinct-field concurrency and same-field conflict | `stableIdentityUserData.test.ts` rebases independent fields and returns `USER_DATA_CONFLICT` with the current record for overlapping stale patches. |
+| Rename, move, copy, delete/path reuse, overwrite, and Save As | `stableIdentityFileOperations.test.ts`, `provenanceRepository.test.ts`, and packaged smoke. Copy recovery proves renderer loss does not repeat filesystem work or overwrite a later destination edit. |
+| Partial batches and persistence failure | Store batch helpers apply only fulfilled records; a coordinator test proves a required unavailable user-data journal leaves the source filesystem unchanged. |
+| Late mapping and rapid identity change | `useImageLoader` rehydrates on mapping broadcasts; store and shadow hooks key responses by UI id plus stable identity/revision and reject stale generations. |
+| False, removed rating, zero, empty strings, and empty arrays | Repository, adapter, rating-storage, and editable-metadata tests cover these values without truthy fallback. |
+| Filters, counts, global tags, automatic tag suppression, and batch export | Store filters/tags, tag suggestions, editable metadata, historical global-tag, and adapter-backed batch-export paths use one authoritative record per asset. |
+| Reset, backup, reopen, and schema preservation | `provenanceRepository.test.ts` verifies new rows in checkpointed backup and across cache reset; packaged smoke reopens schema v5 and copied overlays. |
+| Browser/new flag-off, migrated flag-off, and unavailable catalog | Authority and adapter tests verify explicit routing, no migration for a new profile, durable SQLite authority after opt-out, and errors instead of stale fallback. |
+
+### Validation executed on 2026-09-08
+
+- Focused persistence and consumer suites: 123 tests passed and one platform-specific test was skipped. A parallel aggregate run hit five 5-second Windows resource-contention timeouts; the same repository/file-operation files passed when rerun separately (54 passed, one platform skip), so no functional failure remained.
+- TypeScript: `npx tsc --noEmit` passed.
+- JavaScript syntax: `node --check` passed for the main entry, preload, repository, service, coordinator, smoke, and runner.
+- Focused ESLint: completed with zero errors; warnings were reported only under the repository's non-blocking warning rules.
+- Production renderer build: `npm run build` passed.
+- Windows unpacked packaged smoke: passed inside ASAR with an isolated `--user-data-dir` and synthetic library.
+- Windows portable launcher smoke: passed from a temporary path containing spaces and `ç`; durable data reopened from adjacent `ImageMetaHubData`.
+- Packaged runtime: Electron 38.8.6, Node 22.22.0, SQLite 3.50.4.
+- Visual acceptance was not automated. Linux and macOS were not executed.
+
+## Roadmap state
+
+This delivery closes the phase 2 user-data migration portion of **Stable asset identity foundation**. Public activation remains gated separately by directory/subtree rename support, platform validation, and manual visual acceptance. Phase 3 remains lineage/provenance/audit. C2PA, IPTC, and MCP were not implemented here.

--- a/electron.mjs
+++ b/electron.mjs
@@ -45,6 +45,7 @@ import { resetUserDataContents } from './electron/cacheReset.mjs';
 import { ProvenanceRepositoryLifecycle } from './electron/provenanceRepository.mjs';
 import { StableIdentityIndexer } from './electron/stableIdentityIndexer.mjs';
 import { StableIdentityFileOperationCoordinator } from './electron/stableIdentityFileOperationCoordinator.mjs';
+import { StableIdentityUserDataService } from './electron/stableIdentityUserDataService.mjs';
 import { runStableIdentityFileOperationsSmoke } from './electron/stableIdentityFileOperationsSmoke.mjs';
 import { openAuthorizedCacheDirectory } from './electron/cacheDirectory.mjs';
 import { appendEmbeddingSegmentAtOffset } from './electron/embeddingSegmentFile.mjs';
@@ -615,6 +616,7 @@ let licenseManager;
 let provenanceRepositoryLifecycle;
 let stableIdentityIndexer;
 let stableIdentityFileOperationCoordinator;
+let stableIdentityUserDataService;
 const detachedImageViewerWindows = new Map();
 const detachedImageViewerSnapshots = new Map();
 const detachedImageViewerRequestResolvers = new Map();
@@ -2978,14 +2980,37 @@ app.whenReady().then(async () => {
     userDataPath: app.getPath('userData'),
   });
   provenanceRepositoryLifecycle.initialize();
+  stableIdentityUserDataService = new StableIdentityUserDataService({
+    repositoryLifecycle: provenanceRepositoryLifecycle,
+    userDataPath: app.getPath('userData'),
+    migrationEnabled: provenanceIndexingEnabled,
+    publishChanges: (payload) => {
+      for (const window of BrowserWindow.getAllWindows()) {
+        if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
+          window.webContents.send('stable-user-data-changed', payload);
+        }
+      }
+    },
+  });
+  try {
+    stableIdentityUserDataService.initialize();
+  } catch (error) {
+    console.error('Stable-identity user-data migration could not initialize; application startup will continue.', error);
+  }
   stableIdentityIndexer = new StableIdentityIndexer({
     repositoryLifecycle: provenanceRepositoryLifecycle,
     enabled: provenanceIndexingEnabled && provenanceRepositoryLifecycle.getStatus().available,
   });
+  const stableUserDataStatus = stableIdentityUserDataService.getStatus();
   stableIdentityFileOperationCoordinator = new StableIdentityFileOperationCoordinator({
     repositoryLifecycle: provenanceRepositoryLifecycle,
     indexer: stableIdentityIndexer,
-    enabled: provenanceIndexingEnabled,
+    // A profile that already crossed the user-data authority boundary must keep
+    // journaling known file operations even when indexing is later disabled.
+    // The indexer stays disabled, so this does not restart scans or hashing.
+    enabled: provenanceIndexingEnabled || (
+      stableUserDataStatus.authority === 'sqlite' && stableUserDataStatus.available
+    ),
     publishMappings: (payload) => {
       for (const window of BrowserWindow.getAllWindows()) {
         if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
@@ -3005,6 +3030,7 @@ app.whenReady().then(async () => {
         rootPath: smokeRoot,
         userDataPath: app.getPath('userData'),
         repositoryLifecycle: provenanceRepositoryLifecycle,
+        userDataService: stableIdentityUserDataService,
         indexer: stableIdentityIndexer,
         coordinator: stableIdentityFileOperationCoordinator,
       });
@@ -3327,6 +3353,29 @@ const isPathAllowed = (filePath) => {
   if (allowedDirectoryPaths.size === 0 || !filePath) return false;
   const normalizedFilePath = normalizeAllowedPath(filePath);
   return Array.from(allowedDirectoryPaths).some((allowedPath) => isSameOrChildPath(normalizedFilePath, allowedPath));
+};
+
+const findAllowedDirectoryRoot = (filePath) => {
+  if (!filePath) return null;
+  const normalizedFilePath = normalizeAllowedPath(filePath);
+  return Array.from(allowedDirectoryPaths)
+    .filter((allowedPath) => isSameOrChildPath(normalizedFilePath, allowedPath))
+    .sort((left, right) => right.length - left.length)[0] ?? null;
+};
+
+const stableFileUserDataContext = ({ legacyImageId, sourcePath = null, destinationPath = null, copyUserData = false } = {}) => {
+  if (typeof legacyImageId !== 'string' || !legacyImageId.trim()) return null;
+  const stableStatus = stableIdentityUserDataService?.getStatus?.();
+  return {
+    legacyImageId,
+    copyUserData,
+    ...(stableStatus?.authority === 'sqlite' && sourcePath
+      ? { sourceRootPath: findAllowedDirectoryRoot(sourcePath) }
+      : {}),
+    ...(stableStatus?.authority === 'sqlite' && destinationPath
+      ? { destinationRootPath: findAllowedDirectoryRoot(destinationPath) }
+      : {}),
+  };
 };
 
 // Symlink-aware containment check for write operations (e.g. creating a folder).
@@ -5686,7 +5735,7 @@ function setupFileOperationHandlers() {
   });
 
   // Handle file deletion (move to trash)
-  ipcMain.handle('trash-file', async (event, filePath) => {
+  ipcMain.handle('trash-file', async (event, filePath, userDataContext = null) => {
     let trashAttempted = false;
     try {
       if (!isPathAllowed(filePath)) {
@@ -5698,6 +5747,10 @@ function setupFileOperationHandlers() {
       const coordinated = await executeWithStableIdentity({
         kind: 'delete',
         sourcePath: filePath,
+        userDataContext: stableFileUserDataContext({
+          legacyImageId: userDataContext?.legacyImageId,
+          sourcePath: filePath,
+        }),
         perform: async () => {
           if (isModel3DFileName(filePath)) {
             await trashModel3DWithSidecar(
@@ -5833,7 +5886,7 @@ function setupFileOperationHandlers() {
   });
 
   // Handle file renaming
-  ipcMain.handle('rename-file', async (event, oldPath, newPath) => {
+  ipcMain.handle('rename-file', async (event, oldPath, newPath, userDataContext = null) => {
     try {
       if (!isAllowedOrInternal(oldPath) || !isRenameTargetAllowed(oldPath, newPath)) {
         console.error('SECURITY VIOLATION: Attempted to rename file outside of allowed directories.');
@@ -5867,6 +5920,11 @@ function setupFileOperationHandlers() {
         kind: 'rename',
         sourcePath: oldPath,
         destinationPath: newPath,
+        userDataContext: stableFileUserDataContext({
+          legacyImageId: userDataContext?.legacyImageId,
+          sourcePath: oldPath,
+          destinationPath: newPath,
+        }),
         perform: async () => {
           if (isModel3DFileName(oldPath)) {
             await renameModel3DWithSidecar(fs, oldPath, newPath);
@@ -6274,6 +6332,51 @@ function setupFileOperationHandlers() {
     if (action === 'resume') return { success: true, ...stableIdentityIndexer.resume() };
     return { success: false, enabled: true, error: 'Unsupported provenance backfill action.' };
   });
+
+  const handleStableUserDataRequest = (operation) => {
+    try {
+      if (!stableIdentityUserDataService) throw new Error('Stable user-data service is unavailable.');
+      return { success: true, value: operation(stableIdentityUserDataService) };
+    } catch (error) {
+      return {
+        success: false,
+        error: error?.message || String(error),
+        code: error?.code || 'USER_DATA_OPERATION_FAILED',
+        details: error?.details ?? null,
+      };
+    }
+  };
+
+  ipcMain.handle('stable-user-data-status', () => (
+    stableIdentityUserDataService?.getStatus?.() ?? {
+      initialized: false,
+      authority: 'legacy',
+      available: true,
+      migrationEnabled: provenanceIndexingEnabled,
+      indexingEnabled: provenanceIndexingEnabled,
+    }
+  ));
+  ipcMain.handle('stable-user-data-sync', (_event, { entries } = {}) => (
+    handleStableUserDataRequest((service) => service.syncLegacyBatch(entries))
+  ));
+  ipcMain.handle('stable-user-data-mutate', (_event, input) => (
+    handleStableUserDataRequest((service) => service.mutate(input))
+  ));
+  ipcMain.handle('stable-user-data-reserve-legacy-mutation', (_event, input) => (
+    handleStableUserDataRequest((service) => service.reserveLegacyMutation(input))
+  ));
+  ipcMain.handle('stable-user-data-finalize-legacy-mutation', (_event, input) => (
+    handleStableUserDataRequest((service) => service.finalizeLegacyMutation(input))
+  ));
+  ipcMain.handle('stable-user-data-complete-legacy-scan', () => (
+    handleStableUserDataRequest((service) => service.completeLegacyScan())
+  ));
+  ipcMain.handle('stable-user-data-global-tag-mutation', (_event, input) => (
+    handleStableUserDataRequest((service) => service.mutateAnnotationTagGlobally(input))
+  ));
+  ipcMain.handle('stable-user-data-tag-counts', () => (
+    handleStableUserDataRequest((service) => service.getTagCounts())
+  ));
 
   // ============================================================
   // File Watching Handlers
@@ -7017,6 +7120,11 @@ function setupFileOperationHandlers() {
           sourcePath: provenanceContext.sourcePath || null,
           destinationPath: normalizedFilePath,
           expectedOutputSha256,
+          userDataContext: stableFileUserDataContext({
+            legacyImageId: provenanceContext.userDataContext?.legacyImageId,
+            sourcePath: provenanceContext.sourcePath || normalizedFilePath,
+            destinationPath: normalizedFilePath,
+          }),
           perform: () => fs.writeFile(normalizedFilePath, data),
         });
         return { success: true, provenance: coordinated.provenance };
@@ -7460,7 +7568,8 @@ function setupFileOperationHandlers() {
             destinationDirectoryPath: destDir,
             destinationRelativePath: candidate,
             destinationAbsolutePath: candidatePath,
-            fileName: candidate
+            fileName: candidate,
+            legacyImageId: typeof file.legacyImageId === 'string' ? file.legacyImageId : null,
           });
         } catch {
           failedCount += 1;
@@ -7493,10 +7602,16 @@ function setupFileOperationHandlers() {
           }
         };
 
-        await executeWithStableIdentity({
+        const coordinated = await executeWithStableIdentity({
           kind: mode,
           sourcePath: task.sourceAbsolutePath,
           destinationPath: task.destinationAbsolutePath,
+          userDataContext: stableFileUserDataContext({
+            legacyImageId: task.legacyImageId,
+            sourcePath: task.sourceAbsolutePath,
+            destinationPath: task.destinationAbsolutePath,
+            copyUserData: mode === 'copy',
+          }),
           perform: async () => {
             if (isModel3DFileName(task.sourceAbsolutePath)) {
               await transferModel3DWithSidecar(
@@ -7523,6 +7638,7 @@ function setupFileOperationHandlers() {
           lastModified: stats.mtimeMs,
           birthtimeMs: normalizeBirthtimeMs(stats.birthtimeMs),
           type: getMimeTypeFromName(task.fileName),
+          provenance: coordinated.provenance,
         });
       };
 
@@ -7611,6 +7727,7 @@ app.on('before-quit', () => {
   licenseManager?.dispose?.();
   stableIdentityIndexer?.stop();
   stableIdentityFileOperationCoordinator = null;
+  stableIdentityUserDataService = null;
   provenanceRepositoryLifecycle?.close();
 });
 

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -7,9 +7,10 @@ import {
   PROVENANCE_DIRECTORY_NAME,
   resolveProvenanceCatalogPath,
 } from './provenancePaths.mjs';
+import { StableIdentityUserDataRepository } from './stableIdentityUserDataRepository.mjs';
 
 export { PROVENANCE_DATABASE_NAME, PROVENANCE_DIRECTORY_NAME, resolveProvenanceCatalogPath };
-export const PROVENANCE_SCHEMA_VERSION = 4;
+export const PROVENANCE_SCHEMA_VERSION = 5;
 
 export const ASSET_STATES = Object.freeze(['active', 'missing', 'deleted']);
 export const LOCATION_STATES = Object.freeze(['present', 'missing', 'removed']);
@@ -179,7 +180,110 @@ function migrationFour(database) {
   `);
 }
 
-const MIGRATIONS = new Map([[1, migrationOne], [2, migrationTwo], [3, migrationThree], [4, migrationFour]]);
+function migrationFive(database) {
+  database.exec(`
+    CREATE TABLE user_data_profile_state (
+      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+      authority TEXT NOT NULL CHECK (authority IN ('legacy', 'sqlite')),
+      activated_at TEXT,
+      legacy_scan_complete INTEGER NOT NULL DEFAULT 0 CHECK (legacy_scan_complete IN (0, 1)),
+      legacy_scan_completed_at TEXT,
+      updated_at TEXT NOT NULL
+    ) STRICT;
+
+    INSERT INTO user_data_profile_state (
+      singleton_id, authority, activated_at, legacy_scan_complete, legacy_scan_completed_at, updated_at
+    ) VALUES (1, 'legacy', NULL, 0, NULL, CURRENT_TIMESTAMP);
+
+    CREATE TABLE user_data_sequence (
+      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+      next_value INTEGER NOT NULL CHECK (next_value >= 1)
+    ) STRICT;
+
+    INSERT INTO user_data_sequence (singleton_id, next_value) VALUES (1, 1);
+
+    CREATE TABLE asset_user_data (
+      asset_id TEXT NOT NULL,
+      domain TEXT NOT NULL CHECK (domain IN ('annotation', 'shadow')),
+      payload_json TEXT,
+      tombstone INTEGER NOT NULL CHECK (tombstone IN (0, 1)),
+      record_version INTEGER NOT NULL CHECK (record_version >= 1),
+      field_versions_json TEXT NOT NULL,
+      field_sequences_json TEXT NOT NULL,
+      authority TEXT NOT NULL CHECK (authority IN ('legacy', 'sqlite')),
+      legacy_source_version INTEGER NOT NULL DEFAULT -1,
+      legacy_source_fingerprint TEXT,
+      last_mutation_sequence INTEGER NOT NULL DEFAULT 0,
+      migrated_at TEXT,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (asset_id, domain),
+      FOREIGN KEY (asset_id) REFERENCES assets(asset_id) ON DELETE RESTRICT,
+      CHECK ((tombstone = 1 AND payload_json IS NULL) OR (tombstone = 0 AND payload_json IS NOT NULL))
+    ) STRICT;
+
+    CREATE INDEX asset_user_data_domain_idx ON asset_user_data(domain, tombstone);
+
+    CREATE TABLE legacy_user_data_aliases (
+      domain TEXT NOT NULL CHECK (domain IN ('annotation', 'shadow')),
+      legacy_image_id TEXT NOT NULL,
+      asset_id TEXT NOT NULL,
+      location_id TEXT NOT NULL,
+      revision_id TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN ('bound', 'ambiguous')),
+      first_bound_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL,
+      PRIMARY KEY (domain, legacy_image_id),
+      FOREIGN KEY (asset_id) REFERENCES assets(asset_id) ON DELETE RESTRICT,
+      FOREIGN KEY (location_id) REFERENCES asset_locations(location_id) ON DELETE RESTRICT
+    ) STRICT;
+
+    CREATE INDEX legacy_user_data_alias_asset_idx
+      ON legacy_user_data_aliases(asset_id, domain);
+
+    CREATE TABLE legacy_user_data_pending (
+      domain TEXT NOT NULL CHECK (domain IN ('annotation', 'shadow')),
+      legacy_image_id TEXT NOT NULL,
+      payload_json TEXT,
+      tombstone INTEGER NOT NULL CHECK (tombstone IN (0, 1)),
+      source_version INTEGER NOT NULL CHECK (source_version >= 0),
+      source_fingerprint TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN ('pending', 'ambiguous', 'imported')),
+      updated_at TEXT NOT NULL,
+      migrated_at TEXT,
+      PRIMARY KEY (domain, legacy_image_id),
+      CHECK ((tombstone = 1 AND payload_json IS NULL) OR (tombstone = 0 AND payload_json IS NOT NULL))
+    ) STRICT;
+
+    CREATE TABLE user_data_mutation_intents (
+      mutation_id TEXT PRIMARY KEY,
+      sequence INTEGER NOT NULL UNIQUE,
+      domain TEXT NOT NULL CHECK (domain IN ('annotation', 'shadow')),
+      legacy_image_id TEXT NOT NULL,
+      patch_json TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN ('reserved', 'finalized', 'applied', 'ignored')),
+      source_version INTEGER,
+      source_fingerprint TEXT,
+      result_payload_json TEXT,
+      result_tombstone INTEGER CHECK (result_tombstone IS NULL OR result_tombstone IN (0, 1)),
+      applied_asset_id TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (applied_asset_id) REFERENCES assets(asset_id) ON DELETE RESTRICT
+    ) STRICT;
+
+    CREATE INDEX user_data_mutation_pending_idx
+      ON user_data_mutation_intents(domain, legacy_image_id, sequence)
+      WHERE state = 'finalized';
+  `);
+}
+
+const MIGRATIONS = new Map([
+  [1, migrationOne],
+  [2, migrationTwo],
+  [3, migrationThree],
+  [4, migrationFour],
+  [5, migrationFive],
+]);
 
 function serializeAsset(row) {
   return row ? {
@@ -282,6 +386,7 @@ export class AssetProvenanceRepository {
     this.now = now;
     this.backupDatabase = backupDatabase;
     this.database = null;
+    this.userData = null;
   }
 
   open({ failMigrationVersion = null, targetSchemaVersion = PROVENANCE_SCHEMA_VERSION } = {}) {
@@ -309,6 +414,12 @@ export class AssetProvenanceRepository {
         }
         this.database.exec('PRAGMA synchronous = NORMAL');
         this.applyMigrations({ failMigrationVersion, targetSchemaVersion });
+      }
+      if (readSchemaVersion(this.database) >= 5) {
+        this.userData = new StableIdentityUserDataRepository({
+          database: this.database,
+          now: this.now,
+        });
       }
       return this.getStatus();
     } catch (error) {
@@ -364,6 +475,63 @@ export class AssetProvenanceRepository {
       databasePath: this.databasePath,
       schemaVersion: open ? readSchemaVersion(this.database) : null,
     };
+  }
+
+  getUserDataAuthority() {
+    this.#requireUserDataRepository();
+    return this.userData.getAuthority();
+  }
+
+  activateUserDataAuthority() {
+    this.#requireWritable();
+    this.#requireUserDataRepository();
+    return this.userData.activateAuthority();
+  }
+
+  completeLegacyUserDataScan() {
+    this.#requireWritable();
+    this.#requireUserDataRepository();
+    return this.userData.completeLegacyScan();
+  }
+
+  syncLegacyUserDataBatch(entries) {
+    this.#requireWritable();
+    this.#requireUserDataRepository();
+    return this.userData.syncLegacyBatch(entries);
+  }
+
+  mutateAssetUserData(input) {
+    this.#requireWritable();
+    this.#requireUserDataRepository();
+    return this.userData.mutate(input);
+  }
+
+  reserveLegacyUserDataMutation(input) {
+    this.#requireWritable();
+    this.#requireUserDataRepository();
+    return this.userData.reserveLegacyMutation(input);
+  }
+
+  finalizeLegacyUserDataMutation(input) {
+    this.#requireWritable();
+    this.#requireUserDataRepository();
+    return this.userData.finalizeLegacyMutation(input);
+  }
+
+  mutateAnnotationTagGlobally(input) {
+    this.#requireWritable();
+    this.#requireUserDataRepository();
+    return this.userData.mutateAnnotationTagGlobally(input);
+  }
+
+  getUserDataTagCounts() {
+    this.#requireUserDataRepository();
+    return this.userData.getTagCounts();
+  }
+
+  captureAssetUserDataSnapshot(assetId, copiedAt = this.now().getTime()) {
+    this.#requireUserDataRepository();
+    return this.userData.captureCopySnapshot(assetId, copiedAt);
   }
 
   createAssetWithRevisionAndLocation(input) {
@@ -761,6 +929,10 @@ export class AssetProvenanceRepository {
           revisionId,
           locationId: destinationLocationId,
         };
+        if (operation.payload.userDataSnapshot) {
+          this.#requireUserDataRepository();
+          this.userData.applyCopySnapshot(operation.payload.userDataSnapshot, destinationAssetId);
+        }
       }
 
       const result = { mapping, destinationScope: destination?.rootId ? 'registered' : 'outside' };
@@ -972,7 +1144,10 @@ export class AssetProvenanceRepository {
 
   close() {
     if (!this.database) return;
-    try { this.database.close(); } finally { this.database = null; }
+    try { this.database.close(); } finally {
+      this.database = null;
+      this.userData = null;
+    }
   }
 
   #setFileOperationState(operationId, state, error) {
@@ -1033,6 +1208,15 @@ export class AssetProvenanceRepository {
   #requireWritable() {
     this.#requireOpen();
     if (this.readOnly) throw new ProvenanceRepositoryError('PROVENANCE_READ_ONLY', 'Provenance repository is read-only.');
+  }
+
+  #requireUserDataRepository() {
+    if (!this.userData) {
+      throw new ProvenanceRepositoryError(
+        'PROVENANCE_USER_DATA_UNAVAILABLE',
+        'Stable-identity user-data storage is unavailable for this catalog schema.',
+      );
+    }
   }
 
 }

--- a/electron/stableIdentityFileOperationCoordinator.mjs
+++ b/electron/stableIdentityFileOperationCoordinator.mjs
@@ -67,12 +67,23 @@ export class StableIdentityFileOperationCoordinator {
     return { enabled: true, recovered, pending };
   }
 
-  async executeKnownOperation({ kind, sourcePath = null, destinationPath = null, expectedOutputSha256 = null, perform }) {
+  async executeKnownOperation({
+    kind,
+    sourcePath = null,
+    destinationPath = null,
+    expectedOutputSha256 = null,
+    userDataContext = null,
+    perform,
+  }) {
+    const requiresUserDataJournal = Boolean(userDataContext?.legacyImageId);
     if (!this.enabled) {
       return { value: await perform(), provenance: { enabled: false, available: false } };
     }
     if (!this.#isAvailable()) {
       const status = this.repositoryLifecycle?.getStatus?.();
+      if (requiresUserDataJournal) {
+        throw new Error(status?.error?.message || status?.error || 'The stable user-data catalog is unavailable.');
+      }
       return {
         value: await perform(),
         provenance: {
@@ -92,6 +103,7 @@ export class StableIdentityFileOperationCoordinator {
       try {
         sourceStat = sourcePath ? await this.#statOrNull(path.resolve(sourcePath)) : null;
       } catch (error) {
+        if (requiresUserDataJournal) throw error;
         this.logger.error('Provenance source evidence is unavailable; continuing the authorized file operation.', error);
         return {
           value: await perform(),
@@ -136,8 +148,16 @@ export class StableIdentityFileOperationCoordinator {
             destinationStat,
           }),
         };
-        intent = this.#createIntent({ kind, sourcePath, destinationPath, expectedOutputSha256, beforeEvidence });
+        intent = this.#createIntent({
+          kind,
+          sourcePath,
+          destinationPath,
+          expectedOutputSha256,
+          beforeEvidence,
+          userDataContext,
+        });
       } catch (error) {
+        if (requiresUserDataJournal) throw error;
         this.logger.error('Provenance intent could not be persisted; continuing the authorized file operation.', error);
         return {
           value: await perform(),
@@ -308,16 +328,52 @@ export class StableIdentityFileOperationCoordinator {
   }
 
   #isAvailable() {
-    return Boolean(this.enabled && this.repositoryLifecycle?.getStatus?.().available && this.indexer?.enabled);
+    return Boolean(this.enabled && this.repositoryLifecycle?.getStatus?.().available && this.indexer);
   }
 
-  #createIntent({ kind, sourcePath, destinationPath, expectedOutputSha256, beforeEvidence }) {
+  #createIntent({ kind, sourcePath, destinationPath, expectedOutputSha256, beforeEvidence, userDataContext }) {
     return this.repositoryLifecycle.run((repository) => {
-      const roots = repository.listLibraryRoots();
+      let roots = repository.listLibraryRoots();
+      for (const candidateRoot of [userDataContext?.sourceRootPath, userDataContext?.destinationRootPath]) {
+        if (typeof candidateRoot !== 'string' || !candidateRoot.trim()) continue;
+        const normalizedRoot = normalizeLibraryRootPath(candidateRoot, this.platform);
+        const operationPath = candidateRoot === userDataContext?.sourceRootPath ? sourcePath : destinationPath;
+        if (!operationPath) continue;
+        const relative = pathApiForPlatform(this.platform).relative(normalizedRoot.absolutePath, path.resolve(operationPath));
+        if (!isRelativePathInsideRoot(relative, this.platform) && relative !== '') continue;
+        if (!roots.some((root) => root.pathKey === normalizedRoot.pathKey)) {
+          repository.ensureLibraryRoot(normalizedRoot);
+          roots = repository.listLibraryRoots();
+        }
+      }
       const source = sourcePath ? this.#resolveCatalogPath(sourcePath, roots) : null;
       const destination = destinationPath ? this.#resolveCatalogPath(destinationPath, roots) : null;
       if (source) {
-        const location = repository.getLocationByRootPath(source.rootId, source.relativePathKey);
+        let location = repository.getLocationByRootPath(source.rootId, source.relativePathKey);
+        if (!location && beforeEvidence?.sourceSignature) {
+          const assigned = repository.assignIndexedFile({
+            rootId: source.rootId,
+            relativePath: source.relativePath,
+            relativePathKey: source.relativePathKey,
+            byteSize: beforeEvidence.sourceSignature.byteSize,
+            contentModifiedMs: beforeEvidence.sourceSignature.contentModifiedMs,
+            mimeType: inferMimeTypeFromName(source.relativePath, null),
+          });
+          location = repository.getLocationByRootPath(source.rootId, source.relativePathKey);
+          if (location) {
+            this.publishMappings({
+              rootId: source.rootId,
+              rootPath: source.rootPath,
+              mappings: [{
+                relativePath: source.relativePath,
+                relativePathKey: source.relativePathKey,
+                assetId: assigned.assetId,
+                revisionId: assigned.revisionId,
+                locationId: assigned.locationId,
+              }],
+            });
+          }
+        }
         Object.assign(source, location ? {
           locationId: location.locationId,
           assetId: location.assetId,
@@ -332,6 +388,23 @@ export class StableIdentityFileOperationCoordinator {
           existingRevisionId: location.revisionId,
         } : {});
       }
+      const legacyImageId = typeof userDataContext?.legacyImageId === 'string'
+        ? userDataContext.legacyImageId
+        : null;
+      if (source?.assetId && legacyImageId) {
+        const reference = {
+          assetId: source.assetId,
+          revisionId: source.revisionId,
+          locationId: source.locationId,
+        };
+        repository.syncLegacyUserDataBatch([
+          { domain: 'annotation', legacyImageId, reference },
+          { domain: 'shadow', legacyImageId, reference },
+        ]);
+      }
+      const userDataSnapshot = source?.assetId && userDataContext?.copyUserData === true
+        ? repository.captureAssetUserDataSnapshot(source.assetId)
+        : null;
       const payload = {
         source,
         destination,
@@ -341,6 +414,8 @@ export class StableIdentityFileOperationCoordinator {
           && this.#absolutePathKey(sourcePath) === this.#absolutePathKey(destinationPath)),
         beforeEvidence,
         expectedOutputSha256,
+        sourceLegacyImageId: legacyImageId,
+        userDataSnapshot,
         reserved: {
           assetId: destination && !destination.existingAssetId ? this.randomUUID() : null,
           revisionId: destination && !['rename', 'move', 'delete'].includes(kind) ? this.randomUUID() : null,
@@ -509,6 +584,20 @@ export class StableIdentityFileOperationCoordinator {
       completed = this.repositoryLifecycle.run((repository) => repository.completeFileOperation(operation.operationId, {
         observation: outcome.observation,
       }));
+      const confirmedMapping = completed?.result?.mapping;
+      if (confirmedMapping && operation.payload.destination?.rootPath) {
+        this.publishMappings({
+          rootId: confirmedMapping.rootId,
+          rootPath: operation.payload.destination.rootPath,
+          mappings: [{
+            relativePath: confirmedMapping.relativePath,
+            relativePathKey: operation.payload.destination.relativePathKey,
+            assetId: confirmedMapping.assetId,
+            revisionId: confirmedMapping.revisionId,
+            locationId: confirmedMapping.locationId,
+          }],
+        });
+      }
     } catch (error) {
       if (operationError && typeof operationError === 'object') {
         operationError.provenanceOperationId = operation.operationId;

--- a/electron/stableIdentityFileOperationsSmoke.mjs
+++ b/electron/stableIdentityFileOperationsSmoke.mjs
@@ -1,6 +1,8 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { ProvenanceRepositoryLifecycle } from './provenanceRepository.mjs';
+import { StableIdentityUserDataService } from './stableIdentityUserDataService.mjs';
 
 function assertSmoke(condition, message) {
   if (!condition) throw new Error(`Packaged provenance smoke failed: ${message}`);
@@ -21,6 +23,7 @@ export async function runStableIdentityFileOperationsSmoke({
   rootPath,
   userDataPath,
   repositoryLifecycle,
+  userDataService,
   indexer,
   coordinator,
 }) {
@@ -45,11 +48,34 @@ export async function runStableIdentityFileOperationsSmoke({
   const initial = initialMappings[0];
   assertSmoke(initial?.assetId && initial?.revisionId && initial?.locationId, 'initial identity was not assigned');
 
+  assertSmoke(userDataService?.getStatus?.().authority === 'sqlite', 'stable user-data data service bridge is not authoritative');
+  userDataService.syncLegacyBatch([
+    {
+      domain: 'annotation', legacyImageId: 'packaged-smoke-image',
+      payload: { isFavorite: true, tags: ['packaged'], rating: 5, addedAt: 10, updatedAt: 20 },
+      sourceVersion: 0,
+    },
+    {
+      domain: 'shadow', legacyImageId: 'packaged-smoke-image',
+      payload: { prompt: '', seed: 0, resources: [], tags: [], notes: '', updatedAt: 20 },
+      sourceVersion: 0,
+    },
+  ]);
+  userDataService.completeLegacyScan();
+
   await coordinator.executeKnownOperation({
-    kind: 'rename', sourcePath, destinationPath: renamedPath, perform: () => fs.rename(sourcePath, renamedPath),
+    kind: 'rename',
+    sourcePath,
+    destinationPath: renamedPath,
+    userDataContext: { legacyImageId: 'packaged-smoke-image' },
+    perform: () => fs.rename(sourcePath, renamedPath),
   });
   await coordinator.executeKnownOperation({
-    kind: 'copy', sourcePath: renamedPath, destinationPath: copyPath, perform: () => fs.copyFile(renamedPath, copyPath),
+    kind: 'copy',
+    sourcePath: renamedPath,
+    destinationPath: copyPath,
+    userDataContext: { legacyImageId: 'packaged-smoke-image', copyUserData: true },
+    perform: () => fs.copyFile(renamedPath, copyPath),
   });
   const copyBefore = await fs.stat(copyPath);
   const replacement = Buffer.from('packaged replacement!!');
@@ -71,12 +97,37 @@ export async function runStableIdentityFileOperationsSmoke({
     const copied = repository.getLocationByRootPath(root.rootId, 'copy.bin');
     const sourceAsset = repository.getAsset(initial.assetId);
     const copiedAsset = copied ? repository.getAsset(copied.assetId) : null;
+    const copiedReference = copied ? {
+      assetId: copied.assetId,
+      revisionId: copied.revisionId,
+      locationId: copied.locationId,
+    } : null;
+    const copiedAnnotation = copiedReference
+      ? repository.syncLegacyUserDataBatch([{
+          domain: 'annotation', legacyImageId: 'packaged-smoke-copy', reference: copiedReference,
+        }])[0].record
+      : null;
+    const copiedShadow = copiedReference
+      ? repository.syncLegacyUserDataBatch([{
+          domain: 'shadow', legacyImageId: 'packaged-smoke-copy', reference: copiedReference,
+        }])[0].record
+      : null;
+    const editedCopy = copiedReference && copiedAnnotation
+      ? repository.mutateAssetUserData({
+          domain: 'annotation', legacyImageId: 'packaged-smoke-copy', reference: copiedReference,
+          expectedVersion: copiedAnnotation.version,
+          patch: { set: { rating: 2, updatedAt: 30 } },
+        })
+      : null;
     return {
       root,
       renamed,
       copied,
       sourceAsset,
       copiedAsset,
+      copiedAnnotation,
+      copiedShadow,
+      editedCopy,
       pendingOperations: repository.listPendingFileOperations(),
       status: repository.getStatus(),
     };
@@ -87,7 +138,36 @@ export async function runStableIdentityFileOperationsSmoke({
   assertSmoke(snapshot.renamed?.locationId === initial.locationId, 'rename did not preserve the location');
   assertSmoke(snapshot.copied?.assetId !== initial.assetId, 'copy reused the source asset');
   assertSmoke(snapshot.copiedAsset?.revisions.length === 2, 'overwrite did not create exactly one new revision');
+  assertSmoke(snapshot.copiedAnnotation?.payload?.isFavorite === true, 'annotation was not copied');
+  assertSmoke(snapshot.copiedShadow?.payload?.seed === 0, 'shadow metadata was not copied');
+  assertSmoke(snapshot.editedCopy?.payload?.rating === 2, 'copied annotation was not independently editable');
   assertSmoke(snapshot.pendingOperations.length === 0, 'recovery journal contains pending operations');
+
+  await indexer.waitForIdle();
+  indexer.stop();
+  repositoryLifecycle.close();
+  const reopenedLifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+  reopenedLifecycle.initialize();
+  const reopenedUserDataService = new StableIdentityUserDataService({
+    repositoryLifecycle: reopenedLifecycle,
+    userDataPath,
+    migrationEnabled: false,
+  });
+  const reopenedUserDataStatus = reopenedUserDataService.initialize();
+  const reopened = reopenedLifecycle.run((repository) => {
+    const root = repository.listLibraryRoots().find((entry) => entry.absolutePath === syntheticRoot);
+    const copied = root ? repository.getLocationByRootPath(root.rootId, 'copy.bin') : null;
+    const sourceData = repository.captureAssetUserDataSnapshot(initial.assetId, 40);
+    const copiedData = copied ? repository.captureAssetUserDataSnapshot(copied.assetId, 40) : [];
+    return { status: repository.getStatus(), copied, sourceData, copiedData };
+  });
+  reopenedLifecycle.close();
+  assertSmoke(reopenedUserDataStatus.authority === 'sqlite', 'SQLite authority did not survive a flag-off reopen');
+  assertSmoke(reopenedUserDataStatus.legacyScanComplete === true, 'legacy scan checkpoint did not survive reopen');
+  assertSmoke(reopened.status.schemaVersion === 5, 'reopened catalog schema is not current');
+  assertSmoke(reopened.sourceData.find((entry) => entry.domain === 'annotation')?.payload?.rating === 5, 'source annotation changed with its copy');
+  assertSmoke(reopened.copiedData.find((entry) => entry.domain === 'annotation')?.payload?.rating === 2, 'copied annotation did not survive reopen');
+  assertSmoke(reopened.copiedData.find((entry) => entry.domain === 'shadow')?.payload?.seed === 0, 'copied shadow metadata did not survive reopen');
 
   return {
     success: true,
@@ -108,5 +188,13 @@ export async function runStableIdentityFileOperationsSmoke({
     },
     schemaVersion: snapshot.status.schemaVersion,
     pendingOperations: 0,
+    userData: {
+      authority: reopenedUserDataStatus.authority,
+      legacyScanComplete: reopenedUserDataStatus.legacyScanComplete,
+      sourceRating: 5,
+      copiedRating: 2,
+      copiedShadowSeed: 0,
+      reopened: true,
+    },
   };
 }

--- a/electron/stableIdentityUserDataRepository.mjs
+++ b/electron/stableIdentityUserDataRepository.mjs
@@ -1,0 +1,902 @@
+import crypto from 'node:crypto';
+
+const DOMAINS = new Set(['annotation', 'shadow']);
+const MAX_BATCH_SIZE = 200;
+const MAX_PAYLOAD_BYTES = 256 * 1024;
+const SHADOW_FIELDS = new Set([
+  'prompt', 'negativePrompt', 'model', 'seed', 'steps', 'cfg_scale', 'clip_skip',
+  'sampler', 'scheduler', 'generator', 'version', 'module', 'width', 'height',
+  'duration', 'resources', 'tags', 'notes', 'updatedAt',
+]);
+const ANNOTATION_FIELDS = new Set([
+  'isFavorite', 'tags', 'rating', 'addedAt', 'updatedAt', 'suppressedMetadataTags',
+]);
+
+class UserDataRepositoryError extends Error {
+  constructor(code, message, details = null) {
+    super(message);
+    this.name = 'UserDataRepositoryError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function runTransaction(database, operation) {
+  database.exec('BEGIN IMMEDIATE');
+  try {
+    const result = operation();
+    database.exec('COMMIT');
+    return result;
+  } catch (error) {
+    try { database.exec('ROLLBACK'); } catch { /* preserve original failure */ }
+    throw error;
+  }
+}
+
+function assertDomain(domain) {
+  if (!DOMAINS.has(domain)) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `Unsupported user-data domain: ${domain}.`);
+  }
+  return domain;
+}
+
+function assertNonBlank(value, name, maxLength = 4096) {
+  if (typeof value !== 'string' || !value.trim() || value.length > maxLength) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `${name} must be a non-empty bounded string.`);
+  }
+  return value;
+}
+
+function assertUuid(value, name) {
+  const normalized = assertNonBlank(value, name, 64).toLowerCase();
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(normalized)) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `${name} must be a UUID.`);
+  }
+  return normalized;
+}
+
+function safeInteger(value, name, minimum = 0) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < minimum) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `${name} must be a safe integer >= ${minimum}.`);
+  }
+  return number;
+}
+
+function parseJson(value, fallback) {
+  if (typeof value !== 'string') return fallback;
+  try { return JSON.parse(value); } catch { return fallback; }
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function payloadFingerprint(payload, tombstone) {
+  return crypto.createHash('sha256').update(tombstone ? '<deleted>' : canonicalJson(payload)).digest('hex');
+}
+
+function assertStringArray(value, name, maxItems = 1_000) {
+  if (!Array.isArray(value) || value.length > maxItems || value.some((entry) => typeof entry !== 'string' || entry.length > 1024)) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `${name} must be a bounded string array.`);
+  }
+  return [...value];
+}
+
+function assertTimestamp(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `${name} must be a non-negative finite timestamp.`);
+  }
+  return Math.trunc(number);
+}
+
+function normalizeAnnotationPayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'Annotation payload must be an object.');
+  }
+  const result = {};
+  for (const key of Object.keys(payload)) {
+    if (!ANNOTATION_FIELDS.has(key)) {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `Unsupported annotation field: ${key}.`);
+    }
+  }
+  if (typeof payload.isFavorite !== 'boolean') {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'Annotation isFavorite must be boolean.');
+  }
+  result.isFavorite = payload.isFavorite;
+  result.tags = assertStringArray(payload.tags, 'Annotation tags');
+  if (Object.prototype.hasOwnProperty.call(payload, 'rating')) {
+    if (payload.rating !== undefined && ![1, 2, 3, 4, 5].includes(payload.rating)) {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'Annotation rating must be absent or between 1 and 5.');
+    }
+    if (payload.rating !== undefined) result.rating = payload.rating;
+  }
+  result.addedAt = assertTimestamp(payload.addedAt, 'Annotation addedAt');
+  result.updatedAt = assertTimestamp(payload.updatedAt, 'Annotation updatedAt');
+  if (Object.prototype.hasOwnProperty.call(payload, 'suppressedMetadataTags')) {
+    result.suppressedMetadataTags = assertStringArray(payload.suppressedMetadataTags, 'Suppressed metadata tags');
+  }
+  return result;
+}
+
+function normalizeShadowPayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'Shadow metadata payload must be an object.');
+  }
+  const result = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (!SHADOW_FIELDS.has(key)) {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `Unsupported shadow metadata field: ${key}.`);
+    }
+    if (key === 'tags') {
+      result.tags = assertStringArray(value, 'Shadow metadata tags');
+    } else if (key === 'resources') {
+      if (!Array.isArray(value) || value.length > 1_000) {
+        throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'Shadow metadata resources must be a bounded array.');
+      }
+      result.resources = structuredClone(value);
+    } else if (key === 'updatedAt') {
+      result.updatedAt = assertTimestamp(value, 'Shadow metadata updatedAt');
+    } else if (['seed', 'steps', 'cfg_scale', 'clip_skip', 'width', 'height', 'duration'].includes(key)) {
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `Shadow metadata ${key} must be finite.`);
+      }
+      result[key] = value;
+    } else if (typeof value !== 'string') {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `Shadow metadata ${key} must be a string.`);
+    } else {
+      result[key] = value;
+    }
+  }
+  if (!Object.prototype.hasOwnProperty.call(result, 'updatedAt')) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'Shadow metadata updatedAt is required.');
+  }
+  return result;
+}
+
+function normalizePayload(domain, payload, tombstone = false) {
+  if (tombstone) return null;
+  const normalized = domain === 'annotation'
+    ? normalizeAnnotationPayload(payload)
+    : normalizeShadowPayload(payload);
+  if (Buffer.byteLength(JSON.stringify(normalized), 'utf8') > MAX_PAYLOAD_BYTES) {
+    throw new UserDataRepositoryError('USER_DATA_PAYLOAD_TOO_LARGE', 'User-data payload exceeds the storage limit.');
+  }
+  return normalized;
+}
+
+function normalizePatch(domain, patch) {
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'User-data patch must be an object.');
+  }
+  const allowedFields = domain === 'annotation' ? ANNOTATION_FIELDS : SHADOW_FIELDS;
+  const set = patch.set && typeof patch.set === 'object' && !Array.isArray(patch.set) ? { ...patch.set } : {};
+  const remove = Array.isArray(patch.remove) ? [...new Set(patch.remove)] : [];
+  for (const key of [...Object.keys(set), ...remove]) {
+    if (!allowedFields.has(key)) {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `Unsupported ${domain} patch field: ${key}.`);
+    }
+  }
+  if (domain === 'annotation') {
+    if (Object.prototype.hasOwnProperty.call(set, 'isFavorite') && typeof set.isFavorite !== 'boolean') {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'Annotation isFavorite must be boolean.');
+    }
+    if (Object.prototype.hasOwnProperty.call(set, 'tags')) set.tags = assertStringArray(set.tags, 'Annotation tags');
+    if (Object.prototype.hasOwnProperty.call(set, 'suppressedMetadataTags')) {
+      set.suppressedMetadataTags = assertStringArray(set.suppressedMetadataTags, 'Suppressed metadata tags');
+    }
+    if (Object.prototype.hasOwnProperty.call(set, 'rating') && ![1, 2, 3, 4, 5].includes(set.rating)) {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'Annotation rating must be between 1 and 5.');
+    }
+    for (const key of ['addedAt', 'updatedAt']) {
+      if (Object.prototype.hasOwnProperty.call(set, key)) set[key] = assertTimestamp(set[key], `Annotation ${key}`);
+    }
+  } else {
+    const hasUpdatedAt = Object.prototype.hasOwnProperty.call(set, 'updatedAt');
+    const candidate = { ...set, updatedAt: hasUpdatedAt ? set.updatedAt : 0 };
+    const normalizedCandidate = normalizeShadowPayload(candidate);
+    delete normalizedCandidate.updatedAt;
+    if (hasUpdatedAt) set.updatedAt = candidate.updatedAt;
+    for (const key of Object.keys(normalizedCandidate)) set[key] = normalizedCandidate[key];
+  }
+  const normalized = {
+    set,
+    remove,
+    deleteRecord: patch.deleteRecord === true,
+    addTags: domain === 'annotation' && Array.isArray(patch.addTags) ? assertStringArray(patch.addTags, 'Tags to add') : [],
+    removeTags: domain === 'annotation' && Array.isArray(patch.removeTags) ? assertStringArray(patch.removeTags, 'Tags to remove') : [],
+    suppressTags: domain === 'annotation' && Array.isArray(patch.suppressTags) ? assertStringArray(patch.suppressTags, 'Tags to suppress') : [],
+    unsuppressTags: domain === 'annotation' && Array.isArray(patch.unsuppressTags) ? assertStringArray(patch.unsuppressTags, 'Tags to unsuppress') : [],
+    importTags: domain === 'annotation' && Array.isArray(patch.importTags) ? assertStringArray(patch.importTags, 'Metadata tags') : [],
+  };
+  if (Buffer.byteLength(JSON.stringify(normalized), 'utf8') > MAX_PAYLOAD_BYTES) {
+    throw new UserDataRepositoryError('USER_DATA_PAYLOAD_TOO_LARGE', 'User-data patch exceeds the storage limit.');
+  }
+  return normalized;
+}
+
+function serializeRow(row) {
+  if (!row) return null;
+  return {
+    assetId: row.asset_id,
+    domain: row.domain,
+    payload: row.tombstone ? null : parseJson(row.payload_json, {}),
+    tombstone: Boolean(row.tombstone),
+    version: Number(row.record_version),
+    authority: row.authority,
+    legacySourceVersion: Number(row.legacy_source_version),
+    migratedAt: row.migrated_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class StableIdentityUserDataRepository {
+  constructor({ database, now = () => new Date() }) {
+    this.database = database;
+    this.now = now;
+  }
+
+  getAuthority() {
+    const row = this.database.prepare('SELECT * FROM user_data_profile_state WHERE singleton_id = 1').get();
+    return {
+      authority: row?.authority ?? 'legacy',
+      activatedAt: row?.activated_at ?? null,
+      legacyScanComplete: Boolean(row?.legacy_scan_complete),
+      legacyScanCompletedAt: row?.legacy_scan_completed_at ?? null,
+      updatedAt: row?.updated_at ?? null,
+    };
+  }
+
+  activateAuthority() {
+    const timestamp = this.now().toISOString();
+    this.database.prepare(`
+      UPDATE user_data_profile_state
+      SET authority = 'sqlite', activated_at = COALESCE(activated_at, ?), updated_at = ?
+      WHERE singleton_id = 1
+    `).run(timestamp, timestamp);
+    return this.getAuthority();
+  }
+
+  completeLegacyScan() {
+    const timestamp = this.now().toISOString();
+    return runTransaction(this.database, () => {
+      this.database.prepare(`
+        UPDATE user_data_profile_state
+        SET legacy_scan_complete = 1,
+            legacy_scan_completed_at = COALESCE(legacy_scan_completed_at, ?),
+            updated_at = ?
+        WHERE singleton_id = 1
+      `).run(timestamp, timestamp);
+      return this.getAuthority();
+    });
+  }
+
+  syncLegacyBatch(entries) {
+    if (!Array.isArray(entries) || entries.length > MAX_BATCH_SIZE) {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `Legacy sync batch must contain at most ${MAX_BATCH_SIZE} records.`);
+    }
+    return runTransaction(this.database, () => entries.map((entry) => this.#syncLegacyEntry(entry)));
+  }
+
+  mutate(input) {
+    const domain = assertDomain(input?.domain);
+    const legacyImageId = assertNonBlank(input?.legacyImageId, 'legacyImageId');
+    const expectedVersion = safeInteger(input?.expectedVersion ?? 0, 'expectedVersion');
+    const patch = normalizePatch(domain, input?.patch);
+    return runTransaction(this.database, () => {
+      const reference = this.#validateReference(input?.reference);
+      const binding = this.#bindAlias(domain, legacyImageId, reference);
+      if (binding.state === 'bound') this.#applyPendingForBinding(domain, legacyImageId, reference.assetId);
+      const sequence = this.#nextSequence();
+      return this.#applyPatch({
+        domain,
+        assetId: reference.assetId,
+        patch,
+        expectedVersion,
+        sequence,
+        enforceFieldConflict: true,
+        authority: 'sqlite',
+      });
+    });
+  }
+
+  reserveLegacyMutation(input) {
+    const mutationId = assertUuid(input?.mutationId, 'mutationId');
+    const domain = assertDomain(input?.domain);
+    const legacyImageId = assertNonBlank(input?.legacyImageId, 'legacyImageId');
+    const patch = normalizePatch(domain, input?.patch);
+    return runTransaction(this.database, () => {
+      const existing = this.database.prepare('SELECT * FROM user_data_mutation_intents WHERE mutation_id = ?').get(mutationId);
+      if (existing) {
+        if (existing.domain !== domain || existing.legacy_image_id !== legacyImageId || existing.patch_json !== canonicalJson(patch)) {
+          throw new UserDataRepositoryError('USER_DATA_IDEMPOTENCY_CONFLICT', 'Mutation id was already used for different user data.');
+        }
+        return { mutationId, sequence: Number(existing.sequence), state: existing.state };
+      }
+      const sequence = this.#nextSequence();
+      const timestamp = this.now().toISOString();
+      this.database.prepare(`
+        INSERT INTO user_data_mutation_intents (
+          mutation_id, sequence, domain, legacy_image_id, patch_json, state,
+          source_version, source_fingerprint, result_payload_json, result_tombstone,
+          applied_asset_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 'reserved', NULL, NULL, NULL, NULL, NULL, ?, ?)
+      `).run(mutationId, sequence, domain, legacyImageId, canonicalJson(patch), timestamp, timestamp);
+      return { mutationId, sequence, state: 'reserved' };
+    });
+  }
+
+  finalizeLegacyMutation(input) {
+    const mutationId = assertUuid(input?.mutationId, 'mutationId');
+    const sourceVersion = safeInteger(input?.sourceVersion, 'sourceVersion');
+    const tombstone = input?.tombstone === true;
+    return runTransaction(this.database, () => {
+      const intent = this.database.prepare('SELECT * FROM user_data_mutation_intents WHERE mutation_id = ?').get(mutationId);
+      if (!intent) throw new UserDataRepositoryError('USER_DATA_MUTATION_NOT_FOUND', `Mutation ${mutationId} was not reserved.`);
+      const payload = normalizePayload(intent.domain, input?.payload, tombstone);
+      const fingerprint = payloadFingerprint(payload, tombstone);
+      if (intent.state !== 'reserved') {
+        if (Number(intent.source_version) !== sourceVersion || intent.source_fingerprint !== fingerprint) {
+          throw new UserDataRepositoryError('USER_DATA_IDEMPOTENCY_CONFLICT', 'Finalized mutation result differs from the committed result.');
+        }
+        return {
+          mutationId,
+          sequence: Number(intent.sequence),
+          state: intent.state,
+          record: intent.applied_asset_id ? this.#readRow(intent.applied_asset_id, intent.domain) : null,
+        };
+      }
+      const timestamp = this.now().toISOString();
+      this.#stagePending({
+        domain: intent.domain,
+        legacyImageId: intent.legacy_image_id,
+        payload,
+        tombstone,
+        sourceVersion,
+        fingerprint,
+        state: 'pending',
+        timestamp,
+      });
+      this.database.prepare(`
+        UPDATE user_data_mutation_intents
+        SET state = 'finalized', source_version = ?, source_fingerprint = ?,
+            result_payload_json = ?, result_tombstone = ?, updated_at = ?
+        WHERE mutation_id = ?
+      `).run(sourceVersion, fingerprint, tombstone ? null : JSON.stringify(payload), tombstone ? 1 : 0, timestamp, mutationId);
+      const alias = this.database.prepare(`
+        SELECT asset_id FROM legacy_user_data_aliases
+        WHERE domain = ? AND legacy_image_id = ? AND state = 'bound'
+      `).get(intent.domain, intent.legacy_image_id);
+      if (alias?.asset_id) this.#applyFinalizedIntents(intent.domain, intent.legacy_image_id, alias.asset_id);
+      const finalized = this.database.prepare('SELECT state, applied_asset_id FROM user_data_mutation_intents WHERE mutation_id = ?')
+        .get(mutationId);
+      return {
+        mutationId,
+        sequence: Number(intent.sequence),
+        state: finalized.state,
+        record: finalized.applied_asset_id ? this.#readRow(finalized.applied_asset_id, intent.domain) : null,
+      };
+    });
+  }
+
+  mutateAnnotationTagGlobally({ action, sourceTag, targetTag = null, updatedAt }) {
+    if (!['rename', 'remove'].includes(action)) {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', `Unsupported global tag action: ${action}.`);
+    }
+    const source = assertNonBlank(sourceTag, 'sourceTag', 1024);
+    const target = action === 'rename' ? assertNonBlank(targetTag, 'targetTag', 1024) : null;
+    const sourceUpdatedAt = assertTimestamp(updatedAt, 'updatedAt');
+    return runTransaction(this.database, () => {
+      const rows = this.database.prepare(`
+        SELECT data.* FROM asset_user_data data
+        WHERE data.domain = 'annotation' AND data.tombstone = 0
+      `).all();
+      const changed = [];
+      for (const row of rows) {
+        const payload = parseJson(row.payload_json, {});
+        if (!Array.isArray(payload.tags) || !payload.tags.includes(source)) continue;
+        const patch = action === 'rename'
+          ? {
+              removeTags: [source],
+              addTags: [target],
+              suppressTags: [source],
+              unsuppressTags: [target],
+              set: { updatedAt: sourceUpdatedAt },
+            }
+          : { removeTags: [source], suppressTags: [source], set: { updatedAt: sourceUpdatedAt } };
+        changed.push(this.#applyPatch({
+          domain: 'annotation',
+          assetId: row.asset_id,
+          patch: normalizePatch('annotation', patch),
+          expectedVersion: Number(row.record_version),
+          sequence: this.#nextSequence(),
+          enforceFieldConflict: false,
+          authority: 'sqlite',
+        }));
+      }
+      return changed;
+    });
+  }
+
+  getTagCounts() {
+    const rows = this.database.prepare(`
+      SELECT data.payload_json FROM asset_user_data data
+      WHERE data.domain = 'annotation' AND data.tombstone = 0
+        AND EXISTS (
+          SELECT 1 FROM asset_locations locations
+          WHERE locations.asset_id = data.asset_id AND locations.state = 'present'
+        )
+    `).all();
+    const counts = new Map();
+    for (const row of rows) {
+      const tags = parseJson(row.payload_json, {})?.tags;
+      if (!Array.isArray(tags)) continue;
+      for (const tag of tags) counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+    return [...counts.entries()].map(([name, count]) => ({ name, count }));
+  }
+
+  captureCopySnapshot(assetId, copiedAt) {
+    const normalizedAssetId = assertUuid(assetId, 'assetId');
+    const copyTimestamp = assertTimestamp(copiedAt, 'copiedAt');
+    return this.database.prepare('SELECT * FROM asset_user_data WHERE asset_id = ? ORDER BY domain').all(normalizedAssetId)
+      .map((row) => ({
+        domain: row.domain,
+        tombstone: Boolean(row.tombstone),
+        payload: row.tombstone ? null : parseJson(row.payload_json, {}),
+        copiedAt: copyTimestamp,
+      }));
+  }
+
+  applyCopySnapshot(snapshot, destinationAssetId) {
+    if (!Array.isArray(snapshot) || snapshot.length > 2) {
+      throw new UserDataRepositoryError('USER_DATA_INVALID_INPUT', 'Copy user-data snapshot is invalid.');
+    }
+    const assetId = assertUuid(destinationAssetId, 'destinationAssetId');
+    const timestamp = this.now().toISOString();
+    for (const entry of snapshot) {
+      const domain = assertDomain(entry?.domain);
+      const tombstone = entry?.tombstone === true;
+      let payload = normalizePayload(domain, entry?.payload, tombstone);
+      if (payload && Object.prototype.hasOwnProperty.call(payload, 'updatedAt')) {
+        payload = { ...payload, updatedAt: assertTimestamp(entry.copiedAt, 'copiedAt') };
+      }
+      const fieldVersions = Object.fromEntries(Object.keys(payload ?? {}).map((key) => [key, 1]));
+      if (tombstone) fieldVersions['*'] = 1;
+      const sequence = this.#nextSequence();
+      this.database.prepare(`
+        INSERT OR IGNORE INTO asset_user_data (
+          asset_id, domain, payload_json, tombstone, record_version, field_versions_json, field_sequences_json,
+          authority, legacy_source_version, legacy_source_fingerprint,
+          last_mutation_sequence, migrated_at, updated_at
+        ) VALUES (?, ?, ?, ?, 1, ?, ?, 'sqlite', -1, NULL, ?, NULL, ?)
+      `).run(
+        assetId,
+        domain,
+        tombstone ? null : JSON.stringify(payload),
+        tombstone ? 1 : 0,
+        JSON.stringify(fieldVersions),
+        JSON.stringify(Object.fromEntries(Object.keys(fieldVersions).map((key) => [key, 0]))),
+        sequence,
+        timestamp,
+      );
+    }
+  }
+
+  #syncLegacyEntry(entry) {
+    const domain = assertDomain(entry?.domain);
+    const legacyImageId = assertNonBlank(entry?.legacyImageId, 'legacyImageId');
+    const timestamp = this.now().toISOString();
+    let pending = this.database.prepare(`
+      SELECT * FROM legacy_user_data_pending WHERE domain = ? AND legacy_image_id = ?
+    `).get(domain, legacyImageId);
+
+    if (Object.prototype.hasOwnProperty.call(entry ?? {}, 'sourceVersion')) {
+      const sourceVersion = safeInteger(entry.sourceVersion, 'sourceVersion');
+      const tombstone = entry.tombstone === true;
+      const payload = normalizePayload(domain, entry.payload, tombstone);
+      const fingerprint = payloadFingerprint(payload, tombstone);
+      this.#stagePending({ domain, legacyImageId, payload, tombstone, sourceVersion, fingerprint, state: 'pending', timestamp });
+      pending = this.database.prepare(`
+        SELECT * FROM legacy_user_data_pending WHERE domain = ? AND legacy_image_id = ?
+      `).get(domain, legacyImageId);
+    }
+
+    if (!entry?.reference) {
+      return { domain, legacyImageId, status: pending?.state ?? 'unmapped', record: null };
+    }
+
+    const reference = this.#validateReference(entry.reference);
+    const binding = this.#bindAlias(domain, legacyImageId, reference);
+    if (binding.state === 'ambiguous') {
+      this.database.prepare(`
+        UPDATE legacy_user_data_pending SET state = 'ambiguous', updated_at = ?
+        WHERE domain = ? AND legacy_image_id = ?
+      `).run(timestamp, domain, legacyImageId);
+      return { domain, legacyImageId, status: 'ambiguous', record: this.#readRow(reference.assetId, domain) };
+    }
+
+    this.#applyPendingForBinding(domain, legacyImageId, reference.assetId);
+    const requiresSourceAck = Boolean(this.database.prepare(`
+      SELECT 1 FROM user_data_mutation_intents
+      WHERE domain = ? AND legacy_image_id = ? AND state = 'reserved'
+      LIMIT 1
+    `).get(domain, legacyImageId));
+    return {
+      domain,
+      legacyImageId,
+      status: requiresSourceAck ? 'source_ack_required' : 'bound',
+      record: this.#readRow(reference.assetId, domain),
+    };
+  }
+
+  #validateReference(reference) {
+    if (!reference || typeof reference !== 'object') {
+      throw new UserDataRepositoryError('USER_DATA_MAPPING_REQUIRED', 'A catalog-backed user-data operation requires a stable identity mapping.');
+    }
+    const assetId = assertUuid(reference.assetId, 'assetId');
+    const locationId = assertUuid(reference.locationId, 'locationId');
+    const revisionId = assertUuid(reference.revisionId, 'revisionId');
+    const row = this.database.prepare(`
+      SELECT locations.*, assets.state AS asset_state
+      FROM asset_locations locations
+      JOIN assets ON assets.asset_id = locations.asset_id
+      WHERE locations.location_id = ? AND locations.asset_id = ? AND locations.revision_id = ?
+    `).get(locationId, assetId, revisionId);
+    if (!row || row.state === 'removed' || row.asset_state === 'deleted') {
+      throw new UserDataRepositoryError('USER_DATA_MAPPING_STALE', 'The supplied asset/location/revision mapping is not current.');
+    }
+    return { assetId, locationId, revisionId };
+  }
+
+  #bindAlias(domain, legacyImageId, reference) {
+    const timestamp = this.now().toISOString();
+    const existing = this.database.prepare(`
+      SELECT * FROM legacy_user_data_aliases WHERE domain = ? AND legacy_image_id = ?
+    `).get(domain, legacyImageId);
+    if (!existing) {
+      this.database.prepare(`
+        INSERT INTO legacy_user_data_aliases (
+          domain, legacy_image_id, asset_id, location_id, revision_id, state, first_bound_at, last_seen_at
+        ) VALUES (?, ?, ?, ?, ?, 'bound', ?, ?)
+      `).run(domain, legacyImageId, reference.assetId, reference.locationId, reference.revisionId, timestamp, timestamp);
+      return { state: 'bound', assetId: reference.assetId };
+    }
+    if (existing.asset_id !== reference.assetId) {
+      this.database.prepare(`
+        UPDATE legacy_user_data_aliases SET state = 'ambiguous', last_seen_at = ?
+        WHERE domain = ? AND legacy_image_id = ?
+      `).run(timestamp, domain, legacyImageId);
+      return { state: 'ambiguous', assetId: existing.asset_id };
+    }
+    this.database.prepare(`
+      UPDATE legacy_user_data_aliases
+      SET location_id = ?, revision_id = ?, state = 'bound', last_seen_at = ?
+      WHERE domain = ? AND legacy_image_id = ?
+    `).run(reference.locationId, reference.revisionId, timestamp, domain, legacyImageId);
+    return { state: 'bound', assetId: reference.assetId };
+  }
+
+  #stagePending({ domain, legacyImageId, payload, tombstone, sourceVersion, fingerprint, state, timestamp }) {
+    const existing = this.database.prepare(`
+      SELECT * FROM legacy_user_data_pending WHERE domain = ? AND legacy_image_id = ?
+    `).get(domain, legacyImageId);
+    if (existing) {
+      if (Number(existing.source_version) > sourceVersion) return false;
+      if (Number(existing.source_version) === sourceVersion) {
+        if (existing.source_fingerprint !== fingerprint) {
+          this.database.prepare(`
+            UPDATE legacy_user_data_pending SET state = 'ambiguous', updated_at = ?
+            WHERE domain = ? AND legacy_image_id = ?
+          `).run(timestamp, domain, legacyImageId);
+        }
+        return false;
+      }
+      this.database.prepare(`
+        UPDATE legacy_user_data_pending
+        SET payload_json = ?, tombstone = ?, source_version = ?, source_fingerprint = ?,
+            state = CASE WHEN state = 'ambiguous' THEN state ELSE ? END, updated_at = ?
+        WHERE domain = ? AND legacy_image_id = ?
+      `).run(tombstone ? null : JSON.stringify(payload), tombstone ? 1 : 0, sourceVersion, fingerprint, state, timestamp, domain, legacyImageId);
+      return true;
+    }
+    this.database.prepare(`
+      INSERT INTO legacy_user_data_pending (
+        domain, legacy_image_id, payload_json, tombstone, source_version,
+        source_fingerprint, state, updated_at, migrated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+    `).run(domain, legacyImageId, tombstone ? null : JSON.stringify(payload), tombstone ? 1 : 0, sourceVersion, fingerprint, state, timestamp);
+    return true;
+  }
+
+  #applyPendingForBinding(domain, legacyImageId, assetId) {
+    const pending = this.database.prepare(`
+      SELECT * FROM legacy_user_data_pending
+      WHERE domain = ? AND legacy_image_id = ? AND state != 'ambiguous'
+    `).get(domain, legacyImageId);
+    if (pending) {
+      const rowBeforeImport = this.#rawRow(assetId, domain);
+      this.#applyLegacySnapshot({
+        domain,
+        assetId,
+        payload: pending.tombstone ? null : parseJson(pending.payload_json, {}),
+        tombstone: Boolean(pending.tombstone),
+        sourceVersion: Number(pending.source_version),
+        fingerprint: pending.source_fingerprint,
+      });
+      const timestamp = this.now().toISOString();
+      this.database.prepare(`
+        UPDATE legacy_user_data_pending
+        SET state = 'imported', migrated_at = COALESCE(migrated_at, ?), updated_at = ?
+        WHERE domain = ? AND legacy_image_id = ?
+      `).run(timestamp, timestamp, domain, legacyImageId);
+      if (!rowBeforeImport || rowBeforeImport.authority !== 'sqlite') {
+        this.#adoptFinalizedIntentsCoveredBySnapshot(
+          domain,
+          legacyImageId,
+          assetId,
+          Number(pending.source_version),
+        );
+      }
+    }
+    this.#applyFinalizedIntents(domain, legacyImageId, assetId);
+  }
+
+  #adoptFinalizedIntentsCoveredBySnapshot(domain, legacyImageId, assetId, sourceVersion) {
+    const intents = this.database.prepare(`
+      SELECT * FROM user_data_mutation_intents
+      WHERE domain = ? AND legacy_image_id = ? AND state = 'finalized' AND source_version <= ?
+      ORDER BY sequence
+    `).all(domain, legacyImageId, sourceVersion);
+    if (intents.length === 0) return;
+    const row = this.#rawRow(assetId, domain);
+    if (!row) return;
+    const fieldSequences = parseJson(row.field_sequences_json, {});
+    let lastSequence = Number(row.last_mutation_sequence ?? 0);
+    for (const intent of intents) {
+      const patch = normalizePatch(domain, parseJson(intent.patch_json, {}));
+      const touched = new Set([...Object.keys(patch.set), ...patch.remove]);
+      if (
+        patch.addTags.length || patch.removeTags.length || patch.suppressTags.length
+        || patch.unsuppressTags.length || patch.importTags.length
+      ) touched.add('tags');
+      if (patch.suppressTags.length || patch.unsuppressTags.length || patch.importTags.length) {
+        touched.add('suppressedMetadataTags');
+      }
+      if (patch.deleteRecord) touched.add('*');
+      const sequence = Number(intent.sequence);
+      for (const field of touched) fieldSequences[field] = Math.max(Number(fieldSequences[field] ?? 0), sequence);
+      lastSequence = Math.max(lastSequence, sequence);
+      this.database.prepare(`
+        UPDATE user_data_mutation_intents
+        SET state = 'applied', applied_asset_id = ?, updated_at = ?
+        WHERE mutation_id = ?
+      `).run(assetId, this.now().toISOString(), intent.mutation_id);
+    }
+    this.database.prepare(`
+      UPDATE asset_user_data
+      SET authority = 'sqlite', field_sequences_json = ?, last_mutation_sequence = ?, updated_at = ?
+      WHERE asset_id = ? AND domain = ?
+    `).run(JSON.stringify(fieldSequences), lastSequence, this.now().toISOString(), assetId, domain);
+  }
+
+  #applyLegacySnapshot({ domain, assetId, payload, tombstone, sourceVersion, fingerprint }) {
+    const row = this.#rawRow(assetId, domain);
+    const timestamp = this.now().toISOString();
+    if (row?.authority === 'sqlite') return serializeRow(row);
+    if (row && Number(row.legacy_source_version) >= sourceVersion) return serializeRow(row);
+    const version = row ? Number(row.record_version) + 1 : 1;
+    const fieldVersions = Object.fromEntries(Object.keys(payload ?? {}).map((key) => [key, version]));
+    if (tombstone) fieldVersions['*'] = version;
+    this.database.prepare(`
+      INSERT INTO asset_user_data (
+        asset_id, domain, payload_json, tombstone, record_version, field_versions_json, field_sequences_json,
+        authority, legacy_source_version, legacy_source_fingerprint,
+        last_mutation_sequence, migrated_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, 'legacy', ?, ?, 0, ?, ?)
+      ON CONFLICT(asset_id, domain) DO UPDATE SET
+        payload_json = excluded.payload_json,
+        tombstone = excluded.tombstone,
+        record_version = excluded.record_version,
+        field_versions_json = excluded.field_versions_json,
+        field_sequences_json = excluded.field_sequences_json,
+        legacy_source_version = excluded.legacy_source_version,
+        legacy_source_fingerprint = excluded.legacy_source_fingerprint,
+        migrated_at = COALESCE(asset_user_data.migrated_at, excluded.migrated_at),
+        updated_at = excluded.updated_at
+    `).run(
+      assetId, domain, tombstone ? null : JSON.stringify(payload), tombstone ? 1 : 0,
+      version,
+      JSON.stringify(fieldVersions),
+      JSON.stringify(Object.fromEntries(Object.keys(fieldVersions).map((key) => [key, 0]))),
+      sourceVersion,
+      fingerprint,
+      timestamp,
+      timestamp,
+    );
+    return this.#readRow(assetId, domain);
+  }
+
+  #applyFinalizedIntents(domain, legacyImageId, assetId) {
+    const intents = this.database.prepare(`
+      SELECT * FROM user_data_mutation_intents
+      WHERE domain = ? AND legacy_image_id = ? AND state = 'finalized'
+      ORDER BY sequence
+    `).all(domain, legacyImageId);
+    for (const intent of intents) {
+      const row = this.#rawRow(assetId, domain);
+      this.#applyPatch({
+        domain,
+        assetId,
+        patch: parseJson(intent.patch_json, {}),
+        expectedVersion: row ? Number(row.record_version) : 0,
+        sequence: Number(intent.sequence),
+        enforceFieldConflict: false,
+        enforceSequencePrecedence: true,
+        authority: 'sqlite',
+      });
+      this.database.prepare(`
+        UPDATE user_data_mutation_intents SET state = 'applied', applied_asset_id = ?, updated_at = ?
+        WHERE mutation_id = ?
+      `).run(assetId, this.now().toISOString(), intent.mutation_id);
+    }
+  }
+
+  #applyPatch({
+    domain,
+    assetId,
+    patch,
+    expectedVersion,
+    sequence,
+    enforceFieldConflict,
+    enforceSequencePrecedence = false,
+    authority,
+  }) {
+    const normalizedPatch = normalizePatch(domain, patch);
+    const row = this.#rawRow(assetId, domain);
+    const currentVersion = row ? Number(row.record_version) : 0;
+    const fieldVersions = row ? parseJson(row.field_versions_json, {}) : {};
+    const fieldSequences = row ? parseJson(row.field_sequences_json, {}) : {};
+    const originalTouchedFields = new Set([...Object.keys(normalizedPatch.set), ...normalizedPatch.remove]);
+    if (
+      normalizedPatch.addTags.length || normalizedPatch.removeTags.length
+      || normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length
+      || normalizedPatch.importTags.length
+    ) originalTouchedFields.add('tags');
+    if (normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length || normalizedPatch.importTags.length) {
+      originalTouchedFields.add('suppressedMetadataTags');
+    }
+    if (normalizedPatch.deleteRecord) originalTouchedFields.add('*');
+    if (enforceFieldConflict && currentVersion !== expectedVersion) {
+      const conflict = [...originalTouchedFields]
+        .filter((field) => field !== 'updatedAt')
+        .some((field) => Number(fieldVersions[field] ?? fieldVersions['*'] ?? 0) > expectedVersion);
+      if (conflict) {
+        throw new UserDataRepositoryError(
+          'USER_DATA_CONFLICT',
+          `${domain} changed after version ${expectedVersion}; reload before editing the same field.`,
+          { current: serializeRow(row) },
+        );
+      }
+    }
+
+    const fieldCanApply = (field) => !enforceSequencePrecedence || (
+      Number(fieldSequences[field] ?? 0) <= sequence
+      && Number(fieldSequences['*'] ?? 0) <= sequence
+    );
+    if (enforceSequencePrecedence) {
+      for (const key of Object.keys(normalizedPatch.set)) {
+        if (!fieldCanApply(key)) delete normalizedPatch.set[key];
+      }
+      normalizedPatch.remove = normalizedPatch.remove.filter(fieldCanApply);
+      if (!fieldCanApply('tags') || !fieldCanApply('suppressedMetadataTags')) {
+        normalizedPatch.addTags = [];
+        normalizedPatch.removeTags = [];
+        normalizedPatch.suppressTags = [];
+        normalizedPatch.unsuppressTags = [];
+        normalizedPatch.importTags = [];
+      }
+      if (normalizedPatch.deleteRecord) {
+        const newestFieldSequence = Math.max(0, ...Object.values(fieldSequences).map(Number));
+        if (newestFieldSequence > sequence) normalizedPatch.deleteRecord = false;
+      }
+    }
+    const touchedFields = new Set([...Object.keys(normalizedPatch.set), ...normalizedPatch.remove]);
+    if (
+      normalizedPatch.addTags.length || normalizedPatch.removeTags.length
+      || normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length
+      || normalizedPatch.importTags.length
+    ) touchedFields.add('tags');
+    if (normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length || normalizedPatch.importTags.length) {
+      touchedFields.add('suppressedMetadataTags');
+    }
+    if (normalizedPatch.deleteRecord) touchedFields.add('*');
+    if (touchedFields.size === 0) return serializeRow(row);
+
+    const defaultTimestamp = Number(normalizedPatch.set.updatedAt ?? normalizedPatch.set.addedAt ?? this.now().getTime());
+    let payload = row && !row.tombstone ? parseJson(row.payload_json, {}) : (
+      domain === 'annotation'
+        ? { isFavorite: false, tags: [], addedAt: defaultTimestamp, updatedAt: defaultTimestamp, suppressedMetadataTags: [] }
+        : { updatedAt: defaultTimestamp }
+    );
+    let tombstone = normalizedPatch.deleteRecord;
+    if (!tombstone) {
+      for (const [key, value] of Object.entries(normalizedPatch.set)) payload[key] = structuredClone(value);
+      for (const key of normalizedPatch.remove) delete payload[key];
+      if (domain === 'annotation') {
+        let tags = Array.isArray(payload.tags) ? [...payload.tags] : [];
+        let suppressed = Array.isArray(payload.suppressedMetadataTags) ? [...payload.suppressedMetadataTags] : [];
+        const add = new Set(normalizedPatch.addTags);
+        const remove = new Set(normalizedPatch.removeTags);
+        const suppress = new Set(normalizedPatch.suppressTags);
+        const unsuppress = new Set(normalizedPatch.unsuppressTags);
+        tags = [...new Set([...tags.filter((tag) => !remove.has(tag)), ...add])];
+        suppressed = [...new Set([...suppressed.filter((tag) => !unsuppress.has(tag)), ...suppress])];
+        for (const tag of normalizedPatch.importTags) {
+          if (!suppressed.includes(tag) && !tags.includes(tag)) tags.push(tag);
+        }
+        payload.tags = tags;
+        payload.suppressedMetadataTags = suppressed;
+      }
+      payload = normalizePayload(domain, payload, false);
+    } else {
+      payload = null;
+    }
+
+    const nextVersion = currentVersion + 1;
+    for (const field of touchedFields) {
+      fieldVersions[field] = nextVersion;
+      fieldSequences[field] = Math.max(Number(fieldSequences[field] ?? 0), sequence);
+    }
+    const lastMutationSequence = Math.max(Number(row?.last_mutation_sequence ?? 0), sequence);
+    const timestamp = this.now().toISOString();
+    this.database.prepare(`
+      INSERT INTO asset_user_data (
+        asset_id, domain, payload_json, tombstone, record_version, field_versions_json, field_sequences_json,
+        authority, legacy_source_version, legacy_source_fingerprint,
+        last_mutation_sequence, migrated_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, -1, NULL, ?, NULL, ?)
+      ON CONFLICT(asset_id, domain) DO UPDATE SET
+        payload_json = excluded.payload_json,
+        tombstone = excluded.tombstone,
+        record_version = excluded.record_version,
+        field_versions_json = excluded.field_versions_json,
+        field_sequences_json = excluded.field_sequences_json,
+        authority = excluded.authority,
+        last_mutation_sequence = excluded.last_mutation_sequence,
+        updated_at = excluded.updated_at
+    `).run(
+      assetId, domain, tombstone ? null : JSON.stringify(payload), tombstone ? 1 : 0,
+      nextVersion,
+      JSON.stringify(fieldVersions),
+      JSON.stringify(fieldSequences),
+      authority,
+      lastMutationSequence,
+      timestamp,
+    );
+    return this.#readRow(assetId, domain);
+  }
+
+  #nextSequence() {
+    const row = this.database.prepare(`
+      UPDATE user_data_sequence SET next_value = next_value + 1
+      WHERE singleton_id = 1 RETURNING next_value - 1 AS sequence
+    `).get();
+    return Number(row.sequence);
+  }
+
+  #rawRow(assetId, domain) {
+    return this.database.prepare('SELECT * FROM asset_user_data WHERE asset_id = ? AND domain = ?').get(assetId, domain);
+  }
+
+  #readRow(assetId, domain) {
+    return serializeRow(this.#rawRow(assetId, domain));
+  }
+}
+
+export { UserDataRepositoryError };

--- a/electron/stableIdentityUserDataRepository.mjs
+++ b/electron/stableIdentityUserDataRepository.mjs
@@ -235,6 +235,108 @@ function serializeRow(row) {
   };
 }
 
+function computeUserDataPatch({ domain, row, patch, expectedVersion, sequence, enforceFieldConflict = false, enforceSequencePrecedence = false, now }) {
+  const normalizedPatch = normalizePatch(domain, patch);
+  const currentVersion = row ? Number(row.record_version) : 0;
+  const fieldVersions = row ? parseJson(row.field_versions_json, {}) : {};
+  const fieldSequences = row ? parseJson(row.field_sequences_json, {}) : {};
+  const originalTouchedFields = new Set([...Object.keys(normalizedPatch.set), ...normalizedPatch.remove]);
+  if (
+    normalizedPatch.addTags.length || normalizedPatch.removeTags.length
+    || normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length
+    || normalizedPatch.importTags.length
+  ) originalTouchedFields.add('tags');
+  if (normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length || normalizedPatch.importTags.length) {
+    originalTouchedFields.add('suppressedMetadataTags');
+  }
+  if (normalizedPatch.deleteRecord) originalTouchedFields.add('*');
+  if (enforceFieldConflict && currentVersion !== expectedVersion) {
+    const conflict = [...originalTouchedFields]
+      .filter((field) => field !== 'updatedAt')
+      .some((field) => (field === '*'
+        ? Math.max(0, ...Object.values(fieldVersions).map(Number))
+        : Math.max(Number(fieldVersions[field] ?? 0), Number(fieldVersions['*'] ?? 0))) > expectedVersion);
+    if (conflict) {
+      throw new UserDataRepositoryError(
+        'USER_DATA_CONFLICT',
+        `${domain} changed after version ${expectedVersion}; reload before editing the same field.`,
+        { current: serializeRow(row) },
+      );
+    }
+  }
+
+  const fieldCanApply = (field) => !enforceSequencePrecedence || (
+    Number(fieldSequences[field] ?? 0) <= sequence
+    && Number(fieldSequences['*'] ?? 0) <= sequence
+  );
+  if (enforceSequencePrecedence) {
+    for (const key of Object.keys(normalizedPatch.set)) {
+      if (!fieldCanApply(key)) delete normalizedPatch.set[key];
+    }
+    normalizedPatch.remove = normalizedPatch.remove.filter(fieldCanApply);
+    if (!fieldCanApply('tags') || !fieldCanApply('suppressedMetadataTags')) {
+      normalizedPatch.addTags = [];
+      normalizedPatch.removeTags = [];
+      normalizedPatch.suppressTags = [];
+      normalizedPatch.unsuppressTags = [];
+      normalizedPatch.importTags = [];
+    }
+    if (normalizedPatch.deleteRecord) {
+      const newestFieldSequence = Math.max(0, ...Object.values(fieldSequences).map(Number));
+      if (newestFieldSequence > sequence) normalizedPatch.deleteRecord = false;
+    }
+  }
+  const touchedFields = new Set([...Object.keys(normalizedPatch.set), ...normalizedPatch.remove]);
+  if (
+    normalizedPatch.addTags.length || normalizedPatch.removeTags.length
+    || normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length
+    || normalizedPatch.importTags.length
+  ) touchedFields.add('tags');
+  if (normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length || normalizedPatch.importTags.length) {
+    touchedFields.add('suppressedMetadataTags');
+  }
+  if (normalizedPatch.deleteRecord) touchedFields.add('*');
+  if (touchedFields.size === 0) return null;
+
+  const defaultTimestamp = Number(normalizedPatch.set.updatedAt ?? normalizedPatch.set.addedAt ?? now.getTime());
+  let payload = row && !row.tombstone ? parseJson(row.payload_json, {}) : (
+    domain === 'annotation'
+      ? { isFavorite: false, tags: [], addedAt: defaultTimestamp, updatedAt: defaultTimestamp, suppressedMetadataTags: [] }
+      : { updatedAt: defaultTimestamp }
+  );
+  let tombstone = normalizedPatch.deleteRecord;
+  if (!tombstone) {
+    for (const [key, value] of Object.entries(normalizedPatch.set)) payload[key] = structuredClone(value);
+    for (const key of normalizedPatch.remove) delete payload[key];
+    if (domain === 'annotation') {
+      let tags = Array.isArray(payload.tags) ? [...payload.tags] : [];
+      let suppressed = Array.isArray(payload.suppressedMetadataTags) ? [...payload.suppressedMetadataTags] : [];
+      const add = new Set(normalizedPatch.addTags);
+      const remove = new Set(normalizedPatch.removeTags);
+      const suppress = new Set(normalizedPatch.suppressTags);
+      const unsuppress = new Set(normalizedPatch.unsuppressTags);
+      tags = [...new Set([...tags.filter((tag) => !remove.has(tag)), ...add])];
+      suppressed = [...new Set([...suppressed.filter((tag) => !unsuppress.has(tag)), ...suppress])];
+      for (const tag of normalizedPatch.importTags) {
+        if (!suppressed.includes(tag) && !tags.includes(tag)) tags.push(tag);
+      }
+      payload.tags = tags;
+      payload.suppressedMetadataTags = suppressed;
+    }
+    payload = normalizePayload(domain, payload, false);
+  } else {
+    payload = null;
+  }
+
+  const nextVersion = currentVersion + 1;
+  for (const field of touchedFields) {
+    fieldVersions[field] = nextVersion;
+    fieldSequences[field] = Math.max(Number(fieldSequences[field] ?? 0), sequence);
+  }
+  const lastMutationSequence = Math.max(Number(row?.last_mutation_sequence ?? 0), sequence);
+  return { payload, tombstone, nextVersion, fieldVersions, fieldSequences, lastMutationSequence };
+}
+
 export class StableIdentityUserDataRepository {
   constructor({ database, now = () => new Date() }) {
     this.database = database;
@@ -419,6 +521,24 @@ export class StableIdentityUserDataRepository {
           authority: 'sqlite',
         }));
       }
+      const pendingRows = this.database.prepare(`
+        SELECT * FROM legacy_user_data_pending WHERE domain = 'annotation' AND state = 'pending'
+      `).all();
+      for (const pending of pendingRows) {
+        const projected = this.#readPendingSnapshot(pending);
+        if (!projected?.payload?.tags?.includes(source)) continue;
+        const patch = normalizePatch('annotation', action === 'rename'
+          ? { removeTags: [source], addTags: [target], suppressTags: [source], unsuppressTags: [target], set: { updatedAt: sourceUpdatedAt } }
+          : { removeTags: [source], suppressTags: [source], set: { updatedAt: sourceUpdatedAt } });
+        const timestamp = this.now().toISOString();
+        // Preserve the source fingerprint: retries still acknowledge the same
+        // source snapshot. This durable patch is replayed at read/bind time.
+        this.database.prepare(`
+          INSERT INTO user_data_mutation_intents (
+            mutation_id, sequence, domain, legacy_image_id, patch_json, state, created_at, updated_at
+          ) VALUES (?, ?, 'annotation', ?, ?, 'finalized', ?, ?)
+        `).run(crypto.randomUUID(), this.#nextSequence(), pending.legacy_image_id, canonicalJson(patch), timestamp, timestamp);
+      }
       return changed;
     });
   }
@@ -488,6 +608,46 @@ export class StableIdentityUserDataRepository {
     }
   }
 
+  #readPendingSnapshot(pending) {
+    if (!pending || pending.state !== 'pending') return null;
+    const { domain, legacy_image_id: legacyImageId } = pending;
+    const intents = this.database.prepare(`
+      SELECT * FROM user_data_mutation_intents
+      WHERE domain = ? AND legacy_image_id = ? AND state = 'finalized'
+      ORDER BY sequence
+    `).all(domain, legacyImageId);
+    const fieldSequences = {};
+    // The source snapshot already contains these committed source edits. Global
+    // intents have no source_version and must be replayed, not adopted by it.
+    for (const intent of intents) {
+      if (intent.source_version === null || Number(intent.source_version) > Number(pending.source_version)) continue;
+      const patch = normalizePatch(domain, parseJson(intent.patch_json, {}));
+      const fields = new Set([...Object.keys(patch.set), ...patch.remove]);
+      if (patch.addTags.length || patch.removeTags.length || patch.suppressTags.length || patch.unsuppressTags.length || patch.importTags.length) fields.add('tags');
+      if (patch.suppressTags.length || patch.unsuppressTags.length || patch.importTags.length) fields.add('suppressedMetadataTags');
+      if (patch.deleteRecord) fields.add('*');
+      for (const field of fields) fieldSequences[field] = Math.max(Number(fieldSequences[field] ?? 0), Number(intent.sequence));
+    }
+    let row = { ...pending, record_version: 1, field_versions_json: '{}', field_sequences_json: JSON.stringify(fieldSequences) };
+    for (const intent of intents) {
+      if (intent.source_version !== null && Number(intent.source_version) <= Number(pending.source_version)) continue;
+      const next = computeUserDataPatch({
+        domain, row, patch: parseJson(intent.patch_json, {}), sequence: Number(intent.sequence),
+        enforceSequencePrecedence: true, now: this.now(),
+      });
+      if (!next) continue;
+      row = {
+        ...row, payload_json: next.tombstone ? null : JSON.stringify(next.payload), tombstone: next.tombstone,
+        record_version: next.nextVersion, field_versions_json: JSON.stringify(next.fieldVersions),
+        field_sequences_json: JSON.stringify(next.fieldSequences), last_mutation_sequence: next.lastMutationSequence,
+      };
+    }
+    return {
+      domain, legacyImageId, payload: row.tombstone ? null : parseJson(row.payload_json, {}),
+      tombstone: Boolean(row.tombstone), sourceVersion: Number(pending.source_version),
+    };
+  }
+
   #syncLegacyEntry(entry) {
     const domain = assertDomain(entry?.domain);
     const legacyImageId = assertNonBlank(entry?.legacyImageId, 'legacyImageId');
@@ -508,7 +668,14 @@ export class StableIdentityUserDataRepository {
     }
 
     if (!entry?.reference) {
-      return { domain, legacyImageId, status: pending?.state ?? 'unmapped', record: null };
+      const needsAck = this.database.prepare(`
+        SELECT 1 FROM user_data_mutation_intents
+        WHERE domain = ? AND legacy_image_id = ? AND state = 'reserved' LIMIT 1
+      `).get(domain, legacyImageId);
+      return {
+        domain, legacyImageId, status: needsAck ? 'source_ack_required' : pending?.state ?? 'unmapped',
+        record: null, pending: this.#readPendingSnapshot(pending),
+      };
     }
 
     const reference = this.#validateReference(entry.reference);
@@ -757,103 +924,13 @@ export class StableIdentityUserDataRepository {
     enforceSequencePrecedence = false,
     authority,
   }) {
-    const normalizedPatch = normalizePatch(domain, patch);
     const row = this.#rawRow(assetId, domain);
-    const currentVersion = row ? Number(row.record_version) : 0;
-    const fieldVersions = row ? parseJson(row.field_versions_json, {}) : {};
-    const fieldSequences = row ? parseJson(row.field_sequences_json, {}) : {};
-    const originalTouchedFields = new Set([...Object.keys(normalizedPatch.set), ...normalizedPatch.remove]);
-    if (
-      normalizedPatch.addTags.length || normalizedPatch.removeTags.length
-      || normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length
-      || normalizedPatch.importTags.length
-    ) originalTouchedFields.add('tags');
-    if (normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length || normalizedPatch.importTags.length) {
-      originalTouchedFields.add('suppressedMetadataTags');
-    }
-    if (normalizedPatch.deleteRecord) originalTouchedFields.add('*');
-    if (enforceFieldConflict && currentVersion !== expectedVersion) {
-      const conflict = [...originalTouchedFields]
-        .filter((field) => field !== 'updatedAt')
-        .some((field) => Number(fieldVersions[field] ?? fieldVersions['*'] ?? 0) > expectedVersion);
-      if (conflict) {
-        throw new UserDataRepositoryError(
-          'USER_DATA_CONFLICT',
-          `${domain} changed after version ${expectedVersion}; reload before editing the same field.`,
-          { current: serializeRow(row) },
-        );
-      }
-    }
-
-    const fieldCanApply = (field) => !enforceSequencePrecedence || (
-      Number(fieldSequences[field] ?? 0) <= sequence
-      && Number(fieldSequences['*'] ?? 0) <= sequence
-    );
-    if (enforceSequencePrecedence) {
-      for (const key of Object.keys(normalizedPatch.set)) {
-        if (!fieldCanApply(key)) delete normalizedPatch.set[key];
-      }
-      normalizedPatch.remove = normalizedPatch.remove.filter(fieldCanApply);
-      if (!fieldCanApply('tags') || !fieldCanApply('suppressedMetadataTags')) {
-        normalizedPatch.addTags = [];
-        normalizedPatch.removeTags = [];
-        normalizedPatch.suppressTags = [];
-        normalizedPatch.unsuppressTags = [];
-        normalizedPatch.importTags = [];
-      }
-      if (normalizedPatch.deleteRecord) {
-        const newestFieldSequence = Math.max(0, ...Object.values(fieldSequences).map(Number));
-        if (newestFieldSequence > sequence) normalizedPatch.deleteRecord = false;
-      }
-    }
-    const touchedFields = new Set([...Object.keys(normalizedPatch.set), ...normalizedPatch.remove]);
-    if (
-      normalizedPatch.addTags.length || normalizedPatch.removeTags.length
-      || normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length
-      || normalizedPatch.importTags.length
-    ) touchedFields.add('tags');
-    if (normalizedPatch.suppressTags.length || normalizedPatch.unsuppressTags.length || normalizedPatch.importTags.length) {
-      touchedFields.add('suppressedMetadataTags');
-    }
-    if (normalizedPatch.deleteRecord) touchedFields.add('*');
-    if (touchedFields.size === 0) return serializeRow(row);
-
-    const defaultTimestamp = Number(normalizedPatch.set.updatedAt ?? normalizedPatch.set.addedAt ?? this.now().getTime());
-    let payload = row && !row.tombstone ? parseJson(row.payload_json, {}) : (
-      domain === 'annotation'
-        ? { isFavorite: false, tags: [], addedAt: defaultTimestamp, updatedAt: defaultTimestamp, suppressedMetadataTags: [] }
-        : { updatedAt: defaultTimestamp }
-    );
-    let tombstone = normalizedPatch.deleteRecord;
-    if (!tombstone) {
-      for (const [key, value] of Object.entries(normalizedPatch.set)) payload[key] = structuredClone(value);
-      for (const key of normalizedPatch.remove) delete payload[key];
-      if (domain === 'annotation') {
-        let tags = Array.isArray(payload.tags) ? [...payload.tags] : [];
-        let suppressed = Array.isArray(payload.suppressedMetadataTags) ? [...payload.suppressedMetadataTags] : [];
-        const add = new Set(normalizedPatch.addTags);
-        const remove = new Set(normalizedPatch.removeTags);
-        const suppress = new Set(normalizedPatch.suppressTags);
-        const unsuppress = new Set(normalizedPatch.unsuppressTags);
-        tags = [...new Set([...tags.filter((tag) => !remove.has(tag)), ...add])];
-        suppressed = [...new Set([...suppressed.filter((tag) => !unsuppress.has(tag)), ...suppress])];
-        for (const tag of normalizedPatch.importTags) {
-          if (!suppressed.includes(tag) && !tags.includes(tag)) tags.push(tag);
-        }
-        payload.tags = tags;
-        payload.suppressedMetadataTags = suppressed;
-      }
-      payload = normalizePayload(domain, payload, false);
-    } else {
-      payload = null;
-    }
-
-    const nextVersion = currentVersion + 1;
-    for (const field of touchedFields) {
-      fieldVersions[field] = nextVersion;
-      fieldSequences[field] = Math.max(Number(fieldSequences[field] ?? 0), sequence);
-    }
-    const lastMutationSequence = Math.max(Number(row?.last_mutation_sequence ?? 0), sequence);
+    const computed = computeUserDataPatch({
+      domain, row, patch, expectedVersion, sequence, enforceFieldConflict,
+      enforceSequencePrecedence, now: this.now(),
+    });
+    if (!computed) return serializeRow(row);
+    const { payload, tombstone, nextVersion, fieldVersions, fieldSequences, lastMutationSequence } = computed;
     const timestamp = this.now().toISOString();
     this.database.prepare(`
       INSERT INTO asset_user_data (

--- a/electron/stableIdentityUserDataService.mjs
+++ b/electron/stableIdentityUserDataService.mjs
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { PROVENANCE_DIRECTORY_NAME } from './provenancePaths.mjs';
+
+const AUTHORITY_MARKER_NAME = 'user-data-sqlite-authority.json';
+
+export class StableIdentityUserDataService {
+  constructor({
+    repositoryLifecycle,
+    userDataPath,
+    migrationEnabled = false,
+    publishChanges = () => {},
+    fileSystem = fs,
+    logger = console,
+  }) {
+    this.repositoryLifecycle = repositoryLifecycle;
+    this.migrationEnabled = migrationEnabled;
+    this.publishChanges = publishChanges;
+    this.fileSystem = fileSystem;
+    this.logger = logger;
+    this.markerPath = path.join(userDataPath, PROVENANCE_DIRECTORY_NAME, AUTHORITY_MARKER_NAME);
+    this.authorityHint = false;
+    this.authority = 'legacy';
+    this.legacyScanComplete = false;
+    this.legacyScanCompletedAt = null;
+    this.initialized = false;
+  }
+
+  initialize() {
+    this.authorityHint = this.fileSystem.existsSync(this.markerPath);
+    const available = Boolean(this.repositoryLifecycle?.getStatus?.().available);
+    if (!available) {
+      this.authority = this.authorityHint ? 'sqlite' : 'legacy';
+      this.initialized = true;
+      return this.getStatus();
+    }
+
+    const stored = this.repositoryLifecycle.run((repository) => repository.getUserDataAuthority());
+    this.authority = stored.authority;
+    this.legacyScanComplete = stored.legacyScanComplete;
+    this.legacyScanCompletedAt = stored.legacyScanCompletedAt;
+    if (this.migrationEnabled && this.authority !== 'sqlite') {
+      // The durable external hint is intentionally written first. If activation is
+      // interrupted, the safe failure mode is "SQLite unavailable", never stale
+      // legacy data silently becoming authoritative again.
+      this.#writeAuthorityMarker();
+      this.authorityHint = true;
+      const activated = this.repositoryLifecycle.run((repository) => repository.activateUserDataAuthority());
+      this.authority = activated.authority;
+      this.legacyScanComplete = activated.legacyScanComplete;
+      this.legacyScanCompletedAt = activated.legacyScanCompletedAt;
+    } else if (this.authority === 'sqlite' && !this.authorityHint) {
+      this.#writeAuthorityMarker();
+      this.authorityHint = true;
+    }
+    this.initialized = true;
+    return this.getStatus();
+  }
+
+  getStatus() {
+    const catalogAvailable = Boolean(this.repositoryLifecycle?.getStatus?.().available);
+    return {
+      initialized: this.initialized,
+      authority: this.authorityHint || this.authority === 'sqlite' ? 'sqlite' : 'legacy',
+      available: (this.authorityHint || this.authority === 'sqlite') ? catalogAvailable : true,
+      migrationEnabled: this.migrationEnabled,
+      indexingEnabled: this.migrationEnabled,
+      legacyScanComplete: this.legacyScanComplete,
+      legacyScanCompletedAt: this.legacyScanCompletedAt,
+      error: catalogAvailable ? null : this.repositoryLifecycle?.getStatus?.().error ?? null,
+    };
+  }
+
+  syncLegacyBatch(entries) {
+    this.#requireStableAvailable();
+    const results = this.repositoryLifecycle.run((repository) => repository.syncLegacyUserDataBatch(entries));
+    this.#publishRecords(results.map((result) => result.record).filter(Boolean));
+    return results;
+  }
+
+  mutate(input) {
+    this.#requireStableAvailable();
+    const record = this.repositoryLifecycle.run((repository) => repository.mutateAssetUserData(input));
+    this.#publishRecords([record]);
+    return record;
+  }
+
+  reserveLegacyMutation(input) {
+    this.#requireStableAvailable();
+    return this.repositoryLifecycle.run((repository) => repository.reserveLegacyUserDataMutation(input));
+  }
+
+  finalizeLegacyMutation(input) {
+    this.#requireStableAvailable();
+    const result = this.repositoryLifecycle.run((repository) => repository.finalizeLegacyUserDataMutation(input));
+    if (result.record) this.#publishRecords([result.record]);
+    return result;
+  }
+
+  completeLegacyScan() {
+    this.#requireStableAvailable();
+    const state = this.repositoryLifecycle.run((repository) => repository.completeLegacyUserDataScan());
+    this.legacyScanComplete = state.legacyScanComplete;
+    this.legacyScanCompletedAt = state.legacyScanCompletedAt;
+    return this.getStatus();
+  }
+
+  mutateAnnotationTagGlobally(input) {
+    this.#requireStableAvailable();
+    const records = this.repositoryLifecycle.run((repository) => repository.mutateAnnotationTagGlobally(input));
+    this.#publishRecords(records);
+    return records;
+  }
+
+  getTagCounts() {
+    this.#requireStableAvailable();
+    return this.repositoryLifecycle.run((repository) => repository.getUserDataTagCounts());
+  }
+
+  #requireStableAvailable() {
+    const status = this.getStatus();
+    if (status.authority !== 'sqlite') {
+      const error = new Error('Stable-identity user-data persistence is not active for this profile.');
+      error.code = 'USER_DATA_LEGACY_AUTHORITY';
+      throw error;
+    }
+    if (!status.available) {
+      const error = new Error('Stable-identity user-data persistence is unavailable.');
+      error.code = 'USER_DATA_UNAVAILABLE';
+      throw error;
+    }
+  }
+
+  #publishRecords(records) {
+    if (!records.length) return;
+    for (let offset = 0; offset < records.length; offset += 200) {
+      this.publishChanges({ records: records.slice(offset, offset + 200) });
+    }
+  }
+
+  #writeAuthorityMarker() {
+    const directory = path.dirname(this.markerPath);
+    this.fileSystem.mkdirSync(directory, { recursive: true });
+    const temporaryPath = `${this.markerPath}.${crypto.randomUUID()}.tmp`;
+    try {
+      this.fileSystem.writeFileSync(temporaryPath, JSON.stringify({ authority: 'sqlite', version: 1 }), {
+        encoding: 'utf8',
+        flag: 'wx',
+      });
+      this.fileSystem.renameSync(temporaryPath, this.markerPath);
+    } catch (error) {
+      if (error?.code === 'EEXIST' && this.fileSystem.existsSync(this.markerPath)) return;
+      throw error;
+    } finally {
+      try { this.fileSystem.unlinkSync(temporaryPath); } catch { /* best effort */ }
+    }
+  }
+}
+
+export { AUTHORITY_MARKER_NAME };

--- a/hooks/useImageLoader.ts
+++ b/hooks/useImageLoader.ts
@@ -269,7 +269,7 @@ export function useImageLoader() {
     const {
         addDirectory, setLoading, setProgress, setError, setSuccess,
         removeImages, addImages, appendImagesRaw, mergeImages, clearImages, replaceDirectoryImagesRaw, setIndexingState, setEnrichmentProgress, setDirectoryRefreshing, setDirectoryProgress,
-        recomputeDerivedState,
+        recomputeDerivedState, hydrateAnnotationsForImages,
         setLineageDirectorySignature, setLineageRebuildSuspended, hydratePersistedLineageSnapshot, scheduleLineageRebuild
     } = useImageStore();
 
@@ -326,9 +326,12 @@ export function useImageLoader() {
                 );
                 return identity ? [{ ...image, ...identity }] : [];
             });
-            if (updates.length > 0) mergeImages(updates);
+            if (updates.length > 0) {
+                mergeImages(updates);
+                void hydrateAnnotationsForImages(updates);
+            }
         });
-    }, [mergeImages]);
+    }, [hydrateAnnotationsForImages, mergeImages]);
 
     // Helper function to check if indexing should be cancelled
     const shouldCancelIndexing = useCallback((allowIdle = false) => {

--- a/hooks/useShadowMetadata.ts
+++ b/hooks/useShadowMetadata.ts
@@ -1,97 +1,87 @@
-
-import { useState, useEffect, useCallback } from 'react';
-import { ShadowMetadata } from '../types';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { IndexedImage, ShadowMetadata, UserDataSemanticPatch } from '../types';
 import {
-  getShadowMetadata,
-  saveShadowMetadata as saveToStorage,
-  deleteShadowMetadata as deleteFromStorage,
-} from '../services/imageAnnotationsStorage';
-import { applyShadowMetadataUpdates } from '../utils/editableMetadata';
+  getPersistedShadowMetadata,
+  patchShadowMetadata,
+  registerStableUserDataImages,
+  shadowFromStableRecord,
+  subscribeStableUserDataChanges,
+} from '../services/userDataPersistenceAdapter';
 
-export function useShadowMetadata(imageId?: string) {
+export function useShadowMetadata(image?: IndexedImage | string) {
+  const imageId = typeof image === 'string' ? image : image?.id;
+  const identityKey = typeof image === 'string'
+    ? image
+    : `${image?.id ?? ''}\0${image?.assetId ?? ''}\0${image?.revisionId ?? ''}\0${image?.provenanceLocationId ?? ''}`;
+  const requestGeneration = useRef(0);
   const [metadata, setMetadata] = useState<ShadowMetadata | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  // Fetch metadata when imageId changes
-  useEffect(() => {
-    let isMounted = true;
+  const currentImage = useMemo(() => image, [identityKey]);
 
+  useEffect(() => {
+    const generation = ++requestGeneration.current;
     if (!imageId) {
       setMetadata(null);
       return;
     }
+    if (typeof currentImage !== 'string') registerStableUserDataImages([currentImage]);
+    setIsLoading(true);
+    setError(null);
+    void getPersistedShadowMetadata(currentImage).then((value) => {
+      if (requestGeneration.current === generation) setMetadata(value);
+    }).catch((cause) => {
+      if (requestGeneration.current !== generation) return;
+      console.error('Failed to fetch shadow metadata:', cause);
+      setError(cause instanceof Error ? cause : new Error('Unknown error'));
+      setMetadata(null);
+    }).finally(() => {
+      if (requestGeneration.current === generation) setIsLoading(false);
+    });
 
-    const fetchMetadata = async () => {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const data = await getShadowMetadata(imageId);
-        if (isMounted) {
-          setMetadata(data);
-        }
-      } catch (err) {
-        if (isMounted) {
-          console.error('Failed to fetch shadow metadata:', err);
-          setError(err instanceof Error ? err : new Error('Unknown error'));
-        }
-      } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
-      }
-    };
+    return () => { requestGeneration.current += 1; };
+  }, [currentImage, identityKey, imageId]);
 
-    fetchMetadata();
+  useEffect(() => subscribeStableUserDataChanges((records) => {
+    if (!imageId || typeof currentImage === 'string' || !currentImage.assetId) return;
+    for (const record of records) {
+      if (record.domain !== 'shadow' || record.assetId !== currentImage.assetId) continue;
+      setMetadata(shadowFromStableRecord(record, imageId));
+    }
+  }), [currentImage, identityKey, imageId]);
 
-    return () => {
-      isMounted = false;
-    };
-  }, [imageId]);
+  const saveMetadata = useCallback(async (updates: Partial<ShadowMetadata>) => {
+    if (!imageId) return undefined;
+    const set: Record<string, unknown> = {};
+    const remove: string[] = [];
+    for (const [key, value] of Object.entries(updates)) {
+      if (key === 'imageId' || key === 'assetId' || key === 'persistenceVersion') continue;
+      if (value === null || value === undefined) remove.push(key);
+      else set[key] = value;
+    }
+    try {
+      const saved = await patchShadowMetadata(currentImage, { set, remove } satisfies UserDataSemanticPatch);
+      setMetadata(saved);
+      return saved ?? undefined;
+    } catch (cause) {
+      console.error('Failed to save shadow metadata:', cause);
+      setError(cause instanceof Error ? cause : new Error('Unknown error'));
+      throw cause;
+    }
+  }, [currentImage, imageId, identityKey]);
 
-  // Save metadata
-  const saveMetadata = useCallback(
-    async (updates: Partial<ShadowMetadata>) => {
-      if (!imageId) return;
-
-      try {
-        const newMetadata = applyShadowMetadataUpdates(metadata, {
-          ...updates,
-          imageId,
-          updatedAt: Date.now(),
-        });
-
-        await saveToStorage(newMetadata);
-        setMetadata(newMetadata);
-        return newMetadata;
-      } catch (err) {
-        console.error('Failed to save shadow metadata:', err);
-        setError(err instanceof Error ? err : new Error('Unknown error'));
-        throw err;
-      }
-    },
-    [imageId, metadata]
-  );
-
-  // Delete metadata
   const deleteMetadata = useCallback(async () => {
     if (!imageId) return;
-
     try {
-      await deleteFromStorage(imageId);
+      await patchShadowMetadata(currentImage, { deleteRecord: true });
       setMetadata(null);
-    } catch (err) {
-        console.error('Failed to delete shadow metadata:', err);
-        setError(err instanceof Error ? err : new Error('Unknown error'));
-        throw err;
+    } catch (cause) {
+      console.error('Failed to delete shadow metadata:', cause);
+      setError(cause instanceof Error ? cause : new Error('Unknown error'));
+      throw cause;
     }
-  }, [imageId]);
+  }, [currentImage, imageId, identityKey]);
 
-  return {
-    metadata,
-    isLoading,
-    error,
-    saveMetadata,
-    deleteMetadata,
-  };
+  return { metadata, isLoading, error, saveMetadata, deleteMetadata };
 }

--- a/preload.js
+++ b/preload.js
@@ -220,9 +220,9 @@ const electronAPI = {
   // --- Invokable renderer-to-main functions ---
   getTheme: () => ipcRenderer.invoke('get-theme'),
   getZoomFactor: () => ipcRenderer.invoke('get-zoom-factor'),
-  trashFile: (filePath) => ipcRenderer.invoke('trash-file', filePath),
+  trashFile: (filePath, userDataContext) => ipcRenderer.invoke('trash-file', filePath, userDataContext),
   confirmPermanentDelete: (args) => ipcRenderer.invoke('confirm-permanent-delete', args),
-  renameFile: (oldPath, newPath) => ipcRenderer.invoke('rename-file', oldPath, newPath),
+  renameFile: (oldPath, newPath, userDataContext) => ipcRenderer.invoke('rename-file', oldPath, newPath, userDataContext),
   setCurrentDirectory: (dirPath) => ipcRenderer.invoke('set-current-directory', dirPath),
   updateAllowedPaths: (paths) => ipcRenderer.invoke('update-allowed-paths', paths),
   showDirectoryDialog: () => ipcRenderer.invoke('show-directory-dialog'),
@@ -237,6 +237,19 @@ const electronAPI = {
     const handler = (_event, payload) => callback(payload);
     ipcRenderer.on('provenance-identities-assigned', handler);
     return () => ipcRenderer.removeListener('provenance-identities-assigned', handler);
+  },
+  stableUserDataStatus: () => ipcRenderer.invoke('stable-user-data-status'),
+  stableUserDataSync: (args) => ipcRenderer.invoke('stable-user-data-sync', args),
+  stableUserDataMutate: (input) => ipcRenderer.invoke('stable-user-data-mutate', input),
+  stableUserDataReserveLegacyMutation: (input) => ipcRenderer.invoke('stable-user-data-reserve-legacy-mutation', input),
+  stableUserDataFinalizeLegacyMutation: (input) => ipcRenderer.invoke('stable-user-data-finalize-legacy-mutation', input),
+  stableUserDataCompleteLegacyScan: () => ipcRenderer.invoke('stable-user-data-complete-legacy-scan'),
+  stableUserDataGlobalTagMutation: (input) => ipcRenderer.invoke('stable-user-data-global-tag-mutation', input),
+  stableUserDataTagCounts: () => ipcRenderer.invoke('stable-user-data-tag-counts'),
+  onStableUserDataChanged: (callback) => {
+    const handler = (_event, payload) => callback(payload);
+    ipcRenderer.on('stable-user-data-changed', handler);
+    return () => ipcRenderer.removeListener('stable-user-data-changed', handler);
   },
   resolveMediaUrl: (filePath) => ipcRenderer.invoke('resolve-media-url', filePath),
   readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),

--- a/scripts/runPackagedStableIdentityFileOperationsSmoke.mjs
+++ b/scripts/runPackagedStableIdentityFileOperationsSmoke.mjs
@@ -69,7 +69,16 @@ try {
   const execution = await runExecutable(executablePath, args, env);
   if (execution.code !== 0) fail(`process exited with ${execution.code}.\n${execution.stdout}\n${execution.stderr}`);
   const result = JSON.parse(await fs.readFile(resultPath, 'utf8'));
-  if (!result.success || result.pendingOperations !== 0 || result.schemaVersion !== 4) fail('invalid result payload');
+  if (
+    !result.success
+    || result.pendingOperations !== 0
+    || result.schemaVersion !== 5
+    || result.userData?.authority !== 'sqlite'
+    || result.userData?.legacyScanComplete !== true
+    || result.userData?.copiedRating !== 2
+    || result.userData?.copiedShadowSeed !== 0
+    || result.userData?.reopened !== true
+  ) fail('invalid result payload');
   if (!path.resolve(result.paths.syntheticRoot).startsWith(path.resolve(temporaryRoot))) fail('synthetic data escaped the temporary root');
   if (mode === 'portable') {
     const expectedUserData = path.join(temporaryRoot, 'ImageMetaHubData');

--- a/services/fileOperations.ts
+++ b/services/fileOperations.ts
@@ -2,6 +2,7 @@
 import { IndexedImage } from '../types';
 import { SUPPORTED_MEDIA_EXTENSIONS } from '../utils/mediaTypes.js';
 import { getRelativeImagePath } from '../utils/imagePaths';
+import { prepareUserDataForImages } from './userDataPersistenceAdapter';
 
 // Check if we're running in Electron
 const isElectron = typeof window !== 'undefined' && (window as any).electronAPI;
@@ -25,6 +26,14 @@ export class FileOperations {
       }));
     }
 
+    try {
+      await prepareUserDataForImages(images);
+    } catch (error) {
+      const message = `Files were not deleted because their local user data could not be staged safely: ${error instanceof Error ? error.message : String(error)}`;
+      console.error(message, error);
+      return images.map(() => ({ success: false, error: message }));
+    }
+
     const attempts = await Promise.all(images.map(async (image) => {
       try {
         if (!image.directoryId) {
@@ -38,7 +47,18 @@ export class FileOperations {
             result: { success: false, error: `Failed to construct file path: ${joinResult.error}` },
           };
         }
-        const trashResult = await window.electronAPI!.trashFile(joinResult.path);
+        const trashResult = await window.electronAPI!.trashFile(joinResult.path, {
+          legacyImageId: image.id,
+          ...(image.assetId && image.revisionId && image.provenanceLocationId
+            ? {
+                stableReference: {
+                  assetId: image.assetId,
+                  revisionId: image.revisionId,
+                  locationId: image.provenanceLocationId,
+                },
+              }
+            : {}),
+        });
         return {
           result: trashResult.success
             ? { success: true }
@@ -146,7 +166,18 @@ export class FileOperations {
           return { success: false, error: `Failed to construct new file path: ${newPathResult.error}` };
         }
 
-        const result = await window.electronAPI.renameFile(oldPathResult.path, newPathResult.path);
+        const result = await window.electronAPI.renameFile(oldPathResult.path, newPathResult.path, {
+          legacyImageId: image.id,
+          ...(image.assetId && image.revisionId && image.provenanceLocationId
+            ? {
+                stableReference: {
+                  assetId: image.assetId,
+                  revisionId: image.revisionId,
+                  locationId: image.provenanceLocationId,
+                },
+              }
+            : {}),
+        });
         return { success: result.success, error: result.error };
       } else {
         // For browser environment, we can't rename files directly

--- a/services/fileTransferService.ts
+++ b/services/fileTransferService.ts
@@ -1,5 +1,10 @@
 import { processFiles } from './fileIndexer';
 import { bulkTransferImagePersistence } from './imageAnnotationsStorage';
+import {
+  getUserDataPersistenceStatus,
+  prepareUserDataForImages,
+  registerStableUserDataImages,
+} from './userDataPersistenceAdapter';
 import { useImageStore } from '../store/useImageStore';
 import type {
   Directory,
@@ -140,9 +145,35 @@ export async function transferIndexedImages({
     })
     .filter((entry) => entry.relativePath);
 
-  const sourceFiles = sourceDescriptors.map(({ directoryPath, relativePath }) => ({
+  try {
+    await prepareUserDataForImages(sourceDescriptors.map(({ image }) => image));
+  } catch (error) {
+    const message = `Files were not transferred because their local user data could not be staged safely: ${error instanceof Error ? error.message : String(error)}`;
+    setError(message);
+    setTransferProgress(null);
+    return {
+      success: false,
+      transferredCount: 0,
+      failedCount: sourceDescriptors.length,
+      error: message,
+    };
+  }
+  const userDataStatus = await getUserDataPersistenceStatus();
+  const usesStableUserData = userDataStatus.authority === 'sqlite';
+
+  const sourceFiles = sourceDescriptors.map(({ image, directoryPath, relativePath }) => ({
     directoryPath,
     relativePath,
+    legacyImageId: image.id,
+    ...(image.assetId && image.revisionId && image.provenanceLocationId
+      ? {
+          stableReference: {
+            assetId: image.assetId,
+            revisionId: image.revisionId,
+            locationId: image.provenanceLocationId,
+          },
+        }
+      : {}),
   }));
 
   if (!sourceFiles.length) {
@@ -188,6 +219,7 @@ export async function transferIndexedImages({
   const annotationsMap = new Map(useImageStore.getState().annotations);
 
   const persistenceTransfers: Array<{ sourceImageId: string; targetImageId: string }> = [];
+  const uiTransfers: Array<{ sourceImageId: string; targetImageId: string }> = [];
 
   onStatus?.('Preserving tags and metadata...');
   for (const item of transferredItems) {
@@ -197,14 +229,24 @@ export async function transferIndexedImages({
     }
 
     const targetImageId = `${destinationDirectory.id}::${item.destinationRelativePath}`;
-    persistenceTransfers.push({ sourceImageId: sourceImage.id, targetImageId });
+    uiTransfers.push({ sourceImageId: sourceImage.id, targetImageId });
+    if (!usesStableUserData) {
+      persistenceTransfers.push({ sourceImageId: sourceImage.id, targetImageId });
+    }
 
     const sourceAnnotation = annotationsMap.get(sourceImage.id);
     if (sourceAnnotation) {
+      const mapping = item.provenance?.operation?.result?.mapping;
       annotationsMap.set(targetImageId, {
         ...sourceAnnotation,
         imageId: targetImageId,
-        updatedAt: Date.now(),
+        ...(mode === 'copy'
+          ? {
+              assetId: mapping?.assetId,
+              persistenceVersion: mapping ? 1 : undefined,
+              updatedAt: Date.now(),
+            }
+          : {}),
       });
     }
   }
@@ -231,7 +273,7 @@ export async function transferIndexedImages({
   const refreshAvailableTags = useImageStore.getState().refreshAvailableTags;
 
   if (mode === 'move') {
-    for (const transfer of persistenceTransfers) {
+    for (const transfer of uiTransfers) {
       annotationsMap.delete(transfer.sourceImageId);
     }
   }
@@ -296,7 +338,22 @@ export async function transferIndexedImages({
     {
       fileStats: fileStatsMap,
       onEnrichmentBatch: (batch) => {
-        addImages(batch);
+        const mappingByRelativePath = new Map(transferredItems.flatMap((item) => {
+          const mapping = item.provenance?.operation?.result?.mapping;
+          return mapping ? [[item.destinationRelativePath, mapping] as const] : [];
+        }));
+        const mappedBatch = batch.map((image) => {
+          const mapping = mappingByRelativePath.get(getRelativeImagePath(image));
+          return mapping ? {
+            ...image,
+            assetId: mapping.assetId,
+            revisionId: mapping.revisionId,
+            provenanceLocationId: mapping.locationId,
+            provenanceRootId: mapping.rootId,
+          } : image;
+        });
+        registerStableUserDataImages(mappedBatch);
+        addImages(mappedBatch);
       },
     },
   );

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -1,6 +1,7 @@
 /// <reference lib="dom" />
 
-import type { ClusterPreference, ImageAnnotations, IndexedImage, ShadowMetadata, SmartCollection, TagInfo } from '../types';
+import type { ClusterPreference, ImageAnnotations, IndexedImage, ShadowMetadata, SmartCollection, TagInfo, UserDataSemanticPatch } from '../types';
+import { commitLegacyUserDataPatch, type LegacyUserDataDomain } from './legacyUserDataMigrationSource';
 import {
   getIndexedDbErrorName,
   openPreferencesDatabase,
@@ -21,6 +22,18 @@ type ManualTagRecord = {
 };
 
 const inMemoryAnnotations: Map<string, ImageAnnotations> = new Map();
+
+export async function patchLegacyUserData(domain: LegacyUserDataDomain, imageId: string, patch: UserDataSemanticPatch) {
+  const committed = await commitLegacyUserDataPatch(domain, imageId, patch);
+  if (domain === 'annotation') {
+    if (committed.payload) {
+      inMemoryAnnotations.set(imageId, { ...committed.payload, imageId } as unknown as ImageAnnotations);
+    } else {
+      inMemoryAnnotations.delete(imageId);
+    }
+  }
+  return committed;
+}
 const inMemoryManualTags: Set<string> = new Set();
 let isPersistenceDisabled = false;
 let hasResetAttempted = false;

--- a/services/imageAnnotationsStorage.ts
+++ b/services/imageAnnotationsStorage.ts
@@ -193,21 +193,19 @@ export async function loadAllAnnotations(): Promise<Map<string, ImageAnnotations
  * Save a single annotation to IndexedDB
  */
 export async function saveAnnotation(annotation: ImageAnnotations): Promise<void> {
-  inMemoryAnnotations.set(annotation.imageId, annotation);
-
   if (isPersistenceDisabled) {
-    return;
+    throw new Error('Image annotation persistence is unavailable for this session.');
   }
 
   const db = await openDatabase();
   if (!db) {
-    return;
+    throw new Error('Image annotation persistence is unavailable.');
   }
 
   await new Promise<void>((resolve, reject) => {
     const transaction = db.transaction(STORE_NAME, 'readwrite');
     const store = transaction.objectStore(STORE_NAME);
-    const request = store.put(annotation);
+    store.put(annotation);
 
     const close = () => {
       try {
@@ -217,18 +215,23 @@ export async function saveAnnotation(annotation: ImageAnnotations): Promise<void
       }
     };
 
-    transaction.oncomplete = close;
-    transaction.onabort = close;
-    transaction.onerror = close;
-
-    request.onsuccess = () => resolve();
-    request.onerror = () => {
-      console.error('Failed to save image annotation', request.error);
-      reject(request.error);
+    transaction.oncomplete = () => {
+      inMemoryAnnotations.set(annotation.imageId, annotation);
+      close();
+      resolve();
+    };
+    transaction.onabort = () => {
+      close();
+      reject(transaction.error ?? new Error('Image annotation transaction was aborted.'));
+    };
+    transaction.onerror = () => {
+      close();
+      reject(transaction.error ?? new Error('Image annotation transaction failed.'));
     };
   }).catch((error) => {
     console.error('IndexedDB save error for image annotation:', error);
     disablePersistence(error);
+    throw error;
   });
 }
 
@@ -240,18 +243,14 @@ export async function saveAnnotation(annotation: ImageAnnotations): Promise<void
  * Bulk delete multiple annotations in a single transaction
  */
 export async function bulkDeleteAnnotations(imageIds: string[]): Promise<void> {
-  // Update in-memory cache
-  for (const imageId of imageIds) {
-    inMemoryAnnotations.delete(imageId);
-  }
-
-  if (isPersistenceDisabled || imageIds.length === 0) {
+  if (imageIds.length === 0) {
     return;
   }
+  if (isPersistenceDisabled) throw new Error('Image annotation persistence is unavailable for this session.');
 
   const db = await openDatabase();
   if (!db) {
-    return;
+    throw new Error('Image annotation persistence is unavailable.');
   }
 
   return new Promise<void>((resolve, reject) => {
@@ -259,6 +258,8 @@ export async function bulkDeleteAnnotations(imageIds: string[]): Promise<void> {
     const store = transaction.objectStore(STORE_NAME);
 
     transaction.oncomplete = () => {
+      for (const imageId of imageIds) inMemoryAnnotations.delete(imageId);
+      db.close();
       resolve();
     };
     transaction.onerror = () => {
@@ -273,25 +274,24 @@ export async function bulkDeleteAnnotations(imageIds: string[]): Promise<void> {
   }).catch((error) => {
     console.error('IndexedDB bulk delete error for image annotations:', error);
     disablePersistence(error);
+    throw error;
   });
 }
 
 export async function deleteAnnotation(imageId: string): Promise<void> {
-  inMemoryAnnotations.delete(imageId);
-
   if (isPersistenceDisabled) {
-    return;
+    throw new Error('Image annotation persistence is unavailable for this session.');
   }
 
   const db = await openDatabase();
   if (!db) {
-    return;
+    throw new Error('Image annotation persistence is unavailable.');
   }
 
   await new Promise<void>((resolve, reject) => {
     const transaction = db.transaction(STORE_NAME, 'readwrite');
     const store = transaction.objectStore(STORE_NAME);
-    const request = store.delete(imageId);
+    store.delete(imageId);
 
     const close = () => {
       try {
@@ -301,18 +301,23 @@ export async function deleteAnnotation(imageId: string): Promise<void> {
       }
     };
 
-    transaction.oncomplete = close;
-    transaction.onabort = close;
-    transaction.onerror = close;
-
-    request.onsuccess = () => resolve();
-    request.onerror = () => {
-      console.error('Failed to delete image annotation', request.error);
-      reject(request.error);
+    transaction.oncomplete = () => {
+      inMemoryAnnotations.delete(imageId);
+      close();
+      resolve();
+    };
+    transaction.onabort = () => {
+      close();
+      reject(transaction.error ?? new Error('Image annotation delete transaction was aborted.'));
+    };
+    transaction.onerror = () => {
+      close();
+      reject(transaction.error ?? new Error('Image annotation delete transaction failed.'));
     };
   }).catch((error) => {
     console.error('IndexedDB delete error for image annotation:', error);
     disablePersistence(error);
+    throw error;
   });
 }
 
@@ -337,9 +342,6 @@ export async function bulkTransferImagePersistence(
   mode: 'copy' | 'move'
 ): Promise<void> {
   if (transfers.length === 0) return;
-
-  // 1. Get all current annotations and shadow metadata
-  const sourceImageIds = transfers.map(t => t.sourceImageId);
 
   // We can just loop and get them sequentially for simplicity, or we could do a bulkGet.
   // Given we have in-memory cache for annotations, sequential is relatively fast.
@@ -423,18 +425,13 @@ export async function transferImagePersistence(
  * Bulk save multiple annotations in a single transaction (for performance)
  */
 export async function bulkSaveAnnotations(annotations: ImageAnnotations[]): Promise<void> {
-  // Update in-memory cache
-  for (const annotation of annotations) {
-    inMemoryAnnotations.set(annotation.imageId, annotation);
-  }
-
   if (isPersistenceDisabled) {
-    return;
+    throw new Error('Image annotation persistence is unavailable for this session.');
   }
 
   const db = await openDatabase();
   if (!db) {
-    return;
+    throw new Error('Image annotation persistence is unavailable.');
   }
 
   await new Promise<void>((resolve, reject) => {
@@ -450,6 +447,7 @@ export async function bulkSaveAnnotations(annotations: ImageAnnotations[]): Prom
     };
 
     transaction.oncomplete = () => {
+      for (const annotation of annotations) inMemoryAnnotations.set(annotation.imageId, annotation);
       close();
       resolve();
     };
@@ -470,6 +468,7 @@ export async function bulkSaveAnnotations(annotations: ImageAnnotations[]): Prom
   }).catch((error) => {
     console.error('IndexedDB bulk save error for image annotations:', error);
     disablePersistence(error);
+    throw error;
   });
 }
 
@@ -1427,7 +1426,7 @@ export async function saveShadowMetadata(metadata: ShadowMetadata): Promise<void
   const db = await openDatabase();
   if (!db) return;
 
-  metadata.updatedAt = Date.now();
+  const record = { ...metadata, updatedAt: metadata.updatedAt ?? Date.now() };
 
   return new Promise((resolve, reject) => {
      // Check if store exists
@@ -1438,13 +1437,11 @@ export async function saveShadowMetadata(metadata: ShadowMetadata): Promise<void
 
     const transaction = db.transaction([SHADOW_METADATA_STORE_NAME], 'readwrite');
     const store = transaction.objectStore(SHADOW_METADATA_STORE_NAME);
-    const request = store.put(metadata);
-
-    request.onsuccess = () => resolve();
-    request.onerror = () => {
-      console.error('Error saving shadow metadata:', request.error);
-      reject(request.error);
-    };
+    const transactionDone = () => db.close();
+    store.put(record);
+    transaction.oncomplete = () => { transactionDone(); resolve(); };
+    transaction.onabort = () => { transactionDone(); reject(transaction.error ?? new Error('Shadow metadata transaction was aborted.')); };
+    transaction.onerror = () => { transactionDone(); reject(transaction.error ?? new Error('Shadow metadata transaction failed.')); };
   });
 }
 
@@ -1465,19 +1462,16 @@ export async function bulkSaveShadowMetadata(metadataRecords: ShadowMetadata[]):
     const store = transaction.objectStore(SHADOW_METADATA_STORE_NAME);
 
     for (const record of metadataRecords) {
-      const cleanedRecord = Object.fromEntries(
-        Object.entries(record).filter(([, value]) => value !== null && value !== undefined),
-      ) as ShadowMetadata;
-
       store.put({
-        ...cleanedRecord,
-        updatedAt: Date.now(),
+        ...record,
+        updatedAt: record.updatedAt ?? Date.now(),
       });
     }
 
-    transaction.oncomplete = () => resolve();
+    transaction.oncomplete = () => { db.close(); resolve(); };
     transaction.onerror = () => {
       console.error('Error bulk saving shadow metadata:', transaction.error);
+      db.close();
       reject(transaction.error);
     };
   });
@@ -1504,9 +1498,10 @@ export async function bulkDeleteShadowMetadata(imageIds: string[]): Promise<void
     const transaction = db.transaction([SHADOW_METADATA_STORE_NAME], 'readwrite');
     const store = transaction.objectStore(SHADOW_METADATA_STORE_NAME);
 
-    transaction.oncomplete = () => resolve();
+    transaction.oncomplete = () => { db.close(); resolve(); };
     transaction.onerror = () => {
       console.error('Error bulk deleting shadow metadata:', transaction.error);
+      db.close();
       reject(transaction.error);
     };
 
@@ -1529,13 +1524,10 @@ export async function deleteShadowMetadata(imageId: string): Promise<void> {
 
     const transaction = db.transaction([SHADOW_METADATA_STORE_NAME], 'readwrite');
     const store = transaction.objectStore(SHADOW_METADATA_STORE_NAME);
-    const request = store.delete(imageId);
-
-    request.onsuccess = () => resolve();
-    request.onerror = () => {
-      console.error('Error deleting shadow metadata:', request.error);
-      reject(request.error);
-    };
+    store.delete(imageId);
+    transaction.oncomplete = () => { db.close(); resolve(); };
+    transaction.onabort = () => { db.close(); reject(transaction.error ?? new Error('Shadow metadata delete transaction was aborted.')); };
+    transaction.onerror = () => { db.close(); reject(transaction.error ?? new Error('Shadow metadata delete transaction failed.')); };
   });
 }
 

--- a/services/imageRenameService.ts
+++ b/services/imageRenameService.ts
@@ -1,6 +1,11 @@
 import type { IndexedImage } from '../types';
 import cacheManager from './cacheManager';
 import { transferImagePersistence } from './imageAnnotationsStorage';
+import {
+  getUserDataPersistenceStatus,
+  prepareUserDataForImages,
+  registerStableUserDataImages,
+} from './userDataPersistenceAdapter';
 import { FileOperations } from './fileOperations';
 import { useImageStore } from '../store/useImageStore';
 import { getRelativeImagePath, splitRelativePath } from '../utils/imagePaths';
@@ -70,6 +75,15 @@ export async function renameIndexedImage(
     }
   }
 
+  try {
+    await prepareUserDataForImages([image]);
+  } catch (error) {
+    return {
+      success: false,
+      error: `The file was not renamed because its local user data could not be staged safely: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
   const { fileName: newFileName } = splitRelativePath(newRelativePath);
   const renameResult = await FileOperations.renameFile(image, newFileName);
   if (!renameResult.success) {
@@ -81,7 +95,11 @@ export async function renameIndexedImage(
     return { success: false, error: 'Renamed file, but failed to update the library record.' };
   }
 
-  await transferImagePersistence(oldImageId, renamedImage.id, 'move');
+  registerStableUserDataImages([renamedImage]);
+  const userDataStatus = await getUserDataPersistenceStatus();
+  if (userDataStatus.authority !== 'sqlite') {
+    await transferImagePersistence(oldImageId, renamedImage.id, 'move');
+  }
 
   // Move the visual-search vector to the new id. The embedding is unchanged, so
   // this only rebinds the row; without it every rename would orphan a vector and

--- a/services/legacyUserDataMigrationSource.ts
+++ b/services/legacyUserDataMigrationSource.ts
@@ -1,0 +1,263 @@
+/// <reference lib="dom" />
+
+import type { ImageAnnotations, ShadowMetadata, UserDataSemanticPatch } from '../types';
+import { openPreferencesDatabase, PREFERENCES_STORE_NAMES } from './preferencesDb';
+
+export type LegacyUserDataDomain = 'annotation' | 'shadow';
+
+export interface LegacyUserDataSnapshot {
+  domain: LegacyUserDataDomain;
+  legacyImageId: string;
+  payload: Record<string, unknown> | null;
+  tombstone: boolean;
+  sourceVersion: number;
+  mutationId?: string;
+  patch?: UserDataSemanticPatch;
+}
+
+type MigrationOutboxRecord = LegacyUserDataSnapshot & { key: string };
+
+const OUTBOX_STORE = PREFERENCES_STORE_NAMES.userDataMigrationOutbox;
+
+const outboxKey = (domain: LegacyUserDataDomain, imageId: string) => `${domain}\0${imageId}`;
+
+async function openMigrationDatabase(): Promise<IDBDatabase> {
+  let openError: unknown = null;
+  const db = await openPreferencesDatabase({
+    context: 'stable identity user-data migration',
+    allowReset: false,
+    disablePersistence: (error) => { openError = error ?? new Error('IndexedDB is unavailable.'); },
+  });
+  if (!db) {
+    throw openError instanceof Error ? openError : new Error('Legacy user-data source is unavailable.');
+  }
+  return db;
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed.'));
+  });
+}
+
+function transactionComplete(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction was aborted.'));
+    transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB transaction failed.'));
+  });
+}
+
+function stripRendererKeys(domain: LegacyUserDataDomain, value: ImageAnnotations | ShadowMetadata): Record<string, unknown> {
+  const payload = structuredClone(value) as unknown as Record<string, unknown>;
+  delete payload.imageId;
+  delete payload.assetId;
+  delete payload.persistenceVersion;
+  if (domain === 'annotation') {
+    const annotation = payload as Omit<ImageAnnotations, 'imageId'>;
+    return {
+      isFavorite: annotation.isFavorite,
+      tags: [...annotation.tags],
+      ...(annotation.rating === undefined ? {} : { rating: annotation.rating }),
+      addedAt: annotation.addedAt,
+      updatedAt: annotation.updatedAt,
+      ...(annotation.suppressedMetadataTags ? { suppressedMetadataTags: [...annotation.suppressedMetadataTags] } : {}),
+    };
+  }
+  return structuredClone(payload) as Record<string, unknown>;
+}
+
+export async function readAllLegacyUserDataSnapshots(): Promise<LegacyUserDataSnapshot[]> {
+  const db = await openMigrationDatabase();
+  try {
+    const transaction = db.transaction([
+      PREFERENCES_STORE_NAMES.imageAnnotations,
+      PREFERENCES_STORE_NAMES.shadowMetadata,
+      OUTBOX_STORE,
+    ], 'readonly');
+    const completed = transactionComplete(transaction);
+    const [annotations, shadows, outbox] = await Promise.all([
+      requestResult(transaction.objectStore(PREFERENCES_STORE_NAMES.imageAnnotations).getAll()),
+      requestResult(transaction.objectStore(PREFERENCES_STORE_NAMES.shadowMetadata).getAll()),
+      requestResult(transaction.objectStore(OUTBOX_STORE).getAll()),
+    ]);
+    await completed;
+    const snapshots = new Map<string, LegacyUserDataSnapshot>();
+    for (const annotation of annotations as ImageAnnotations[]) {
+      snapshots.set(outboxKey('annotation', annotation.imageId), {
+        domain: 'annotation',
+        legacyImageId: annotation.imageId,
+        payload: stripRendererKeys('annotation', annotation),
+        tombstone: false,
+        sourceVersion: 0,
+      });
+    }
+    for (const shadow of shadows as ShadowMetadata[]) {
+      snapshots.set(outboxKey('shadow', shadow.imageId), {
+        domain: 'shadow',
+        legacyImageId: shadow.imageId,
+        payload: stripRendererKeys('shadow', shadow),
+        tombstone: false,
+        sourceVersion: 0,
+      });
+    }
+    for (const rawRecord of outbox as MigrationOutboxRecord[]) {
+      const record = rawRecord as MigrationOutboxRecord;
+      snapshots.set(outboxKey(record.domain, record.legacyImageId), {
+        domain: record.domain,
+        legacyImageId: record.legacyImageId,
+        payload: record.tombstone ? null : structuredClone(record.payload),
+        tombstone: record.tombstone,
+        sourceVersion: record.sourceVersion,
+        mutationId: record.mutationId,
+        patch: record.patch ? structuredClone(record.patch) : undefined,
+      });
+    }
+    return [...snapshots.values()];
+  } finally {
+    db.close();
+  }
+}
+
+function applyPatch(
+  domain: LegacyUserDataDomain,
+  current: Record<string, unknown> | null,
+  patch: UserDataSemanticPatch,
+): Record<string, unknown> | null {
+  if (patch.deleteRecord) return null;
+  const timestamp = Number(patch.set?.updatedAt ?? patch.set?.addedAt ?? Date.now());
+  const next: Record<string, unknown> = current
+    ? structuredClone(current)
+    : domain === 'annotation'
+      ? { isFavorite: false, tags: [], addedAt: timestamp, updatedAt: timestamp, suppressedMetadataTags: [] }
+      : { updatedAt: timestamp };
+  for (const [key, value] of Object.entries(patch.set ?? {})) next[key] = structuredClone(value);
+  for (const key of patch.remove ?? []) delete next[key];
+  if (domain === 'annotation') {
+    const removed = new Set(patch.removeTags ?? []);
+    const tags = new Set((Array.isArray(next.tags) ? next.tags : []).filter((tag): tag is string => typeof tag === 'string' && !removed.has(tag)));
+    for (const tag of patch.addTags ?? []) tags.add(tag);
+    const unsuppressed = new Set(patch.unsuppressTags ?? []);
+    const suppressed = new Set((Array.isArray(next.suppressedMetadataTags) ? next.suppressedMetadataTags : [])
+      .filter((tag): tag is string => typeof tag === 'string' && !unsuppressed.has(tag)));
+    for (const tag of patch.suppressTags ?? []) suppressed.add(tag);
+    for (const tag of patch.importTags ?? []) {
+      if (!suppressed.has(tag)) tags.add(tag);
+    }
+    next.tags = [...tags];
+    next.suppressedMetadataTags = [...suppressed];
+  }
+  return next;
+}
+
+export async function readLegacyUserDataSnapshot(
+  domain: LegacyUserDataDomain,
+  imageId: string,
+): Promise<LegacyUserDataSnapshot | null> {
+  const db = await openMigrationDatabase();
+  try {
+    const sourceStoreName = domain === 'annotation'
+      ? PREFERENCES_STORE_NAMES.imageAnnotations
+      : PREFERENCES_STORE_NAMES.shadowMetadata;
+    const transaction = db.transaction([sourceStoreName, OUTBOX_STORE], 'readonly');
+    const completed = transactionComplete(transaction);
+    const outboxPromise = requestResult(transaction.objectStore(OUTBOX_STORE).get(outboxKey(domain, imageId)));
+    const sourcePromise = requestResult(transaction.objectStore(sourceStoreName).get(imageId));
+    const [outbox, source] = await Promise.all([outboxPromise, sourcePromise]);
+    await completed;
+    if (outbox) {
+      const record = outbox as MigrationOutboxRecord;
+      return {
+        domain,
+        legacyImageId: imageId,
+        payload: record.tombstone ? null : structuredClone(record.payload),
+        tombstone: record.tombstone,
+        sourceVersion: record.sourceVersion,
+        mutationId: record.mutationId,
+        patch: record.patch ? structuredClone(record.patch) : undefined,
+      };
+    }
+    if (!source) return null;
+    return {
+      domain,
+      legacyImageId: imageId,
+      payload: stripRendererKeys(domain, source as ImageAnnotations | ShadowMetadata),
+      tombstone: false,
+      sourceVersion: 0,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+export async function commitLegacyUserDataPatch(
+  domain: LegacyUserDataDomain,
+  imageId: string,
+  patch: UserDataSemanticPatch,
+  mutationId: string,
+): Promise<LegacyUserDataSnapshot> {
+  const db = await openMigrationDatabase();
+  try {
+    const sourceStoreName = domain === 'annotation'
+      ? PREFERENCES_STORE_NAMES.imageAnnotations
+      : PREFERENCES_STORE_NAMES.shadowMetadata;
+    const transaction = db.transaction([sourceStoreName, OUTBOX_STORE], 'readwrite');
+    const completed = transactionComplete(transaction);
+    const sourceStore = transaction.objectStore(sourceStoreName);
+    const outboxStore = transaction.objectStore(OUTBOX_STORE);
+    const outboxRequest = outboxStore.get(outboxKey(domain, imageId));
+    const sourceRequest = sourceStore.get(imageId);
+    let result: LegacyUserDataSnapshot | null = null;
+    let outboxValue: MigrationOutboxRecord | undefined;
+    let sourceValue: ImageAnnotations | ShadowMetadata | undefined;
+    let readFailure: unknown = null;
+
+    // Queue dependent writes synchronously from the second read callback. An
+    // IndexedDB transaction may become inactive before an awaited Promise.all
+    // continuation runs, even though both individual requests succeeded.
+    const queueCommittedSnapshot = () => {
+      if (outboxRequest.readyState !== 'done' || sourceRequest.readyState !== 'done' || result || readFailure) return;
+      const currentPayload = outboxValue
+        ? outboxValue.payload
+        : sourceValue
+          ? stripRendererKeys(domain, sourceValue)
+          : null;
+      const payload = applyPatch(domain, currentPayload, patch);
+      const sourceVersion = Number(outboxValue?.sourceVersion ?? 0) + 1;
+      result = {
+        domain,
+        legacyImageId: imageId,
+        payload,
+        tombstone: payload === null,
+        sourceVersion,
+        mutationId,
+        patch: structuredClone(patch),
+      };
+      if (payload === null) sourceStore.delete(imageId);
+      else sourceStore.put({ ...structuredClone(payload), imageId });
+      outboxStore.put({ ...result, key: outboxKey(domain, imageId) } satisfies MigrationOutboxRecord);
+    };
+
+    outboxRequest.onsuccess = () => {
+      outboxValue = outboxRequest.result as MigrationOutboxRecord | undefined;
+      queueCommittedSnapshot();
+    };
+    sourceRequest.onsuccess = () => {
+      sourceValue = sourceRequest.result as ImageAnnotations | ShadowMetadata | undefined;
+      queueCommittedSnapshot();
+    };
+    const failRead = (request: IDBRequest) => {
+      readFailure = request.error ?? new Error('IndexedDB migration source read failed.');
+      try { transaction.abort(); } catch { /* completion rejects with the original read failure below */ }
+    };
+    outboxRequest.onerror = () => failRead(outboxRequest);
+    sourceRequest.onerror = () => failRead(sourceRequest);
+    await completed;
+    if (readFailure) throw readFailure;
+    if (!result) throw new Error('Legacy user-data transaction completed without a committed snapshot.');
+    return result;
+  } finally {
+    db.close();
+  }
+}

--- a/services/legacyUserDataMigrationSource.ts
+++ b/services/legacyUserDataMigrationSource.ts
@@ -195,7 +195,7 @@ export async function commitLegacyUserDataPatch(
   domain: LegacyUserDataDomain,
   imageId: string,
   patch: UserDataSemanticPatch,
-  mutationId: string,
+  mutationId?: string,
 ): Promise<LegacyUserDataSnapshot> {
   const db = await openMigrationDatabase();
   try {
@@ -224,7 +224,7 @@ export async function commitLegacyUserDataPatch(
           ? stripRendererKeys(domain, sourceValue)
           : null;
       const payload = applyPatch(domain, currentPayload, patch);
-      const sourceVersion = Number(outboxValue?.sourceVersion ?? 0) + 1;
+      const sourceVersion = mutationId ? Number(outboxValue?.sourceVersion ?? 0) + 1 : 0;
       result = {
         domain,
         legacyImageId: imageId,
@@ -236,11 +236,11 @@ export async function commitLegacyUserDataPatch(
       };
       if (payload === null) sourceStore.delete(imageId);
       else sourceStore.put({ ...structuredClone(payload), imageId });
-      outboxStore.put({ ...result, key: outboxKey(domain, imageId) } satisfies MigrationOutboxRecord);
+      if (mutationId) outboxStore.put({ ...result, key: outboxKey(domain, imageId) } satisfies MigrationOutboxRecord);
     };
 
     outboxRequest.onsuccess = () => {
-      outboxValue = outboxRequest.result as MigrationOutboxRecord | undefined;
+      outboxValue = mutationId ? outboxRequest.result as MigrationOutboxRecord | undefined : undefined;
       queueCommittedSnapshot();
     };
     sourceRequest.onsuccess = () => {

--- a/services/preferencesDb.ts
+++ b/services/preferencesDb.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 
 export const PREFERENCES_DB_NAME = 'image-metahub-preferences';
-export const PREFERENCES_DB_VERSION = 7;
+export const PREFERENCES_DB_VERSION = 8;
 
 export const PREFERENCES_STORE_NAMES = {
   folderSelection: 'folderSelection',
@@ -10,6 +10,7 @@ export const PREFERENCES_STORE_NAMES = {
   clusterPreferences: 'clusterPreferences',
   smartCollections: 'smartCollections',
   shadowMetadata: 'shadowMetadata',
+  userDataMigrationOutbox: 'userDataMigrationOutbox',
   automationRules: 'automationRules',
 } as const;
 
@@ -175,6 +176,7 @@ function upgradePreferencesDatabase(request: IDBOpenDBRequest, oldVersion: numbe
   ensureIndex(smartCollectionsStore, 'type', 'type', { unique: false });
 
   ensureObjectStore(db, transaction, PREFERENCES_STORE_NAMES.shadowMetadata, { keyPath: 'imageId' });
+  ensureObjectStore(db, transaction, PREFERENCES_STORE_NAMES.userDataMigrationOutbox, { keyPath: 'key' });
   ensureObjectStore(db, transaction, PREFERENCES_STORE_NAMES.automationRules, { keyPath: 'id' });
 
   const manualTagsStore = ensureObjectStore(db, transaction, PREFERENCES_STORE_NAMES.manualTags, { keyPath: 'name' });
@@ -182,8 +184,8 @@ function upgradePreferencesDatabase(request: IDBOpenDBRequest, oldVersion: numbe
     seedManualTagsFromAnnotations(annotationStore, manualTagsStore);
   }
 
-  if (oldVersion < 7) {
-    console.log('Shared preferences database upgraded to v7.');
+  if (oldVersion < 8) {
+    console.log('Shared preferences database upgraded to v8.');
   }
 }
 

--- a/services/userDataPersistenceAdapter.ts
+++ b/services/userDataPersistenceAdapter.ts
@@ -1,0 +1,616 @@
+/// <reference lib="dom" />
+
+import type {
+  ImageAnnotations,
+  IndexedImage,
+  ShadowMetadata,
+  StableUserDataDomain,
+  StableUserDataRecord,
+  StableUserDataReference,
+  StableUserDataStatus,
+  TagInfo,
+  UserDataSemanticPatch,
+} from '../types';
+import {
+  deleteAnnotation as deleteLegacyAnnotation,
+  deleteShadowMetadata as deleteLegacyShadow,
+  ensureManualTagExists,
+  getAllManualTagNames,
+  getAnnotation as getLegacyAnnotation,
+  getShadowMetadata as getLegacyShadow,
+  loadAllAnnotations as loadAllLegacyAnnotations,
+  saveAnnotation as saveLegacyAnnotation,
+  saveShadowMetadata as saveLegacyShadow,
+} from './imageAnnotationsStorage';
+import {
+  commitLegacyUserDataPatch,
+  readAllLegacyUserDataSnapshots,
+  readLegacyUserDataSnapshot,
+  type LegacyUserDataSnapshot,
+} from './legacyUserDataMigrationSource';
+
+const MAX_SYNC_BATCH = 200;
+const referencesByImageId = new Map<string, StableUserDataReference>();
+const imagesByAssetId = new Map<string, Set<string>>();
+const recordsByAssetDomain = new Map<string, StableUserDataRecord>();
+const localPendingByImageDomain = new Map<string, LegacyUserDataSnapshot>();
+const listeners = new Set<(records: StableUserDataRecord[]) => void>();
+let statusPromise: Promise<StableUserDataStatus> | null = null;
+let legacyFullScanPromise: Promise<void> | null = null;
+let mainUnsubscribe: (() => void) | null = null;
+
+const cacheKey = (assetId: string, domain: StableUserDataDomain) => `${assetId}\0${domain}`;
+const localKey = (imageId: string, domain: StableUserDataDomain) => `${imageId}\0${domain}`;
+
+class UserDataPersistenceError extends Error {
+  code: string;
+  current?: StableUserDataRecord;
+
+  constructor(code: string, message: string, current?: StableUserDataRecord) {
+    super(message);
+    this.name = 'UserDataPersistenceError';
+    this.code = code;
+    this.current = current;
+  }
+}
+
+export class UserDataBatchPersistenceError extends Error {
+  persisted: ImageAnnotations[];
+  failures: unknown[];
+
+  constructor(persisted: ImageAnnotations[], failures: unknown[]) {
+    super(`${failures.length} user-data record${failures.length === 1 ? '' : 's'} could not be persisted.`);
+    this.name = 'UserDataBatchPersistenceError';
+    this.persisted = persisted;
+    this.failures = failures;
+  }
+}
+
+const hasDesktopBridge = (): boolean =>
+  typeof window !== 'undefined' && Boolean(window.electronAPI?.stableUserDataStatus);
+
+const legacyStatus = (): StableUserDataStatus => ({
+  initialized: true,
+  authority: 'legacy',
+  available: true,
+  migrationEnabled: false,
+  indexingEnabled: false,
+  error: null,
+});
+
+export async function getUserDataPersistenceStatus(force = false): Promise<StableUserDataStatus> {
+  if (!hasDesktopBridge()) return legacyStatus();
+  if (force || !statusPromise) {
+    statusPromise = window.electronAPI.stableUserDataStatus().catch((error) => ({
+      initialized: false,
+      authority: 'sqlite' as const,
+      available: false,
+      migrationEnabled: false,
+      indexingEnabled: false,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }));
+  }
+  return statusPromise;
+}
+
+function referenceForImage(image: Pick<IndexedImage, 'assetId' | 'revisionId' | 'provenanceLocationId'>): StableUserDataReference | null {
+  if (!image.assetId || !image.revisionId || !image.provenanceLocationId) return null;
+  return {
+    assetId: image.assetId,
+    revisionId: image.revisionId,
+    locationId: image.provenanceLocationId,
+  };
+}
+
+const statusErrorMessage = (status: StableUserDataStatus): string =>
+  typeof status.error === 'object' && status.error?.message
+    ? status.error.message
+    : 'Stable user-data catalog is unavailable.';
+
+export function registerStableUserDataImages(images: IndexedImage[]): void {
+  for (const image of images) {
+    const reference = referenceForImage(image);
+    const previous = referencesByImageId.get(image.id);
+    if (previous && (!reference || previous.assetId !== reference.assetId)) {
+      imagesByAssetId.get(previous.assetId)?.delete(image.id);
+      localPendingByImageDomain.delete(localKey(image.id, 'annotation'));
+      localPendingByImageDomain.delete(localKey(image.id, 'shadow'));
+    }
+    if (!reference) {
+      referencesByImageId.delete(image.id);
+      continue;
+    }
+    referencesByImageId.set(image.id, reference);
+    const imageIds = imagesByAssetId.get(reference.assetId) ?? new Set<string>();
+    imageIds.add(image.id);
+    imagesByAssetId.set(reference.assetId, imageIds);
+  }
+  ensureMainSubscription();
+}
+
+function cacheAndPublish(records: StableUserDataRecord[]): void {
+  const accepted: StableUserDataRecord[] = [];
+  for (const record of records) {
+    const key = cacheKey(record.assetId, record.domain);
+    const current = recordsByAssetDomain.get(key);
+    if (current && current.version >= record.version) continue;
+    recordsByAssetDomain.set(key, structuredClone(record));
+    accepted.push(record);
+    for (const imageId of imagesByAssetId.get(record.assetId) ?? []) {
+      localPendingByImageDomain.delete(localKey(imageId, record.domain));
+    }
+  }
+  if (accepted.length > 0) {
+    for (const listener of listeners) listener(accepted.map((record) => structuredClone(record)));
+  }
+}
+
+function ensureMainSubscription(): void {
+  if (mainUnsubscribe || !hasDesktopBridge() || !window.electronAPI.onStableUserDataChanged) return;
+  mainUnsubscribe = window.electronAPI.onStableUserDataChanged(({ records }) => cacheAndPublish(records));
+}
+
+export function subscribeStableUserDataChanges(
+  listener: (records: StableUserDataRecord[]) => void,
+): () => void {
+  listeners.add(listener);
+  ensureMainSubscription();
+  return () => listeners.delete(listener);
+}
+
+function unwrap<T>(result: { success: boolean; value?: T; error?: string; code?: string; details?: { current?: StableUserDataRecord } | null }): T {
+  if (result.success) return result.value as T;
+  const current = result.details?.current;
+  if (current) cacheAndPublish([current]);
+  throw new UserDataPersistenceError(
+    result.code ?? 'USER_DATA_OPERATION_FAILED',
+    result.error ?? 'User data could not be persisted.',
+    current,
+  );
+}
+
+function annotationFromPayload(
+  imageId: string,
+  payload: Record<string, unknown>,
+  record?: StableUserDataRecord,
+): ImageAnnotations {
+  return {
+    imageId,
+    isFavorite: payload.isFavorite === true,
+    tags: Array.isArray(payload.tags) ? payload.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+    ...(Object.prototype.hasOwnProperty.call(payload, 'rating') ? { rating: payload.rating as ImageAnnotations['rating'] } : {}),
+    addedAt: Number(payload.addedAt ?? 0),
+    updatedAt: Number(payload.updatedAt ?? 0),
+    ...(Array.isArray(payload.suppressedMetadataTags)
+      ? { suppressedMetadataTags: payload.suppressedMetadataTags.filter((tag): tag is string => typeof tag === 'string') }
+      : {}),
+    ...(record ? { assetId: record.assetId, persistenceVersion: record.version } : {}),
+  };
+}
+
+function shadowFromPayload(
+  imageId: string,
+  payload: Record<string, unknown>,
+  record?: StableUserDataRecord,
+): ShadowMetadata {
+  return {
+    ...(structuredClone(payload) as Omit<ShadowMetadata, 'imageId'>),
+    imageId,
+    updatedAt: Number(payload.updatedAt ?? 0),
+    ...(record ? { assetId: record.assetId, persistenceVersion: record.version } : {}),
+  };
+}
+
+function recordForImage(imageId: string, domain: StableUserDataDomain): StableUserDataRecord | null {
+  const reference = referencesByImageId.get(imageId);
+  return reference ? recordsByAssetDomain.get(cacheKey(reference.assetId, domain)) ?? null : null;
+}
+
+async function finalizeOutbox(snapshot: LegacyUserDataSnapshot): Promise<void> {
+  if (!snapshot.mutationId || !hasDesktopBridge()) return;
+  const result = unwrap(await window.electronAPI.stableUserDataFinalizeLegacyMutation({
+    mutationId: snapshot.mutationId,
+    sourceVersion: snapshot.sourceVersion,
+    payload: snapshot.payload,
+    tombstone: snapshot.tombstone,
+  }));
+  if (result.record) cacheAndPublish([result.record]);
+}
+
+async function stageAllLegacyUserDataIfNeeded(status: StableUserDataStatus): Promise<void> {
+  if (
+    status.authority !== 'sqlite'
+    || !status.available
+    || !status.migrationEnabled
+    || status.legacyScanComplete
+  ) return;
+  if (!legacyFullScanPromise) {
+    legacyFullScanPromise = (async () => {
+      const snapshots = await readAllLegacyUserDataSnapshots();
+      for (const snapshot of snapshots) {
+        if (snapshot.mutationId) await finalizeOutbox(snapshot);
+      }
+      for (let offset = 0; offset < snapshots.length; offset += MAX_SYNC_BATCH) {
+        const batch = snapshots.slice(offset, offset + MAX_SYNC_BATCH);
+        const synced = unwrap(await window.electronAPI.stableUserDataSync({
+          entries: batch.map((snapshot) => ({
+            domain: snapshot.domain,
+            legacyImageId: snapshot.legacyImageId,
+            payload: snapshot.payload,
+            tombstone: snapshot.tombstone,
+            sourceVersion: snapshot.sourceVersion,
+          })),
+        }));
+        for (const outcome of synced) {
+          if (outcome.record) cacheAndPublish([outcome.record]);
+        }
+      }
+      const completedStatus = unwrap(await window.electronAPI.stableUserDataCompleteLegacyScan());
+      statusPromise = Promise.resolve(completedStatus);
+    })().catch((error) => {
+      legacyFullScanPromise = null;
+      throw error;
+    });
+  }
+  await legacyFullScanPromise;
+}
+
+async function syncImageDomains(
+  imageIds: string[],
+  domains: StableUserDataDomain[],
+): Promise<Map<string, StableUserDataRecord | LegacyUserDataSnapshot | null>> {
+  const status = await getUserDataPersistenceStatus();
+  const results = new Map<string, StableUserDataRecord | LegacyUserDataSnapshot | null>();
+  if (status.authority !== 'sqlite') return results;
+  if (!status.available) {
+    throw new UserDataPersistenceError('USER_DATA_UNAVAILABLE', statusErrorMessage(status));
+  }
+  await stageAllLegacyUserDataIfNeeded(status);
+  const effectiveStatus = await getUserDataPersistenceStatus();
+  const probes = imageIds.flatMap((imageId) => domains.map((domain) => ({
+    domain,
+    legacyImageId: imageId,
+    ...(referencesByImageId.get(imageId) ? { reference: referencesByImageId.get(imageId) } : {}),
+  })));
+  const sourceRequired: typeof probes = [];
+  for (let offset = 0; offset < probes.length; offset += MAX_SYNC_BATCH) {
+    const batch = probes.slice(offset, offset + MAX_SYNC_BATCH);
+    const synced = unwrap(await window.electronAPI.stableUserDataSync({ entries: batch }));
+    for (let index = 0; index < synced.length; index += 1) {
+      const outcome = synced[index];
+      const entry = batch[index];
+      if (outcome.record) cacheAndPublish([outcome.record]);
+      if (outcome.record && outcome.status !== 'source_ack_required') {
+        results.set(localKey(entry.legacyImageId, entry.domain), outcome.record);
+      } else if (outcome.status !== 'source_ack_required' && effectiveStatus.legacyScanComplete) {
+        results.set(localKey(entry.legacyImageId, entry.domain), null);
+      } else {
+        sourceRequired.push(entry);
+      }
+    }
+  }
+
+  const sourceEntries = await Promise.all(sourceRequired.map(async (entry) => {
+    const snapshot = await readLegacyUserDataSnapshot(entry.domain, entry.legacyImageId);
+    if (snapshot?.mutationId) await finalizeOutbox(snapshot);
+    return { entry, snapshot };
+  }));
+  const snapshotsToSync = sourceEntries.filter(
+    (candidate): candidate is typeof candidate & { snapshot: LegacyUserDataSnapshot } => Boolean(candidate.snapshot),
+  );
+  for (const { entry, snapshot } of sourceEntries) {
+    if (!snapshot) results.set(localKey(entry.legacyImageId, entry.domain), recordForImage(entry.legacyImageId, entry.domain));
+  }
+  for (let offset = 0; offset < snapshotsToSync.length; offset += MAX_SYNC_BATCH) {
+    const batch = snapshotsToSync.slice(offset, offset + MAX_SYNC_BATCH);
+    const synced = unwrap(await window.electronAPI.stableUserDataSync({
+      entries: batch.map(({ entry, snapshot }) => ({
+        ...entry,
+        payload: snapshot.payload,
+        tombstone: snapshot.tombstone,
+        sourceVersion: snapshot.sourceVersion,
+      })),
+    }));
+    for (let index = 0; index < synced.length; index += 1) {
+      const outcome = synced[index];
+      const { entry, snapshot } = batch[index];
+      if (outcome.record) cacheAndPublish([outcome.record]);
+      if (!outcome.record && ['unmapped', 'pending'].includes(outcome.status)) {
+        localPendingByImageDomain.set(localKey(entry.legacyImageId, entry.domain), snapshot);
+      }
+      results.set(
+        localKey(entry.legacyImageId, entry.domain),
+        outcome.record ?? (['unmapped', 'pending'].includes(outcome.status) ? snapshot : null),
+      );
+    }
+  }
+  return results;
+}
+
+export async function loadAnnotationsForImages(images: IndexedImage[]): Promise<Map<string, ImageAnnotations>> {
+  registerStableUserDataImages(images);
+  const status = await getUserDataPersistenceStatus();
+  if (status.authority !== 'sqlite') return loadAllLegacyAnnotations();
+  const values = await syncImageDomains(images.map((image) => image.id), ['annotation']);
+  const annotations = new Map<string, ImageAnnotations>();
+  for (const image of images) {
+    const value = values.get(localKey(image.id, 'annotation'));
+    if (!value || value.tombstone || !value.payload) continue;
+    annotations.set(image.id, annotationFromPayload(image.id, value.payload, 'version' in value ? value : undefined));
+  }
+  return annotations;
+}
+
+export async function hydrateUserDataForImages(images: IndexedImage[]): Promise<{
+  annotations: Map<string, ImageAnnotations>;
+  shadows: Map<string, ShadowMetadata>;
+}> {
+  registerStableUserDataImages(images);
+  const status = await getUserDataPersistenceStatus();
+  if (status.authority !== 'sqlite') {
+    const annotations = new Map<string, ImageAnnotations>();
+    const shadows = new Map<string, ShadowMetadata>();
+    await Promise.all(images.map(async (image) => {
+      const [annotation, shadow] = await Promise.all([getLegacyAnnotation(image.id), getLegacyShadow(image.id)]);
+      if (annotation) annotations.set(image.id, annotation);
+      if (shadow) shadows.set(image.id, shadow);
+    }));
+    return { annotations, shadows };
+  }
+  const values = await syncImageDomains(images.map((image) => image.id), ['annotation', 'shadow']);
+  const annotations = new Map<string, ImageAnnotations>();
+  const shadows = new Map<string, ShadowMetadata>();
+  for (const image of images) {
+    const annotation = values.get(localKey(image.id, 'annotation'));
+    if (annotation && !annotation.tombstone && annotation.payload) {
+      annotations.set(image.id, annotationFromPayload(image.id, annotation.payload, 'version' in annotation ? annotation : undefined));
+    }
+    const shadow = values.get(localKey(image.id, 'shadow'));
+    if (shadow && !shadow.tombstone && shadow.payload) {
+      shadows.set(image.id, shadowFromPayload(image.id, shadow.payload, 'version' in shadow ? shadow : undefined));
+    }
+  }
+  return { annotations, shadows };
+}
+
+async function persistUnmappedPatch(
+  domain: StableUserDataDomain,
+  imageId: string,
+  patch: UserDataSemanticPatch,
+): Promise<LegacyUserDataSnapshot> {
+  const mutationId = crypto.randomUUID();
+  unwrap(await window.electronAPI.stableUserDataReserveLegacyMutation({ mutationId, domain, legacyImageId: imageId, patch }));
+  const committed = await commitLegacyUserDataPatch(domain, imageId, patch, mutationId);
+  localPendingByImageDomain.set(localKey(imageId, domain), committed);
+  await finalizeOutbox(committed);
+  return committed;
+}
+
+function applyLocalPatch(
+  domain: StableUserDataDomain,
+  current: Record<string, unknown> | null,
+  patch: UserDataSemanticPatch,
+): Record<string, unknown> | null {
+  if (patch.deleteRecord) return null;
+  const timestamp = Number(patch.set?.updatedAt ?? patch.set?.addedAt ?? Date.now());
+  const next: Record<string, unknown> = current
+    ? structuredClone(current)
+    : domain === 'annotation'
+      ? { isFavorite: false, tags: [], addedAt: timestamp, updatedAt: timestamp, suppressedMetadataTags: [] }
+      : { updatedAt: timestamp };
+  for (const [key, value] of Object.entries(patch.set ?? {})) next[key] = structuredClone(value);
+  for (const key of patch.remove ?? []) delete next[key];
+  if (domain === 'annotation') {
+    const removed = new Set(patch.removeTags ?? []);
+    const tags = new Set((Array.isArray(next.tags) ? next.tags : []).filter((tag): tag is string => typeof tag === 'string' && !removed.has(tag)));
+    for (const tag of patch.addTags ?? []) tags.add(tag);
+    const unsuppressed = new Set(patch.unsuppressTags ?? []);
+    const suppressed = new Set((Array.isArray(next.suppressedMetadataTags) ? next.suppressedMetadataTags : [])
+      .filter((tag): tag is string => typeof tag === 'string' && !unsuppressed.has(tag)));
+    for (const tag of patch.suppressTags ?? []) suppressed.add(tag);
+    for (const tag of patch.importTags ?? []) if (!suppressed.has(tag)) tags.add(tag);
+    next.tags = [...tags];
+    next.suppressedMetadataTags = [...suppressed];
+  }
+  return next;
+}
+
+async function mutateDomain(
+  domain: StableUserDataDomain,
+  imageId: string,
+  patch: UserDataSemanticPatch,
+): Promise<StableUserDataRecord | LegacyUserDataSnapshot> {
+  const status = await getUserDataPersistenceStatus();
+  if (status.authority !== 'sqlite') {
+    const current = domain === 'annotation' ? await getLegacyAnnotation(imageId) : await getLegacyShadow(imageId);
+    const payload = applyLocalPatch(domain, current ? { ...current, imageId: undefined } : null, patch);
+    if (!payload) {
+      if (domain === 'annotation') await deleteLegacyAnnotation(imageId);
+      else await deleteLegacyShadow(imageId);
+    } else if (domain === 'annotation') {
+      await saveLegacyAnnotation({ ...(payload as unknown as ImageAnnotations), imageId });
+    } else {
+      await saveLegacyShadow({ ...(payload as unknown as ShadowMetadata), imageId });
+    }
+    return { domain, legacyImageId: imageId, payload, tombstone: !payload, sourceVersion: 0 };
+  }
+  if (!status.available) {
+    throw new UserDataPersistenceError('USER_DATA_UNAVAILABLE', statusErrorMessage(status));
+  }
+  const reference = referencesByImageId.get(imageId);
+  if (!reference) return persistUnmappedPatch(domain, imageId, patch);
+  if (!recordForImage(imageId, domain)) await syncImageDomains([imageId], [domain]);
+  const current = recordForImage(imageId, domain);
+  const record = unwrap(await window.electronAPI.stableUserDataMutate({
+    domain,
+    legacyImageId: imageId,
+    reference,
+    expectedVersion: current?.version ?? 0,
+    patch,
+  }));
+  cacheAndPublish([record]);
+  return record;
+}
+
+export async function patchAnnotation(imageId: string, patch: UserDataSemanticPatch): Promise<ImageAnnotations | null> {
+  const timestamp = Date.now();
+  const result = await mutateDomain('annotation', imageId, {
+    ...patch,
+    set: { ...patch.set, updatedAt: patch.set?.updatedAt ?? timestamp },
+  });
+  if (result.tombstone || !result.payload) return null;
+  return annotationFromPayload(imageId, result.payload, 'version' in result ? result : undefined);
+}
+
+export async function patchShadowMetadata(image: IndexedImage | string, patch: UserDataSemanticPatch): Promise<ShadowMetadata | null> {
+  const imageId = typeof image === 'string' ? image : image.id;
+  if (typeof image !== 'string') registerStableUserDataImages([image]);
+  const result = await mutateDomain('shadow', imageId, {
+    ...patch,
+    set: { ...patch.set, updatedAt: patch.set?.updatedAt ?? Date.now() },
+  });
+  if (result.tombstone || !result.payload) return null;
+  return shadowFromPayload(imageId, result.payload, 'version' in result ? result : undefined);
+}
+
+export async function getPersistedShadowMetadata(image: IndexedImage | string): Promise<ShadowMetadata | null> {
+  const imageId = typeof image === 'string' ? image : image.id;
+  if (typeof image !== 'string') registerStableUserDataImages([image]);
+  const status = await getUserDataPersistenceStatus();
+  if (status.authority !== 'sqlite') return getLegacyShadow(imageId);
+  const values = await syncImageDomains([imageId], ['shadow']);
+  const value = values.get(localKey(imageId, 'shadow'));
+  return value && !value.tombstone && value.payload
+    ? shadowFromPayload(imageId, value.payload, 'version' in value ? value : undefined)
+    : null;
+}
+
+export async function saveAnnotations(records: ImageAnnotations[]): Promise<ImageAnnotations[]> {
+  const persisted: ImageAnnotations[] = [];
+  const failures: unknown[] = [];
+  for (const annotation of records) {
+    try {
+      const current = recordForImage(annotation.imageId, 'annotation')?.payload
+        ?? localPendingByImageDomain.get(localKey(annotation.imageId, 'annotation'))?.payload
+        ?? null;
+      const set: Record<string, unknown> = {};
+      const remove: string[] = [];
+      for (const key of ['isFavorite', 'tags', 'rating', 'addedAt', 'updatedAt', 'suppressedMetadataTags'] as const) {
+        if (Object.prototype.hasOwnProperty.call(annotation, key)) {
+          const value = annotation[key];
+          if (value === undefined) {
+            if (current && Object.prototype.hasOwnProperty.call(current, key)) remove.push(key);
+          } else if (!current || !Object.is(current[key], value)) {
+            set[key] = structuredClone(value);
+          }
+        } else if (current && Object.prototype.hasOwnProperty.call(current, key)) {
+          remove.push(key);
+        }
+      }
+      const saved = await patchAnnotation(annotation.imageId, { set, remove });
+      if (saved) persisted.push(saved);
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) throw new UserDataBatchPersistenceError(persisted, failures);
+  return persisted;
+}
+
+export async function saveShadows(records: ShadowMetadata[], imagesById?: Map<string, IndexedImage>): Promise<ShadowMetadata[]> {
+  const persisted: ShadowMetadata[] = [];
+  for (const shadow of records) {
+    const image = imagesById?.get(shadow.imageId) ?? shadow.imageId;
+    const current = await getPersistedShadowMetadata(image);
+    const payload = structuredClone(shadow) as unknown as Record<string, unknown>;
+    delete payload.imageId;
+    delete payload.assetId;
+    delete payload.persistenceVersion;
+    const set: Record<string, unknown> = {};
+    const remove = new Set(current
+      ? Object.keys(current).filter((key) => (
+          !['imageId', 'assetId', 'persistenceVersion'].includes(key)
+          && !Object.prototype.hasOwnProperty.call(payload, key)
+        ))
+      : []);
+    for (const [key, value] of Object.entries(payload)) {
+      if (value === null || value === undefined) remove.add(key);
+      else set[key] = value;
+    }
+    const saved = await patchShadowMetadata(image, { set, remove: [...remove] });
+    if (saved) persisted.push(saved);
+  }
+  return persisted;
+}
+
+export async function prepareUserDataForImages(images: IndexedImage[]): Promise<void> {
+  registerStableUserDataImages(images);
+  const status = await getUserDataPersistenceStatus();
+  if (status.authority === 'sqlite') await syncImageDomains(images.map((image) => image.id), ['annotation', 'shadow']);
+}
+
+export async function mutateAnnotationTagGlobally(
+  action: 'rename' | 'remove',
+  sourceTag: string,
+  targetTag?: string,
+): Promise<StableUserDataRecord[] | null> {
+  const status = await getUserDataPersistenceStatus();
+  if (status.authority !== 'sqlite') return null;
+  if (!status.available) throw new UserDataPersistenceError('USER_DATA_UNAVAILABLE', statusErrorMessage(status));
+  const records = unwrap(await window.electronAPI.stableUserDataGlobalTagMutation({
+    action,
+    sourceTag,
+    targetTag,
+    updatedAt: Date.now(),
+  }));
+  cacheAndPublish(records);
+  return records;
+}
+
+export async function getAllAuthoritativeTags(): Promise<TagInfo[]> {
+  const manualTags = await getAllManualTagNames();
+  const status = await getUserDataPersistenceStatus();
+  if (status.authority !== 'sqlite') {
+    const annotations = await loadAllLegacyAnnotations();
+    const counts = new Map(manualTags.map((name) => [name, 0]));
+    for (const annotation of annotations.values()) {
+      for (const tag of annotation.tags) counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+    return [...counts].map(([name, count]) => ({ name, count })).sort((a, b) => a.name.localeCompare(b.name));
+  }
+  if (!status.available) throw new UserDataPersistenceError('USER_DATA_UNAVAILABLE', statusErrorMessage(status));
+  const stableTags = unwrap(await window.electronAPI.stableUserDataTagCounts());
+  const counts = new Map(manualTags.map((name) => [name, 0]));
+  for (const tag of stableTags) counts.set(tag.name, tag.count);
+  return [...counts].map(([name, count]) => ({ name, count })).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function ensureAuthoritativeManualTags(tags: string[]): Promise<void> {
+  await Promise.all([...new Set(tags)].map((tag) => ensureManualTagExists(tag)));
+}
+
+export function annotationFromStableRecord(record: StableUserDataRecord, imageId: string): ImageAnnotations | null {
+  return record.domain === 'annotation' && !record.tombstone && record.payload
+    ? annotationFromPayload(imageId, record.payload, record)
+    : null;
+}
+
+export function shadowFromStableRecord(record: StableUserDataRecord, imageId: string): ShadowMetadata | null {
+  return record.domain === 'shadow' && !record.tombstone && record.payload
+    ? shadowFromPayload(imageId, record.payload, record)
+    : null;
+}
+
+export function __resetUserDataPersistenceAdapterForTests(): void {
+  referencesByImageId.clear();
+  imagesByAssetId.clear();
+  recordsByAssetDomain.clear();
+  localPendingByImageDomain.clear();
+  statusPromise = null;
+  legacyFullScanPromise = null;
+  mainUnsubscribe?.();
+  mainUnsubscribe = null;
+  listeners.clear();
+}
+
+export { UserDataPersistenceError };

--- a/services/userDataPersistenceAdapter.ts
+++ b/services/userDataPersistenceAdapter.ts
@@ -12,15 +12,12 @@ import type {
   UserDataSemanticPatch,
 } from '../types';
 import {
-  deleteAnnotation as deleteLegacyAnnotation,
-  deleteShadowMetadata as deleteLegacyShadow,
+  patchLegacyUserData,
   ensureManualTagExists,
   getAllManualTagNames,
   getAnnotation as getLegacyAnnotation,
   getShadowMetadata as getLegacyShadow,
   loadAllAnnotations as loadAllLegacyAnnotations,
-  saveAnnotation as saveLegacyAnnotation,
-  saveShadowMetadata as saveLegacyShadow,
 } from './imageAnnotationsStorage';
 import {
   commitLegacyUserDataPatch,
@@ -282,6 +279,9 @@ async function syncImageDomains(
       if (outcome.record) cacheAndPublish([outcome.record]);
       if (outcome.record && outcome.status !== 'source_ack_required') {
         results.set(localKey(entry.legacyImageId, entry.domain), outcome.record);
+      } else if (outcome.pending && outcome.status !== 'source_ack_required') {
+        localPendingByImageDomain.set(localKey(entry.legacyImageId, entry.domain), outcome.pending);
+        results.set(localKey(entry.legacyImageId, entry.domain), outcome.pending);
       } else if (outcome.status !== 'source_ack_required' && effectiveStatus.legacyScanComplete) {
         results.set(localKey(entry.legacyImageId, entry.domain), null);
       } else {
@@ -316,11 +316,11 @@ async function syncImageDomains(
       const { entry, snapshot } = batch[index];
       if (outcome.record) cacheAndPublish([outcome.record]);
       if (!outcome.record && ['unmapped', 'pending'].includes(outcome.status)) {
-        localPendingByImageDomain.set(localKey(entry.legacyImageId, entry.domain), snapshot);
+        localPendingByImageDomain.set(localKey(entry.legacyImageId, entry.domain), outcome.pending ?? snapshot);
       }
       results.set(
         localKey(entry.legacyImageId, entry.domain),
-        outcome.record ?? (['unmapped', 'pending'].includes(outcome.status) ? snapshot : null),
+        outcome.record ?? outcome.pending ?? (['unmapped', 'pending'].includes(outcome.status) ? snapshot : null),
       );
     }
   }
@@ -377,42 +377,26 @@ async function persistUnmappedPatch(
   domain: StableUserDataDomain,
   imageId: string,
   patch: UserDataSemanticPatch,
-): Promise<LegacyUserDataSnapshot> {
+): Promise<StableUserDataRecord | LegacyUserDataSnapshot> {
   const mutationId = crypto.randomUUID();
   unwrap(await window.electronAPI.stableUserDataReserveLegacyMutation({ mutationId, domain, legacyImageId: imageId, patch }));
   const committed = await commitLegacyUserDataPatch(domain, imageId, patch, mutationId);
   localPendingByImageDomain.set(localKey(imageId, domain), committed);
   await finalizeOutbox(committed);
-  return committed;
-}
-
-function applyLocalPatch(
-  domain: StableUserDataDomain,
-  current: Record<string, unknown> | null,
-  patch: UserDataSemanticPatch,
-): Record<string, unknown> | null {
-  if (patch.deleteRecord) return null;
-  const timestamp = Number(patch.set?.updatedAt ?? patch.set?.addedAt ?? Date.now());
-  const next: Record<string, unknown> = current
-    ? structuredClone(current)
-    : domain === 'annotation'
-      ? { isFavorite: false, tags: [], addedAt: timestamp, updatedAt: timestamp, suppressedMetadataTags: [] }
-      : { updatedAt: timestamp };
-  for (const [key, value] of Object.entries(patch.set ?? {})) next[key] = structuredClone(value);
-  for (const key of patch.remove ?? []) delete next[key];
-  if (domain === 'annotation') {
-    const removed = new Set(patch.removeTags ?? []);
-    const tags = new Set((Array.isArray(next.tags) ? next.tags : []).filter((tag): tag is string => typeof tag === 'string' && !removed.has(tag)));
-    for (const tag of patch.addTags ?? []) tags.add(tag);
-    const unsuppressed = new Set(patch.unsuppressTags ?? []);
-    const suppressed = new Set((Array.isArray(next.suppressedMetadataTags) ? next.suppressedMetadataTags : [])
-      .filter((tag): tag is string => typeof tag === 'string' && !unsuppressed.has(tag)));
-    for (const tag of patch.suppressTags ?? []) suppressed.add(tag);
-    for (const tag of patch.importTags ?? []) if (!suppressed.has(tag)) tags.add(tag);
-    next.tags = [...tags];
-    next.suppressedMetadataTags = [...suppressed];
+  // A global tag operation can live in the SQLite journal without changing the
+  // retained IndexedDB source. Confirm the projected result, not that raw source.
+  const [outcome] = unwrap(await window.electronAPI.stableUserDataSync({
+    entries: [{ domain, legacyImageId: imageId, reference: referencesByImageId.get(imageId) }],
+  }));
+  if (outcome.record) {
+    cacheAndPublish([outcome.record]);
+    return outcome.record;
   }
-  return next;
+  if (outcome.pending) {
+    localPendingByImageDomain.set(localKey(imageId, domain), outcome.pending);
+    return outcome.pending;
+  }
+  throw new UserDataPersistenceError('USER_DATA_MAPPING_STALE', 'The committed user data could not be resolved to this image.');
 }
 
 async function mutateDomain(
@@ -421,19 +405,7 @@ async function mutateDomain(
   patch: UserDataSemanticPatch,
 ): Promise<StableUserDataRecord | LegacyUserDataSnapshot> {
   const status = await getUserDataPersistenceStatus();
-  if (status.authority !== 'sqlite') {
-    const current = domain === 'annotation' ? await getLegacyAnnotation(imageId) : await getLegacyShadow(imageId);
-    const payload = applyLocalPatch(domain, current ? { ...current, imageId: undefined } : null, patch);
-    if (!payload) {
-      if (domain === 'annotation') await deleteLegacyAnnotation(imageId);
-      else await deleteLegacyShadow(imageId);
-    } else if (domain === 'annotation') {
-      await saveLegacyAnnotation({ ...(payload as unknown as ImageAnnotations), imageId });
-    } else {
-      await saveLegacyShadow({ ...(payload as unknown as ShadowMetadata), imageId });
-    }
-    return { domain, legacyImageId: imageId, payload, tombstone: !payload, sourceVersion: 0 };
-  }
+  if (status.authority !== 'sqlite') return patchLegacyUserData(domain, imageId, patch);
   if (!status.available) {
     throw new UserDataPersistenceError('USER_DATA_UNAVAILABLE', statusErrorMessage(status));
   }
@@ -557,6 +529,7 @@ export async function mutateAnnotationTagGlobally(
   const status = await getUserDataPersistenceStatus();
   if (status.authority !== 'sqlite') return null;
   if (!status.available) throw new UserDataPersistenceError('USER_DATA_UNAVAILABLE', statusErrorMessage(status));
+  await stageAllLegacyUserDataIfNeeded(status);
   const records = unwrap(await window.electronAPI.stableUserDataGlobalTagMutation({
     action,
     sourceTag,

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -5398,13 +5398,8 @@ export const useImageStore = create<ImageState>((set, get) => {
                 const stableRecords = await mutateAnnotationTagGlobally('rename', normalizedSource, normalizedTarget);
                 if (stableRecords) {
                     updatedAnnotations.length = 0;
-                    for (const record of stableRecords) {
-                        for (const image of get().images) {
-                            if (image.assetId !== record.assetId) continue;
-                            const annotation = annotationFromStableRecord(record, image.id);
-                            if (annotation) updatedAnnotations.push(annotation);
-                        }
-                    }
+                    const hydrated = await loadAnnotationsForImages(get().images);
+                    updatedAnnotations.push(...hydrated.values());
                 } else if (updatedAnnotations.length > 0) {
                     const persisted = await persistAnnotationSnapshots(updatedAnnotations);
                     updatedAnnotations.splice(0, updatedAnnotations.length, ...persisted);
@@ -5487,13 +5482,8 @@ export const useImageStore = create<ImageState>((set, get) => {
                 const stableRecords = await mutateAnnotationTagGlobally('remove', normalizedTag);
                 if (stableRecords) {
                     updatedAnnotations.length = 0;
-                    for (const record of stableRecords) {
-                        for (const image of get().images) {
-                            if (image.assetId !== record.assetId) continue;
-                            const annotation = annotationFromStableRecord(record, image.id);
-                            if (annotation) updatedAnnotations.push(annotation);
-                        }
-                    }
+                    const hydrated = await loadAnnotationsForImages(get().images);
+                    updatedAnnotations.push(...hydrated.values());
                 } else if (updatedAnnotations.length > 0) {
                     const persisted = await persistAnnotationSnapshots(updatedAnnotations);
                     updatedAnnotations.splice(0, updatedAnnotations.length, ...persisted);
@@ -5590,13 +5580,8 @@ export const useImageStore = create<ImageState>((set, get) => {
                 const stableRecords = await mutateAnnotationTagGlobally('remove', normalizedTag);
                 if (stableRecords) {
                     updatedAnnotations.length = 0;
-                    for (const record of stableRecords) {
-                        for (const image of get().images) {
-                            if (image.assetId !== record.assetId) continue;
-                            const annotation = annotationFromStableRecord(record, image.id);
-                            if (annotation) updatedAnnotations.push(annotation);
-                        }
-                    }
+                    const hydrated = await loadAnnotationsForImages(get().images);
+                    updatedAnnotations.push(...hydrated.values());
                 } else if (updatedAnnotations.length > 0) {
                     const persisted = await persistAnnotationSnapshots(updatedAnnotations);
                     updatedAnnotations.splice(0, updatedAnnotations.length, ...persisted);

--- a/store/useImageStore.ts
+++ b/store/useImageStore.ts
@@ -1,12 +1,8 @@
 import { create } from 'zustand';
-import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, AutoTag, IndexedImageTransferProgress, InclusionFilterMode, ImageRating, SmartCollection, AutomationRule, type AdvancedFilters, type FilterOptions, type SelectedFiltersUpdate, type TagMatchMode, type ImageScope, type ExploreDimension, type SortOrder, type SemanticSearchResult } from '../types';
+import { IndexedImage, Directory, ThumbnailStatus, ImageAnnotations, TagInfo, ImageCluster, TFIDFModel, IndexedImageTransferProgress, InclusionFilterMode, ImageRating, SmartCollection, AutomationRule, type AdvancedFilters, type FilterOptions, type SelectedFiltersUpdate, type TagMatchMode, type ImageScope, type ExploreDimension, type SortOrder, type SemanticSearchResult, type UserDataSemanticPatch } from '../types';
 import { resolveScopeImageIds, filterImagesByScope, getScopeToastMessage } from '../utils/imageScope';
 import { loadSelectedFolders, saveSelectedFolders, loadExcludedFolders, saveExcludedFolders } from '../services/folderSelectionStorage';
 import {
-  loadAllAnnotations,
-  saveAnnotation,
-  bulkSaveAnnotations,
-  getAllTags,
   ensureManualTagExists,
   renameManualTag,
   deleteManualTag,
@@ -22,6 +18,18 @@ import {
   resolveSmartCollectionImages,
   saveSmartCollection,
 } from '../services/imageAnnotationsStorage';
+import {
+  annotationFromStableRecord,
+  getAllAuthoritativeTags,
+  hydrateUserDataForImages,
+  loadAnnotationsForImages,
+  mutateAnnotationTagGlobally,
+  patchAnnotation,
+  registerStableUserDataImages,
+  saveAnnotations,
+  subscribeStableUserDataChanges,
+  UserDataBatchPersistenceError,
+} from '../services/userDataPersistenceAdapter';
 import {
     deleteAutomationRule,
     getAllAutomationRules,
@@ -331,25 +339,6 @@ const drainPendingMetadataTagImports = (): IndexedImage[] => {
     const images = Array.from(pendingMetadataTagImportMap.values());
     pendingMetadataTagImportMap.clear();
     return images;
-};
-
-const buildAnnotationRecord = (
-    imageId: string,
-    currentAnnotation: ImageAnnotations | undefined,
-    overrides: Partial<Pick<ImageAnnotations, 'isFavorite' | 'tags' | 'rating'>>,
-): ImageAnnotations => {
-    const hasFavoriteOverride = Object.prototype.hasOwnProperty.call(overrides, 'isFavorite');
-    const hasTagsOverride = Object.prototype.hasOwnProperty.call(overrides, 'tags');
-    const hasRatingOverride = Object.prototype.hasOwnProperty.call(overrides, 'rating');
-
-    return {
-        imageId,
-        isFavorite: hasFavoriteOverride ? overrides.isFavorite ?? false : currentAnnotation?.isFavorite ?? false,
-        tags: hasTagsOverride ? overrides.tags ?? [] : currentAnnotation?.tags ?? [],
-        rating: hasRatingOverride ? overrides.rating : currentAnnotation?.rating,
-        addedAt: currentAnnotation?.addedAt ?? Date.now(),
-        updatedAt: Date.now(),
-    };
 };
 
 type ManualTagFilterState = Pick<ImageState, 'selectedTags' | 'excludedTags'>;
@@ -1106,6 +1095,7 @@ interface ImageState {
 
   // Annotations Actions
   loadAnnotations: () => Promise<void>;
+  hydrateAnnotationsForImages: (images: IndexedImage[]) => Promise<void>;
   toggleFavorite: (imageId: string) => Promise<void>;
   bulkToggleFavorite: (imageIds: string[], isFavorite: boolean) => Promise<void>;
   addTagToImage: (imageId: string, tag: string) => Promise<void>;
@@ -1178,6 +1168,7 @@ export const useImageStore = create<ImageState>((set, get) => {
     let searchDatasetSourceImages: IndexedImage[] | null = null;
     let searchWorkerSyncedDatasetVersion = -1;
     let latestSearchCriteriaKey = '';
+    let stableUserDataUnsubscribe: (() => void) | null = null;
 
     const clearPendingQueue = () => {
         pendingImagesQueue = [];
@@ -1281,7 +1272,8 @@ export const useImageStore = create<ImageState>((set, get) => {
         // Import tags from metadata only after annotations are available.
         if (addedImages.length > 0) {
             if (get().isAnnotationsLoaded) {
-                void get().importMetadataTags(addedImages);
+                void get().hydrateAnnotationsForImages(addedImages)
+                    .then(() => get().importMetadataTags(addedImages));
             } else {
                 queueMetadataTagImports(addedImages);
             }
@@ -1359,7 +1351,8 @@ export const useImageStore = create<ImageState>((set, get) => {
         });
 
         if (get().isAnnotationsLoaded) {
-            void get().importMetadataTags(updatesToMerge);
+            void get().hydrateAnnotationsForImages(updatesToMerge)
+                .then(() => get().importMetadataTags(updatesToMerge));
         }
         maybeQueueLineageBuild(700);
 
@@ -1679,14 +1672,26 @@ export const useImageStore = create<ImageState>((set, get) => {
             return { ...newState, ...filterAndSort(newState) };
         });
 
+        let annotationPersistenceFailed = false;
         await Promise.all([
-            annotationsToPersist.length > 0 ? bulkSaveAnnotations(annotationsToPersist) : Promise.resolve(),
+            annotationsToPersist.length > 0
+                ? persistAnnotationSnapshots(annotationsToPersist)
+                : Promise.resolve(),
             ...Array.from(tagCatalogUpdates).map((tagName) => ensureManualTagExists(tagName)),
             ...collectionsToPersist.map((collection) => saveSmartCollection(collection)),
             updatedRule ? saveAutomationRule(updatedRule) : Promise.resolve(),
         ]).catch(error => {
             console.error('Failed to apply automation rule:', error);
+            annotationPersistenceFailed = annotationsToPersist.length > 0;
         });
+
+        if (annotationPersistenceFailed) {
+            await get().hydrateAnnotationsForImages(
+                annotationsToPersist
+                    .map((annotation) => getImageById(get(), annotation.imageId))
+                    .filter((image): image is IndexedImage => Boolean(image)),
+            );
+        }
 
         if (annotationsToPersist.length > 0 || tagCatalogUpdates.size > 0) {
             await get().refreshAvailableTags();
@@ -3373,6 +3378,84 @@ export const useImageStore = create<ImageState>((set, get) => {
         return snapshot;
     };
 
+    const applyConfirmedAnnotations = (confirmed: ImageAnnotations[]) => {
+        if (confirmed.length === 0) return;
+        set(state => {
+            const annotations = new Map(state.annotations);
+            for (const annotation of confirmed) annotations.set(annotation.imageId, annotation);
+            const images = applyAnnotationsToImages(state.images, annotations);
+            const newState = { ...state, annotations, images };
+            return { ...newState, ...filterAndSort(newState) };
+        });
+    };
+
+    const persistAnnotationPatchBatch = async (
+        updates: Array<{ imageId: string; patch: UserDataSemanticPatch }>,
+    ): Promise<ImageAnnotations[]> => {
+        const outcomes = await Promise.allSettled(
+            updates.map(({ imageId, patch }) => patchAnnotation(imageId, patch)),
+        );
+        const confirmed = outcomes
+            .filter((outcome): outcome is PromiseFulfilledResult<ImageAnnotations | null> => outcome.status === 'fulfilled')
+            .map((outcome) => outcome.value)
+            .filter((annotation): annotation is ImageAnnotations => Boolean(annotation));
+        applyConfirmedAnnotations(confirmed);
+        const failures = outcomes.filter((outcome): outcome is PromiseRejectedResult => outcome.status === 'rejected');
+        if (failures.length > 0) {
+            throw new AggregateError(
+                failures.map((failure) => failure.reason),
+                `${failures.length} annotation update${failures.length === 1 ? '' : 's'} failed.`,
+            );
+        }
+        return confirmed;
+    };
+
+    const persistAnnotationSnapshots = async (records: ImageAnnotations[]): Promise<ImageAnnotations[]> => {
+        try {
+            const confirmed = await saveAnnotations(records);
+            applyConfirmedAnnotations(confirmed);
+            return confirmed;
+        } catch (error) {
+            if (error instanceof UserDataBatchPersistenceError) applyConfirmedAnnotations(error.persisted);
+            throw error;
+        }
+    };
+
+    const ensureStableUserDataSubscription = () => {
+        if (stableUserDataUnsubscribe) return;
+        stableUserDataUnsubscribe = subscribeStableUserDataChanges((records) => {
+            const state = get();
+            const confirmed: ImageAnnotations[] = [];
+            const removedImageIds = new Set<string>();
+            for (const record of records) {
+                if (record.domain !== 'annotation') continue;
+                for (const image of state.images) {
+                    if (image.assetId !== record.assetId) continue;
+                    const annotation = annotationFromStableRecord(record, image.id);
+                    if (annotation) confirmed.push(annotation);
+                    else removedImageIds.add(image.id);
+                }
+            }
+            if (confirmed.length === 0 && removedImageIds.size === 0) return;
+            set(current => {
+                const annotations = new Map(current.annotations);
+                for (const imageId of removedImageIds) annotations.delete(imageId);
+                for (const annotation of confirmed) annotations.set(annotation.imageId, annotation);
+                const images = current.images.map((image) => {
+                    if (removedImageIds.has(image.id)) {
+                        return { ...image, isFavorite: false, tags: [], rating: undefined };
+                    }
+                    const annotation = annotations.get(image.id);
+                    return annotation
+                        ? { ...image, isFavorite: annotation.isFavorite, tags: annotation.tags, rating: annotation.rating }
+                        : image;
+                });
+                const newState = { ...current, annotations, images };
+                return { ...newState, ...filterAndSort(newState) };
+            });
+        });
+    };
+
 
     return {
         // Initial State
@@ -3960,7 +4043,8 @@ export const useImageStore = create<ImageState>((set, get) => {
             set(state => _updateStateIncremental(state, { updated: updatesToApply }));
 
             if (get().isAnnotationsLoaded) {
-                void get().importMetadataTags(updatesToApply);
+                void get().hydrateAnnotationsForImages(updatesToApply)
+                    .then(() => get().importMetadataTags(updatesToApply));
             }
             maybeQueueLineageBuild(700);
         },
@@ -4066,7 +4150,6 @@ export const useImageStore = create<ImageState>((set, get) => {
                     annotations.set(nextImageId, {
                         ...annotation,
                         imageId: nextImageId,
-                        updatedAt: Date.now(),
                     });
                 }
 
@@ -5009,8 +5092,24 @@ export const useImageStore = create<ImageState>((set, get) => {
 
         // Annotations Actions
         loadAnnotations: async () => {
-            const annotationsMap = await loadAllAnnotations();
-            const tags = await getAllTags();
+            const images = get().images;
+            registerStableUserDataImages(images);
+            ensureStableUserDataSubscription();
+            let annotationsMap: Map<string, ImageAnnotations>;
+            let tags: TagInfo[];
+            try {
+                annotationsMap = await loadAnnotationsForImages(images);
+                tags = await getAllAuthoritativeTags();
+            } catch (error) {
+                console.error('Authoritative user data is unavailable:', error);
+                set({
+                    annotations: new Map(),
+                    availableTags: [],
+                    isAnnotationsLoaded: true,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+                return;
+            }
             const queuedMetadataImports = drainPendingMetadataTagImports();
 
             set(state => {
@@ -5033,109 +5132,88 @@ export const useImageStore = create<ImageState>((set, get) => {
             }
         },
 
+        hydrateAnnotationsForImages: async (images) => {
+            if (images.length === 0) return;
+            const requestedIdentity = new Map(images.map((image) => [
+                image.id,
+                `${image.assetId ?? ''}\0${image.revisionId ?? ''}\0${image.provenanceLocationId ?? ''}`,
+            ]));
+            registerStableUserDataImages(images);
+            ensureStableUserDataSubscription();
+            try {
+                const hydrated = await hydrateUserDataForImages(images);
+                set(state => {
+                    const annotations = new Map(state.annotations);
+                    const currentHydratedIds = new Set(state.images
+                        .filter((image) => requestedIdentity.get(image.id) === `${image.assetId ?? ''}\0${image.revisionId ?? ''}\0${image.provenanceLocationId ?? ''}`)
+                        .map((image) => image.id));
+                    for (const imageId of currentHydratedIds) annotations.delete(imageId);
+                    for (const annotation of hydrated.annotations.values()) {
+                        if (currentHydratedIds.has(annotation.imageId)) annotations.set(annotation.imageId, annotation);
+                    }
+                    const nextImages = state.images.map((image) => {
+                        if (!currentHydratedIds.has(image.id)) return image;
+                        const annotation = annotations.get(image.id);
+                        return annotation
+                            ? { ...image, isFavorite: annotation.isFavorite, tags: annotation.tags, rating: annotation.rating }
+                            : { ...image, isFavorite: false, tags: [], rating: undefined };
+                    });
+                    const newState = { ...state, annotations, images: nextImages };
+                    return { ...newState, ...filterAndSort(newState) };
+                });
+            } catch (error) {
+                console.error('Failed to hydrate stable user data:', error);
+                set({ error: error instanceof Error ? error.message : String(error) });
+            }
+        },
+
         toggleFavorite: async (imageId) => {
             const { annotations } = get();
 
             const currentAnnotation = annotations.get(imageId);
             const newIsFavorite = !(currentAnnotation?.isFavorite ?? false);
 
-            const updatedAnnotation = buildAnnotationRecord(imageId, currentAnnotation, {
-                isFavorite: newIsFavorite,
-            });
-
-            // Update in-memory state
-            set(state => {
-                const newAnnotations = new Map(state.annotations);
-                newAnnotations.set(imageId, updatedAnnotation);
-
-                const updatedImages = state.images.map(img =>
-                    img.id === imageId ? { ...img, isFavorite: newIsFavorite, rating: updatedAnnotation.rating } : img
-                );
-
-                const newState = {
-                    ...state,
-                    annotations: newAnnotations,
-                    images: updatedImages,
-                };
-
-                return { ...newState, ...filterAndSort(newState) };
-            });
-
-            // Persist to IndexedDB (async, don't await)
-            saveAnnotation(updatedAnnotation).catch(error => {
+            try {
+                const updatedAnnotation = await patchAnnotation(imageId, { set: { isFavorite: newIsFavorite } });
+                if (updatedAnnotation) applyConfirmedAnnotations([updatedAnnotation]);
+            } catch (error) {
                 console.error('Failed to save annotation:', error);
-            });
+                set({ error: error instanceof Error ? error.message : String(error) });
+                throw error;
+            }
         },
 
         bulkToggleFavorite: async (imageIds, isFavorite) => {
-            const { annotations } = get();
-            const updatedAnnotations: ImageAnnotations[] = [];
-
-            for (const imageId of imageIds) {
-                const current = annotations.get(imageId);
-                updatedAnnotations.push(buildAnnotationRecord(imageId, current, {
-                    isFavorite,
-                }));
-            }
-
-            // Update state
-            set(state => {
-                const newAnnotations = new Map(state.annotations);
-                for (const annotation of updatedAnnotations) {
-                    newAnnotations.set(annotation.imageId, annotation);
-                }
-
-                const updatedImages = state.images.map(img => {
-                    const annotation = newAnnotations.get(img.id);
-                    if (annotation && imageIds.includes(img.id)) {
-                        return { ...img, isFavorite: annotation.isFavorite, rating: annotation.rating };
-                    }
-                    return img;
-                });
-
-                const newState = {
-                    ...state,
-                    annotations: newAnnotations,
-                    images: updatedImages,
-                };
-
-                return { ...newState, ...filterAndSort(newState) };
-            });
-
-            // Persist to IndexedDB
-            bulkSaveAnnotations(updatedAnnotations).catch(error => {
+            try {
+                await persistAnnotationPatchBatch(imageIds.map((imageId) => ({
+                    imageId,
+                    patch: { set: { isFavorite } },
+                })));
+            } catch (error) {
                 console.error('Failed to bulk save annotations:', error);
-            });
+                set({ error: error instanceof Error ? error.message : String(error) });
+            }
         },
 
         setImageRating: async (imageId, rating) => {
-            const { annotations } = get();
-            const currentAnnotation = annotations.get(imageId);
-            const normalizedRating = rating ?? undefined;
-            const updatedAnnotation = buildAnnotationRecord(imageId, currentAnnotation, {
-                rating: normalizedRating,
-            });
-
-            set(state => {
-                const newAnnotations = new Map(state.annotations);
-                newAnnotations.set(imageId, updatedAnnotation);
-
-                const updatedImages = state.images.map(img =>
-                    img.id === imageId ? { ...img, rating: normalizedRating } : img
-                );
-
-                const newState = {
-                    ...state,
-                    annotations: newAnnotations,
-                    images: updatedImages,
+            try {
+                const state = get();
+                const currentAnnotation = state.annotations.get(imageId);
+                const currentImage = getImageById(state, imageId);
+                const initialSet = currentAnnotation ? {} : {
+                    isFavorite: currentImage?.isFavorite === true,
+                    tags: [...(currentImage?.tags ?? [])],
+                    addedAt: Date.now(),
                 };
-
-                return { ...newState, ...filterAndSort(newState) };
-            });
-
-            saveAnnotation(updatedAnnotation).catch(error => {
+                const updatedAnnotation = await patchAnnotation(imageId, rating === null
+                    ? { set: initialSet, remove: ['rating'] }
+                    : { set: { ...initialSet, rating } });
+                if (updatedAnnotation) applyConfirmedAnnotations([updatedAnnotation]);
+            } catch (error) {
                 console.error('Failed to save image rating:', error);
-            });
+                set({ error: error instanceof Error ? error.message : String(error) });
+                throw error;
+            }
         },
 
         bulkSetImageRating: async (imageIds, rating) => {
@@ -5143,37 +5221,27 @@ export const useImageStore = create<ImageState>((set, get) => {
                 return;
             }
 
-            const { annotations } = get();
-            const normalizedRating = rating ?? undefined;
-            const updatedAnnotations = imageIds.map(imageId =>
-                buildAnnotationRecord(imageId, annotations.get(imageId), {
-                    rating: normalizedRating,
-                })
-            );
-
-            set(state => {
-                const newAnnotations = new Map(state.annotations);
-                for (const annotation of updatedAnnotations) {
-                    newAnnotations.set(annotation.imageId, annotation);
-                }
-
-                const imageIdsSet = new Set(imageIds);
-                const updatedImages = state.images.map(img =>
-                    imageIdsSet.has(img.id) ? { ...img, rating: normalizedRating } : img
-                );
-
-                const newState = {
-                    ...state,
-                    annotations: newAnnotations,
-                    images: updatedImages,
-                };
-
-                return { ...newState, ...filterAndSort(newState) };
-            });
-
-            bulkSaveAnnotations(updatedAnnotations).catch(error => {
+            try {
+                await persistAnnotationPatchBatch(imageIds.map((imageId) => ({
+                    imageId,
+                    patch: (() => {
+                        const state = get();
+                        const currentAnnotation = state.annotations.get(imageId);
+                        const currentImage = getImageById(state, imageId);
+                        const initialSet = currentAnnotation ? {} : {
+                            isFavorite: currentImage?.isFavorite === true,
+                            tags: [...(currentImage?.tags ?? [])],
+                            addedAt: Date.now(),
+                        };
+                        return rating === null
+                            ? { set: initialSet, remove: ['rating'] }
+                            : { set: { ...initialSet, rating } };
+                    })(),
+                })));
+            } catch (error) {
                 console.error('Failed to bulk save image ratings:', error);
-            });
+                set({ error: error instanceof Error ? error.message : String(error) });
+            }
         },
 
         addTagToImage: async (imageId, tag) => {
@@ -5188,41 +5256,21 @@ export const useImageStore = create<ImageState>((set, get) => {
                 return;
             }
 
-            const updatedAnnotation = buildAnnotationRecord(imageId, currentAnnotation, {
-                tags: [...(currentAnnotation?.tags ?? []), normalizedTag],
-            });
-
-            let nextRecentTags = get().recentTags;
-
-            // Update state
-            set(state => {
-                const newAnnotations = new Map(state.annotations);
-                newAnnotations.set(imageId, updatedAnnotation);
-
-                const updatedImages = state.images.map(img =>
-                    img.id === imageId ? { ...img, tags: updatedAnnotation.tags, rating: updatedAnnotation.rating } : img
-                );
-
-                nextRecentTags = updateRecentTags(state.recentTags, normalizedTag);
-                const newState = {
-                    ...state,
-                    annotations: newAnnotations,
-                    images: updatedImages,
-                    recentTags: nextRecentTags,
-                };
-
-                return { ...newState, ...filterAndSort(newState) };
-            });
-
-            persistRecentTags(nextRecentTags);
-
-            // Persist and refresh tags
-            await Promise.all([
-                saveAnnotation(updatedAnnotation),
-                ensureManualTagExists(normalizedTag),
-            ]).catch(error => {
+            try {
+                const updatedAnnotation = await patchAnnotation(imageId, {
+                    addTags: [normalizedTag],
+                    unsuppressTags: [normalizedTag],
+                });
+                if (updatedAnnotation) applyConfirmedAnnotations([updatedAnnotation]);
+                const nextRecentTags = updateRecentTags(get().recentTags, normalizedTag);
+                set({ recentTags: nextRecentTags });
+                persistRecentTags(nextRecentTags);
+                await ensureManualTagExists(normalizedTag);
+            } catch (error) {
                 console.error('Failed to save annotation:', error);
-            });
+                set({ error: error instanceof Error ? error.message : String(error) });
+                throw error;
+            }
             await get().refreshAvailableTags();
         },
 
@@ -5234,35 +5282,18 @@ export const useImageStore = create<ImageState>((set, get) => {
                 return;
             }
 
-            const updatedAnnotation: ImageAnnotations = {
-                ...currentAnnotation,
-                tags: currentAnnotation.tags.filter(t => t !== tag),
-                updatedAt: Date.now(),
-            };
-
-            // Update state
-            set(state => {
-                const newAnnotations = new Map(state.annotations);
-                newAnnotations.set(imageId, updatedAnnotation);
-
-                const updatedImages = state.images.map(img =>
-                    img.id === imageId ? { ...img, tags: updatedAnnotation.tags, rating: updatedAnnotation.rating } : img
-                );
-
-                const newState = {
-                    ...state,
-                    annotations: newAnnotations,
-                    images: updatedImages,
-                };
-
-                return { ...newState, ...filterAndSort(newState) };
-            });
-
-            // Persist and refresh tags
-            saveAnnotation(updatedAnnotation).catch(error => {
+            try {
+                const updatedAnnotation = await patchAnnotation(imageId, {
+                    removeTags: [tag],
+                    suppressTags: [tag],
+                });
+                if (updatedAnnotation) applyConfirmedAnnotations([updatedAnnotation]);
+            } catch (error) {
                 console.error('Failed to save annotation:', error);
-            });
-            get().refreshAvailableTags();
+                set({ error: error instanceof Error ? error.message : String(error) });
+                throw error;
+            }
+            await get().refreshAvailableTags();
         },
 
         removeAutoTagFromImage: (imageId, tag) => {
@@ -5290,105 +5321,33 @@ export const useImageStore = create<ImageState>((set, get) => {
             const normalizedTag = normalizeTagName(tag);
             if (!normalizedTag || imageIds.length === 0) return;
 
-            const { annotations } = get();
-            const updatedAnnotations: ImageAnnotations[] = [];
-
-            for (const imageId of imageIds) {
-                const current = annotations.get(imageId);
-                if (current?.tags.includes(normalizedTag)) {
-                    continue; // Skip if already tagged
-                }
-
-                updatedAnnotations.push(buildAnnotationRecord(imageId, current, {
-                    tags: [...(current?.tags ?? []), normalizedTag],
-                }));
-            }
-
-            let nextRecentTags = get().recentTags;
-
-            // Update state
-            set(state => {
-                const newAnnotations = new Map(state.annotations);
-                for (const annotation of updatedAnnotations) {
-                    newAnnotations.set(annotation.imageId, annotation);
-                }
-
-                const updatedImages = state.images.map(img => {
-                    const annotation = newAnnotations.get(img.id);
-                    if (annotation && imageIds.includes(img.id)) {
-                        return { ...img, tags: annotation.tags, rating: annotation.rating };
-                    }
-                    return img;
-                });
-
-                nextRecentTags = updateRecentTags(state.recentTags, normalizedTag);
-                const newState = {
-                    ...state,
-                    annotations: newAnnotations,
-                    images: updatedImages,
-                    recentTags: nextRecentTags,
-                };
-
-                return { ...newState, ...filterAndSort(newState) };
-            });
-
-            persistRecentTags(nextRecentTags);
-
-            // Persist and refresh tags
-            await Promise.all([
-                bulkSaveAnnotations(updatedAnnotations),
-                ensureManualTagExists(normalizedTag),
-            ]).catch(error => {
+            try {
+                await persistAnnotationPatchBatch(imageIds.map((imageId) => ({
+                    imageId,
+                    patch: { addTags: [normalizedTag], unsuppressTags: [normalizedTag] },
+                })));
+                const nextRecentTags = updateRecentTags(get().recentTags, normalizedTag);
+                set({ recentTags: nextRecentTags });
+                persistRecentTags(nextRecentTags);
+                await ensureManualTagExists(normalizedTag);
+            } catch (error) {
                 console.error('Failed to bulk save annotations:', error);
-            });
+                set({ error: error instanceof Error ? error.message : String(error) });
+            }
             await get().refreshAvailableTags();
         },
 
         bulkRemoveTag: async (imageIds, tag) => {
-            const { annotations } = get();
-            const updatedAnnotations: ImageAnnotations[] = [];
-
-            for (const imageId of imageIds) {
-                const current = annotations.get(imageId);
-                if (!current || !current.tags.includes(tag)) {
-                    continue; // Skip if doesn't have this tag
-                }
-
-                updatedAnnotations.push({
-                    ...current,
-                    tags: current.tags.filter(t => t !== tag),
-                    updatedAt: Date.now(),
-                });
-            }
-
-            // Update state
-            set(state => {
-                const newAnnotations = new Map(state.annotations);
-                for (const annotation of updatedAnnotations) {
-                    newAnnotations.set(annotation.imageId, annotation);
-                }
-
-                const updatedImages = state.images.map(img => {
-                    const annotation = newAnnotations.get(img.id);
-                    if (annotation && imageIds.includes(img.id)) {
-                        return { ...img, tags: annotation.tags, rating: annotation.rating };
-                    }
-                    return img;
-                });
-
-                const newState = {
-                    ...state,
-                    annotations: newAnnotations,
-                    images: updatedImages,
-                };
-
-                return { ...newState, ...filterAndSort(newState) };
-            });
-
-            // Persist and refresh tags
-            await bulkSaveAnnotations(updatedAnnotations).catch(error => {
+            const targets = imageIds.filter((imageId) => get().annotations.get(imageId)?.tags.includes(tag));
+            try {
+                await persistAnnotationPatchBatch(targets.map((imageId) => ({
+                    imageId,
+                    patch: { removeTags: [tag], suppressTags: [tag] },
+                })));
+            } catch (error) {
                 console.error('Failed to bulk save annotations:', error);
-            });
+                set({ error: error instanceof Error ? error.message : String(error) });
+            }
             await get().refreshAvailableTags();
         },
 
@@ -5435,6 +5394,27 @@ export const useImageStore = create<ImageState>((set, get) => {
                 });
             }
 
+            try {
+                const stableRecords = await mutateAnnotationTagGlobally('rename', normalizedSource, normalizedTarget);
+                if (stableRecords) {
+                    updatedAnnotations.length = 0;
+                    for (const record of stableRecords) {
+                        for (const image of get().images) {
+                            if (image.assetId !== record.assetId) continue;
+                            const annotation = annotationFromStableRecord(record, image.id);
+                            if (annotation) updatedAnnotations.push(annotation);
+                        }
+                    }
+                } else if (updatedAnnotations.length > 0) {
+                    const persisted = await persistAnnotationSnapshots(updatedAnnotations);
+                    updatedAnnotations.splice(0, updatedAnnotations.length, ...persisted);
+                }
+            } catch (error) {
+                console.error('Failed to persist renamed annotation tags:', error);
+                set({ error: error instanceof Error ? error.message : String(error) });
+                return;
+            }
+
             let nextRecentTags = get().recentTags;
 
             set(state => {
@@ -5474,7 +5454,6 @@ export const useImageStore = create<ImageState>((set, get) => {
             persistRecentTags(nextRecentTags);
 
             await Promise.all([
-                updatedAnnotations.length > 0 ? bulkSaveAnnotations(updatedAnnotations) : Promise.resolve(),
                 renameManualTag(normalizedSource, normalizedTarget),
                 ...updatedCollections.map((collection) => saveSmartCollection(collection)),
             ]).catch(error => {
@@ -5504,6 +5483,27 @@ export const useImageStore = create<ImageState>((set, get) => {
                 });
             }
 
+            try {
+                const stableRecords = await mutateAnnotationTagGlobally('remove', normalizedTag);
+                if (stableRecords) {
+                    updatedAnnotations.length = 0;
+                    for (const record of stableRecords) {
+                        for (const image of get().images) {
+                            if (image.assetId !== record.assetId) continue;
+                            const annotation = annotationFromStableRecord(record, image.id);
+                            if (annotation) updatedAnnotations.push(annotation);
+                        }
+                    }
+                } else if (updatedAnnotations.length > 0) {
+                    const persisted = await persistAnnotationSnapshots(updatedAnnotations);
+                    updatedAnnotations.splice(0, updatedAnnotations.length, ...persisted);
+                }
+            } catch (error) {
+                console.error('Failed to persist cleared annotation tag:', error);
+                set({ error: error instanceof Error ? error.message : String(error) });
+                return;
+            }
+
             set(state => {
                 const newAnnotations = new Map(state.annotations);
                 for (const annotation of updatedAnnotations) {
@@ -5524,7 +5524,6 @@ export const useImageStore = create<ImageState>((set, get) => {
 
             await Promise.all([
                 ensureManualTagExists(normalizedTag),
-                updatedAnnotations.length > 0 ? bulkSaveAnnotations(updatedAnnotations) : Promise.resolve(),
             ]).catch(error => {
                 console.error('Failed to clear tag:', error);
             });
@@ -5587,6 +5586,27 @@ export const useImageStore = create<ImageState>((set, get) => {
                 });
             }
 
+            try {
+                const stableRecords = await mutateAnnotationTagGlobally('remove', normalizedTag);
+                if (stableRecords) {
+                    updatedAnnotations.length = 0;
+                    for (const record of stableRecords) {
+                        for (const image of get().images) {
+                            if (image.assetId !== record.assetId) continue;
+                            const annotation = annotationFromStableRecord(record, image.id);
+                            if (annotation) updatedAnnotations.push(annotation);
+                        }
+                    }
+                } else if (updatedAnnotations.length > 0) {
+                    const persisted = await persistAnnotationSnapshots(updatedAnnotations);
+                    updatedAnnotations.splice(0, updatedAnnotations.length, ...persisted);
+                }
+            } catch (error) {
+                console.error('Failed to persist purged annotation tag:', error);
+                set({ error: error instanceof Error ? error.message : String(error) });
+                return;
+            }
+
             let nextRecentTags = get().recentTags;
 
             set(state => {
@@ -5612,7 +5632,6 @@ export const useImageStore = create<ImageState>((set, get) => {
             persistRecentTags(nextRecentTags);
 
             await Promise.all([
-                updatedAnnotations.length > 0 ? bulkSaveAnnotations(updatedAnnotations) : Promise.resolve(),
                 deleteManualTag(normalizedTag),
             ]).catch(error => {
                 console.error('Failed to purge tag:', error);
@@ -5662,8 +5681,16 @@ export const useImageStore = create<ImageState>((set, get) => {
         },
 
         refreshAvailableTags: async () => {
-            const tags = await getAllTags();
-            set({ availableTags: tags });
+            try {
+                const tags = await getAllAuthoritativeTags();
+                set({ availableTags: tags });
+            } catch (error) {
+                console.error('Failed to load authoritative tags:', error);
+                set({
+                    availableTags: [],
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            }
         },
 
         refreshAvailableAutoTags: () => {
@@ -5716,52 +5743,32 @@ export const useImageStore = create<ImageState>((set, get) => {
 
                 const currentAnnotation = annotations.get(image.id);
                 const existingTags = currentAnnotation?.tags ?? [];
+                const suppressedTags = currentAnnotation?.suppressedMetadataTags ?? [];
 
                 // Normalize and filter out duplicates
                 const newTags = metadataTags
                     .map(tag => normalizeTagName(tag))
-                    .filter(tag => tag && !existingTags.includes(tag));
+                    .filter(tag => tag && !existingTags.includes(tag) && !suppressedTags.includes(tag));
 
                 if (newTags.length === 0) continue;
 
-                const updatedAnnotation = buildAnnotationRecord(image.id, currentAnnotation, {
-                    tags: [...existingTags, ...newTags],
-                });
-
-                updatedAnnotations.push(updatedAnnotation);
+                try {
+                    const updatedAnnotation = await patchAnnotation(image.id, { importTags: newTags });
+                    if (updatedAnnotation) updatedAnnotations.push(updatedAnnotation);
+                } catch (error) {
+                    console.error(`Failed to import metadata tags for ${image.id}:`, error);
+                    set({ error: error instanceof Error ? error.message : String(error) });
+                }
             }
 
             if (updatedAnnotations.length > 0) {
-                // Update state
-                set(state => {
-                    const newAnnotations = new Map(state.annotations);
-                    for (const annotation of updatedAnnotations) {
-                        newAnnotations.set(annotation.imageId, annotation);
-                    }
-
-                    const updatedImages = state.images.map(img => {
-                        const annotation = newAnnotations.get(img.id);
-                        return annotation ? { ...img, tags: annotation.tags, rating: annotation.rating } : img;
-                    });
-
-                    const newState = {
-                        ...state,
-                        annotations: newAnnotations,
-                        images: updatedImages,
-                    };
-
-                    return { ...newState, ...filterAndSort(newState) };
-                });
+                applyConfirmedAnnotations(updatedAnnotations);
 
                 const importedTagNames = Array.from(new Set(
                     updatedAnnotations.flatMap(annotation => annotation.tags)
                 ));
 
-                // Persist annotations
-                await Promise.all([
-                    bulkSaveAnnotations(updatedAnnotations),
-                    ...importedTagNames.map(tagName => ensureManualTagExists(tagName)),
-                ]).catch(error => {
+                await Promise.all(importedTagNames.map(tagName => ensureManualTagExists(tagName))).catch(error => {
                     console.error('Failed to import metadata tags:', error);
                 });
 

--- a/types.ts
+++ b/types.ts
@@ -281,6 +281,26 @@ export interface IndexedImageTransferResultItem {
   lastModified?: number;
   birthtimeMs?: number;
   type?: string;
+  provenance?: {
+    enabled: boolean;
+    available?: boolean;
+    pending?: boolean;
+    error?: string;
+    operation?: {
+      operationId: string;
+      kind: IndexedImageTransferMode;
+      state: string;
+      result?: {
+        mapping?: {
+          assetId: string;
+          revisionId: string;
+          locationId: string;
+          rootId: string;
+          relativePath: string;
+        } | null;
+      } | null;
+    };
+  };
 }
 
 export interface UpdateReleaseNote {
@@ -429,7 +449,7 @@ export interface TrialActivationResult {
 }
 
 export interface ElectronAPI {
-  trashFile: (filename: string) => Promise<{
+  trashFile: (filename: string, userDataContext?: StableUserDataOperationContext) => Promise<{
     success: boolean;
     error?: string;
     permanentDeleteToken?: string;
@@ -443,7 +463,11 @@ export interface ElectronAPI {
     failedTokens: string[];
     error?: string;
   }>;
-  renameFile: (oldName: string, newName: string) => Promise<{ success: boolean; error?: string }>;
+  renameFile: (
+    oldName: string,
+    newName: string,
+    userDataContext?: StableUserDataOperationContext,
+  ) => Promise<{ success: boolean; error?: string }>;
   setCurrentDirectory: (dirPath: string) => Promise<{ success: boolean; error?: string }>;
   updateAllowedPaths: (paths: string[]) => Promise<{ success: boolean; error?: string }>;
   showDirectoryDialog: () => Promise<{ success: boolean; path?: string; name?: string; canceled?: boolean; error?: string }>;
@@ -470,6 +494,30 @@ export interface ElectronAPI {
       observationVersion?: number;
     }>;
   }) => void) => () => void;
+  stableUserDataStatus: () => Promise<StableUserDataStatus>;
+  stableUserDataSync: (args: { entries: StableUserDataSyncEntry[] }) => Promise<StableUserDataIpcResult<StableUserDataSyncResult[]>>;
+  stableUserDataMutate: (input: StableUserDataMutationInput) => Promise<StableUserDataIpcResult<StableUserDataRecord>>;
+  stableUserDataReserveLegacyMutation: (input: {
+    mutationId: string;
+    domain: StableUserDataDomain;
+    legacyImageId: string;
+    patch: UserDataSemanticPatch;
+  }) => Promise<StableUserDataIpcResult<{ mutationId: string; sequence: number; state: string }>>;
+  stableUserDataFinalizeLegacyMutation: (input: {
+    mutationId: string;
+    sourceVersion: number;
+    payload: Record<string, unknown> | null;
+    tombstone: boolean;
+  }) => Promise<StableUserDataIpcResult<{ mutationId: string; sequence: number; state: string; record?: StableUserDataRecord | null }>>;
+  stableUserDataCompleteLegacyScan: () => Promise<StableUserDataIpcResult<StableUserDataStatus>>;
+  stableUserDataGlobalTagMutation: (input: {
+    action: 'rename' | 'remove';
+    sourceTag: string;
+    targetTag?: string;
+    updatedAt: number;
+  }) => Promise<StableUserDataIpcResult<StableUserDataRecord[]>>;
+  stableUserDataTagCounts: () => Promise<StableUserDataIpcResult<TagInfo[]>>;
+  onStableUserDataChanged: (callback: (payload: { records: StableUserDataRecord[] }) => void) => () => void;
   readFile: (filePath: string) => Promise<{ success: boolean; data?: Buffer; error?: string; errorType?: string; errorCode?: string }>;
   hashFileSha256: (filePath: string, requestId: string) => Promise<{ success: boolean; sha256?: string; error?: string; errorType?: string; errorCode?: string }>;
   cancelFileSha256: (requestId: string) => void;
@@ -481,14 +529,23 @@ export interface ElectronAPI {
   writeFile: (
     filePath: string,
     data: any,
-    provenanceContext?: { kind: 'save_as' | 'overwrite'; sourcePath?: string },
+    provenanceContext?: {
+      kind: 'save_as' | 'overwrite';
+      sourcePath?: string;
+      userDataContext?: StableUserDataOperationContext;
+    },
   ) => Promise<{ success: boolean; error?: string; provenance?: { enabled: boolean; available?: boolean; pending?: boolean; error?: string } }>;
   writeModel3DExport: (args: { filePath: string; modelData: Uint8Array; sidecarData?: Uint8Array }) => Promise<{ success: boolean; error?: string }>;
   exportBatchToFolder: (args: ExportBatchRequest & { destDir: string }) => Promise<{ success: boolean; exportedCount: number; failedCount: number; error?: string }>;
   exportBatchToZip: (args: ExportBatchRequest & { destZipPath: string }) => Promise<{ success: boolean; exportedCount: number; failedCount: number; error?: string }>;
   cancelBatchExport: (args: { exportId: string }) => Promise<{ success: boolean; error?: string }>;
   transferIndexedImages: (args: {
-    files: { directoryPath: string; relativePath: string }[];
+    files: {
+      directoryPath: string;
+      relativePath: string;
+      legacyImageId?: string;
+      stableReference?: StableUserDataReference;
+    }[];
     destDir: string;
     mode: IndexedImageTransferMode;
     transferId?: string;
@@ -713,6 +770,88 @@ export interface EditableMetadataFields {
 export interface ShadowMetadata extends EditableMetadataFields {
   imageId: string; // Key, links to IndexedImage.id
   updatedAt: number;
+  assetId?: string;
+  persistenceVersion?: number;
+}
+
+export type StableUserDataDomain = 'annotation' | 'shadow';
+
+export interface StableUserDataReference {
+  assetId: string;
+  revisionId: string;
+  locationId: string;
+}
+
+export interface StableUserDataOperationContext {
+  legacyImageId: string;
+  stableReference?: StableUserDataReference;
+  copyUserData?: boolean;
+}
+
+export interface UserDataSemanticPatch {
+  set?: Record<string, unknown>;
+  remove?: string[];
+  deleteRecord?: boolean;
+  addTags?: string[];
+  removeTags?: string[];
+  suppressTags?: string[];
+  unsuppressTags?: string[];
+  importTags?: string[];
+}
+
+export interface StableUserDataRecord {
+  assetId: string;
+  domain: StableUserDataDomain;
+  payload: Record<string, unknown> | null;
+  tombstone: boolean;
+  version: number;
+  authority: 'legacy' | 'sqlite';
+  legacySourceVersion: number;
+  migratedAt: string | null;
+  updatedAt: string;
+}
+
+export interface StableUserDataStatus {
+  initialized: boolean;
+  authority: 'legacy' | 'sqlite';
+  available: boolean;
+  migrationEnabled: boolean;
+  indexingEnabled: boolean;
+  legacyScanComplete?: boolean;
+  legacyScanCompletedAt?: string | null;
+  error?: { code?: string; message?: string } | null;
+}
+
+export interface StableUserDataIpcResult<T> {
+  success: boolean;
+  value?: T;
+  error?: string;
+  code?: string;
+  details?: { current?: StableUserDataRecord } | null;
+}
+
+export interface StableUserDataSyncEntry {
+  domain: StableUserDataDomain;
+  legacyImageId: string;
+  reference?: StableUserDataReference;
+  payload?: Record<string, unknown> | null;
+  tombstone?: boolean;
+  sourceVersion?: number;
+}
+
+export interface StableUserDataSyncResult {
+  domain: StableUserDataDomain;
+  legacyImageId: string;
+  status: 'bound' | 'pending' | 'unmapped' | 'ambiguous' | 'source_ack_required';
+  record: StableUserDataRecord | null;
+}
+
+export interface StableUserDataMutationInput {
+  domain: StableUserDataDomain;
+  legacyImageId: string;
+  reference: StableUserDataReference;
+  expectedVersion: number;
+  patch: UserDataSemanticPatch;
 }
 
 export interface MetadataClipboardPayload {
@@ -1203,6 +1342,9 @@ export interface ImageAnnotations {
   rating?: ImageRating;          // Optional 1-5 user rating
   addedAt: number;               // Timestamp when first annotated
   updatedAt: number;             // Timestamp of last update
+  assetId?: string;
+  persistenceVersion?: number;
+  suppressedMetadataTags?: string[];
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -844,6 +844,13 @@ export interface StableUserDataSyncResult {
   legacyImageId: string;
   status: 'bound' | 'pending' | 'unmapped' | 'ambiguous' | 'source_ack_required';
   record: StableUserDataRecord | null;
+  pending?: {
+    domain: StableUserDataDomain;
+    legacyImageId: string;
+    payload: Record<string, unknown> | null;
+    tombstone: boolean;
+    sourceVersion: number;
+  } | null;
 }
 
 export interface StableUserDataMutationInput {

--- a/utils/editableMetadata.ts
+++ b/utils/editableMetadata.ts
@@ -113,13 +113,13 @@ export const sanitizeEditableMetadataFields = (
 
   const prompt = typeof fields.prompt === 'string' ? fields.prompt : undefined;
   const negativePrompt = typeof fields.negativePrompt === 'string' ? fields.negativePrompt : undefined;
-  const model = typeof fields.model === 'string' && fields.model.trim() ? fields.model.trim() : undefined;
-  const sampler = typeof fields.sampler === 'string' && fields.sampler.trim() ? fields.sampler.trim() : undefined;
-  const scheduler = typeof fields.scheduler === 'string' && fields.scheduler.trim() ? fields.scheduler.trim() : undefined;
+  const model = typeof fields.model === 'string' ? fields.model.trim() : undefined;
+  const sampler = typeof fields.sampler === 'string' ? fields.sampler.trim() : undefined;
+  const scheduler = typeof fields.scheduler === 'string' ? fields.scheduler.trim() : undefined;
   const notes = typeof fields.notes === 'string' ? fields.notes : undefined;
-  const generator = typeof fields.generator === 'string' && fields.generator.trim() ? fields.generator.trim() : undefined;
-  const version = typeof fields.version === 'string' && fields.version.trim() ? fields.version.trim() : undefined;
-  const module = typeof fields.module === 'string' && fields.module.trim() ? fields.module.trim() : undefined;
+  const generator = typeof fields.generator === 'string' ? fields.generator.trim() : undefined;
+  const version = typeof fields.version === 'string' ? fields.version.trim() : undefined;
+  const module = typeof fields.module === 'string' ? fields.module.trim() : undefined;
   const tags = Array.isArray(fields.tags)
     ? fields.tags.map((tag) => String(tag).trim()).filter(Boolean)
     : undefined;
@@ -140,8 +140,8 @@ export const sanitizeEditableMetadataFields = (
     ...(coerceFiniteNumber(fields.width) !== undefined ? { width: coerceFiniteNumber(fields.width) } : {}),
     ...(coerceFiniteNumber(fields.height) !== undefined ? { height: coerceFiniteNumber(fields.height) } : {}),
     ...(coerceFiniteNumber(fields.duration) !== undefined ? { duration: coerceFiniteNumber(fields.duration) } : {}),
-    ...(resources && resources.length > 0 ? { resources } : {}),
-    ...(tags && tags.length > 0 ? { tags } : {}),
+    ...(resources !== undefined ? { resources } : {}),
+    ...(tags !== undefined ? { tags } : {}),
     ...(notes !== undefined ? { notes } : {}),
   };
 };
@@ -216,7 +216,7 @@ export const getEditableMetadataFields = (
     width: shadowMetadata?.width ?? metadata?.width,
     height: shadowMetadata?.height ?? metadata?.height,
     duration: shadowMetadata?.duration,
-    resources: shadowResources && shadowResources.length > 0 ? shadowResources : baseResources,
+    resources: shadowResources !== undefined ? shadowResources : baseResources,
     tags: shadowMetadata?.tags ?? (metadata as BaseMetadataWithNotes | undefined)?.tags,
     notes: shadowMetadata?.notes ?? getMetadataNotes(metadata),
   });
@@ -276,7 +276,9 @@ export const buildEffectiveMetadata = (
     notes: editable.notes ?? getMetadataNotes(base),
   };
 
-  if (nextMetadata.model) {
+  if (Object.prototype.hasOwnProperty.call(shadowMetadata ?? {}, 'model') && shadowMetadata?.model === '') {
+    nextMetadata.models = [];
+  } else if (nextMetadata.model) {
     nextMetadata.models = [nextMetadata.model];
   }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['./__tests__/setupIndexedDb.ts'],
     exclude: ['**/node_modules/**', '**/.git/**', '**/.claude/**'],
   },
 });


### PR DESCRIPTION
## Summary
- Migrate annotations and shadow metadata to assetId-backed SQLite authority, integrating rename, move, copy, overwrite, filters, tags, viewers, and batch export.
- Preserve legacy import with resumable checkpoints and tombstones. Pending annotations and overrides remain readable from SQLite before identity assignment, including after indexing is disabled.
- Reject stale whole-record deletions and stale edits after deletion. Serialize legacy read-modify-write patches in one IndexedDB transaction so concurrent independent edits survive.
- Apply global tag rename/removal to pending records through the existing mutation journal, preserving source retries, mutation ordering, and tag suppression when an identity is assigned later.
- Keep stable identity disabled by default and directory/subtree activation gated separately.

## Validation
- Latest corrections: 92 focused tests passed; 1 platform-specific test skipped. Coverage includes pending reads, global tag operations across retries/reopen/mapping, deletion conflicts, concurrent legacy writes, and existing persistence/file-operation consumers.
- Latest corrections: TypeScript and focused ESLint completed with zero errors; existing lint warnings remain. Diff whitespace check passed.
- Before these corrections: 123 focused tests passed with 1 platform-specific skip; production renderer build and Windows unpacked/portable packaged smokes passed with synthetic profiles. Build and packaged smokes were not rerun for this correction commit.
- Visual acceptance remains manual.

## Out of scope
No public activation, C2PA, IPTC, MCP, audit history, provenance edges, generation runs, parser changes, or UI redesign.
