### PR TITLE
feat: preserve stable identity across directory operations

### DIFF
--- a/__tests__/stableIdentityFileOperations.test.ts
+++ b/__tests__/stableIdentityFileOperations.test.ts
@@ -770,6 +770,7 @@ describe('stable identity file-operation coordination', () => {
     await fs.writeFile(path.join(sourceDirectory, 'inside.bin'), 'inside');
     const runtime = createRuntime(userDataPath, { coordinator: { logger: { error: () => {}, warn: () => {} } } });
     const [original] = await registerRoot(runtime.indexer, rootA, ['recover me/inside.bin']);
+    await runtime.indexer.waitForIdle();
     const repository = (runtime.lifecycle as any).repository;
     const complete = repository.completeFileOperation.bind(repository);
     let failOnce = true;

--- a/__tests__/stableIdentityFileOperations.test.ts
+++ b/__tests__/stableIdentityFileOperations.test.ts
@@ -671,15 +671,30 @@ describe('stable identity file-operation coordination', () => {
     lifecycle.close();
   });
 
-  it('bypasses file identity coordination for directory renames', async () => {
+  it('preserves descendant identities, revisions, and user data across a nested directory rename', async () => {
     const { userDataPath, rootA } = await workspace();
-    const sourceDirectory = path.join(rootA, 'folder');
-    const destinationDirectory = path.join(rootA, 'renamed-folder');
-    await fs.mkdir(sourceDirectory);
-    await fs.writeFile(path.join(sourceDirectory, 'inside.bin'), 'inside');
-    const { lifecycle, indexer, coordinator } = createRuntime(userDataPath);
-    const [inside] = await registerRoot(indexer, rootA, ['folder/inside.bin']);
+    const sourceDirectory = path.join(rootA, '..archive ç');
+    const destinationDirectory = path.join(rootA, 'renamed folder ç');
+    await fs.mkdir(path.join(sourceDirectory, 'nested'), { recursive: true });
+    await Promise.all([
+      fs.writeFile(path.join(sourceDirectory, 'inside.bin'), 'inside'),
+      fs.writeFile(path.join(sourceDirectory, 'nested', 'second.bin'), 'second'),
+    ]);
+    const { lifecycle, indexer, coordinator, mappings } = createRuntime(userDataPath);
+    const originals = await registerRoot(indexer, rootA, ['..archive ç/inside.bin', '..archive ç/nested/second.bin']);
     await indexer.waitForIdle();
+    lifecycle.run((repository) => repository.syncLegacyUserDataBatch([
+      {
+        domain: 'annotation', legacyImageId: 'legacy-inside',
+        reference: { assetId: originals[0].assetId, revisionId: originals[0].revisionId, locationId: originals[0].locationId },
+        payload: { isFavorite: true, tags: ['kept'], rating: 4, addedAt: 1, updatedAt: 2 }, sourceVersion: 0,
+      },
+      {
+        domain: 'shadow', legacyImageId: 'legacy-inside',
+        reference: { assetId: originals[0].assetId, revisionId: originals[0].revisionId, locationId: originals[0].locationId },
+        payload: { prompt: '', seed: 0, tags: [], notes: 'kept', updatedAt: 2 }, sourceVersion: 0,
+      },
+    ]));
 
     const result = await coordinator.executeKnownOperation({
       kind: 'rename',
@@ -688,20 +703,307 @@ describe('stable identity file-operation coordination', () => {
       perform: () => fs.rename(sourceDirectory, destinationDirectory),
     });
 
-    expect(result.provenance).toMatchObject({
-      enabled: true,
-      available: true,
-      tracked: false,
-      reason: 'directory_operation_not_supported',
-    });
+    expect(result.provenance).toMatchObject({ enabled: true, available: true });
+    expect(result.provenance.pending).not.toBe(true);
     expect(lifecycle.run((repository) => repository.listPendingFileOperations())).toHaveLength(0);
-    expect(lifecycle.run((repository) => repository.getAsset(inside.assetId))?.locations[0].relativePath)
-      .toBe('folder/inside.bin');
     const root = lifecycle.run((repository) => repository.listLibraryRoots()[0]);
-    expect(lifecycle.run((repository) => repository.getLocationByRootPath(root.rootId, 'renamed-folder'))).toBeNull();
-    await expect(fs.stat(path.join(destinationDirectory, 'inside.bin'))).resolves.toBeDefined();
+    for (const [index, relativePath] of ['renamed folder ç/inside.bin', 'renamed folder ç/nested/second.bin'].entries()) {
+      expect(lifecycle.run((repository) => repository.getLocationByRootPath(root.rootId, relativePath))).toMatchObject({
+        assetId: originals[index].assetId,
+        revisionId: originals[index].revisionId,
+        locationId: originals[index].locationId,
+        state: 'present',
+      });
+    }
+    expect(mappings).toEqual(expect.arrayContaining(originals.map((identity) => expect.objectContaining({
+      assetId: identity.assetId,
+      revisionId: identity.revisionId,
+      locationId: identity.locationId,
+    }))));
+    const snapshot = lifecycle.run((repository) => repository.captureAssetUserDataSnapshot(originals[0].assetId));
+    expect(snapshot.find((entry) => entry.domain === 'annotation')?.payload)
+      .toMatchObject({ isFavorite: true, tags: ['kept'], rating: 4 });
+    expect(snapshot.find((entry) => entry.domain === 'shadow')?.payload)
+      .toMatchObject({ prompt: '', seed: 0, tags: [], notes: 'kept' });
     indexer.stop();
     lifecycle.close();
+  });
+
+  it('relocates a registered root without changing descendant catalog paths or creating another root', async () => {
+    const { userDataPath, rootA } = await workspace();
+    const nestedPath = path.join('sub folder', 'nested', 'inside.bin');
+    await fs.mkdir(path.dirname(path.join(rootA, nestedPath)), { recursive: true });
+    await fs.writeFile(path.join(rootA, nestedPath), 'inside');
+    const runtime = createRuntime(userDataPath);
+    const [original] = await registerRoot(runtime.indexer, rootA, [nestedPath]);
+    const nestedRegisteredRootPath = path.join(rootA, 'sub folder');
+    const [nestedOriginal] = await registerRoot(runtime.indexer, nestedRegisteredRootPath, ['nested/inside.bin']);
+    const originalRoots = runtime.lifecycle.run((repository) => repository.listLibraryRoots());
+    const originalRoot = originalRoots.find((root) => root.absolutePath === rootA)!;
+    const originalNestedRoot = originalRoots.find((root) => root.absolutePath === nestedRegisteredRootPath)!;
+    const destinationRoot = path.join(path.dirname(rootA), 'Library renamed ç');
+
+    await runtime.coordinator.executeKnownOperation({
+      kind: 'rename', sourcePath: rootA, destinationPath: destinationRoot,
+      perform: () => fs.rename(rootA, destinationRoot),
+    });
+
+    const roots = runtime.lifecycle.run((repository) => repository.listLibraryRoots());
+    expect(roots).toHaveLength(2);
+    const relocatedRoot = roots.find((root) => root.rootId === originalRoot.rootId)!;
+    const relocatedNestedRoot = roots.find((root) => root.rootId === originalNestedRoot.rootId)!;
+    expect(relocatedRoot).toMatchObject({ absolutePath: destinationRoot });
+    expect(relocatedNestedRoot).toMatchObject({ absolutePath: path.join(destinationRoot, 'sub folder') });
+    expect(runtime.lifecycle.run((repository) => repository.getLocationByRootPath(relocatedRoot.rootId, nestedPath.replace(/\\/g, '/'))))
+      .toMatchObject({ assetId: original.assetId, revisionId: original.revisionId, locationId: original.locationId });
+    expect(runtime.lifecycle.run((repository) => repository.getLocationByRootPath(relocatedNestedRoot.rootId, 'nested/inside.bin')))
+      .toMatchObject({ assetId: nestedOriginal.assetId, revisionId: nestedOriginal.revisionId, locationId: nestedOriginal.locationId });
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+  });
+
+  it('recovers a directory rename after filesystem success and catalog failure without repeating the rename', async () => {
+    const { userDataPath, rootA } = await workspace();
+    const sourceDirectory = path.join(rootA, 'recover me');
+    const destinationDirectory = path.join(rootA, 'recovered');
+    await fs.mkdir(sourceDirectory);
+    await fs.writeFile(path.join(sourceDirectory, 'inside.bin'), 'inside');
+    const runtime = createRuntime(userDataPath, { coordinator: { logger: { error: () => {}, warn: () => {} } } });
+    const [original] = await registerRoot(runtime.indexer, rootA, ['recover me/inside.bin']);
+    const repository = (runtime.lifecycle as any).repository;
+    const complete = repository.completeFileOperation.bind(repository);
+    let failOnce = true;
+    repository.completeFileOperation = (...args: unknown[]) => {
+      if (failOnce) {
+        failOnce = false;
+        throw new Error('synthetic directory catalog failure');
+      }
+      return complete(...args);
+    };
+    let filesystemCalls = 0;
+    const result = await runtime.coordinator.executeKnownOperation({
+      kind: 'rename', sourcePath: sourceDirectory, destinationPath: destinationDirectory,
+      perform: async () => { filesystemCalls += 1; await fs.rename(sourceDirectory, destinationDirectory); },
+    });
+    expect(result.provenance).toMatchObject({ pending: true });
+    expect(filesystemCalls).toBe(1);
+    repository.completeFileOperation = complete;
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+
+    const reopened = createRuntime(userDataPath);
+    expect(await reopened.coordinator.initializeRecovery()).toMatchObject({ recovered: 1, pending: 0 });
+    expect(await reopened.coordinator.initializeRecovery()).toMatchObject({ recovered: 0, pending: 0 });
+    const root = reopened.lifecycle.run((repo) => repo.listLibraryRoots()[0]);
+    expect(reopened.lifecycle.run((repo) => repo.getLocationByRootPath(root.rootId, 'recovered/inside.bin')))
+      .toMatchObject({ assetId: original.assetId, revisionId: original.revisionId, locationId: original.locationId });
+    expect(filesystemCalls).toBe(1);
+    reopened.indexer.stop();
+    reopened.lifecycle.close();
+  });
+
+  it('invalidates queued descendant hashes and stale scans while a directory rename is committed', async () => {
+    const { userDataPath, rootA } = await workspace();
+    const sourceDirectory = path.join(rootA, 'hashing');
+    const destinationDirectory = path.join(rootA, 'hashed');
+    await fs.mkdir(sourceDirectory);
+    await fs.writeFile(path.join(sourceDirectory, 'inside.bin'), 'inside');
+    let releaseHash!: () => void;
+    let reportHashStarted!: () => void;
+    const hashReleased = new Promise<void>((resolve) => { releaseHash = resolve; });
+    const hashStarted = new Promise<void>((resolve) => { reportHashStarted = resolve; });
+    const runtime = createRuntime(userDataPath, {
+      indexer: {
+        createReadStream: (filePath: string, options?: object) => Readable.from((async function* () {
+          reportHashStarted();
+          await hashReleased;
+          for await (const chunk of fsSync.createReadStream(filePath, options)) yield chunk;
+        })()),
+      },
+    });
+    const staleToken = runtime.indexer.beginScan(rootA);
+    const [original] = await registerRoot(runtime.indexer, rootA, ['hashing/inside.bin']);
+    await hashStarted;
+    const staleFiles = [await record(rootA, 'hashing/inside.bin')];
+
+    await runtime.coordinator.executeKnownOperation({
+      kind: 'rename', sourcePath: sourceDirectory, destinationPath: destinationDirectory,
+      perform: () => fs.rename(sourceDirectory, destinationDirectory),
+    });
+    releaseHash();
+    await runtime.indexer.waitForIdle();
+    expect(await runtime.indexer.indexScan({
+      rootPath: rootA, files: staleFiles, recursive: true, scanComplete: true, scanToken: staleToken,
+    })).toMatchObject({ stale: true, assigned: 0, reconciled: false });
+    expect(runtime.lifecycle.run((repository) => repository.getAsset(original.assetId))?.revisions[0].hashState).toBe('pending');
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+  });
+
+  it('keeps the legacy behavior and creates no journal when stable identity is disabled', async () => {
+    const { userDataPath, rootA } = await workspace();
+    const sourceDirectory = path.join(rootA, 'legacy');
+    const destinationDirectory = path.join(rootA, 'legacy renamed');
+    await fs.mkdir(sourceDirectory);
+    const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+    lifecycle.initialize();
+    const indexer = new StableIdentityIndexer({ repositoryLifecycle: lifecycle, enabled: false });
+    const coordinator = new StableIdentityFileOperationCoordinator({ repositoryLifecycle: lifecycle, indexer, enabled: false });
+    const result = await coordinator.executeKnownOperation({
+      kind: 'rename', sourcePath: sourceDirectory, destinationPath: destinationDirectory,
+      perform: () => fs.rename(sourceDirectory, destinationDirectory),
+    });
+    expect(result.provenance).toEqual({ enabled: false, available: false });
+    expect(lifecycle.run((repository) => repository.listPendingFileOperations())).toHaveLength(0);
+    indexer.stop();
+    lifecycle.close();
+  });
+
+  it('moves a subtree across registered roots and marks it missing when later moved out of scope', async () => {
+    const { base, userDataPath, rootA, rootB } = await workspace();
+    const sourceDirectory = path.join(rootA, 'source tree');
+    const registeredDestination = path.join(rootB, 'moved tree');
+    const outsideDestination = path.join(base, 'outside tree');
+    await fs.mkdir(path.join(sourceDirectory, 'nested'), { recursive: true });
+    await fs.writeFile(path.join(sourceDirectory, 'nested', 'inside.bin'), 'inside');
+    const runtime = createRuntime(userDataPath);
+    const [original] = await registerRoot(runtime.indexer, rootA, ['source tree/nested/inside.bin']);
+    await registerRoot(runtime.indexer, rootB);
+
+    await runtime.coordinator.executeKnownOperation({
+      kind: 'move', sourcePath: sourceDirectory, destinationPath: registeredDestination,
+      perform: async () => {
+        await fs.cp(sourceDirectory, registeredDestination, { recursive: true });
+        await fs.rm(sourceDirectory, { recursive: true });
+      },
+    });
+    const roots = runtime.lifecycle.run((repository) => repository.listLibraryRoots());
+    const rootBRecord = roots.find((root) => root.absolutePath === rootB)!;
+    expect(runtime.lifecycle.run((repository) => repository.getLocationByRootPath(rootBRecord.rootId, 'moved tree/nested/inside.bin')))
+      .toMatchObject({ assetId: original.assetId, revisionId: original.revisionId, locationId: original.locationId });
+
+    await runtime.coordinator.executeKnownOperation({
+      kind: 'move', sourcePath: registeredDestination, destinationPath: outsideDestination,
+      perform: async () => {
+        await fs.cp(registeredDestination, outsideDestination, { recursive: true });
+        await fs.rm(registeredDestination, { recursive: true });
+      },
+    });
+    expect(runtime.lifecycle.run((repository) => repository.getAsset(original.assetId))).toMatchObject({
+      state: 'missing',
+      locations: [expect.objectContaining({ locationId: original.locationId, state: 'missing' })],
+    });
+    expect(runtime.lifecycle.run((repository) => repository.listLibraryRoots())).toHaveLength(2);
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+  });
+
+  it('defers watcher observations below a directory operation and rejects the pre-operation scan', async () => {
+    const { userDataPath, rootA } = await workspace();
+    const sourceDirectory = path.join(rootA, 'watched');
+    const destinationDirectory = path.join(rootA, 'watched renamed');
+    await fs.mkdir(sourceDirectory);
+    await fs.writeFile(path.join(sourceDirectory, 'inside.bin'), 'inside');
+    const runtime = createRuntime(userDataPath);
+    const [original] = await registerRoot(runtime.indexer, rootA, ['watched/inside.bin']);
+    await runtime.indexer.waitForIdle();
+    const staleToken = runtime.indexer.beginScan(rootA);
+    const staleFiles = [await record(rootA, 'watched/inside.bin')];
+    let reportRenamed!: () => void;
+    let releaseOperation!: () => void;
+    const renamed = new Promise<void>((resolve) => { reportRenamed = resolve; });
+    const operationReleased = new Promise<void>((resolve) => { releaseOperation = resolve; });
+    const operation = runtime.coordinator.executeKnownOperation({
+      kind: 'rename', sourcePath: sourceDirectory, destinationPath: destinationDirectory,
+      perform: async () => {
+        await fs.rename(sourceDirectory, destinationDirectory);
+        reportRenamed();
+        await operationReleased;
+      },
+    });
+    await renamed;
+    await runtime.coordinator.observeWatcherRemovals({
+      rootPath: rootA, files: [{ relativePath: 'watched/inside.bin' }],
+    });
+    await runtime.coordinator.observeWatcherFiles({
+      rootPath: rootA,
+      files: [{ relativePath: 'watched renamed/inside.bin', size: 6, lastModified: 0, contentModifiedMs: 0 }],
+    });
+    releaseOperation();
+    await operation;
+
+    expect(await runtime.indexer.indexScan({
+      rootPath: rootA, files: staleFiles, recursive: true, scanComplete: true, scanToken: staleToken,
+    })).toMatchObject({ stale: true, assigned: 0, reconciled: false });
+    const root = runtime.lifecycle.run((repository) => repository.listLibraryRoots()[0]);
+    expect(runtime.lifecycle.run((repository) => repository.getLocationByRootPath(root.rootId, 'watched renamed/inside.bin')))
+      .toMatchObject({ assetId: original.assetId, revisionId: original.revisionId, locationId: original.locationId });
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+  });
+
+  it('aborts a denied directory rename without changing catalog state or leaving recovery work', async () => {
+    const { userDataPath, rootA } = await workspace();
+    const sourceDirectory = path.join(rootA, 'denied');
+    const destinationDirectory = path.join(rootA, 'not moved');
+    await fs.mkdir(sourceDirectory);
+    await fs.writeFile(path.join(sourceDirectory, 'inside.bin'), 'inside');
+    const runtime = createRuntime(userDataPath);
+    const [original] = await registerRoot(runtime.indexer, rootA, ['denied/inside.bin']);
+    await expect(runtime.coordinator.executeKnownOperation({
+      kind: 'rename', sourcePath: sourceDirectory, destinationPath: destinationDirectory,
+      perform: async () => { throw Object.assign(new Error('synthetic permission denied'), { code: 'EACCES' }); },
+    })).rejects.toMatchObject({ code: 'EACCES' });
+    const root = runtime.lifecycle.run((repository) => repository.listLibraryRoots()[0]);
+    expect(runtime.lifecycle.run((repository) => repository.getLocationByRootPath(root.rootId, 'denied/inside.bin')))
+      .toMatchObject({ assetId: original.assetId, revisionId: original.revisionId, locationId: original.locationId });
+    expect(runtime.lifecycle.run((repository) => repository.listPendingFileOperations())).toHaveLength(0);
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+  });
+
+  it('rejects an existing directory destination before filesystem mutation or journal creation', async () => {
+    const { userDataPath, rootA } = await workspace();
+    const sourceDirectory = path.join(rootA, 'source');
+    const destinationDirectory = path.join(rootA, 'destination');
+    await Promise.all([fs.mkdir(sourceDirectory), fs.mkdir(destinationDirectory)]);
+    await fs.writeFile(path.join(sourceDirectory, 'inside.bin'), 'inside');
+    const runtime = createRuntime(userDataPath);
+    await registerRoot(runtime.indexer, rootA, ['source/inside.bin']);
+    let filesystemCalls = 0;
+    await expect(runtime.coordinator.executeKnownOperation({
+      kind: 'rename', sourcePath: sourceDirectory, destinationPath: destinationDirectory,
+      perform: async () => { filesystemCalls += 1; },
+    })).rejects.toMatchObject({ code: 'EEXIST' });
+    expect(filesystemCalls).toBe(0);
+    expect(runtime.lifecycle.run((repository) => repository.listPendingFileOperations())).toHaveLength(0);
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+  });
+
+  it('keeps a partially copied directory move pending without relocating descendants', async () => {
+    const { userDataPath, rootA, rootB } = await workspace();
+    const sourceDirectory = path.join(rootA, 'partial');
+    const destinationDirectory = path.join(rootB, 'partial');
+    await fs.mkdir(sourceDirectory);
+    await fs.writeFile(path.join(sourceDirectory, 'inside.bin'), 'inside');
+    const runtime = createRuntime(userDataPath, { coordinator: { logger: { error: () => {}, warn: () => {} } } });
+    const [original] = await registerRoot(runtime.indexer, rootA, ['partial/inside.bin']);
+    await registerRoot(runtime.indexer, rootB);
+    await expect(runtime.coordinator.executeKnownOperation({
+      kind: 'move', sourcePath: sourceDirectory, destinationPath: destinationDirectory,
+      perform: async () => {
+        await fs.cp(sourceDirectory, destinationDirectory, { recursive: true });
+        throw Object.assign(new Error('synthetic source removal failure'), { code: 'EACCES' });
+      },
+    })).rejects.toMatchObject({ code: 'EACCES', provenanceOperationId: expect.any(String) });
+    expect(runtime.lifecycle.run((repository) => repository.listPendingFileOperations())).toHaveLength(1);
+    const rootARecord = runtime.lifecycle.run((repository) => repository.listLibraryRoots().find((root) => root.absolutePath === rootA))!;
+    expect(runtime.lifecycle.run((repository) => repository.getLocationByRootPath(rootARecord.rootId, 'partial/inside.bin')))
+      .toMatchObject({ assetId: original.assetId, state: 'present' });
+    expect(await runtime.coordinator.initializeRecovery()).toMatchObject({ recovered: 0, pending: 1 });
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
   });
 
   it('does not claim a failed case-only rename and recovers a committed delete after a catalog failure', async () => {

--- a/__tests__/stableIdentityFileOperations.test.ts
+++ b/__tests__/stableIdentityFileOperations.test.ts
@@ -762,6 +762,79 @@ describe('stable identity file-operation coordination', () => {
     runtime.lifecycle.close();
   });
 
+  it.each([false, true])('relocates nested registered roots during a subtree rename (empty: %s)', async (empty) => {
+    const { userDataPath, rootA } = await workspace();
+    const source = path.join(rootA, 'parent');
+    const destination = path.join(rootA, 'renamed');
+    const nested = path.join(source, 'nested');
+    const relocatedNested = path.join(destination, 'nested');
+    await fs.mkdir(nested, { recursive: true });
+    if (!empty) await fs.writeFile(path.join(nested, 'inside.bin'), 'inside');
+    const runtime = createRuntime(userDataPath);
+    const parentMappings = await registerRoot(runtime.indexer, rootA, empty ? [] : ['parent/nested/inside.bin']);
+    const nestedMappings = await registerRoot(runtime.indexer, nested, empty ? [] : ['inside.bin']);
+    await runtime.indexer.waitForIdle();
+    const originalRoots = runtime.lifecycle.run((repo) => repo.listLibraryRoots());
+    const nestedRoot = originalRoots.find((root) => root.absolutePath === nested)!;
+
+    const result = await runtime.coordinator.executeKnownOperation({
+      kind: 'rename', sourcePath: source, destinationPath: destination,
+      perform: async () => {
+        if (!empty) {
+          expect(await runtime.indexer.observeFiles({
+            rootPath: nested,
+            files: [{ name: 'inside.bin', size: 123, contentModifiedMs: 1 }],
+          })).toMatchObject({ assigned: 0 });
+        }
+        await fs.rename(source, destination);
+      },
+    });
+    expect(result.provenance.operation?.state).toBe('completed');
+    const rescanned = await registerRoot(runtime.indexer, relocatedNested, empty ? [] : ['inside.bin']);
+    expect(rescanned).toEqual(nestedMappings.map(({ assetId, revisionId, locationId }) => (
+      expect.objectContaining({ assetId, revisionId, locationId })
+    )));
+    if (!empty) {
+      const parentRoot = originalRoots.find((root) => root.absolutePath === rootA)!;
+      expect(runtime.lifecycle.run((repo) => repo.getLocationByRootPath(parentRoot.rootId, 'renamed/nested/inside.bin')))
+        .toMatchObject({ assetId: parentMappings[0].assetId, locationId: parentMappings[0].locationId });
+    }
+    await runtime.indexer.waitForIdle();
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+
+    const reopened = createRuntime(userDataPath);
+    expect(await reopened.coordinator.initializeRecovery()).toMatchObject({ pending: 0 });
+    const roots = reopened.lifecycle.run((repo) => repo.listLibraryRoots());
+    expect(roots).toHaveLength(2);
+    expect(roots.find((root) => root.rootId === nestedRoot.rootId)?.absolutePath).toBe(relocatedNested);
+    reopened.indexer.stop();
+    reopened.lifecycle.close();
+  });
+
+  it.runIf(process.platform === 'win32')('observes external deletions after a case-only directory rename', async () => {
+    const { userDataPath, rootA } = await workspace();
+    const source = path.join(rootA, 'Mixed');
+    const destination = path.join(rootA, 'MIXED');
+    await fs.mkdir(source);
+    await fs.writeFile(path.join(source, 'inside.bin'), 'inside');
+    const runtime = createRuntime(userDataPath);
+    const [original] = await registerRoot(runtime.indexer, rootA, ['Mixed/inside.bin']);
+    await runtime.indexer.waitForIdle();
+    await runtime.coordinator.executeKnownOperation({
+      kind: 'rename', sourcePath: source, destinationPath: destination,
+      perform: () => fs.rename(source, destination),
+    });
+    await fs.unlink(path.join(destination, 'inside.bin'));
+    await runtime.coordinator.observeWatcherRemovals({
+      rootPath: rootA, files: [{ relativePath: 'MIXED/inside.bin' }],
+    });
+    expect(runtime.lifecycle.run((repo) => repo.getAsset(original.assetId))?.locations[0])
+      .toMatchObject({ locationId: original.locationId, state: 'missing' });
+    runtime.indexer.stop();
+    runtime.lifecycle.close();
+  });
+
   it('recovers a directory rename after filesystem success and catalog failure without repeating the rename', async () => {
     const { userDataPath, rootA } = await workspace();
     const sourceDirectory = path.join(rootA, 'recover me');

--- a/docs/stable-identity-directory-operations.md
+++ b/docs/stable-identity-directory-operations.md
@@ -38,7 +38,7 @@ Destinations outside registered roots remain outside the catalog. The coordinato
 
 - Stable file-operation suite: 47 tests passed and one platform-specific test was skipped. The directory matrix covers nested trees, registered and nested roots, cross-root/out-of-scope moves, spaces/accents/`..archive`, destination conflict, permission failure, watcher/backfill interleavings, an in-flight hash, catalog failure after filesystem success, repeated recovery, partial copy-then-delete, user data, and flag-off behavior.
 - Repository, indexer, and stable user-data suites: 26 tests passed when run as separate suites. A parallel aggregate run produced only known Windows five-second resource-contention timeouts; the same files passed separately.
-- TypeScript, JavaScript syntax, focused ESLint, and the production renderer build passed. ESLint retained only pre-existing non-blocking test warnings.
+- TypeScript, JavaScript syntax, focused ESLint, and the production renderer build passed. ESLint retained only non-blocking test-file `no-explicit-any` warnings.
 - Windows unpacked and real portable packaged smokes passed using generated temporary paths with spaces and `ç`. Both preserved a directory descendant's asset/revision/location and annotation across reopen with an empty recovery queue.
 - Packaged runtime: Electron 38.8.6, Node 22.22.0, SQLite 3.50.4.
 - Visual validation was not automated. Linux and macOS were not executed.

--- a/docs/stable-identity-directory-operations.md
+++ b/docs/stable-identity-directory-operations.md
@@ -1,0 +1,44 @@
+# Stable identity for directory operations
+
+## Supported product flow and authority
+
+The folder tree currently exposes **Rename Folder** for a registered root or a discovered subfolder. It calls the existing authorized `rename-file` IPC; the product does not expose folder drag/move or directory merging. The stable-identity coordinator accepts both `rename` and `move` so an existing authorized caller can preserve the same contract, but this work adds no UI operation and no new filesystem permission.
+
+When stable identity is enabled, SQLite remains authoritative for asset, revision, location, annotation, and shadow identity. `IndexedImage.id` and renderer folder paths remain projections. When the flag is off for a profile that has not crossed the stable authority boundary, the existing filesystem and renderer behavior remains unchanged and no directory migration starts.
+
+## Operation matrix
+
+| Operation/API | Existing source and consumers | Stable-identity behavior |
+| --- | --- | --- |
+| Root or subfolder rename | `DirectoryList.tsx` -> preload `renameFile` -> `rename-file` IPC -> `fs.rename` | The existing coordinator snapshots every current descendant location before the rename. Catalog completion remaps the snapshot atomically and broadcasts confirmed mappings. |
+| Registered-root rename | Same flow, followed by renderer root/path/watcher rebinding | The existing `rootId` moves to the new absolute path. Any separately registered roots below it move by the same prefix in the same transaction; descendant relative paths do not change. |
+| Subtree rename/move inside a root | Coordinator `rename`/`move` boundary | Location IDs, asset IDs, revision IDs, and asset-owned user data are retained; only the root/relative-path projection changes. |
+| Subtree move to another registered root | Existing coordinator `move` contract; no new folder UI | Descendant locations change root and path atomically. Equal bytes never create or merge assets. |
+| Move outside registered roots | Existing authorization rules | Descendant locations become `missing`; no root is registered and no hash starts. |
+| Destination conflict / permission failure | Existing `rename-file` preflight and filesystem errors | A directory destination is rejected before the journal/filesystem mutation. An unapplied failure aborts the intent and leaves source locations current. No directory merge policy is introduced. |
+| Watcher add/remove and scans | Existing watcher observers and indexer scan generations | Source and destination prefixes are locked. Older scans are invalidated; descendant watcher observations are deferred and discarded after the atomic catalog remap. A late observation from a retired source is ignored while that path is absent. |
+| Pending SHA-256 | Existing single hash queue | Every queued or active task under the affected prefixes is version-invalidated. A result opened at the old path cannot commit; a later authorized scan at the new path resumes the pending revision. |
+| Annotations and shadow metadata | Stable user-data repository/adapter keyed by `assetId` | No copy/delete is performed. The same assets continue to own the same records and tombstones. Legacy aliases remain bound to location/asset identity, not to a reused pathname. |
+
+## Journal and recovery contract
+
+Directory operations reuse `provenance_operations`; the schema remains version 5 because the journal payload is internal JSON and the existing operation kinds already include `rename` and `move`. An intent contains the source/destination directories, pre-operation filesystem evidence, all affected registered roots, and the exact descendant location snapshot. SQLite validates every recorded asset/location/revision/root/path relation again before completion.
+
+Filesystem work never runs in a SQLite transaction. After the authorized filesystem call returns, catalog remapping and journal completion share one SQLite transaction. If the filesystem succeeded and catalog completion failed, `fs_applied` allows idempotent recovery. Recovery only inspects the recorded paths and completes the catalog; it never repeats a rename, copy, delete, or cross-volume cleanup.
+
+For an `intended` journal entry, source-missing/destination-present recovery requires matching filesystem identity evidence. Both paths present, both absent, mismatched evidence, inaccessible paths, or a partially copied cross-volume directory remain `pending_recovery`. That state blocks descendant operations and ordinary assignment rather than claiming the move completed.
+
+## Boundaries
+
+Destinations outside registered roots remain outside the catalog. The coordinator does not register roots, initiate scans, or start hashes for them. Directory merge, new folder-move UI, lineage edges, audit history, C2PA, IPTC, MCP, parser changes, and redesign are not part of this work.
+
+`IMH_ENABLE_PROVENANCE_INDEXING` remains off by default. Windows packaged validation uses only a generated temporary profile and synthetic folders/files. Visual validation remains manual; Linux and macOS remain separate activation gates until their packaged tests are executed.
+
+## Validation executed on 2026-09-08
+
+- Stable file-operation suite: 47 tests passed and one platform-specific test was skipped. The directory matrix covers nested trees, registered and nested roots, cross-root/out-of-scope moves, spaces/accents/`..archive`, destination conflict, permission failure, watcher/backfill interleavings, an in-flight hash, catalog failure after filesystem success, repeated recovery, partial copy-then-delete, user data, and flag-off behavior.
+- Repository, indexer, and stable user-data suites: 26 tests passed when run as separate suites. A parallel aggregate run produced only known Windows five-second resource-contention timeouts; the same files passed separately.
+- TypeScript, JavaScript syntax, focused ESLint, and the production renderer build passed. ESLint retained only pre-existing non-blocking test warnings.
+- Windows unpacked and real portable packaged smokes passed using generated temporary paths with spaces and `ç`. Both preserved a directory descendant's asset/revision/location and annotation across reopen with an empty recovery queue.
+- Packaged runtime: Electron 38.8.6, Node 22.22.0, SQLite 3.50.4.
+- Visual validation was not automated. Linux and macOS were not executed.

--- a/docs/stable-identity-file-operations.md
+++ b/docs/stable-identity-file-operations.md
@@ -4,7 +4,7 @@
 
 | Operation | Renderer entry | Filesystem mutation | Provenance integration |
 | --- | --- | --- | --- |
-| File rename, including case-only | `services/imageRenameService.ts` -> `services/fileOperations.ts` | `rename-file` in `electron.mjs` -> `fs.rename` / model sidecar helper | Coordinated `rename`; retain the source asset, revision, and location ID. Directory renames explicitly bypass the file-only coordinator so a directory is never registered as a media asset; subtree identity migration remains a later activation gate. |
+| File or supported folder rename, including case-only | `services/imageRenameService.ts`, `components/DirectoryList.tsx` -> `services/fileOperations.ts` or preload | `rename-file` in `electron.mjs` -> `fs.rename` / model sidecar helper | Files retain their source asset, revision, and location ID. A folder operation snapshots and atomically remaps descendant locations; a registered root retains its root ID and relocates nested registered roots with it. |
 | Move between folders/roots/volumes | `services/fileTransferService.ts` | `transfer-indexed-images` -> `fs.rename`, or copy plus `fs.unlink` after `EXDEV` | Coordinated `move`; relocate only after the source disappeared and destination exists. A failed cross-volume delete remains pending with both files unassociated as a completed move. |
 | Copy | `services/fileTransferService.ts` | `transfer-indexed-images` -> timestamp-preserving copy | Coordinated `copy`; reserve and create a distinct asset/revision/location. Existing destinations use overwrite semantics. |
 | Editor Save As | `ImageModal.tsx`, `ImageEditorWorkspace.tsx` | `write-file` -> `fs.writeFile` | Coordinated `save_as`; create a distinct asset inside a registered root, or advance the existing destination asset when the OS-approved path already exists. |
@@ -29,7 +29,7 @@ If intent persistence is unavailable, the existing authorized filesystem operati
 
 ## Activation boundary
 
-`IMH_ENABLE_PROVENANCE_INDEXING` remains off by default. No annotation/shadow-metadata migration, provenance graph, product audit history, C2PA, IPTC, MCP, or UI redesign is introduced here. Visual acceptance remains manual. Linux and macOS packaged validation remain pending until executed on those platforms.
+`IMH_ENABLE_PROVENANCE_INDEXING` remains off by default. Directory/subtree identity preservation and asset-owned annotation/shadow persistence are implemented, but public activation remains separate. No provenance graph, product audit history, C2PA, IPTC, MCP, or UI redesign is introduced here. Visual acceptance remains manual. Linux and macOS packaged validation remain pending until executed on those platforms.
 
 ## Reproducible packaged smoke
 

--- a/docs/stable-identity-user-data-migration.md
+++ b/docs/stable-identity-user-data-migration.md
@@ -34,7 +34,7 @@ Shadow metadata remains a set of local overrides, not byte history. Missing fiel
 
 File-operation recovery reuses `provenance_operations`; no second filesystem coordinator is introduced. A transfer intent can bind pending legacy data before mutation and carries the source user-data snapshot needed to finish a copy after renderer exit. Missing library entries never delete durable rows, and a deleted asset retains its tombstoned or historical user data without exposing it to a new asset at the same path.
 
-The feature flag remains off by default. Directory/subtree rename, Linux/macOS packaged validation, and public activation remain separate gates. This phase does not add provenance edges, audit history, generation runs, C2PA, IPTC, MCP, parser changes, or UI redesign.
+The feature flag remains off by default. Directory/subtree rename is implemented by the follow-up directory-operation contract; Linux/macOS packaged validation and public activation remain separate gates. This phase does not add provenance edges, audit history, generation runs, C2PA, IPTC, MCP, parser changes, or UI redesign.
 
 ## Acceptance evidence
 
@@ -69,4 +69,4 @@ All automated fixtures use generated temporary profiles, SQLite catalogs, Indexe
 
 ## Roadmap state
 
-This delivery closes the phase 2 user-data migration portion of **Stable asset identity foundation**. Public activation remains gated separately by directory/subtree rename support, platform validation, and manual visual acceptance. Phase 3 remains lineage/provenance/audit. C2PA, IPTC, and MCP were not implemented here.
+The user-data migration and directory/subtree operation follow-up close the implementation portions of phase 2 **Stable asset identity foundation**. Public activation remains gated separately by platform validation and manual visual acceptance. Phase 3 remains lineage/provenance/audit. C2PA, IPTC, and MCP were not implemented here.

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -1196,15 +1196,15 @@ export class AssetProvenanceRepository {
       throw new ProvenanceRepositoryError('PROVENANCE_OPERATION_INVALID', 'Directory relocation payload is invalid.');
     }
     const entries = directory.entries;
-    if (directory.mode === 'root') {
-      const rootRelocations = Array.isArray(directory.rootRelocations) && directory.rootRelocations.length > 0
-        ? directory.rootRelocations
-        : [{
-            rootId: directory.sourceRootId,
-            destinationRootPath: directory.destinationRootPath,
-            destinationRootPathKey: directory.destinationRootPathKey,
-          }];
-      const relocatingRootIds = new Set(rootRelocations.map((relocation) => assertUuid(relocation.rootId, 'directory rootId')));
+    const rootRelocations = Array.isArray(directory.rootRelocations) && directory.rootRelocations.length > 0
+      ? directory.rootRelocations
+      : directory.mode === 'root' ? [{
+          rootId: directory.sourceRootId,
+          destinationRootPath: directory.destinationRootPath,
+          destinationRootPathKey: directory.destinationRootPathKey,
+        }] : [];
+    const relocatingRootIds = new Set(rootRelocations.map((relocation) => assertUuid(relocation.rootId, 'directory rootId')));
+    if (rootRelocations.length > 0) {
       for (const relocation of rootRelocations) {
         const rootId = assertUuid(relocation.rootId, 'directory rootId');
         assertNonBlank(relocation.destinationRootPath, 'directory destinationRootPath');
@@ -1242,6 +1242,7 @@ export class AssetProvenanceRepository {
 
     if (destinationRootId && directory.mode === 'subtree') {
       for (const entry of entries) {
+        if (relocatingRootIds.has(entry.sourceRootId)) continue;
         const destinationPathKey = assertNonBlank(entry.destinationRelativePathKey, 'directory entry destinationRelativePathKey');
         const conflict = this.database.prepare(`
           SELECT location_id FROM asset_locations
@@ -1274,7 +1275,8 @@ export class AssetProvenanceRepository {
         throw new ProvenanceRepositoryError('PROVENANCE_LOCATION_NOT_FOUND', `Directory descendant location ${locationId} is no longer current.`);
       }
 
-      const entryDestinationRootId = directory.mode === 'root'
+      const relocatesRoot = relocatingRootIds.has(entry.sourceRootId);
+      const entryDestinationRootId = relocatesRoot
         ? assertUuid(entry.destinationRootId, 'directory entry destinationRootId')
         : destinationRootId;
       if (!entryDestinationRootId) {
@@ -1282,10 +1284,10 @@ export class AssetProvenanceRepository {
         continue;
       }
 
-      const relativePath = directory.mode === 'root'
+      const relativePath = relocatesRoot
         ? current.relative_path
         : assertNonBlank(entry.destinationRelativePath, 'directory entry destinationRelativePath');
-      const relativePathKey = directory.mode === 'root'
+      const relativePathKey = relocatesRoot
         ? current.relative_path_key
         : assertNonBlank(entry.destinationRelativePathKey, 'directory entry destinationRelativePathKey');
       this.database.prepare(`

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -794,9 +794,12 @@ export class AssetProvenanceRepository {
         throw new ProvenanceRepositoryError('PROVENANCE_OPERATION_ABORTED', `File operation ${normalizedOperationId} was aborted.`);
       }
 
-      const { source = null, destination = null, reserved = {} } = operation.payload;
+      const { source = null, destination = null, reserved = {}, directory = null } = operation.payload;
       let mapping = null;
-      if (operation.kind === 'rename' || operation.kind === 'move') {
+      let mappings = null;
+      if ((operation.kind === 'rename' || operation.kind === 'move') && directory) {
+        mappings = this.#completeDirectoryRelocation(directory, timestamp);
+      } else if (operation.kind === 'rename' || operation.kind === 'move') {
         if (!source?.locationId || !source?.assetId) {
           throw new ProvenanceRepositoryError('PROVENANCE_OPERATION_INVALID', 'A move or rename intent requires a known source location.');
         }
@@ -935,7 +938,13 @@ export class AssetProvenanceRepository {
         }
       }
 
-      const result = { mapping, destinationScope: destination?.rootId ? 'registered' : 'outside' };
+      const result = {
+        mapping,
+        ...(mappings ? { mappings } : {}),
+        destinationScope: directory
+          ? (directory.destinationRootId || directory.mode === 'root' ? 'registered' : 'outside')
+          : (destination?.rootId ? 'registered' : 'outside'),
+      };
       this.database.prepare(`
         UPDATE provenance_operations
         SET state = 'completed', result_json = ?, last_error = NULL, updated_at = ?, completed_at = ?
@@ -1180,6 +1189,123 @@ export class AssetProvenanceRepository {
     `).get(location.asset_id).count);
     this.database.prepare('UPDATE assets SET state = ?, updated_at = ? WHERE asset_id = ?')
       .run(presentCount ? 'active' : 'missing', timestamp, location.asset_id);
+  }
+
+  #completeDirectoryRelocation(directory, timestamp) {
+    if (!directory || !['root', 'subtree'].includes(directory.mode) || !Array.isArray(directory.entries)) {
+      throw new ProvenanceRepositoryError('PROVENANCE_OPERATION_INVALID', 'Directory relocation payload is invalid.');
+    }
+    const entries = directory.entries;
+    if (directory.mode === 'root') {
+      const rootRelocations = Array.isArray(directory.rootRelocations) && directory.rootRelocations.length > 0
+        ? directory.rootRelocations
+        : [{
+            rootId: directory.sourceRootId,
+            destinationRootPath: directory.destinationRootPath,
+            destinationRootPathKey: directory.destinationRootPathKey,
+          }];
+      const relocatingRootIds = new Set(rootRelocations.map((relocation) => assertUuid(relocation.rootId, 'directory rootId')));
+      for (const relocation of rootRelocations) {
+        const rootId = assertUuid(relocation.rootId, 'directory rootId');
+        assertNonBlank(relocation.destinationRootPath, 'directory destinationRootPath');
+        const destinationPathKey = assertNonBlank(relocation.destinationRootPathKey, 'directory destinationRootPathKey');
+        const currentRoot = this.database.prepare('SELECT * FROM library_roots WHERE root_id = ?').get(rootId);
+        if (!currentRoot) {
+          throw new ProvenanceRepositoryError('PROVENANCE_ROOT_NOT_FOUND', `Library root ${rootId} was not found.`);
+        }
+        const conflictingRoot = this.database.prepare('SELECT root_id FROM library_roots WHERE path_key = ? AND root_id != ?')
+          .get(destinationPathKey, rootId);
+        if (conflictingRoot && !relocatingRootIds.has(conflictingRoot.root_id)) {
+          throw new ProvenanceRepositoryError('PROVENANCE_PATH_CONFLICT', 'The destination is already registered as another library root.');
+        }
+      }
+      for (const relocation of rootRelocations) {
+        this.database.prepare('UPDATE library_roots SET path_key = ? WHERE root_id = ?')
+          .run(`__relocating__:${relocation.rootId}`, relocation.rootId);
+      }
+      for (const relocation of rootRelocations) {
+        this.database.prepare(`
+          UPDATE library_roots SET absolute_path = ?, path_key = ?, last_seen_at = ? WHERE root_id = ?
+        `).run(
+          relocation.destinationRootPath,
+          relocation.destinationRootPathKey,
+          timestamp,
+          relocation.rootId,
+        );
+      }
+    }
+
+    const destinationRootId = directory.mode === 'root'
+      ? null
+      : (directory.destinationRootId ? assertUuid(directory.destinationRootId, 'directory.destinationRootId') : null);
+    const movedLocationIds = new Set(entries.map((entry) => assertUuid(entry.locationId, 'directory entry locationId')));
+
+    if (destinationRootId && directory.mode === 'subtree') {
+      for (const entry of entries) {
+        const destinationPathKey = assertNonBlank(entry.destinationRelativePathKey, 'directory entry destinationRelativePathKey');
+        const conflict = this.database.prepare(`
+          SELECT location_id FROM asset_locations
+          WHERE root_id = ? AND relative_path_key = ? AND state = 'present'
+          LIMIT 1
+        `).get(destinationRootId, destinationPathKey);
+        if (conflict && !movedLocationIds.has(conflict.location_id)) {
+          throw new ProvenanceRepositoryError('PROVENANCE_PATH_CONFLICT', `A catalog location already occupies ${entry.destinationRelativePath}.`);
+        }
+      }
+    }
+
+    const mappings = [];
+    for (const entry of entries) {
+      const locationId = assertUuid(entry.locationId, 'directory entry locationId');
+      const assetId = assertUuid(entry.assetId, 'directory entry assetId');
+      const revisionId = assertUuid(entry.revisionId, 'directory entry revisionId');
+      const current = this.database.prepare(`
+        SELECT * FROM asset_locations
+        WHERE location_id = ? AND asset_id = ? AND revision_id = ?
+          AND root_id = ? AND relative_path_key = ? AND state != 'removed'
+      `).get(
+        locationId,
+        assetId,
+        revisionId,
+        assertUuid(entry.sourceRootId, 'directory entry sourceRootId'),
+        assertNonBlank(entry.sourceRelativePathKey, 'directory entry sourceRelativePathKey'),
+      );
+      if (!current) {
+        throw new ProvenanceRepositoryError('PROVENANCE_LOCATION_NOT_FOUND', `Directory descendant location ${locationId} is no longer current.`);
+      }
+
+      const entryDestinationRootId = directory.mode === 'root'
+        ? assertUuid(entry.destinationRootId, 'directory entry destinationRootId')
+        : destinationRootId;
+      if (!entryDestinationRootId) {
+        this.#markLocationMissingWithinTransaction(locationId, timestamp);
+        continue;
+      }
+
+      const relativePath = directory.mode === 'root'
+        ? current.relative_path
+        : assertNonBlank(entry.destinationRelativePath, 'directory entry destinationRelativePath');
+      const relativePathKey = directory.mode === 'root'
+        ? current.relative_path_key
+        : assertNonBlank(entry.destinationRelativePathKey, 'directory entry destinationRelativePathKey');
+      this.database.prepare(`
+        UPDATE asset_locations
+        SET root_id = ?, relative_path = ?, relative_path_key = ?, state = 'present',
+            last_observed_at = ?, missing_at = NULL
+        WHERE location_id = ? AND asset_id = ? AND revision_id = ? AND state != 'removed'
+      `).run(entryDestinationRootId, relativePath, relativePathKey, timestamp, locationId, assetId, revisionId);
+      this.database.prepare("UPDATE assets SET state = 'active', updated_at = ? WHERE asset_id = ?")
+        .run(timestamp, assetId);
+      mappings.push({
+        rootId: entryDestinationRootId,
+        relativePath,
+        relativePathKey,
+        assetId,
+        revisionId,
+        locationId,
+      });
+    }
+    return mappings;
   }
 
   #insertRevision({ assetId, revisionId, sha256, hashState, byteSize, mimeType = null, width = null, height = null, contentModifiedMs = null, observedAt = null, timestamp }) {

--- a/electron/stableIdentityFileOperationCoordinator.mjs
+++ b/electron/stableIdentityFileOperationCoordinator.mjs
@@ -478,12 +478,10 @@ export class StableIdentityFileOperationCoordinator {
 
     const mode = sourceRoot ? 'root' : 'subtree';
     const pathApi = pathApiForPlatform(this.platform);
-    const affectedRoots = mode === 'root'
-      ? roots.filter((root) => {
-          const relative = pathApi.relative(sourceAbsolutePath, root.absolutePath);
-          return relative === '' || isRelativePathInsideRoot(relative, this.platform);
-        })
-      : [];
+    const affectedRoots = roots.filter((root) => {
+      const relative = pathApi.relative(sourceAbsolutePath, root.absolutePath);
+      return relative === '' || isRelativePathInsideRoot(relative, this.platform);
+    });
     const affectedRootIds = new Set(affectedRoots.map((root) => root.rootId));
     const destinationRoot = mode === 'root'
       ? sourceRoot
@@ -496,14 +494,17 @@ export class StableIdentityFileOperationCoordinator {
       if (conflict) throw new Error('The destination is already registered as another library root.');
     }
 
-    const locations = mode === 'root'
-      ? affectedRoots.flatMap((root) => repository.listPresentLocations(root.rootId).map((location) => ({
-          ...location,
-          sourceRootId: root.rootId,
-        })))
-      : repository.listPresentLocationsUnderPath(sourceDirectory.rootId, sourceDirectory.relativePathKey);
+    const locations = [
+      ...(mode === 'subtree'
+        ? repository.listPresentLocationsUnderPath(sourceDirectory.rootId, sourceDirectory.relativePathKey)
+        : []),
+      ...affectedRoots.flatMap((root) => repository.listPresentLocations(root.rootId).map((location) => ({
+        ...location,
+        sourceRootId: root.rootId,
+      }))),
+    ];
     const entries = locations.map((location) => {
-      if (mode === 'root') {
+      if (affectedRootIds.has(location.sourceRootId)) {
         return {
           locationId: location.locationId,
           assetId: location.assetId,
@@ -534,7 +535,7 @@ export class StableIdentityFileOperationCoordinator {
         destinationRelativePathKey: normalizedDestination?.relativePathKey ?? null,
       };
     });
-    if (mode === 'subtree' && entries.length === 0) {
+    if (mode === 'subtree' && entries.length === 0 && affectedRoots.length === 0) {
       return {
         operationId: null,
         kind,
@@ -546,30 +547,28 @@ export class StableIdentityFileOperationCoordinator {
     const normalizedDestinationRoot = mode === 'root'
       ? normalizeLibraryRootPath(destinationAbsolutePath, this.platform)
       : null;
-    const rootRelocations = mode === 'root'
-      ? affectedRoots.map((root) => {
-          const suffix = pathApi.relative(sourceAbsolutePath, root.absolutePath);
-          const relocatedPath = suffix ? pathApi.resolve(destinationAbsolutePath, suffix) : destinationAbsolutePath;
-          const normalized = normalizeLibraryRootPath(relocatedPath, this.platform);
-          return {
-            rootId: root.rootId,
-            sourceRootPath: root.absolutePath,
-            sourceRootPathKey: root.pathKey,
-            destinationRootPath: normalized.absolutePath,
-            destinationRootPathKey: normalized.pathKey,
-          };
-        })
-      : [];
-    if (mode === 'root') {
-      for (const relocation of rootRelocations) {
-        const conflict = roots.find((root) => (
-          root.pathKey === relocation.destinationRootPathKey && !affectedRootIds.has(root.rootId)
-        ));
-        if (conflict) throw new Error('The destination would overlap another registered library root.');
-      }
-    } else if (destinationRoot) {
+    const rootRelocations = affectedRoots.map((root) => {
+      const suffix = pathApi.relative(sourceAbsolutePath, root.absolutePath);
+      const relocatedPath = suffix ? pathApi.resolve(destinationAbsolutePath, suffix) : destinationAbsolutePath;
+      const normalized = normalizeLibraryRootPath(relocatedPath, this.platform);
+      return {
+        rootId: root.rootId,
+        sourceRootPath: root.absolutePath,
+        sourceRootPathKey: root.pathKey,
+        destinationRootPath: normalized.absolutePath,
+        destinationRootPathKey: normalized.pathKey,
+      };
+    });
+    for (const relocation of rootRelocations) {
+      const conflict = roots.find((root) => (
+        root.pathKey === relocation.destinationRootPathKey && !affectedRootIds.has(root.rootId)
+      ));
+      if (conflict) throw new Error('The destination would overlap another registered library root.');
+    }
+    if (mode === 'subtree' && destinationRoot) {
       const movedLocationIds = new Set(entries.map((entry) => entry.locationId));
       for (const entry of entries) {
+        if (affectedRootIds.has(entry.sourceRootId)) continue;
         const conflict = repository.getLocationByRootPath(destinationRoot.rootId, entry.destinationRelativePathKey);
         if (conflict?.state === 'present' && !movedLocationIds.has(conflict.locationId)) {
           throw new Error(`A catalog location already occupies ${entry.destinationRelativePath}.`);
@@ -1027,13 +1026,10 @@ export class StableIdentityFileOperationCoordinator {
   #directoryOperationScopes(payload) {
     const directory = payload.directory;
     if (!directory) return [];
-    if (directory.mode === 'root' && Array.isArray(directory.rootRelocations)) {
-      return directory.rootRelocations.flatMap((relocation) => [
-        { absolutePath: relocation.sourceRootPath, rootPath: relocation.sourceRootPath, relativePath: '' },
-        { absolutePath: relocation.destinationRootPath, rootPath: relocation.destinationRootPath, relativePath: '' },
-      ]);
-    }
-    const scopes = [];
+    const scopes = (directory.rootRelocations ?? []).flatMap((relocation) => [
+      { absolutePath: relocation.sourceRootPath, rootPath: relocation.sourceRootPath, relativePath: '' },
+      { absolutePath: relocation.destinationRootPath, rootPath: relocation.destinationRootPath, relativePath: '' },
+    ]);
     if (directory.sourceRootPath !== null && directory.sourceRootPath !== undefined) {
       scopes.push({
         absolutePath: directory.sourceAbsolutePath,
@@ -1059,6 +1055,8 @@ export class StableIdentityFileOperationCoordinator {
 
   #retireDirectorySource(payload) {
     if (!payload.directory) return;
+    if (this.#absolutePathKey(payload.directory.sourceAbsolutePath)
+      === this.#absolutePathKey(payload.directory.destinationAbsolutePath)) return;
     this.retiredDirectoryScopes.add(this.#absolutePathKey(payload.directory.sourceAbsolutePath));
   }
 

--- a/electron/stableIdentityFileOperationCoordinator.mjs
+++ b/electron/stableIdentityFileOperationCoordinator.mjs
@@ -642,7 +642,7 @@ export class StableIdentityFileOperationCoordinator {
         if (
           verifyExpectedOutput
           && operation.state !== 'fs_applied'
-          && !this.#matchesRecordedMove(destinationStat, beforeEvidence)
+          && !this.#matchesRecordedDirectoryMove(destinationStat, beforeEvidence)
         ) {
           return { state: 'pending_recovery', reason: 'Destination directory evidence does not match the recorded source.' };
         }
@@ -1015,6 +1015,13 @@ export class StableIdentityFileOperationCoordinator {
   #absolutePathKey(value) {
     const normalized = path.resolve(value);
     return this.platform === 'win32' ? normalized.toLocaleLowerCase('en-US') : normalized;
+  }
+
+  #matchesRecordedDirectoryMove(stat, beforeEvidence) {
+    const source = beforeEvidence?.sourceSignature;
+    const current = signatureFromStat(stat);
+    return source?.device !== null && source?.inode !== null
+      && current.device === source.device && current.inode === source.inode;
   }
 
   #directoryOperationScopes(payload) {

--- a/electron/stableIdentityFileOperationCoordinator.mjs
+++ b/electron/stableIdentityFileOperationCoordinator.mjs
@@ -43,6 +43,7 @@ export class StableIdentityFileOperationCoordinator {
     this.activePathLocks = new Map();
     this.recoveryBlockedPaths = new Set();
     this.deferredWatcherObservations = new Map();
+    this.retiredDirectoryScopes = new Set();
   }
 
   async initializeRecovery() {
@@ -95,7 +96,7 @@ export class StableIdentityFileOperationCoordinator {
     }
     const absolutePaths = [sourcePath, destinationPath].filter(Boolean).map((value) => path.resolve(value));
     return this.#withPathLocks(absolutePaths, async () => {
-      const blockedPath = absolutePaths.find((value) => this.recoveryBlockedPaths.has(this.#absolutePathKey(value)));
+      const blockedPath = absolutePaths.find((value) => this.#isRecoveryBlocked(this.#absolutePathKey(value)));
       if (blockedPath) {
         throw new Error(`A pending provenance recovery blocks another operation on ${blockedPath}.`);
       }
@@ -110,17 +111,9 @@ export class StableIdentityFileOperationCoordinator {
           provenance: { enabled: true, available: false, error: error?.message || String(error) },
         };
       }
-      if (['rename', 'move'].includes(kind) && sourceStat?.isDirectory?.()) {
-        return {
-          value: await perform(),
-          provenance: {
-            enabled: true,
-            available: true,
-            tracked: false,
-            reason: 'directory_operation_not_supported',
-          },
-        };
-      }
+      const requiresDirectoryJournal = Boolean(
+        sourceStat?.isDirectory?.() && ['rename', 'move'].includes(kind)
+      );
       if (sourcePath && ['rename', 'move', 'delete'].includes(kind) && !sourceStat) {
         return {
           value: await perform(),
@@ -148,6 +141,9 @@ export class StableIdentityFileOperationCoordinator {
             destinationStat,
           }),
         };
+        if (requiresDirectoryJournal && destinationStat && !beforeEvidence.sameFilePathAlias) {
+          throw Object.assign(new Error('A file with that name already exists.'), { code: 'EEXIST' });
+        }
         intent = this.#createIntent({
           kind,
           sourcePath,
@@ -155,9 +151,10 @@ export class StableIdentityFileOperationCoordinator {
           expectedOutputSha256,
           beforeEvidence,
           userDataContext,
+          sourceIsDirectory: Boolean(sourceStat?.isDirectory?.()),
         });
       } catch (error) {
-        if (requiresUserDataJournal) throw error;
+        if (requiresUserDataJournal || requiresDirectoryJournal) throw error;
         this.logger.error('Provenance intent could not be persisted; continuing the authorized file operation.', error);
         return {
           value: await perform(),
@@ -276,14 +273,14 @@ export class StableIdentityFileOperationCoordinator {
     for (const file of files) {
       const relativePath = file.relativePath || file.name;
       const key = this.#absolutePathKey(path.resolve(rootPath, relativePath));
-      if (this.activePathLocks.has(key) || this.recoveryBlockedPaths.has(key)) {
+      if (this.#isPathLocked(key) || this.#isRecoveryBlocked(key)) {
         this.deferredWatcherObservations.set(key, {
           kind: 'observed',
           rootPath,
           relativePath,
           bytesChanged: bytesChanged && file.provenanceBytesChanged !== false,
         });
-      } else {
+      } else if (!(await this.#isRetiredStaleObservation(path.resolve(rootPath, relativePath)))) {
         ready.push({
           ...file,
           name: relativePath,
@@ -307,6 +304,10 @@ export class StableIdentityFileOperationCoordinator {
       const folderPath = prefix ? path.resolve(rootPath, prefix) : path.resolve(rootPath);
       const folderStat = await this.#statOrNull(folderPath);
       if (folderStat) continue;
+      const retiredFolderKey = this.#absolutePathKey(folderPath);
+      for (const retiredScope of [...this.retiredDirectoryScopes]) {
+        if (this.#pathsOverlap(retiredFolderKey, retiredScope)) this.retiredDirectoryScopes.delete(retiredScope);
+      }
       this.indexer.invalidateRoot(rootPath);
       if (!root) continue;
       const locations = prefix
@@ -319,7 +320,10 @@ export class StableIdentityFileOperationCoordinator {
     }
     for (const relativePath of relativePaths) {
       const key = this.#absolutePathKey(path.resolve(rootPath, relativePath));
-      if (this.activePathLocks.has(key) || this.recoveryBlockedPaths.has(key)) {
+      if (await this.#isRetiredStaleObservation(path.resolve(rootPath, relativePath), { removal: true })) {
+        continue;
+      }
+      if (this.#isPathLocked(key) || this.#isRecoveryBlocked(key)) {
         this.deferredWatcherObservations.set(key, { kind: 'missing', rootPath, relativePath });
       } else {
         await this.#applyMissingObservation({ rootPath, relativePath });
@@ -331,7 +335,7 @@ export class StableIdentityFileOperationCoordinator {
     return Boolean(this.enabled && this.repositoryLifecycle?.getStatus?.().available && this.indexer);
   }
 
-  #createIntent({ kind, sourcePath, destinationPath, expectedOutputSha256, beforeEvidence, userDataContext }) {
+  #createIntent({ kind, sourcePath, destinationPath, expectedOutputSha256, beforeEvidence, userDataContext, sourceIsDirectory }) {
     return this.repositoryLifecycle.run((repository) => {
       let roots = repository.listLibraryRoots();
       for (const candidateRoot of [userDataContext?.sourceRootPath, userDataContext?.destinationRootPath]) {
@@ -345,6 +349,16 @@ export class StableIdentityFileOperationCoordinator {
           repository.ensureLibraryRoot(normalizedRoot);
           roots = repository.listLibraryRoots();
         }
+      }
+      if (sourceIsDirectory && ['rename', 'move'].includes(kind)) {
+        return this.#createDirectoryIntent({
+          repository,
+          roots,
+          kind,
+          sourcePath,
+          destinationPath,
+          beforeEvidence,
+        });
       }
       const source = sourcePath ? this.#resolveCatalogPath(sourcePath, roots) : null;
       const destination = destinationPath ? this.#resolveCatalogPath(destinationPath, roots) : null;
@@ -445,8 +459,200 @@ export class StableIdentityFileOperationCoordinator {
     return null;
   }
 
+  #createDirectoryIntent({ repository, roots, kind, sourcePath, destinationPath, beforeEvidence }) {
+    const sourceAbsolutePath = path.resolve(sourcePath);
+    const destinationAbsolutePath = path.resolve(destinationPath);
+    const normalizedSourceRoot = normalizeLibraryRootPath(sourceAbsolutePath, this.platform);
+    const sourceRoot = roots.find((root) => root.pathKey === normalizedSourceRoot.pathKey) ?? null;
+    const sourceDirectory = sourceRoot
+      ? { rootId: sourceRoot.rootId, rootPath: sourceRoot.absolutePath, relativePath: '', relativePathKey: '' }
+      : this.#resolveCatalogDirectoryPath(sourceAbsolutePath, roots);
+    if (!sourceDirectory) {
+      return {
+        operationId: null,
+        kind,
+        state: 'untracked',
+        payload: { sourceAbsolutePath, destinationAbsolutePath, beforeEvidence },
+      };
+    }
+
+    const mode = sourceRoot ? 'root' : 'subtree';
+    const pathApi = pathApiForPlatform(this.platform);
+    const affectedRoots = mode === 'root'
+      ? roots.filter((root) => {
+          const relative = pathApi.relative(sourceAbsolutePath, root.absolutePath);
+          return relative === '' || isRelativePathInsideRoot(relative, this.platform);
+        })
+      : [];
+    const affectedRootIds = new Set(affectedRoots.map((root) => root.rootId));
+    const destinationRoot = mode === 'root'
+      ? sourceRoot
+      : this.#resolveCatalogDirectoryPath(destinationAbsolutePath, roots);
+    if (mode === 'root') {
+      const normalizedDestinationRoot = normalizeLibraryRootPath(destinationAbsolutePath, this.platform);
+      const conflict = roots.find((root) => (
+        root.pathKey === normalizedDestinationRoot.pathKey && !affectedRootIds.has(root.rootId)
+      ));
+      if (conflict) throw new Error('The destination is already registered as another library root.');
+    }
+
+    const locations = mode === 'root'
+      ? affectedRoots.flatMap((root) => repository.listPresentLocations(root.rootId).map((location) => ({
+          ...location,
+          sourceRootId: root.rootId,
+        })))
+      : repository.listPresentLocationsUnderPath(sourceDirectory.rootId, sourceDirectory.relativePathKey);
+    const entries = locations.map((location) => {
+      if (mode === 'root') {
+        return {
+          locationId: location.locationId,
+          assetId: location.assetId,
+          revisionId: location.revisionId,
+          sourceRootId: location.sourceRootId,
+          destinationRootId: location.sourceRootId,
+          sourceRelativePath: location.relativePath,
+          sourceRelativePathKey: location.relativePathKey,
+          destinationRelativePath: location.relativePath,
+          destinationRelativePathKey: location.relativePathKey,
+        };
+      }
+      const suffix = location.relativePath.slice(sourceDirectory.relativePath.length).replace(/^\/+/, '');
+      const destinationRelativePath = destinationRoot
+        ? [destinationRoot.relativePath, suffix].filter(Boolean).join('/')
+        : null;
+      const normalizedDestination = destinationRelativePath
+        ? normalizeRelativeCatalogPath(destinationRelativePath, this.platform)
+        : null;
+      return {
+        locationId: location.locationId,
+        assetId: location.assetId,
+        revisionId: location.revisionId,
+        sourceRootId: sourceDirectory.rootId,
+        sourceRelativePath: location.relativePath,
+        sourceRelativePathKey: location.relativePathKey,
+        destinationRelativePath: normalizedDestination?.relativePath ?? null,
+        destinationRelativePathKey: normalizedDestination?.relativePathKey ?? null,
+      };
+    });
+    if (mode === 'subtree' && entries.length === 0) {
+      return {
+        operationId: null,
+        kind,
+        state: 'untracked',
+        payload: { sourceAbsolutePath, destinationAbsolutePath, beforeEvidence },
+      };
+    }
+
+    const normalizedDestinationRoot = mode === 'root'
+      ? normalizeLibraryRootPath(destinationAbsolutePath, this.platform)
+      : null;
+    const rootRelocations = mode === 'root'
+      ? affectedRoots.map((root) => {
+          const suffix = pathApi.relative(sourceAbsolutePath, root.absolutePath);
+          const relocatedPath = suffix ? pathApi.resolve(destinationAbsolutePath, suffix) : destinationAbsolutePath;
+          const normalized = normalizeLibraryRootPath(relocatedPath, this.platform);
+          return {
+            rootId: root.rootId,
+            sourceRootPath: root.absolutePath,
+            sourceRootPathKey: root.pathKey,
+            destinationRootPath: normalized.absolutePath,
+            destinationRootPathKey: normalized.pathKey,
+          };
+        })
+      : [];
+    if (mode === 'root') {
+      for (const relocation of rootRelocations) {
+        const conflict = roots.find((root) => (
+          root.pathKey === relocation.destinationRootPathKey && !affectedRootIds.has(root.rootId)
+        ));
+        if (conflict) throw new Error('The destination would overlap another registered library root.');
+      }
+    } else if (destinationRoot) {
+      const movedLocationIds = new Set(entries.map((entry) => entry.locationId));
+      for (const entry of entries) {
+        const conflict = repository.getLocationByRootPath(destinationRoot.rootId, entry.destinationRelativePathKey);
+        if (conflict?.state === 'present' && !movedLocationIds.has(conflict.locationId)) {
+          throw new Error(`A catalog location already occupies ${entry.destinationRelativePath}.`);
+        }
+      }
+    }
+    const directory = {
+      mode,
+      sourceRootId: sourceDirectory.rootId,
+      sourceRootPath: sourceDirectory.rootPath,
+      sourceRelativePath: sourceDirectory.relativePath,
+      sourceRelativePathKey: sourceDirectory.relativePathKey,
+      destinationRootId: destinationRoot?.rootId ?? null,
+      destinationRootPath: mode === 'root'
+        ? normalizedDestinationRoot.absolutePath
+        : destinationRoot?.rootPath ?? null,
+      destinationRootPathKey: mode === 'root' ? normalizedDestinationRoot.pathKey : null,
+      destinationRelativePath: mode === 'subtree' ? destinationRoot?.relativePath ?? null : '',
+      destinationRelativePathKey: mode === 'subtree' ? destinationRoot?.relativePathKey ?? null : '',
+      rootRelocations,
+      sourceAbsolutePath,
+      destinationAbsolutePath,
+      entries,
+    };
+    const payload = {
+      source: sourceDirectory,
+      destination: destinationRoot,
+      sourceAbsolutePath,
+      destinationAbsolutePath,
+      samePathKey: this.#absolutePathKey(sourceAbsolutePath) === this.#absolutePathKey(destinationAbsolutePath),
+      beforeEvidence,
+      directory,
+      expectedOutputSha256: null,
+      reserved: {},
+    };
+    return repository.createFileOperationIntent({ operationId: this.randomUUID(), kind, payload });
+  }
+
+  #resolveCatalogDirectoryPath(absolutePath, roots) {
+    const resolved = path.resolve(absolutePath);
+    const pathApi = pathApiForPlatform(this.platform);
+    for (const root of roots) {
+      const relative = pathApi.relative(root.absolutePath, resolved);
+      if (!isRelativePathInsideRoot(relative, this.platform) || relative === '') continue;
+      const normalized = normalizeRelativeCatalogPath(relative, this.platform);
+      return { rootId: root.rootId, rootPath: root.absolutePath, ...normalized };
+    }
+    return null;
+  }
+
   async #inspectOutcome(operation, { verifyExpectedOutput = true } = {}) {
     const { source, destination, expectedOutputSha256, beforeEvidence = {} } = operation.payload;
+    if (operation.payload.directory) {
+      const sourceStat = await this.#statOrNull(operation.payload.directory.sourceAbsolutePath);
+      const destinationStat = await this.#statOrNull(operation.payload.directory.destinationAbsolutePath);
+      if ((operation.payload.samePathKey || beforeEvidence.sameFilePathAlias) && destinationStat?.isDirectory?.()) {
+        if (verifyExpectedOutput && operation.state !== 'fs_applied') {
+          const actualPath = await this.#realPathOrNull(operation.payload.directory.destinationAbsolutePath);
+          if (!actualPath) return { state: 'pending_recovery', reason: 'Directory rename spelling could not be verified.' };
+          if (path.resolve(actualPath) === path.resolve(operation.payload.directory.sourceAbsolutePath)) {
+            return { state: 'aborted', reason: 'Case-only directory rename was not applied.' };
+          }
+          if (path.resolve(actualPath) !== path.resolve(operation.payload.directory.destinationAbsolutePath)) {
+            return { state: 'pending_recovery', reason: 'Directory rename spelling is ambiguous.' };
+          }
+        }
+        return { state: 'completed', observation: null };
+      }
+      if (!sourceStat && destinationStat?.isDirectory?.()) {
+        if (
+          verifyExpectedOutput
+          && operation.state !== 'fs_applied'
+          && !this.#matchesRecordedMove(destinationStat, beforeEvidence)
+        ) {
+          return { state: 'pending_recovery', reason: 'Destination directory evidence does not match the recorded source.' };
+        }
+        return { state: 'completed', observation: null };
+      }
+      if (sourceStat?.isDirectory?.() && !destinationStat) {
+        return { state: 'aborted', reason: 'Filesystem directory mutation was not applied.' };
+      }
+      return { state: 'pending_recovery', reason: 'Directory move outcome is ambiguous; no destructive recovery was attempted.' };
+    }
     const sourceStat = source ? await this.#statOrNull(path.resolve(source.rootPath, source.relativePath)) : null;
     const destinationStat = destination ? await this.#statOrNull(path.resolve(destination.rootPath, destination.relativePath)) : null;
     if (operation.kind === 'delete') {
@@ -598,6 +804,20 @@ export class StableIdentityFileOperationCoordinator {
           }],
         });
       }
+      const confirmedMappings = completed?.result?.mappings;
+      if (Array.isArray(confirmedMappings) && confirmedMappings.length > 0) {
+        const roots = this.repositoryLifecycle.run((repository) => repository.listLibraryRoots());
+        const grouped = new Map();
+        for (const confirmed of confirmedMappings) {
+          const batch = grouped.get(confirmed.rootId) ?? [];
+          batch.push(confirmed);
+          grouped.set(confirmed.rootId, batch);
+        }
+        for (const [rootId, mappings] of grouped) {
+          const root = roots.find((entry) => entry.rootId === rootId);
+          if (root) this.publishMappings({ rootId, rootPath: root.absolutePath, mappings });
+        }
+      }
     } catch (error) {
       if (operationError && typeof operationError === 'object') {
         operationError.provenanceOperationId = operation.operationId;
@@ -610,6 +830,7 @@ export class StableIdentityFileOperationCoordinator {
     }
 
     this.#unblockOperationPaths(operation.payload);
+    this.#retireDirectorySource(operation.payload);
     try {
       await this.#observeCompletedDestination(operation.payload);
       await this.#flushDeferredForOperation(operation.payload);
@@ -632,6 +853,7 @@ export class StableIdentityFileOperationCoordinator {
           this.repositoryLifecycle.run((repository) => repository.markFileOperationPending(operation.operationId, error));
           return 'pending_recovery';
         }
+        this.#retireDirectorySource(operation.payload);
         this.#unblockOperationPaths(operation.payload);
         try {
           await this.#observeCompletedDestination(operation.payload);
@@ -652,6 +874,7 @@ export class StableIdentityFileOperationCoordinator {
   }
 
   async #observeCompletedDestination(payload) {
+    if (payload.directory) return;
     const destination = payload.destination;
     if (!destination?.rootId) return;
     const absolutePath = path.resolve(destination.rootPath, destination.relativePath);
@@ -671,6 +894,14 @@ export class StableIdentityFileOperationCoordinator {
   }
 
   #blockOperationPaths(payload) {
+    if (payload.directory) {
+      for (const scope of this.#directoryOperationScopes(payload)) {
+        this.recoveryBlockedPaths.add(this.#absolutePathKey(scope.absolutePath));
+        this.indexer.invalidateRoot(scope.rootPath);
+        this.indexer.blockCatalogSubtree(scope.rootPath, scope.relativePath);
+      }
+      return;
+    }
     for (const entry of [payload.source, payload.destination]) {
       if (!entry?.rootPath || !entry.relativePath) continue;
       const absolute = path.resolve(entry.rootPath, entry.relativePath);
@@ -681,6 +912,13 @@ export class StableIdentityFileOperationCoordinator {
   }
 
   #unblockOperationPaths(payload) {
+    if (payload.directory) {
+      for (const scope of this.#directoryOperationScopes(payload)) {
+        this.recoveryBlockedPaths.delete(this.#absolutePathKey(scope.absolutePath));
+        this.indexer.unblockCatalogSubtree(scope.rootPath, scope.relativePath);
+      }
+      return;
+    }
     for (const entry of [payload.source, payload.destination]) {
       if (!entry?.rootPath || !entry.relativePath) continue;
       const absolute = path.resolve(entry.rootPath, entry.relativePath);
@@ -690,6 +928,15 @@ export class StableIdentityFileOperationCoordinator {
   }
 
   async #flushDeferredForOperation(payload) {
+    if (payload.directory) {
+      const scopes = this.#operationAbsolutePaths(payload).map((value) => this.#absolutePathKey(value));
+      for (const key of [...this.deferredWatcherObservations.keys()]) {
+        if (scopes.some((scope) => this.#pathsOverlap(key, scope))) {
+          this.deferredWatcherObservations.delete(key);
+        }
+      }
+      return;
+    }
     for (const absolutePath of this.#operationAbsolutePaths(payload)) {
       const key = this.#absolutePathKey(absolutePath);
       const observation = this.deferredWatcherObservations.get(key);
@@ -733,6 +980,11 @@ export class StableIdentityFileOperationCoordinator {
   }
 
   #operationAbsolutePaths(payload) {
+    if (payload.directory) {
+      return [payload.directory.sourceAbsolutePath, payload.directory.destinationAbsolutePath]
+        .filter(Boolean)
+        .map((entry) => path.resolve(entry));
+    }
     return [payload.source, payload.destination]
       .filter((entry) => entry?.rootPath && entry.relativePath)
       .map((entry) => path.resolve(entry.rootPath, entry.relativePath));
@@ -741,7 +993,9 @@ export class StableIdentityFileOperationCoordinator {
   async #withPathLocks(absolutePaths, operation) {
     const keys = [...new Set(absolutePaths.map((value) => this.#absolutePathKey(value)))].sort();
     while (true) {
-      const blockers = keys.map((key) => this.activePathLocks.get(key)).filter(Boolean);
+      const blockers = [...this.activePathLocks.entries()]
+        .filter(([activeKey]) => keys.some((key) => this.#pathsOverlap(activeKey, key)))
+        .map(([, blocker]) => blocker);
       if (blockers.length === 0) break;
       await Promise.race(blockers);
     }
@@ -761,6 +1015,79 @@ export class StableIdentityFileOperationCoordinator {
   #absolutePathKey(value) {
     const normalized = path.resolve(value);
     return this.platform === 'win32' ? normalized.toLocaleLowerCase('en-US') : normalized;
+  }
+
+  #directoryOperationScopes(payload) {
+    const directory = payload.directory;
+    if (!directory) return [];
+    if (directory.mode === 'root' && Array.isArray(directory.rootRelocations)) {
+      return directory.rootRelocations.flatMap((relocation) => [
+        { absolutePath: relocation.sourceRootPath, rootPath: relocation.sourceRootPath, relativePath: '' },
+        { absolutePath: relocation.destinationRootPath, rootPath: relocation.destinationRootPath, relativePath: '' },
+      ]);
+    }
+    const scopes = [];
+    if (directory.sourceRootPath !== null && directory.sourceRootPath !== undefined) {
+      scopes.push({
+        absolutePath: directory.sourceAbsolutePath,
+        rootPath: directory.sourceRootPath,
+        relativePath: directory.sourceRelativePath ?? '',
+      });
+    }
+    if (directory.mode === 'root') {
+      scopes.push({
+        absolutePath: directory.destinationAbsolutePath,
+        rootPath: directory.destinationRootPath,
+        relativePath: '',
+      });
+    } else if (directory.destinationRootPath) {
+      scopes.push({
+        absolutePath: directory.destinationAbsolutePath,
+        rootPath: directory.destinationRootPath,
+        relativePath: directory.destinationRelativePath ?? '',
+      });
+    }
+    return scopes;
+  }
+
+  #retireDirectorySource(payload) {
+    if (!payload.directory) return;
+    this.retiredDirectoryScopes.add(this.#absolutePathKey(payload.directory.sourceAbsolutePath));
+  }
+
+  #pathsOverlap(left, right) {
+    const separator = path.sep;
+    return left === right || left.startsWith(`${right}${separator}`) || right.startsWith(`${left}${separator}`);
+  }
+
+  #isAbsolutePathWithin(candidate, scope) {
+    const separator = path.sep;
+    return candidate === scope || candidate.startsWith(`${scope}${separator}`);
+  }
+
+  #isPathLocked(candidate) {
+    for (const scope of this.activePathLocks.keys()) {
+      if (this.#pathsOverlap(candidate, scope)) return true;
+    }
+    return false;
+  }
+
+  #isRecoveryBlocked(candidate) {
+    for (const scope of this.recoveryBlockedPaths) {
+      if (this.#pathsOverlap(candidate, scope)) return true;
+    }
+    return false;
+  }
+
+  async #isRetiredStaleObservation(absolutePath, { removal = false } = {}) {
+    const candidate = this.#absolutePathKey(absolutePath);
+    const retired = [...this.retiredDirectoryScopes].filter((scope) => this.#isAbsolutePathWithin(candidate, scope));
+    if (retired.length === 0) return false;
+    if (removal) return true;
+    const stat = await this.#statOrNull(absolutePath);
+    if (!stat) return true;
+    for (const scope of retired) this.retiredDirectoryScopes.delete(scope);
+    return false;
   }
 
   async #isSameFilePathAlias({ kind, sourcePath, destinationPath, sourceStat, destinationStat }) {

--- a/electron/stableIdentityFileOperationsSmoke.mjs
+++ b/electron/stableIdentityFileOperationsSmoke.mjs
@@ -33,20 +33,31 @@ export async function runStableIdentityFileOperationsSmoke({
   const sourcePath = path.join(syntheticRoot, 'original.bin');
   const renamedPath = path.join(syntheticRoot, 'renamed.bin');
   const copyPath = path.join(syntheticRoot, 'copy.bin');
+  const directorySourcePath = path.join(syntheticRoot, '..archive ç');
+  const directoryDestinationPath = path.join(syntheticRoot, 'renamed folder ç');
+  const directoryRelativePath = '..archive ç/nested/inside.bin';
+  const renamedDirectoryRelativePath = 'renamed folder ç/nested/inside.bin';
+  await fs.mkdir(path.join(directorySourcePath, 'nested'), { recursive: true });
   await fs.writeFile(sourcePath, 'packaged synthetic bytes');
+  await fs.writeFile(path.join(directorySourcePath, 'nested', 'inside.bin'), 'directory synthetic bytes');
 
   const scanToken = indexer.beginScan(syntheticRoot);
   const initialMappings = [];
   await indexer.indexScan({
     rootPath: syntheticRoot,
-    files: [await observedFile(syntheticRoot, 'original.bin')],
+    files: await Promise.all([
+      observedFile(syntheticRoot, 'original.bin'),
+      observedFile(syntheticRoot, directoryRelativePath),
+    ]),
     recursive: true,
     scanComplete: true,
     scanToken,
     onBatch: ({ mappings }) => initialMappings.push(...mappings),
   });
   const initial = initialMappings[0];
+  const directoryInitial = initialMappings.find((mapping) => mapping.relativePath === directoryRelativePath);
   assertSmoke(initial?.assetId && initial?.revisionId && initial?.locationId, 'initial identity was not assigned');
+  assertSmoke(directoryInitial?.assetId && directoryInitial?.revisionId && directoryInitial?.locationId, 'directory descendant identity was not assigned');
 
   assertSmoke(userDataService?.getStatus?.().authority === 'sqlite', 'stable user-data data service bridge is not authoritative');
   userDataService.syncLegacyBatch([
@@ -62,6 +73,17 @@ export async function runStableIdentityFileOperationsSmoke({
     },
   ]);
   userDataService.completeLegacyScan();
+  userDataService.syncLegacyBatch([{
+    domain: 'annotation',
+    legacyImageId: 'packaged-directory-image',
+    reference: {
+      assetId: directoryInitial.assetId,
+      revisionId: directoryInitial.revisionId,
+      locationId: directoryInitial.locationId,
+    },
+    payload: { isFavorite: true, tags: ['directory'], rating: 4, addedAt: 11, updatedAt: 21 },
+    sourceVersion: 0,
+  }]);
 
   await coordinator.executeKnownOperation({
     kind: 'rename',
@@ -69,6 +91,12 @@ export async function runStableIdentityFileOperationsSmoke({
     destinationPath: renamedPath,
     userDataContext: { legacyImageId: 'packaged-smoke-image' },
     perform: () => fs.rename(sourcePath, renamedPath),
+  });
+  await coordinator.executeKnownOperation({
+    kind: 'rename',
+    sourcePath: directorySourcePath,
+    destinationPath: directoryDestinationPath,
+    perform: () => fs.rename(directorySourcePath, directoryDestinationPath),
   });
   await coordinator.executeKnownOperation({
     kind: 'copy',
@@ -95,6 +123,7 @@ export async function runStableIdentityFileOperationsSmoke({
     assertSmoke(root, 'synthetic root was not registered');
     const renamed = repository.getLocationByRootPath(root.rootId, 'renamed.bin');
     const copied = repository.getLocationByRootPath(root.rootId, 'copy.bin');
+    const renamedDirectoryDescendant = repository.getLocationByRootPath(root.rootId, renamedDirectoryRelativePath);
     const sourceAsset = repository.getAsset(initial.assetId);
     const copiedAsset = copied ? repository.getAsset(copied.assetId) : null;
     const copiedReference = copied ? {
@@ -123,6 +152,8 @@ export async function runStableIdentityFileOperationsSmoke({
       root,
       renamed,
       copied,
+      renamedDirectoryDescendant,
+      directoryUserData: repository.captureAssetUserDataSnapshot(directoryInitial.assetId, 40),
       sourceAsset,
       copiedAsset,
       copiedAnnotation,
@@ -137,6 +168,10 @@ export async function runStableIdentityFileOperationsSmoke({
   assertSmoke(snapshot.renamed?.revisionId === initial.revisionId, 'rename did not preserve the revision');
   assertSmoke(snapshot.renamed?.locationId === initial.locationId, 'rename did not preserve the location');
   assertSmoke(snapshot.copied?.assetId !== initial.assetId, 'copy reused the source asset');
+  assertSmoke(snapshot.renamedDirectoryDescendant?.assetId === directoryInitial.assetId, 'directory rename did not preserve the descendant asset');
+  assertSmoke(snapshot.renamedDirectoryDescendant?.revisionId === directoryInitial.revisionId, 'directory rename did not preserve the descendant revision');
+  assertSmoke(snapshot.renamedDirectoryDescendant?.locationId === directoryInitial.locationId, 'directory rename did not preserve the descendant location');
+  assertSmoke(snapshot.directoryUserData.find((entry) => entry.domain === 'annotation')?.payload?.rating === 4, 'directory descendant annotation was not preserved');
   assertSmoke(snapshot.copiedAsset?.revisions.length === 2, 'overwrite did not create exactly one new revision');
   assertSmoke(snapshot.copiedAnnotation?.payload?.isFavorite === true, 'annotation was not copied');
   assertSmoke(snapshot.copiedShadow?.payload?.seed === 0, 'shadow metadata was not copied');
@@ -157,9 +192,11 @@ export async function runStableIdentityFileOperationsSmoke({
   const reopened = reopenedLifecycle.run((repository) => {
     const root = repository.listLibraryRoots().find((entry) => entry.absolutePath === syntheticRoot);
     const copied = root ? repository.getLocationByRootPath(root.rootId, 'copy.bin') : null;
+    const renamedDirectoryDescendant = root ? repository.getLocationByRootPath(root.rootId, renamedDirectoryRelativePath) : null;
     const sourceData = repository.captureAssetUserDataSnapshot(initial.assetId, 40);
     const copiedData = copied ? repository.captureAssetUserDataSnapshot(copied.assetId, 40) : [];
-    return { status: repository.getStatus(), copied, sourceData, copiedData };
+    const directoryData = repository.captureAssetUserDataSnapshot(directoryInitial.assetId, 40);
+    return { status: repository.getStatus(), copied, renamedDirectoryDescendant, sourceData, copiedData, directoryData };
   });
   reopenedLifecycle.close();
   assertSmoke(reopenedUserDataStatus.authority === 'sqlite', 'SQLite authority did not survive a flag-off reopen');
@@ -168,6 +205,8 @@ export async function runStableIdentityFileOperationsSmoke({
   assertSmoke(reopened.sourceData.find((entry) => entry.domain === 'annotation')?.payload?.rating === 5, 'source annotation changed with its copy');
   assertSmoke(reopened.copiedData.find((entry) => entry.domain === 'annotation')?.payload?.rating === 2, 'copied annotation did not survive reopen');
   assertSmoke(reopened.copiedData.find((entry) => entry.domain === 'shadow')?.payload?.seed === 0, 'copied shadow metadata did not survive reopen');
+  assertSmoke(reopened.renamedDirectoryDescendant?.assetId === directoryInitial.assetId, 'directory descendant identity did not survive reopen');
+  assertSmoke(reopened.directoryData.find((entry) => entry.domain === 'annotation')?.payload?.rating === 4, 'directory descendant annotation did not survive reopen');
 
   return {
     success: true,
@@ -185,6 +224,8 @@ export async function runStableIdentityFileOperationsSmoke({
       renamedRevisionId: snapshot.renamed.revisionId,
       copiedAssetId: snapshot.copied.assetId,
       copiedRevisionCount: snapshot.copiedAsset.revisions.length,
+      directoryAssetId: directoryInitial.assetId,
+      directoryRevisionId: directoryInitial.revisionId,
     },
     schemaVersion: snapshot.status.schemaVersion,
     pendingOperations: 0,
@@ -194,6 +235,7 @@ export async function runStableIdentityFileOperationsSmoke({
       sourceRating: 5,
       copiedRating: 2,
       copiedShadowSeed: 0,
+      directoryRating: 4,
       reopened: true,
     },
   };

--- a/electron/stableIdentityIndexer.mjs
+++ b/electron/stableIdentityIndexer.mjs
@@ -63,6 +63,7 @@ export class StableIdentityIndexer {
     this.scanGenerationByRootKey = new Map();
     this.pathVersionByCatalogKey = new Map();
     this.blockedCatalogPathKeys = new Set();
+    this.blockedCatalogSubtreeKeys = new Set();
   }
 
   beginScan(rootPath) {
@@ -97,6 +98,34 @@ export class StableIdentityIndexer {
 
   unblockCatalogPath(rootPath, relativePath) {
     this.blockedCatalogPathKeys.delete(this.#catalogPathKey(rootPath, relativePath));
+  }
+
+  invalidateCatalogSubtree(rootPath, relativePath = '') {
+    const subtreeKey = this.#catalogSubtreeKey(rootPath, relativePath);
+    for (const catalogPathKey of this.pathVersionByCatalogKey.keys()) {
+      if (this.#catalogKeyIsWithinSubtree(catalogPathKey, subtreeKey)) {
+        this.pathVersionByCatalogKey.set(
+          catalogPathKey,
+          (this.pathVersionByCatalogKey.get(catalogPathKey) ?? 0) + 1,
+        );
+      }
+    }
+    this.hashQueue = this.hashQueue.filter((task) => {
+      if (!this.#catalogKeyIsWithinSubtree(task.catalogPathKey, subtreeKey)) return true;
+      this.queuedRevisionIds.delete(task.revisionId);
+      this.replacementHashTasksByRevision.delete(task.revisionId);
+      return false;
+    });
+  }
+
+  blockCatalogSubtree(rootPath, relativePath = '') {
+    const subtreeKey = this.#catalogSubtreeKey(rootPath, relativePath);
+    this.blockedCatalogSubtreeKeys.add(subtreeKey);
+    this.invalidateCatalogSubtree(rootPath, relativePath);
+  }
+
+  unblockCatalogSubtree(rootPath, relativePath = '') {
+    this.blockedCatalogSubtreeKeys.delete(this.#catalogSubtreeKey(rootPath, relativePath));
   }
 
   pause() {
@@ -204,9 +233,12 @@ export class StableIdentityIndexer {
     const root = normalizeLibraryRootPath(rootPath, this.platform);
     const normalizedPath = normalizeRelativeCatalogPath(relativePath, this.platform);
     const catalogPathKey = `${root.pathKey}\0${normalizedPath.relativePathKey}`;
-    if (this.blockedCatalogPathKeys.has(catalogPathKey)) return null;
+    if (this.#isCatalogPathBlocked(catalogPathKey)) return null;
     this.invalidateCatalogPath(rootPath, relativePath);
-    const rootRecord = this.repositoryLifecycle.run((repository) => repository.ensureLibraryRoot(root));
+    const rootRecord = this.repositoryLifecycle.run((repository) => (
+      repository.listLibraryRoots().find((entry) => entry.pathKey === root.pathKey) ?? null
+    ));
+    if (!rootRecord) return null;
     return this.repositoryLifecycle.run((repository) => (
       repository.markLocationMissingByRootPath(rootRecord.rootId, normalizedPath.relativePathKey)
     ));
@@ -231,6 +263,27 @@ export class StableIdentityIndexer {
     return `${root.pathKey}\0${normalizedPath.relativePathKey}`;
   }
 
+  #catalogSubtreeKey(rootPath, relativePath = '') {
+    const root = normalizeLibraryRootPath(rootPath, this.platform);
+    if (!relativePath) return `${root.pathKey}\0`;
+    const normalizedPath = normalizeRelativeCatalogPath(relativePath, this.platform);
+    return `${root.pathKey}\0${normalizedPath.relativePathKey}`;
+  }
+
+  #catalogKeyIsWithinSubtree(catalogPathKey, subtreeKey) {
+    return subtreeKey.endsWith('\0')
+      ? catalogPathKey.startsWith(subtreeKey)
+      : catalogPathKey === subtreeKey || catalogPathKey.startsWith(`${subtreeKey}/`);
+  }
+
+  #isCatalogPathBlocked(catalogPathKey) {
+    if (this.blockedCatalogPathKeys.has(catalogPathKey)) return true;
+    for (const subtreeKey of this.blockedCatalogSubtreeKeys) {
+      if (this.#catalogKeyIsWithinSubtree(catalogPathKey, subtreeKey)) return true;
+    }
+    return false;
+  }
+
   #assignObservedFiles({ root, rootRecord, scanPath, files, requiredScanGeneration = null }) {
     const mappings = [];
     for (const file of files) {
@@ -242,7 +295,10 @@ export class StableIdentityIndexer {
       const rootRelativePath = path.relative(root.absolutePath, absoluteFilePath).replace(/\\/g, '/');
       const normalizedPath = normalizeRelativeCatalogPath(rootRelativePath, this.platform);
       const catalogPathKey = `${root.pathKey}\0${normalizedPath.relativePathKey}`;
-      if (this.blockedCatalogPathKeys.has(catalogPathKey)) continue;
+      if (this.#isCatalogPathBlocked(catalogPathKey)) continue;
+      if (!this.pathVersionByCatalogKey.has(catalogPathKey)) {
+        this.pathVersionByCatalogKey.set(catalogPathKey, 0);
+      }
       const pathVersion = this.pathVersionByCatalogKey.get(catalogPathKey) ?? 0;
       const contentModifiedMs = normalizedTimestamp(file.contentModifiedMs ?? file.lastModified);
       const identity = this.repositoryLifecycle.run((repository) => repository.assignIndexedFile({
@@ -292,7 +348,7 @@ export class StableIdentityIndexer {
           });
           const after = await this.stat(task.filePath);
           if (!sameFileSignature(after, task)) continue;
-          if (this.blockedCatalogPathKeys.has(task.catalogPathKey)) continue;
+          if (this.#isCatalogPathBlocked(task.catalogPathKey)) continue;
           if ((this.pathVersionByCatalogKey.get(task.catalogPathKey) ?? 0) !== task.pathVersion) continue;
           this.repositoryLifecycle.run((repository) => repository.completeRevisionHashIfUnchanged(task.revisionId, {
             sha256,
@@ -301,7 +357,7 @@ export class StableIdentityIndexer {
           }));
         } catch (error) {
           const stillCurrent = (this.pathVersionByCatalogKey.get(task.catalogPathKey) ?? 0) === task.pathVersion;
-          if (!this.stopped && stillCurrent && !this.blockedCatalogPathKeys.has(task.catalogPathKey)) {
+          if (!this.stopped && stillCurrent && !this.#isCatalogPathBlocked(task.catalogPathKey)) {
             this.logger.warn('Could not hash provenance revision; it remains pending for a later scan.', error);
           }
         } finally {


### PR DESCRIPTION
# Stable identity for directory operations

## Supported product flow and authority

The folder tree currently exposes **Rename Folder** for a registered root or a discovered subfolder. It calls the existing authorized `rename-file` IPC; the product does not expose folder drag/move or directory merging. The stable-identity coordinator accepts both `rename` and `move` so an existing authorized caller can preserve the same contract, but this work adds no UI operation and no new filesystem permission.

When stable identity is enabled, SQLite remains authoritative for asset, revision, location, annotation, and shadow identity. `IndexedImage.id` and renderer folder paths remain projections. When the flag is off for a profile that has not crossed the stable authority boundary, the existing filesystem and renderer behavior remains unchanged and no directory migration starts.

## Operation matrix

| Operation/API | Existing source and consumers | Stable-identity behavior |
| --- | --- | --- |
| Root or subfolder rename | `DirectoryList.tsx` -> preload `renameFile` -> `rename-file` IPC -> `fs.rename` | The existing coordinator snapshots every current descendant location before the rename. Catalog completion remaps the snapshot atomically and broadcasts confirmed mappings. |
| Registered-root rename | Same flow, followed by renderer root/path/watcher rebinding | The existing `rootId` moves to the new absolute path. Any separately registered roots below it move by the same prefix in the same transaction; descendant relative paths do not change. |
| Subtree rename/move inside a root | Coordinator `rename`/`move` boundary | Location IDs, asset IDs, revision IDs, and asset-owned user data are retained; only the root/relative-path projection changes. |
| Subtree move to another registered root | Existing coordinator `move` contract; no new folder UI | Descendant locations change root and path atomically. Equal bytes never create or merge assets. |
| Move outside registered roots | Existing authorization rules | Descendant locations become `missing`; no root is registered and no hash starts. |
| Destination conflict / permission failure | Existing `rename-file` preflight and filesystem errors | A directory destination is rejected before the journal/filesystem mutation. An unapplied failure aborts the intent and leaves source locations current. No directory merge policy is introduced. |
| Watcher add/remove and scans | Existing watcher observers and indexer scan generations | Source and destination prefixes are locked. Older scans are invalidated; descendant watcher observations are deferred and discarded after the atomic catalog remap. A late observation from a retired source is ignored while that path is absent. |
| Pending SHA-256 | Existing single hash queue | Every queued or active task under the affected prefixes is version-invalidated. A result opened at the old path cannot commit; a later authorized scan at the new path resumes the pending revision. |
| Annotations and shadow metadata | Stable user-data repository/adapter keyed by `assetId` | No copy/delete is performed. The same assets continue to own the same records and tombstones. Legacy aliases remain bound to location/asset identity, not to a reused pathname. |

## Journal and recovery contract

Directory operations reuse `provenance_operations`; the schema remains version 5 because the journal payload is internal JSON and the existing operation kinds already include `rename` and `move`. An intent contains the source/destination directories, pre-operation filesystem evidence, all affected registered roots, and the exact descendant location snapshot. SQLite validates every recorded asset/location/revision/root/path relation again before completion.

Filesystem work never runs in a SQLite transaction. After the authorized filesystem call returns, catalog remapping and journal completion share one SQLite transaction. If the filesystem succeeded and catalog completion failed, `fs_applied` allows idempotent recovery. Recovery only inspects the recorded paths and completes the catalog; it never repeats a rename, copy, delete, or cross-volume cleanup.

For an `intended` journal entry, source-missing/destination-present recovery requires matching filesystem identity evidence. Both paths present, both absent, mismatched evidence, inaccessible paths, or a partially copied cross-volume directory remain `pending_recovery`. That state blocks descendant operations and ordinary assignment rather than claiming the move completed.

## Boundaries

Destinations outside registered roots remain outside the catalog. The coordinator does not register roots, initiate scans, or start hashes for them. Directory merge, new folder-move UI, lineage edges, audit history, C2PA, IPTC, MCP, parser changes, and redesign are not part of this work.

`IMH_ENABLE_PROVENANCE_INDEXING` remains off by default. Windows packaged validation uses only a generated temporary profile and synthetic folders/files. Visual validation remains manual; Linux and macOS remain separate activation gates until their packaged tests are executed.

## Validation executed on 2026-09-08

- Stable file-operation suite: 47 tests passed and one platform-specific test was skipped. The directory matrix covers nested trees, registered and nested roots, cross-root/out-of-scope moves, spaces/accents/`..archive`, destination conflict, permission failure, watcher/backfill interleavings, an in-flight hash, catalog failure after filesystem success, repeated recovery, partial copy-then-delete, user data, and flag-off behavior.
- Repository, indexer, and stable user-data suites: 26 tests passed when run as separate suites. A parallel aggregate run produced only known Windows five-second resource-contention timeouts; the same files passed separately.
- TypeScript, JavaScript syntax, focused ESLint, and the production renderer build passed. ESLint retained only non-blocking test-file `no-explicit-any` warnings.
- Windows unpacked and real portable packaged smokes passed using generated temporary paths with spaces and `ç`. Both preserved a directory descendant's asset/revision/location and annotation across reopen with an empty recovery queue.
- Packaged runtime: Electron 38.8.6, Node 22.22.0, SQLite 3.50.4.
- Visual validation was not automated. Linux and macOS were not executed.
