### PR TITLE
feat: add Prompt Library v1

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import { useImageStore } from './store/useImageStore';
 import { useSettingsStore } from './store/useSettingsStore';
 import { useSemanticStore } from './store/useSemanticStore';
 import { useLicenseStore } from './store/useLicenseStore';
+import { initializeSavedPromptSynchronization } from './store/useSavedPromptStore';
 import { useImageLoader } from './hooks/useImageLoader';
 import { useImageSelection } from './hooks/useImageSelection';
 import { useClusterCacheRestore } from './hooks/useClusterCacheRestore';
@@ -271,6 +272,8 @@ export default function App() {
   useGenerationQueueSync();
   useComfyUIQueueMonitor();
   useComfyUIEmbeddedProgress();
+
+  useEffect(() => initializeSavedPromptSynchronization(), []);
 
   // --- Hooks ---
   const { handleSelectFolder, handleUpdateFolder, handleLoadFromStorage, handleRemoveDirectory, loadDirectory, processNewWatchedFiles } = useImageLoader();

--- a/App.tsx
+++ b/App.tsx
@@ -44,6 +44,7 @@ import ModelPromptPickerModal from './components/ModelPromptPickerModal';
 import CollectionsWorkspace from './components/CollectionsWorkspace';
 import ComfyUIWorkspace from './components/ComfyUIWorkspace';
 import ImageEditorWorkspace from './components/ImageEditorWorkspace';
+import PromptLibrary from './components/PromptLibrary';
 import GridToolbar from './components/GridToolbar';
 import AnalyticsSummaryStrip from './components/AnalyticsSummaryStrip';
 import BatchExportModal from './components/BatchExportModal';
@@ -543,7 +544,7 @@ export default function App() {
   const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false);
   const [currentVersion, setCurrentVersion] = useState<string>('0.10.0');
   const [isQueueOpen, setIsQueueOpen] = useState(false);
-  const [libraryView, setLibraryView] = useState<'library' | 'explore' | 'collections' | 'comfyui' | 'editor'>('library');
+  const [libraryView, setLibraryView] = useState<'library' | 'prompts' | 'explore' | 'collections' | 'comfyui' | 'editor'>('library');
   const [isA1111GenerateModalOpen, setIsA1111GenerateModalOpen] = useState(false);
   const [isComfyUIGenerateModalOpen, setIsComfyUIGenerateModalOpen] = useState(false);
   const [selectedImageForGeneration, setSelectedImageForGeneration] = useState<IndexedImage | null>(null);
@@ -707,8 +708,8 @@ export default function App() {
     }
   }, [activeImageScope, clusters, collections, safeImages, validateActiveImageScope]);
 
-  const hasLeftSidebar = hasDirectories && libraryView !== 'comfyui' && libraryView !== 'editor';
-  const hasRightSidebar = Boolean(isQueueOpen || (previewImage && libraryView !== 'comfyui' && libraryView !== 'editor'));
+  const hasLeftSidebar = hasDirectories && !['prompts', 'comfyui', 'editor'].includes(libraryView);
+  const hasRightSidebar = Boolean(isQueueOpen || (previewImage && !['prompts', 'comfyui', 'editor'].includes(libraryView)));
   const previousHasRightSidebarRef = useRef(hasRightSidebar);
   const rightSidebarVisibilityChanged = previousHasRightSidebarRef.current !== hasRightSidebar;
   useLayoutEffect(() => {
@@ -4181,9 +4182,9 @@ export default function App() {
             </div>
           )}
 
-          {!isStartupHydrating && !isLoading && !hasDirectories && <FolderSelector onSelectFolder={handleSelectFolder} />}
+          {!isStartupHydrating && !isLoading && !hasDirectories && libraryView !== 'prompts' && <FolderSelector onSelectFolder={handleSelectFolder} />}
 
-          {hasDirectories && (
+          {(hasDirectories || libraryView === 'prompts') && (
             <>
                 {libraryView === 'library' && (
                   <AnalyticsSummaryStrip
@@ -4389,6 +4390,8 @@ export default function App() {
                           jumpToGroupRequest={pendingJumpGroupRequest}
                         />
                   )
+                ) : libraryView === 'prompts' ? (
+                  <PromptLibrary onViewSource={handleOpenFileFromDeepLink} />
                 ) : libraryView === 'explore' ? (
                   <ExploreWorkspace
                     onNavigateToLibrary={() => {

--- a/__tests__/Header.classic-mode.test.tsx
+++ b/__tests__/Header.classic-mode.test.tsx
@@ -66,6 +66,18 @@ describe('Header classic mode', () => {
     expect(screen.getByRole('button', { name: /explore/i })).toBeTruthy();
   });
 
+  it('keeps Library as a text destination and opens prompts from a compact bookmark button', () => {
+    const onLibraryViewChange = vi.fn();
+    renderHeader({ onLibraryViewChange });
+
+    expect(screen.queryByRole('button', { name: /^prompts$/i })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Prompt Library' }));
+    expect(onLibraryViewChange).toHaveBeenCalledWith('prompts');
+
+    fireEvent.click(screen.getByRole('button', { name: /^library$/i }));
+    expect(onLibraryViewChange).toHaveBeenCalledWith('library');
+  });
+
   it('shows the legacy tabs as Explore deep-links when classic mode is on', () => {
     useSettingsStore.setState({ classicMode: true });
     const onNavigateExplore = vi.fn();

--- a/__tests__/ImageGrid.contextMenu.test.tsx
+++ b/__tests__/ImageGrid.contextMenu.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ImageGrid from '../components/ImageGrid';
 import { useImageSelection } from '../hooks/useImageSelection';
 import { useImageStore } from '../store/useImageStore';
@@ -21,6 +21,8 @@ const contextMenuStateMock = {
   image: undefined as IndexedImage | undefined,
   directoryPath: 'D:/library',
 };
+
+afterEach(() => cleanup());
 
 vi.mock('../hooks/useContextMenu', () => ({
   useContextMenu: () => ({

--- a/__tests__/ImageTable.contextMenu.test.tsx
+++ b/__tests__/ImageTable.contextMenu.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import ImageTable from '../components/ImageTable';
 import { useImageSelection } from '../hooks/useImageSelection';
 import { useImageStore } from '../store/useImageStore';
@@ -16,6 +16,8 @@ const contextMenuStateMock = {
   image: undefined as IndexedImage | undefined,
   directoryPath: 'D:/library',
 };
+
+afterEach(() => cleanup());
 
 vi.mock('../hooks/useContextMenu', () => ({
   useContextMenu: () => ({
@@ -123,6 +125,7 @@ describe('ImageTable context menu', () => {
       showFullFilePath: false,
     } as any);
   });
+
 
   it('does not mount 3D thumbnail renderers when thumbnails are disabled', () => {
     const image = createImage({ id: 'model-1', name: 'model.glb', fileType: 'model/gltf-binary' });

--- a/__tests__/PromptLibrary.test.tsx
+++ b/__tests__/PromptLibrary.test.tsx
@@ -87,6 +87,21 @@ describe('PromptLibrary', () => {
     expect(screen.getByText('1 of 2')).toBeTruthy();
   });
 
+  it('opens the detail modal from the card while Copy stays in-place and shows feedback', async () => {
+    serviceMocks.list.mockResolvedValue([prompt('prompt-1', 'card prompt', 'card negative')]);
+    render(<PromptLibrary onViewSource={vi.fn()} />);
+    const card = (await screen.findByText('card prompt')).closest('article') as HTMLElement;
+
+    fireEvent.click(card);
+    expect(screen.getByRole('dialog', { name: 'Saved prompt details' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Close prompt details' }));
+    expect(document.activeElement).toBe(card);
+
+    fireEvent.click(within(card).getByRole('button', { name: 'Copy' }));
+    expect(await within(card).findByRole('button', { name: 'Copied' })).toBeTruthy();
+    expect(screen.queryByRole('dialog', { name: 'Saved prompt details' })).toBeNull();
+  });
+
   it('shows a resolved source thumbnail and opens the resolved file', async () => {
     const record = prompt('prompt-1', 'source prompt');
     record.source = {
@@ -119,10 +134,10 @@ describe('PromptLibrary', () => {
     expect(onViewSource).toHaveBeenCalledWith('D:/synthetic/source.png');
 
     fireEvent.click(screen.getByRole('button', { name: 'Random' }));
-    const dialog = screen.getByRole('dialog', { name: 'Random saved prompt' });
+    const dialog = screen.getByRole('dialog', { name: 'Saved prompt details' });
     fireEvent.click(within(dialog).getByRole('button', { name: 'View Source' }));
     expect(onViewSource).toHaveBeenCalledTimes(2);
-    expect(screen.queryByRole('dialog', { name: 'Random saved prompt' })).toBeNull();
+    expect(screen.queryByRole('dialog', { name: 'Saved prompt details' })).toBeNull();
   });
 
   it('Random opens a modal, avoids immediate repetition, and closes without scrolling the grid', async () => {
@@ -133,13 +148,13 @@ describe('PromptLibrary', () => {
     await screen.findByText('one');
     fireEvent.click(screen.getByRole('button', { name: 'Random' }));
     expect(useSavedPromptStore.getState().selectedPromptId).toBe('prompt-2');
-    expect(screen.getByRole('dialog', { name: 'Random saved prompt' })).toBeTruthy();
+    expect(screen.getByRole('dialog', { name: 'Saved prompt details' })).toBeTruthy();
     expect(screen.getAllByText('two')).toHaveLength(2);
     expect(screen.getByRole('button', { name: 'Another' })).toBeTruthy();
     expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
 
-    fireEvent.mouseDown(screen.getByRole('dialog', { name: 'Random saved prompt' }).parentElement as HTMLElement);
-    expect(screen.queryByRole('dialog', { name: 'Random saved prompt' })).toBeNull();
+    fireEvent.mouseDown(screen.getByRole('dialog', { name: 'Saved prompt details' }).parentElement as HTMLElement);
+    expect(screen.queryByRole('dialog', { name: 'Saved prompt details' })).toBeNull();
     expect(screen.getByText('one')).toBeTruthy();
   });
 
@@ -182,6 +197,10 @@ describe('PromptLibrary', () => {
     serviceMocks.list.mockResolvedValue([prompt('prompt-1', 'one'), prompt('prompt-2', 'two')]);
     render(<PromptLibrary onViewSource={vi.fn()} />);
     await screen.findByText('one');
+    expect(screen.queryByRole('button', { name: 'Remove saved prompt' })).toBeNull();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Prompt actions' })[0]);
+    expect(screen.getByRole('button', { name: 'Remove saved prompt' })).toBeTruthy();
+    fireEvent.mouseDown(document.body);
     expect(screen.queryByRole('button', { name: 'Remove saved prompt' })).toBeNull();
     fireEvent.click(screen.getAllByRole('button', { name: 'Prompt actions' })[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Remove saved prompt' }));

--- a/__tests__/PromptLibrary.test.tsx
+++ b/__tests__/PromptLibrary.test.tsx
@@ -102,6 +102,31 @@ describe('PromptLibrary', () => {
     expect(screen.queryByRole('dialog', { name: 'Saved prompt details' })).toBeNull();
   });
 
+  it('navigates the ordered prompt list with buttons and arrow keys without wrapping', async () => {
+    serviceMocks.list.mockResolvedValue([
+      prompt('prompt-1', 'one'),
+      prompt('prompt-2', 'two'),
+      prompt('prompt-3', 'three'),
+    ]);
+    render(<PromptLibrary onViewSource={vi.fn()} />);
+    const middleCard = (await screen.findByText('two')).closest('article') as HTMLElement;
+
+    fireEvent.click(middleCard);
+    fireEvent.click(screen.getByRole('button', { name: 'Previous' }));
+    expect(screen.getAllByText('three')).toHaveLength(2);
+    expect((screen.getByRole('button', { name: 'Previous' }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(screen.getAllByText('two')).toHaveLength(2);
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(screen.getAllByText('one')).toHaveLength(2);
+    expect((screen.getByRole('button', { name: 'Next' }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    expect(screen.getAllByText('two')).toHaveLength(2);
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
   it('shows a resolved source thumbnail and opens the resolved file', async () => {
     const record = prompt('prompt-1', 'source prompt');
     record.source = {

--- a/__tests__/PromptLibrary.test.tsx
+++ b/__tests__/PromptLibrary.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import PromptLibrary from '../components/PromptLibrary';
 import { useSavedPromptStore } from '../store/useSavedPromptStore';
 import type { SavedPrompt } from '../types';
@@ -25,9 +25,15 @@ vi.mock('../utils/imageUtils', () => ({
   copyTextToClipboard: vi.fn().mockResolvedValue({ success: true }),
 }));
 
-const prompt = (id: string, positivePrompt: string, negativePrompt = ''): SavedPrompt => ({
+const prompt = (
+  id: string,
+  positivePrompt: string,
+  negativePrompt = '',
+  sourceCreatedAt: number | null = null,
+): SavedPrompt => ({
   id,
   createdAt: Number(id.replace(/\D/g, '')) || 1,
+  sourceCreatedAt,
   positivePrompt,
   negativePrompt,
   textBasis: 'effective',
@@ -103,13 +109,23 @@ describe('PromptLibrary', () => {
     Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
     const onViewSource = vi.fn();
 
-    render(<PromptLibrary onViewSource={onViewSource} />);
+    render(
+      <React.StrictMode>
+        <PromptLibrary onViewSource={onViewSource} />
+      </React.StrictMode>,
+    );
     expect((await screen.findByAltText('Current source') as HTMLImageElement).src).toContain('blob:thumbnail');
     fireEvent.click(screen.getByRole('button', { name: 'View Source' }));
     expect(onViewSource).toHaveBeenCalledWith('D:/synthetic/source.png');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Random' }));
+    const dialog = screen.getByRole('dialog', { name: 'Random saved prompt' });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'View Source' }));
+    expect(onViewSource).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('dialog', { name: 'Random saved prompt' })).toBeNull();
   });
 
-  it('Random avoids the currently selected prompt when alternatives exist', async () => {
+  it('Random opens a modal, avoids immediate repetition, and closes without scrolling the grid', async () => {
     const records = [prompt('prompt-1', 'one'), prompt('prompt-2', 'two')];
     serviceMocks.list.mockResolvedValue(records);
     useSavedPromptStore.setState({ selectedPromptId: 'prompt-1' });
@@ -117,9 +133,49 @@ describe('PromptLibrary', () => {
     await screen.findByText('one');
     fireEvent.click(screen.getByRole('button', { name: 'Random' }));
     expect(useSavedPromptStore.getState().selectedPromptId).toBe('prompt-2');
-    expect(screen.getByText('two').closest('article')?.getAttribute('aria-current')).toBe('true');
-    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
-    expect(document.activeElement).toBe(screen.getByText('two').closest('article'));
+    expect(screen.getByRole('dialog', { name: 'Random saved prompt' })).toBeTruthy();
+    expect(screen.getAllByText('two')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'Another' })).toBeTruthy();
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(screen.getByRole('dialog', { name: 'Random saved prompt' }).parentElement as HTMLElement);
+    expect(screen.queryByRole('dialog', { name: 'Random saved prompt' })).toBeNull();
+    expect(screen.getByText('one')).toBeTruthy();
+  });
+
+  it('shows complete positive and negative text in the Random modal and Another changes the result', async () => {
+    const first = prompt('prompt-1', 'first complete prompt', 'first negative');
+    const second = prompt('prompt-2', 'second complete prompt', 'second negative');
+    serviceMocks.list.mockResolvedValue([first, second]);
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    render(<PromptLibrary onViewSource={vi.fn()} />);
+    await screen.findByText('first complete prompt');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Random' }));
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getAllByText('second complete prompt')).toHaveLength(2);
+    expect(screen.getByText('second negative')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Copy' })).toHaveLength(3);
+    fireEvent.click(screen.getByRole('button', { name: 'Another' }));
+    expect(screen.getAllByText('first complete prompt')).toHaveLength(2);
+    expect(screen.getByText('first negative')).toBeTruthy();
+  });
+
+  it('sorts by saved or source-created time in either direction with unknown created dates last', async () => {
+    const savedLater = prompt('prompt-2', 'saved later', '', 100);
+    const createdLater = prompt('prompt-1', 'created later', '', 300);
+    const unknown = prompt('prompt-3', 'unknown created');
+    serviceMocks.list.mockResolvedValue([savedLater, createdLater, unknown]);
+    render(<PromptLibrary onViewSource={vi.fn()} />);
+    await screen.findByText('saved later');
+
+    const cardPrompts = () => screen.getAllByRole('article').map((card) => card.querySelector('p')?.textContent);
+    expect(cardPrompts()).toEqual(['unknown created', 'saved later', 'created later']);
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sort prompts by' }), { target: { value: 'created' } });
+    expect(cardPrompts()).toEqual(['created later', 'saved later', 'unknown created']);
+    fireEvent.click(screen.getByRole('button', { name: 'Sort direction: Newest' }));
+    expect(cardPrompts()).toEqual(['saved later', 'created later', 'unknown created']);
   });
 
   it('keeps removal behind a discreet action menu and requires confirmation', async () => {

--- a/__tests__/PromptLibrary.test.tsx
+++ b/__tests__/PromptLibrary.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import PromptLibrary from '../components/PromptLibrary';
+import { useSavedPromptStore } from '../store/useSavedPromptStore';
+import type { SavedPrompt } from '../types';
+
+const serviceMocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  remove: vi.fn(),
+  save: vi.fn(),
+  subscribe: vi.fn(() => () => undefined),
+  resolve: vi.fn(),
+}));
+
+vi.mock('../services/savedPromptService', () => ({
+  listSavedPrompts: serviceMocks.list,
+  removeSavedPrompt: serviceMocks.remove,
+  savePrompt: serviceMocks.save,
+  subscribeSavedPromptChanges: serviceMocks.subscribe,
+  resolveSavedPromptSource: serviceMocks.resolve,
+}));
+
+vi.mock('../utils/imageUtils', () => ({
+  copyTextToClipboard: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+const prompt = (id: string, positivePrompt: string, negativePrompt = ''): SavedPrompt => ({
+  id,
+  createdAt: Number(id.replace(/\D/g, '')) || 1,
+  positivePrompt,
+  negativePrompt,
+  textBasis: 'effective',
+  source: null,
+});
+
+describe('PromptLibrary', () => {
+  beforeEach(() => {
+    serviceMocks.list.mockReset().mockResolvedValue([]);
+    serviceMocks.remove.mockReset().mockResolvedValue({ id: 'prompt-1', removed: true });
+    serviceMocks.subscribe.mockClear();
+    useSavedPromptStore.setState({ prompts: [], isLoading: false, error: null, selectedPromptId: null });
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => cleanup());
+
+  it('shows an explicit empty state and disables Random', async () => {
+    render(<PromptLibrary onViewSource={vi.fn()} />);
+    expect(await screen.findByText('No saved prompts yet')).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'Random' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows literal positive and expandable negative text with both copy actions', async () => {
+    serviceMocks.list.mockResolvedValue([prompt('prompt-1', '  Positive\nline  ', 'negative')]);
+    render(<PromptLibrary onViewSource={vi.fn()} />);
+    expect((await screen.findByText(/Positive/)).textContent).toContain('Positive\nline');
+    expect(screen.getByText('Negative prompt')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^Copy$/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Copy Negative' })).toBeTruthy();
+  });
+
+  it('Random avoids the currently selected prompt when alternatives exist', async () => {
+    const records = [prompt('prompt-1', 'one'), prompt('prompt-2', 'two')];
+    serviceMocks.list.mockResolvedValue(records);
+    useSavedPromptStore.setState({ selectedPromptId: 'prompt-1' });
+    render(<PromptLibrary onViewSource={vi.fn()} />);
+    await screen.findByText('one');
+    fireEvent.click(screen.getByRole('button', { name: 'Random' }));
+    expect(useSavedPromptStore.getState().selectedPromptId).toBe('prompt-2');
+  });
+
+  it('requires inline confirmation and removes only the selected bookmark', async () => {
+    serviceMocks.list.mockResolvedValue([prompt('prompt-1', 'one'), prompt('prompt-2', 'two')]);
+    render(<PromptLibrary onViewSource={vi.fn()} />);
+    await screen.findByText('one');
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove saved prompt' });
+    fireEvent.click(removeButtons[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    await waitFor(() => expect(serviceMocks.remove).toHaveBeenCalledTimes(1));
+    expect(useSavedPromptStore.getState().prompts).toHaveLength(1);
+  });
+
+  it('does not let an older list response replace a newer one', async () => {
+    let resolveOlder!: (value: SavedPrompt[]) => void;
+    let resolveNewer!: (value: SavedPrompt[]) => void;
+    serviceMocks.list
+      .mockImplementationOnce(() => new Promise<SavedPrompt[]>((resolve) => { resolveOlder = resolve; }))
+      .mockImplementationOnce(() => new Promise<SavedPrompt[]>((resolve) => { resolveNewer = resolve; }));
+    const olderLoad = useSavedPromptStore.getState().load();
+    const newerLoad = useSavedPromptStore.getState().load();
+    resolveNewer([prompt('prompt-2', 'newer')]);
+    await newerLoad;
+    resolveOlder([prompt('prompt-1', 'older')]);
+    await olderLoad;
+    expect(useSavedPromptStore.getState().prompts.map((record) => record.positivePrompt)).toEqual(['newer']);
+  });
+});

--- a/__tests__/PromptLibrary.test.tsx
+++ b/__tests__/PromptLibrary.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, fireEvent, render as renderView, screen, waitFor, within } from '@testing-library/react';
 import PromptLibrary from '../components/PromptLibrary';
 import { useSavedPromptStore } from '../store/useSavedPromptStore';
 import type { SavedPrompt } from '../types';
@@ -39,6 +39,12 @@ const prompt = (
   textBasis: 'effective',
   source: null,
 });
+
+const render = (ui: React.ReactElement) => {
+  // App owns the production bootstrap; preload the store before mounting this isolated view.
+  void useSavedPromptStore.getState().load();
+  return renderView(ui);
+};
 
 describe('PromptLibrary', () => {
   beforeEach(() => {

--- a/__tests__/PromptLibrary.test.tsx
+++ b/__tests__/PromptLibrary.test.tsx
@@ -39,11 +39,16 @@ describe('PromptLibrary', () => {
     serviceMocks.list.mockReset().mockResolvedValue([]);
     serviceMocks.remove.mockReset().mockResolvedValue({ id: 'prompt-1', removed: true });
     serviceMocks.subscribe.mockClear();
+    serviceMocks.resolve.mockReset();
     useSavedPromptStore.setState({ prompts: [], isLoading: false, error: null, selectedPromptId: null });
     Element.prototype.scrollIntoView = vi.fn();
+    Object.defineProperty(window, 'electronAPI', { value: undefined, configurable: true, writable: true });
   });
 
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    Object.defineProperty(window, 'electronAPI', { value: undefined, configurable: true, writable: true });
+  });
 
   it('shows an explicit empty state and disables Random', async () => {
     render(<PromptLibrary onViewSource={vi.fn()} />);
@@ -51,13 +56,57 @@ describe('PromptLibrary', () => {
     expect((screen.getByRole('button', { name: 'Random' }) as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it('shows literal positive and expandable negative text with both copy actions', async () => {
+  it('shows a compact prompt and reveals the full negative prompt on expansion', async () => {
     serviceMocks.list.mockResolvedValue([prompt('prompt-1', '  Positive\nline  ', 'negative')]);
     render(<PromptLibrary onViewSource={vi.fn()} />);
     expect((await screen.findByText(/Positive/)).textContent).toContain('Positive\nline');
-    expect(screen.getByText('Negative prompt')).toBeTruthy();
     expect(screen.getByRole('button', { name: /^Copy$/ })).toBeTruthy();
+    expect(screen.queryByText('Negative prompt')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+    expect(screen.getByText('Negative prompt')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy Negative' })).toBeTruthy();
+  });
+
+  it('filters live and case-insensitively across positive and negative prompt text', async () => {
+    serviceMocks.list.mockResolvedValue([
+      prompt('prompt-1', 'Golden landscape', 'rain'),
+      prompt('prompt-2', 'Studio portrait', 'NOISY background'),
+    ]);
+    render(<PromptLibrary onViewSource={vi.fn()} />);
+    await screen.findByText('Golden landscape');
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search saved prompts' }), { target: { value: 'noisy' } });
+    expect(screen.queryByText('Golden landscape')).toBeNull();
+    expect(screen.getByText('Studio portrait')).toBeTruthy();
+    expect(screen.getByText('1 of 2')).toBeTruthy();
+  });
+
+  it('shows a resolved source thumbnail and opens the resolved file', async () => {
+    const record = prompt('prompt-1', 'source prompt');
+    record.source = {
+      kind: 'path',
+      pathAtSave: { directoryPath: 'D:/synthetic', relativePath: 'source.png', fileSize: 3, contentModifiedMs: 4 },
+    };
+    serviceMocks.list.mockResolvedValue([record]);
+    serviceMocks.resolve.mockResolvedValue({ status: 'available', absolutePath: 'D:/synthetic/source.png', sourceChanged: false });
+    const generateThumbnailFromPath = vi.fn().mockResolvedValue({
+      success: true,
+      data: new Uint8Array([1, 2, 3]),
+      mimeType: 'image/webp',
+    });
+    Object.defineProperty(window, 'electronAPI', {
+      value: { generateThumbnailFromPath },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(URL, 'createObjectURL', { value: vi.fn(() => 'blob:thumbnail'), configurable: true });
+    Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
+    const onViewSource = vi.fn();
+
+    render(<PromptLibrary onViewSource={onViewSource} />);
+    expect((await screen.findByAltText('Current source') as HTMLImageElement).src).toContain('blob:thumbnail');
+    fireEvent.click(screen.getByRole('button', { name: 'View Source' }));
+    expect(onViewSource).toHaveBeenCalledWith('D:/synthetic/source.png');
   });
 
   it('Random avoids the currently selected prompt when alternatives exist', async () => {
@@ -68,14 +117,18 @@ describe('PromptLibrary', () => {
     await screen.findByText('one');
     fireEvent.click(screen.getByRole('button', { name: 'Random' }));
     expect(useSavedPromptStore.getState().selectedPromptId).toBe('prompt-2');
+    expect(screen.getByText('two').closest('article')?.getAttribute('aria-current')).toBe('true');
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByText('two').closest('article'));
   });
 
-  it('requires inline confirmation and removes only the selected bookmark', async () => {
+  it('keeps removal behind a discreet action menu and requires confirmation', async () => {
     serviceMocks.list.mockResolvedValue([prompt('prompt-1', 'one'), prompt('prompt-2', 'two')]);
     render(<PromptLibrary onViewSource={vi.fn()} />);
     await screen.findByText('one');
-    const removeButtons = screen.getAllByRole('button', { name: 'Remove saved prompt' });
-    fireEvent.click(removeButtons[0]);
+    expect(screen.queryByRole('button', { name: 'Remove saved prompt' })).toBeNull();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Prompt actions' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove saved prompt' }));
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
     await waitFor(() => expect(serviceMocks.remove).toHaveBeenCalledTimes(1));
     expect(useSavedPromptStore.getState().prompts).toHaveLength(1);

--- a/__tests__/cacheReset.savedPrompts.test.ts
+++ b/__tests__/cacheReset.savedPrompts.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resetAllCaches } from '../utils/cacheReset';
+import { SAVED_PROMPTS_DATABASE_NAME } from '../services/savedPromptStorage';
+
+describe('resetAllCaches saved prompts preservation', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not delete the dedicated browser prompt database', async () => {
+    vi.useFakeTimers();
+    const deleted: string[] = [];
+    const deleteDatabase = vi.fn((name: string) => {
+      deleted.push(name);
+      const request: Record<string, unknown> = {};
+      queueMicrotask(() => (request.onsuccess as (() => void) | undefined)?.());
+      return request;
+    });
+    vi.stubGlobal('indexedDB', {
+      databases: vi.fn().mockResolvedValue([
+        { name: 'image-metahub-preferences' },
+        { name: SAVED_PROMPTS_DATABASE_NAME },
+      ]),
+      deleteDatabase,
+    });
+    Object.defineProperty(window, 'electronAPI', { configurable: true, value: undefined });
+
+    await resetAllCaches();
+
+    expect(deleted).toEqual(['image-metahub-preferences']);
+    expect(deleted).not.toContain(SAVED_PROMPTS_DATABASE_NAME);
+  });
+});

--- a/__tests__/helpers/fakeIndexedDb.ts
+++ b/__tests__/helpers/fakeIndexedDb.ts
@@ -171,8 +171,17 @@ function createObjectStore(
     },
     index,
     get: (key: IDBValidKey | IDBKeyRange) => request(() => store.records.get(String(key))),
+    getKey: (key: IDBValidKey | IDBKeyRange) => request(() => (
+      store.records.has(String(key)) ? String(key) : undefined
+    )),
     getAll: () => request(() => [...store.records.values()]),
     getAllKeys: () => request(() => [...store.records.keys()]),
+    add: (value: unknown) => request(() => {
+      const key = String((value as Record<string, unknown>)[store.keyPath]);
+      if (store.records.has(key)) throw new DOMException(`Key ${key} already exists.`, 'ConstraintError');
+      store.records.set(key, cloneValue(value));
+      return key;
+    }),
     put: (value: unknown) => request(() => {
       const key = String((value as Record<string, unknown>)[store.keyPath]);
       store.records.set(key, cloneValue(value));

--- a/__tests__/savedPromptRepository.test.ts
+++ b/__tests__/savedPromptRepository.test.ts
@@ -1,0 +1,179 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AssetProvenanceRepository, PROVENANCE_SCHEMA_VERSION } from '../electron/provenanceRepository.mjs';
+import { SavedPromptRepository } from '../electron/savedPromptRepository.mjs';
+
+const temporaryDirectories: string[] = [];
+const makeTempDirectory = () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'imh-prompts-'));
+  temporaryDirectories.push(directory);
+  return directory;
+};
+
+const uuid = (suffix: number) => `00000000-0000-4000-8000-${String(suffix).padStart(12, '0')}`;
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('saved prompt repository', () => {
+  it('migrates to v6 and preserves literal prompts across reopen and idempotent removal', () => {
+    const directory = makeTempDirectory();
+    const databasePath = path.join(directory, 'catalog.sqlite');
+    const repository = new AssetProvenanceRepository({ databasePath, randomUUID: () => uuid(1) });
+    expect(repository.open().schemaVersion).toBe(PROVENANCE_SCHEMA_VERSION);
+
+    const result = repository.savePrompt({
+      positivePrompt: '  Literal\nPrompt  ',
+      negativePrompt: '',
+      textBasis: 'effective',
+      source: null,
+    });
+    expect(result).toMatchObject({ status: 'saved', prompt: { positivePrompt: '  Literal\nPrompt  ', negativePrompt: '' } });
+    repository.close();
+
+    const reopened = new AssetProvenanceRepository({ databasePath });
+    reopened.open();
+    expect(reopened.listSavedPrompts()).toEqual([result.prompt]);
+    expect(reopened.removeSavedPrompt(result.prompt.id)).toEqual({ id: result.prompt.id, removed: true });
+    expect(reopened.removeSavedPrompt(result.prompt.id)).toEqual({ id: result.prompt.id, removed: false });
+    reopened.close();
+  });
+
+  it('deduplicates only exact pairs and remains correct under digest collisions', () => {
+    const directory = makeTempDirectory();
+    const owner = new AssetProvenanceRepository({ databasePath: path.join(directory, 'catalog.sqlite') });
+    owner.open();
+    let nextId = 10;
+    const prompts = new SavedPromptRepository({
+      database: owner.database,
+      digest: () => 'collision',
+      randomUUID: () => uuid(nextId++),
+      now: () => nextId,
+    });
+    const first = prompts.save({ positivePrompt: 'Cat', negativePrompt: 'bad', textBasis: 'effective', source: null });
+    const differentCase = prompts.save({ positivePrompt: 'cat', negativePrompt: 'bad', textBasis: 'effective', source: null });
+    const differentWhitespace = prompts.save({ positivePrompt: 'Cat ', negativePrompt: 'bad', textBasis: 'effective', source: null });
+    const duplicate = prompts.save({ positivePrompt: 'Cat', negativePrompt: 'bad', textBasis: 'original', source: null });
+    expect([first.status, differentCase.status, differentWhitespace.status, duplicate.status]).toEqual([
+      'saved', 'saved', 'saved', 'already-saved',
+    ]);
+    expect(duplicate.prompt).toEqual(first.prompt);
+    expect(prompts.list()).toHaveLength(3);
+    owner.close();
+  });
+
+  it('keeps the first historical origin after a duplicate save from another image', () => {
+    const directory = makeTempDirectory();
+    const repository = new AssetProvenanceRepository({ databasePath: path.join(directory, 'catalog.sqlite') });
+    repository.open();
+    const sourceA = { kind: 'path' as const, pathAtSave: { directoryPath: directory, relativePath: 'a.png', fileSize: 1, contentModifiedMs: 2 } };
+    const sourceB = { kind: 'path' as const, pathAtSave: { directoryPath: directory, relativePath: 'b.png', fileSize: 3, contentModifiedMs: 4 } };
+    const first = repository.savePrompt({ positivePrompt: 'same', negativePrompt: '', textBasis: 'effective', source: sourceA });
+    const duplicate = repository.savePrompt({ positivePrompt: 'same', negativePrompt: '', textBasis: 'effective', source: sourceB });
+    expect(duplicate.status).toBe('already-saved');
+    expect(duplicate.prompt.id).toBe(first.prompt.id);
+    expect(duplicate.prompt.source).toEqual(sourceA);
+    repository.close();
+  });
+
+  it('validates stable references, follows known moves, and reports overwrite changes', () => {
+    const directory = makeTempDirectory();
+    const originalPath = path.join(directory, 'source.png');
+    fs.writeFileSync(originalPath, 'one');
+    const stat = fs.statSync(originalPath);
+    const repository = new AssetProvenanceRepository({ databasePath: path.join(directory, 'catalog.sqlite') });
+    repository.open();
+    const rootId = uuid(21);
+    const assetId = uuid(22);
+    const revisionId = uuid(23);
+    const locationId = uuid(24);
+    repository.ensureLibraryRoot({ rootId, absolutePath: directory, pathKey: directory.toLowerCase() });
+    repository.createAssetWithRevisionAndLocation({
+      assetId, revisionId, locationId, rootId, relativePath: 'source.png', relativePathKey: 'source.png',
+      byteSize: stat.size, contentModifiedMs: stat.mtimeMs,
+    });
+    const saved = repository.savePrompt({
+      positivePrompt: 'stable', negativePrompt: '', textBasis: 'effective',
+      source: {
+        kind: 'stable',
+        reference: { assetId, revisionId, locationId, rootId },
+        pathAtSave: { directoryPath: directory, relativePath: 'source.png', fileSize: stat.size, contentModifiedMs: stat.mtimeMs },
+      },
+    });
+    expect(repository.resolveSavedPromptSource(saved.prompt.id)).toMatchObject({ status: 'available', absolutePath: originalPath, sourceChanged: false });
+
+    const movedPath = path.join(directory, 'moved.png');
+    fs.renameSync(originalPath, movedPath);
+    repository.relocateLocation(locationId, { rootId, relativePath: 'moved.png', relativePathKey: 'moved.png' });
+    expect(repository.resolveSavedPromptSource(saved.prompt.id)).toMatchObject({ status: 'available', absolutePath: movedPath, sourceChanged: false });
+
+    fs.writeFileSync(movedPath, 'two-two');
+    repository.addRevision(assetId, { revisionId: uuid(25), locationId, byteSize: 7, contentModifiedMs: fs.statSync(movedPath).mtimeMs });
+    expect(repository.resolveSavedPromptSource(saved.prompt.id)).toMatchObject({ status: 'available', absolutePath: movedPath, sourceChanged: true });
+
+    const invalidCombination = repository.savePrompt({
+      positivePrompt: 'stale reference combination', negativePrompt: '', textBasis: 'effective',
+      source: {
+        kind: 'stable',
+        reference: { assetId, revisionId, locationId, rootId },
+        pathAtSave: { directoryPath: directory, relativePath: 'moved.png', fileSize: 7, contentModifiedMs: fs.statSync(movedPath).mtimeMs },
+      },
+    });
+    expect(invalidCombination.prompt.source).toMatchObject({ kind: 'path' });
+    repository.close();
+  });
+
+  it('downgrades an unconfirmed stable reference to a valid path and never inserts on failure', () => {
+    const directory = makeTempDirectory();
+    const repository = new AssetProvenanceRepository({ databasePath: path.join(directory, 'catalog.sqlite') });
+    repository.open();
+    const result = repository.savePrompt({
+      positivePrompt: 'path fallback', negativePrompt: '', textBasis: 'effective',
+      source: {
+        kind: 'stable',
+        reference: { assetId: uuid(31), revisionId: uuid(32), locationId: uuid(33), rootId: uuid(34) },
+        pathAtSave: { directoryPath: directory, relativePath: 'source.png', fileSize: null, contentModifiedMs: null },
+      },
+    });
+    expect(result.prompt.source).toEqual({
+      kind: 'path',
+      pathAtSave: { directoryPath: directory, relativePath: 'source.png', fileSize: null, contentModifiedMs: null },
+    });
+
+    repository.database.exec("CREATE TRIGGER reject_prompt BEFORE INSERT ON saved_prompts BEGIN SELECT RAISE(ABORT, 'commit failed'); END;");
+    expect(() => repository.savePrompt({ positivePrompt: 'will fail', negativePrompt: '', textBasis: 'effective', source: null })).toThrow('commit failed');
+    expect(repository.listSavedPrompts().map((prompt) => prompt.positivePrompt)).toEqual(['path fallback']);
+    repository.close();
+  });
+
+  it('serializes duplicate saves and includes prompts in verified catalog backups', async () => {
+    const directory = makeTempDirectory();
+    const databasePath = path.join(directory, 'catalog.sqlite');
+    let nextId = 40;
+    const repository = new AssetProvenanceRepository({
+      databasePath,
+      randomUUID: () => uuid(nextId++),
+    });
+    repository.open();
+    const input = { positivePrompt: 'concurrent', negativePrompt: 'pair', textBasis: 'effective' as const, source: null };
+    const results = await Promise.all([
+      Promise.resolve().then(() => repository.savePrompt(input)),
+      Promise.resolve().then(() => repository.savePrompt(input)),
+    ]);
+    expect(results.map((result) => result.status).sort()).toEqual(['already-saved', 'saved']);
+    expect(new Set(results.map((result) => result.prompt.id)).size).toBe(1);
+
+    const backupPath = path.join(directory, 'backup.sqlite');
+    repository.createBackup(backupPath);
+    repository.close();
+    const backup = new AssetProvenanceRepository({ databasePath: backupPath, readOnly: true });
+    backup.open();
+    expect(backup.listSavedPrompts()).toEqual([results[0].prompt]);
+    backup.close();
+  });
+});

--- a/__tests__/savedPromptRepository.test.ts
+++ b/__tests__/savedPromptRepository.test.ts
@@ -181,6 +181,34 @@ describe('saved prompt repository', () => {
     repository.close();
   });
 
+  it('accepts in-root names beginning with two dots while rejecting an actual parent traversal', () => {
+    const directory = makeTempDirectory();
+    const repository = new AssetProvenanceRepository({ databasePath: path.join(directory, 'catalog.sqlite') });
+    repository.open();
+    const inRootPath = path.join('..drafts', 'image.png');
+    const accepted = repository.savePrompt({
+      positivePrompt: 'in-root dotted folder', negativePrompt: '', textBasis: 'effective',
+      source: {
+        kind: 'path',
+        pathAtSave: { directoryPath: directory, relativePath: inRootPath, fileSize: null, contentModifiedMs: null },
+      },
+    });
+    expect(accepted.prompt.source).toEqual({
+      kind: 'path',
+      pathAtSave: { directoryPath: directory, relativePath: inRootPath, fileSize: null, contentModifiedMs: null },
+    });
+
+    const rejected = repository.savePrompt({
+      positivePrompt: 'actual parent traversal', negativePrompt: '', textBasis: 'effective',
+      source: {
+        kind: 'path',
+        pathAtSave: { directoryPath: directory, relativePath: path.join('..', 'outside.png'), fileSize: null, contentModifiedMs: null },
+      },
+    });
+    expect(rejected.prompt.source).toBeNull();
+    repository.close();
+  });
+
   it('serializes duplicate saves and includes prompts in verified catalog backups', async () => {
     const directory = makeTempDirectory();
     const databasePath = path.join(directory, 'catalog.sqlite');

--- a/__tests__/savedPromptRepository.test.ts
+++ b/__tests__/savedPromptRepository.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 });
 
 describe('saved prompt repository', () => {
-  it('migrates to v6 and preserves literal prompts across reopen and idempotent removal', () => {
+  it('migrates to the current schema and preserves literal prompts across reopen and idempotent removal', () => {
     const directory = makeTempDirectory();
     const databasePath = path.join(directory, 'catalog.sqlite');
     const repository = new AssetProvenanceRepository({ databasePath, randomUUID: () => uuid(1) });
@@ -32,8 +32,12 @@ describe('saved prompt repository', () => {
       negativePrompt: '',
       textBasis: 'effective',
       source: null,
+      sourceCreatedAt: 1_700_000_000_000,
     });
-    expect(result).toMatchObject({ status: 'saved', prompt: { positivePrompt: '  Literal\nPrompt  ', negativePrompt: '' } });
+    expect(result).toMatchObject({
+      status: 'saved',
+      prompt: { positivePrompt: '  Literal\nPrompt  ', negativePrompt: '', sourceCreatedAt: 1_700_000_000_000 },
+    });
     repository.close();
 
     const reopened = new AssetProvenanceRepository({ databasePath });
@@ -42,6 +46,27 @@ describe('saved prompt repository', () => {
     expect(reopened.removeSavedPrompt(result.prompt.id)).toEqual({ id: result.prompt.id, removed: true });
     expect(reopened.removeSavedPrompt(result.prompt.id)).toEqual({ id: result.prompt.id, removed: false });
     reopened.close();
+  });
+
+  it('migrates v6 bookmarks without inventing an image creation timestamp', () => {
+    const directory = makeTempDirectory();
+    const databasePath = path.join(directory, 'catalog.sqlite');
+    let repository = new AssetProvenanceRepository({ databasePath });
+    repository.open({ targetSchemaVersion: 6 });
+    repository.database.prepare(`
+      INSERT INTO saved_prompts (
+        id, created_at, positive_prompt, negative_prompt, text_basis, source_json, prompt_digest
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(uuid(2), 100, 'legacy prompt', '', 'effective', null, 'legacy-digest');
+    repository.close();
+
+    repository = new AssetProvenanceRepository({ databasePath });
+    expect(repository.open().schemaVersion).toBe(PROVENANCE_SCHEMA_VERSION);
+    expect(repository.listSavedPrompts()).toEqual([expect.objectContaining({
+      id: uuid(2),
+      sourceCreatedAt: null,
+    })]);
+    repository.close();
   });
 
   it('deduplicates only exact pairs and remains correct under digest collisions', () => {
@@ -73,11 +98,16 @@ describe('saved prompt repository', () => {
     repository.open();
     const sourceA = { kind: 'path' as const, pathAtSave: { directoryPath: directory, relativePath: 'a.png', fileSize: 1, contentModifiedMs: 2 } };
     const sourceB = { kind: 'path' as const, pathAtSave: { directoryPath: directory, relativePath: 'b.png', fileSize: 3, contentModifiedMs: 4 } };
-    const first = repository.savePrompt({ positivePrompt: 'same', negativePrompt: '', textBasis: 'effective', source: sourceA });
-    const duplicate = repository.savePrompt({ positivePrompt: 'same', negativePrompt: '', textBasis: 'effective', source: sourceB });
+    const first = repository.savePrompt({
+      positivePrompt: 'same', negativePrompt: '', textBasis: 'effective', source: sourceA, sourceCreatedAt: 100,
+    });
+    const duplicate = repository.savePrompt({
+      positivePrompt: 'same', negativePrompt: '', textBasis: 'effective', source: sourceB, sourceCreatedAt: 200,
+    });
     expect(duplicate.status).toBe('already-saved');
     expect(duplicate.prompt.id).toBe(first.prompt.id);
     expect(duplicate.prompt.source).toEqual(sourceA);
+    expect(duplicate.prompt.sourceCreatedAt).toBe(100);
     repository.close();
   });
 

--- a/__tests__/savedPromptService.test.ts
+++ b/__tests__/savedPromptService.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(window, 'electronAPI', { value: undefined, configurable: true, writable: true });
+});
+
+describe('saved prompt service environment selection', () => {
+  it('does not fall back to IndexedDB when the desktop API is unavailable', async () => {
+    Object.defineProperty(window, 'electronAPI', { value: {}, configurable: true, writable: true });
+    const open = vi.spyOn(indexedDB, 'open');
+    const service = await import('../services/savedPromptService');
+    const input = { positivePrompt: 'desktop', negativePrompt: '', textBasis: 'effective' as const, source: null };
+
+    await expect(service.listSavedPrompts()).rejects.toThrow('desktop storage is unavailable');
+    await expect(service.savePrompt(input)).rejects.toThrow('desktop storage is unavailable');
+    await expect(service.removeSavedPrompt(crypto.randomUUID())).rejects.toThrow('desktop storage is unavailable');
+    await expect(service.resolveSavedPromptSource(crypto.randomUUID())).rejects.toThrow('desktop storage is unavailable');
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a desktop IPC failure without opening browser storage', async () => {
+    Object.defineProperty(window, 'electronAPI', {
+      value: {
+        savedPromptsList: vi.fn().mockResolvedValue({ success: false, error: 'catalog unavailable' }),
+      },
+      configurable: true,
+      writable: true,
+    });
+    const open = vi.spyOn(indexedDB, 'open');
+    const service = await import('../services/savedPromptService');
+
+    await expect(service.listSavedPrompts()).rejects.toThrow('catalog unavailable');
+    expect(open).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/savedPromptStorage.test.ts
+++ b/__tests__/savedPromptStorage.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { installFakeIndexedDb } from './helpers/fakeIndexedDb';
+
+describe('browser saved prompt storage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    installFakeIndexedDb();
+  });
+
+  it('preserves literal text, stores no durable browser source, and removes idempotently', async () => {
+    const storage = await import('../services/savedPromptStorage');
+    const input = {
+      positivePrompt: '  Literal\nPrompt  ',
+      negativePrompt: '',
+      textBasis: 'original' as const,
+      source: {
+        kind: 'path' as const,
+        pathAtSave: {
+          directoryPath: 'D:/synthetic',
+          relativePath: 'image.png',
+          fileSize: 12,
+          contentModifiedMs: 34,
+        },
+      },
+    };
+
+    const saved = await storage.saveBrowserPrompt(input);
+    expect(saved).toMatchObject({
+      status: 'saved',
+      prompt: {
+        positivePrompt: input.positivePrompt,
+        negativePrompt: '',
+        textBasis: 'original',
+        source: null,
+      },
+    });
+    await expect(storage.listBrowserSavedPrompts()).resolves.toEqual([saved.prompt]);
+    await expect(storage.removeBrowserSavedPrompt(saved.prompt.id)).resolves.toEqual({ id: saved.prompt.id, removed: true });
+    await expect(storage.removeBrowserSavedPrompt(saved.prompt.id)).resolves.toEqual({ id: saved.prompt.id, removed: false });
+  });
+
+  it('serializes concurrent exact saves while keeping distinct whitespace', async () => {
+    const storage = await import('../services/savedPromptStorage');
+    const input = { positivePrompt: 'same', negativePrompt: 'pair', textBasis: 'effective' as const, source: null };
+    const results = await Promise.all([
+      storage.saveBrowserPrompt(input),
+      storage.saveBrowserPrompt(input),
+    ]);
+    expect(results.map((result) => result.status).sort()).toEqual(['already-saved', 'saved']);
+    expect(new Set(results.map((result) => result.prompt.id)).size).toBe(1);
+
+    const whitespace = await storage.saveBrowserPrompt({ ...input, positivePrompt: 'same ' });
+    expect(whitespace.status).toBe('saved');
+    await expect(storage.listBrowserSavedPrompts()).resolves.toHaveLength(2);
+  });
+});

--- a/__tests__/savedPromptStorage.test.ts
+++ b/__tests__/savedPromptStorage.test.ts
@@ -13,6 +13,7 @@ describe('browser saved prompt storage', () => {
       positivePrompt: '  Literal\nPrompt  ',
       negativePrompt: '',
       textBasis: 'original' as const,
+      sourceCreatedAt: 1_700_000_000_000,
       source: {
         kind: 'path' as const,
         pathAtSave: {
@@ -31,6 +32,7 @@ describe('browser saved prompt storage', () => {
         positivePrompt: input.positivePrompt,
         negativePrompt: '',
         textBasis: 'original',
+        sourceCreatedAt: 1_700_000_000_000,
         source: null,
       },
     });
@@ -41,13 +43,16 @@ describe('browser saved prompt storage', () => {
 
   it('serializes concurrent exact saves while keeping distinct whitespace', async () => {
     const storage = await import('../services/savedPromptStorage');
-    const input = { positivePrompt: 'same', negativePrompt: 'pair', textBasis: 'effective' as const, source: null };
+    const input = {
+      positivePrompt: 'same', negativePrompt: 'pair', textBasis: 'effective' as const, source: null, sourceCreatedAt: 100,
+    };
     const results = await Promise.all([
       storage.saveBrowserPrompt(input),
       storage.saveBrowserPrompt(input),
     ]);
     expect(results.map((result) => result.status).sort()).toEqual(['already-saved', 'saved']);
     expect(new Set(results.map((result) => result.prompt.id)).size).toBe(1);
+    expect(results.every((result) => result.prompt.sourceCreatedAt === 100)).toBe(true);
 
     const whitespace = await storage.saveBrowserPrompt({ ...input, positivePrompt: 'same ' });
     expect(whitespace.status).toBe('saved');

--- a/__tests__/savedPromptStore.test.ts
+++ b/__tests__/savedPromptStore.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import { initializeSavedPromptSynchronization, useSavedPromptStore } from '../store/useSavedPromptStore';
+
+const serviceMocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  subscribe: vi.fn(),
+}));
+
+vi.mock('../services/savedPromptService', () => ({
+  listSavedPrompts: serviceMocks.list,
+  removeSavedPrompt: vi.fn(),
+  savePrompt: vi.fn(),
+  subscribeSavedPromptChanges: serviceMocks.subscribe,
+}));
+
+describe('saved prompt store bootstrap', () => {
+  afterEach(() => {
+    useSavedPromptStore.setState({ prompts: [], isLoading: false, error: null, selectedPromptId: null });
+    vi.restoreAllMocks();
+  });
+
+  it('loads persisted prompts and owns the change subscription independently of Prompt Library', async () => {
+    const unsubscribe = vi.fn();
+    serviceMocks.subscribe.mockReturnValue(unsubscribe);
+    serviceMocks.list.mockResolvedValue([{
+      id: '00000000-0000-4000-8000-000000000001',
+      createdAt: 10,
+      sourceCreatedAt: null,
+      positivePrompt: 'persisted prompt',
+      negativePrompt: '',
+      textBasis: 'effective',
+      source: null,
+    }]);
+
+    const stop = initializeSavedPromptSynchronization();
+    await waitFor(() => expect(useSavedPromptStore.getState().prompts).toEqual([
+      expect.objectContaining({ positivePrompt: 'persisted prompt' }),
+    ]));
+    expect(serviceMocks.subscribe).toHaveBeenCalledTimes(1);
+
+    stop();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/stableIdentityFileOperations.test.ts
+++ b/__tests__/stableIdentityFileOperations.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import { afterEach, describe, expect, it } from 'vitest';
-import { ProvenanceRepositoryLifecycle, resolveProvenanceCatalogPath } from '../electron/provenanceRepository.mjs';
+import { PROVENANCE_SCHEMA_VERSION, ProvenanceRepositoryLifecycle, resolveProvenanceCatalogPath } from '../electron/provenanceRepository.mjs';
 import { StableIdentityIndexer } from '../electron/stableIdentityIndexer.mjs';
 import { StableIdentityFileOperationCoordinator } from '../electron/stableIdentityFileOperationCoordinator.mjs';
 import { runStableIdentityFileOperationsSmoke } from '../electron/stableIdentityFileOperationsSmoke.mjs';
@@ -1903,7 +1903,7 @@ describe('stable identity file-operation coordination', () => {
     const lifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
     lifecycle.initialize();
     expect(resolveProvenanceCatalogPath(userDataPath)).toContain(path.join('provenance', 'catalog.sqlite'));
-    expect(lifecycle.run((repository) => repository.getStatus().schemaVersion)).toBe(5);
+    expect(lifecycle.run((repository) => repository.getStatus().schemaVersion)).toBe(PROVENANCE_SCHEMA_VERSION);
     lifecycle.close();
   });
 
@@ -1926,7 +1926,7 @@ describe('stable identity file-operation coordination', () => {
       indexer,
       coordinator,
     });
-    expect(result).toMatchObject({ success: true, schemaVersion: 5, pendingOperations: 0 });
+    expect(result).toMatchObject({ success: true, schemaVersion: PROVENANCE_SCHEMA_VERSION, pendingOperations: 0 });
     indexer.stop();
     lifecycle.close();
   });

--- a/__tests__/useSavePrompt.test.ts
+++ b/__tests__/useSavePrompt.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { IndexedImage, ShadowMetadata } from '../types';
+import { buildSavedPromptSource, composeSavedPromptInput } from '../hooks/useSavePrompt';
+
+const image = (overrides: Partial<IndexedImage> = {}): IndexedImage => ({
+  id: 'directory::nested/image.png',
+  name: 'image.png',
+  handle: {} as FileSystemFileHandle,
+  metadata: { normalizedMetadata: { prompt: 'original positive', negativePrompt: 'original negative' } } as IndexedImage['metadata'],
+  metadataString: '',
+  lastModified: 10,
+  contentModifiedMs: 9,
+  fileSize: 8,
+  models: [],
+  loras: [],
+  scheduler: '',
+  directoryId: 'directory',
+  ...overrides,
+});
+
+describe('saved prompt composition', () => {
+  afterEach(() => { delete window.electronAPI; });
+
+  it('captures effective shadow text literally and defaults a missing negative to empty', () => {
+    const shadow = { imageId: 'directory::nested/image.png', prompt: '  shadow\npositive  ', negativePrompt: '', updatedAt: 1 } as ShadowMetadata;
+    expect(composeSavedPromptInput(image(), shadow, null, false)).toEqual({
+      positivePrompt: '  shadow\npositive  ',
+      negativePrompt: '',
+      textBasis: 'effective',
+      source: null,
+    });
+  });
+
+  it('captures the displayed original instead of shadow metadata', () => {
+    const shadow = { imageId: 'directory::nested/image.png', prompt: 'edited', updatedAt: 1 } as ShadowMetadata;
+    expect(composeSavedPromptInput(image(), shadow, null, true)).toMatchObject({
+      positivePrompt: 'original positive',
+      negativePrompt: 'original negative',
+      textBasis: 'original',
+    });
+  });
+
+  it('uses trim only to reject an empty positive prompt', () => {
+    const target = image({ metadata: { normalizedMetadata: { prompt: ' \n ', negativePrompt: 'kept' } } as IndexedImage['metadata'] });
+    expect(() => composeSavedPromptInput(target, null)).toThrow('no positive prompt');
+  });
+
+  it('creates stable source only with the complete identity set and otherwise uses path', () => {
+    window.electronAPI = {} as never;
+    const base = image();
+    expect(buildSavedPromptSource(base, 'D:\\Library')).toMatchObject({ kind: 'path' });
+    expect(buildSavedPromptSource(image({
+      assetId: 'asset', revisionId: 'revision', provenanceLocationId: 'location', provenanceRootId: 'root',
+    }), 'D:\\Library')).toEqual({
+      kind: 'stable',
+      reference: { assetId: 'asset', revisionId: 'revision', locationId: 'location', rootId: 'root' },
+      pathAtSave: {
+        directoryPath: 'D:\\Library', relativePath: 'nested/image.png', fileSize: 8, contentModifiedMs: 9,
+      },
+    });
+  });
+});

--- a/__tests__/useSavePrompt.test.ts
+++ b/__tests__/useSavePrompt.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import type { IndexedImage, ShadowMetadata } from '../types';
-import { buildSavedPromptSource, composeSavedPromptInput } from '../hooks/useSavePrompt';
+import { buildSavedPromptSource, composeSavedPromptInput, useIsPromptSaved } from '../hooks/useSavePrompt';
+import { useSavedPromptStore } from '../store/useSavedPromptStore';
 
 const image = (overrides: Partial<IndexedImage> = {}): IndexedImage => ({
   id: 'directory::nested/image.png',
@@ -19,7 +21,10 @@ const image = (overrides: Partial<IndexedImage> = {}): IndexedImage => ({
 });
 
 describe('saved prompt composition', () => {
-  afterEach(() => { delete window.electronAPI; });
+  afterEach(() => {
+    delete window.electronAPI;
+    useSavedPromptStore.setState({ prompts: [] });
+  });
 
   it('captures effective shadow text literally and defaults a missing negative to empty', () => {
     const shadow = { imageId: 'directory::nested/image.png', prompt: '  shadow\npositive  ', negativePrompt: '', updatedAt: 1 } as ShadowMetadata;
@@ -64,5 +69,27 @@ describe('saved prompt composition', () => {
         directoryPath: 'D:\\Library', relativePath: 'nested/image.png', fileSize: 8, contentModifiedMs: 9,
       },
     });
+  });
+
+  it('reports a saved state only for the exact positive and negative prompt pair', () => {
+    useSavedPromptStore.setState({
+      prompts: [{
+        id: 'saved-prompt',
+        createdAt: 1,
+        sourceCreatedAt: null,
+        positivePrompt: '  exact prompt  ',
+        negativePrompt: 'exact negative',
+        textBasis: 'effective',
+        source: null,
+      }],
+    });
+
+    const { result, rerender } = renderHook(
+      ({ positive, negative }) => useIsPromptSaved(positive, negative),
+      { initialProps: { positive: '  exact prompt  ', negative: 'exact negative' } },
+    );
+    expect(result.current).toBe(true);
+    rerender({ positive: 'exact prompt', negative: 'exact negative' });
+    expect(result.current).toBe(false);
   });
 });

--- a/__tests__/useSavePrompt.test.ts
+++ b/__tests__/useSavePrompt.test.ts
@@ -28,6 +28,7 @@ describe('saved prompt composition', () => {
       negativePrompt: '',
       textBasis: 'effective',
       source: null,
+      sourceCreatedAt: 10,
     });
   });
 
@@ -37,7 +38,12 @@ describe('saved prompt composition', () => {
       positivePrompt: 'original positive',
       negativePrompt: 'original negative',
       textBasis: 'original',
+      sourceCreatedAt: 10,
     });
+  });
+
+  it('stores no source creation timestamp when the image date is invalid', () => {
+    expect(composeSavedPromptInput(image({ lastModified: 0 }), null)).toMatchObject({ sourceCreatedAt: null });
   });
 
   it('uses trim only to reject an empty positive prompt', () => {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Settings, Bug, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft, Workflow, Image as ImageIcon, Compass } from 'lucide-react';
+import { Settings, Bug, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft, Workflow, Image as ImageIcon, Compass, Library } from 'lucide-react';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
@@ -12,7 +12,7 @@ import type { ExploreDimension } from '../types';
 import { useLicenseStore } from '../store/useLicenseStore';
 import { formatLicenseValidity } from '../utils/licenseDisplay';
 
-type LibraryView = 'library' | 'explore' | 'collections' | 'comfyui' | 'editor';
+type LibraryView = 'library' | 'prompts' | 'explore' | 'collections' | 'comfyui' | 'editor';
 
 interface HeaderProps {
     onOpenSettings: () => void;
@@ -310,6 +310,7 @@ const Header: React.FC<HeaderProps> = ({
   const viewTabs = useMemo(
     () => [
       { id: 'library' as const, label: 'Library' },
+      { id: 'prompts' as const, label: 'Prompts', icon: Library },
       { id: 'explore' as const, label: 'Explore', icon: Compass },
       { id: 'editor' as const, label: 'Image Editor', icon: ImageIcon },
       { id: 'comfyui' as const, label: 'ComfyUI', icon: Workflow },

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Settings, Bug, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft, Workflow, Image as ImageIcon, Compass, Library } from 'lucide-react';
+import { Settings, Bug, Crown, Sparkles, Layers, Layers2, Eye, EyeOff, ArrowLeft, Workflow, Image as ImageIcon, Compass, Bookmark } from 'lucide-react';
 import { useFeatureAccess } from '../hooks/useFeatureAccess';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useImageStore } from '../store/useImageStore';
@@ -310,7 +310,6 @@ const Header: React.FC<HeaderProps> = ({
   const viewTabs = useMemo(
     () => [
       { id: 'library' as const, label: 'Library' },
-      { id: 'prompts' as const, label: 'Prompts', icon: Library },
       { id: 'explore' as const, label: 'Explore', icon: Compass },
       { id: 'editor' as const, label: 'Image Editor', icon: ImageIcon },
       { id: 'comfyui' as const, label: 'ComfyUI', icon: Workflow },
@@ -368,8 +367,8 @@ const Header: React.FC<HeaderProps> = ({
                   const Icon = 'icon' in tab ? tab.icon : null;
                   const isComfyUITab = tab.id === 'comfyui';
                   return (
+                    <React.Fragment key={tab.id}>
                     <button
-                      key={tab.id}
                       onClick={() => handleViewTabClick(tab.id)}
                       onDragEnter={isComfyUITab ? (event) => {
                         if (hasInternalImageDragType(event.dataTransfer)) {
@@ -416,6 +415,20 @@ const Header: React.FC<HeaderProps> = ({
                       {Icon && <Icon size={14} />}
                       <span>{tab.label}</span>
                     </button>
+                    {tab.id === 'library' && (
+                      <button
+                        type="button"
+                        onClick={() => handleViewTabClick('prompts')}
+                        className={`app-top-segment px-2.5 ${
+                          libraryView === 'prompts' ? 'app-top-segment-active' : ''
+                        }`}
+                        title="Prompt Library"
+                        aria-label="Prompt Library"
+                      >
+                        <Bookmark size={14} />
+                      </button>
+                    )}
+                    </React.Fragment>
                   );
                 })}
                 {classicTabs.map((tab) => (

--- a/components/ImageGrid.tsx
+++ b/components/ImageGrid.tsx
@@ -19,7 +19,8 @@ import { Heart, Info, Copy, CheckCircle, Folder, Clipboard, Sparkles, GitCompare
   RefreshCw,
   Image as ImageIcon,
   Workflow,
-  Trash2
+  Trash2,
+  Bookmark
 } from 'lucide-react';
 import { copyTextToClipboard } from '../utils/imageUtils';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
@@ -61,6 +62,7 @@ import {
 import { clearInternalImageDragData, setInternalImageDragData } from '../utils/internalImageDrag';
 import { isMacPlatform } from '../utils/platform';
 import { canNativeDragIndexedFile } from '../utils/model3DTransfer';
+import { useSavePrompt } from '../hooks/useSavePrompt';
 
 // macOS ignores Electron's startDrag() unless it is invoked synchronously from the
 // dragstart handler, so native external drag has to be kicked off differently there
@@ -1158,6 +1160,9 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   const blurSensitiveImages = useSettingsStore((state) => state.blurSensitiveImages);
   const enableSafeMode = useSettingsStore((state) => state.enableSafeMode);
   const directories = useImageStore((state) => state.directories);
+  const setSuccess = useImageStore((state) => state.setSuccess);
+  const setError = useImageStore((state) => state.setError);
+  const savePrompt = useSavePrompt();
   const filterAndSortImages = useImageStore((state) => state.filterAndSortImages);
 
   const focusedImageIndex = useImageStore((state) => state.focusedImageIndex);
@@ -1245,6 +1250,19 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   } = useContextMenu();
 
   const submenuHorizontalClass = contextMenu.horizontalDirection === 'left' ? 'right-full' : 'left-full';
+
+  const handleSaveContextPrompt = useCallback(async () => {
+    const target = contextMenu.image;
+    if (!target) return;
+    const directoryPath = directories.find((directory) => directory.id === target.directoryId)?.path;
+    hideContextMenu();
+    try {
+      const result = await savePrompt(target, { directoryPath, readAuthoritativeShadow: true });
+      setSuccess(result.status === 'already-saved' ? 'Already saved' : 'Prompt saved');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not save prompt.');
+    }
+  }, [contextMenu.image, directories, hideContextMenu, savePrompt, setError, setSuccess]);
 
   const getGridScrollElement = useCallback(() => gridScrollRef.current ?? gridScopeRef.current, []);
 
@@ -2399,6 +2417,14 @@ const ImageGrid: React.FC<ImageGridProps> = ({
           >
             <Copy className="w-4 h-4" />
             Copy to Clipboard
+          </button>
+
+          <button
+            onClick={() => void handleSaveContextPrompt()}
+            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+          >
+            <Bookmark className="w-4 h-4" />
+            Save Prompt
           </button>
 
           <div className="border-t border-gray-600 my-1"></div>

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -55,7 +55,7 @@ import { getAvifCarrierConflicts } from '../utils/imageMetaHubAvifExtension.mjs'
 import { buildEffectiveMetadata, getEditableMetadataFields } from '../utils/editableMetadata';
 import { eventMatchesKeybinding, isTypingElement } from '../utils/hotkeyUtils';
 import { useShadowMetadata } from '../hooks/useShadowMetadata';
-import { useSavePrompt } from '../hooks/useSavePrompt';
+import { useIsPromptSaved, useSavePrompt } from '../hooks/useSavePrompt';
 import { MetadataEditorModal, type MetadataEditorDraft } from './MetadataEditorModal';
 import BatchExportModal from './BatchExportModal';
 import ImageLineageSection from './ImageLineageSection';
@@ -1827,6 +1827,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
   const nMeta: BaseMetadata | undefined = getUsableNormalizedMetadata(liveImage);
   const canFindSimilar = Boolean(nMeta?.prompt) && Boolean(onFindSimilar);
   const effectiveMetadata = buildEffectiveMetadata(nMeta, shadowMetadata, showOriginal);
+  const isPromptSaved = useIsPromptSaved(effectiveMetadata?.prompt, effectiveMetadata?.negativePrompt);
 
   // The single checkpoint reference (if any) links the "Model" value.
   const checkpointRef = useMemo(
@@ -4331,9 +4332,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
                         setError(cause instanceof Error ? cause.message : 'Could not save prompt.');
                       }
                     }}
-                    className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2 text-sm font-medium text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-40"
+                    className={`inline-flex w-full items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${isPromptSaved ? 'border-accent bg-accent text-white hover:bg-accent/90' : 'border-accent/40 bg-accent/10 text-accent hover:bg-accent/20'}`}
+                    aria-pressed={isPromptSaved}
                   >
-                    <Bookmark size={14} /> Save Prompt
+                    <Bookmark size={14} fill={isPromptSaved ? 'currentColor' : 'none'} /> {isPromptSaved ? 'Saved' : 'Save Prompt'}
                   </button>
                 )}
                 <MetadataItem label="Negative Prompt" value={effectiveMetadata?.negativePrompt} isPrompt onCopy={() => copyToClipboard(effectiveMetadata?.negativePrompt || '', 'Negative Prompt', true)} />

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -4,7 +4,7 @@ import { FileOperations } from '../services/fileOperations';
 import { getRenameBasename, renameIndexedImage } from '../services/imageRenameService';
 import { copyImageToClipboard, copyTextToClipboard, showInExplorer } from '../utils/imageUtils';
 import { motion } from 'framer-motion';
-import { AlertTriangle, Copy, Pencil, Pin, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Repeat1, Shuffle, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw, SlidersHorizontal, Workflow, Image as ImageIcon, ExternalLink } from 'lucide-react';
+import { AlertTriangle, Copy, Pencil, Pin, Trash2, ChevronDown, ChevronRight, Folder, Download, Clipboard, Sparkles, GitCompare, Heart, X, Zap, CheckCircle, ArrowUp, Play, Pause, Volume2, VolumeX, Repeat, Repeat1, Shuffle, Eye, EyeOff, Search, Minus, Maximize2, Minimize2, RefreshCw, SlidersHorizontal, Workflow, Image as ImageIcon, ExternalLink, Bookmark } from 'lucide-react';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
 import { useGenerateWithA1111 } from '../hooks/useGenerateWithA1111';
 import { useCopyToComfyUI } from '../hooks/useCopyToComfyUI';
@@ -55,6 +55,7 @@ import { getAvifCarrierConflicts } from '../utils/imageMetaHubAvifExtension.mjs'
 import { buildEffectiveMetadata, getEditableMetadataFields } from '../utils/editableMetadata';
 import { eventMatchesKeybinding, isTypingElement } from '../utils/hotkeyUtils';
 import { useShadowMetadata } from '../hooks/useShadowMetadata';
+import { useSavePrompt } from '../hooks/useSavePrompt';
 import { MetadataEditorModal, type MetadataEditorDraft } from './MetadataEditorModal';
 import BatchExportModal from './BatchExportModal';
 import ImageLineageSection from './ImageLineageSection';
@@ -1191,7 +1192,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
     )
   );
   const liveImage = imageFromStore ?? image;
-  const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata, deleteMetadata: deleteShadowMetadata } = useShadowMetadata(liveImage);
+  const { metadata: shadowMetadata, isLoading: isShadowLoading, error: shadowError, saveMetadata: saveShadowMetadata, deleteMetadata: deleteShadowMetadata } = useShadowMetadata(liveImage);
+  const savePrompt = useSavePrompt();
   const thumbnail = useResolvedThumbnail(liveImage);
   const isVideo = isVideoFileName(image.name, image.fileType);
   const isAudio = isAudioFileName(image.name, image.fileType);
@@ -4312,6 +4314,28 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   }}
                 />
                 <MetadataItem label="Prompt" value={effectiveMetadata?.prompt} isPrompt onCopy={() => copyToClipboard(effectiveMetadata?.prompt || '', 'Prompt', true)} />
+                {effectiveMetadata?.prompt && (
+                  <button
+                    type="button"
+                    disabled={isShadowLoading || Boolean(shadowError)}
+                    onClick={async () => {
+                      try {
+                        const result = await savePrompt(liveImage, {
+                          directoryPath,
+                          showOriginal,
+                          shadowMetadata,
+                          shadowReady: !isShadowLoading && !shadowError,
+                        });
+                        setSuccess(result.status === 'already-saved' ? 'Already saved' : 'Prompt saved');
+                      } catch (cause) {
+                        setError(cause instanceof Error ? cause.message : 'Could not save prompt.');
+                      }
+                    }}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2 text-sm font-medium text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    <Bookmark size={14} /> Save Prompt
+                  </button>
+                )}
                 <MetadataItem label="Negative Prompt" value={effectiveMetadata?.negativePrompt} isPrompt onCopy={() => copyToClipboard(effectiveMetadata?.negativePrompt || '', 'Negative Prompt', true)} />
                 
                 {/* Shadow Resources List */}

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -35,7 +35,7 @@ import { MetadataEditorModal, type MetadataEditorDraft } from './MetadataEditorM
 import BatchExportModal from './BatchExportModal';
 import { hasCompactedRuntimeMetadata, hydrateImageRawMetadata, type RawMetadataHydrationOptions } from '../services/rawMetadataHydration';
 import { useMediaDiagnostics } from '../hooks/useMediaDiagnostics';
-import { useSavePrompt } from '../hooks/useSavePrompt';
+import { useIsPromptSaved, useSavePrompt } from '../hooks/useSavePrompt';
 
 const formatLoRA = (lora: string | LoRAInfo): string => {
   if (typeof lora === 'string') {
@@ -310,6 +310,7 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   // Calculate these BEFORE the early return to maintain hook order
   const nMeta: BaseMetadata | undefined = activeImage?.metadata?.normalizedMetadata;
   const effectiveMetadata = activeImage ? buildEffectiveMetadata(nMeta, shadowMetadata, showOriginal) : undefined;
+  const isPromptSaved = useIsPromptSaved(effectiveMetadata?.prompt, effectiveMetadata?.negativePrompt);
   const rawMetadataImage = hydratedRawMetadataImage?.id === activeImage?.id ? hydratedRawMetadataImage : activeImage;
   const ensureFullRawMetadata = useCallback(async (
     options: RawMetadataHydrationOptions = {},
@@ -827,9 +828,10 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
                       setError(cause instanceof Error ? cause.message : 'Could not save prompt.');
                     }
                   }}
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2 text-sm font-medium text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-40"
+                  className={`inline-flex w-full items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${isPromptSaved ? 'border-accent bg-accent text-white hover:bg-accent/90' : 'border-accent/40 bg-accent/10 text-accent hover:bg-accent/20'}`}
+                  aria-pressed={isPromptSaved}
                 >
-                  <Bookmark size={14} /> Save Prompt
+                  <Bookmark size={14} fill={isPromptSaved ? 'currentColor' : 'none'} /> {isPromptSaved ? 'Saved' : 'Save Prompt'}
                 </button>
               )}
               <MetadataItem label="Negative Prompt" value={effectiveMetadata?.negativePrompt} isPrompt onCopy={(v) => copyToClipboard(v, "Negative Prompt")} />

--- a/components/ImagePreviewSidebar.tsx
+++ b/components/ImagePreviewSidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState, FC } from 'react';
 import { motion } from 'framer-motion';
-import { AlertTriangle, Clipboard, Sparkles, ChevronDown, ChevronRight, Heart, X, Zap, CheckCircle, ArrowUp, Copy, Search, Pencil, Download, Eye, EyeOff, ExternalLink } from 'lucide-react';
+import { AlertTriangle, Clipboard, Sparkles, ChevronDown, ChevronRight, Heart, X, Zap, CheckCircle, ArrowUp, Copy, Search, Pencil, Download, Eye, EyeOff, ExternalLink, Bookmark } from 'lucide-react';
 import { useImageStore } from '../store/useImageStore';
 import { type BaseMetadata, type IndexedImage, type LoRAInfo } from '../types';
 import { useCopyToA1111 } from '../hooks/useCopyToA1111';
@@ -35,6 +35,7 @@ import { MetadataEditorModal, type MetadataEditorDraft } from './MetadataEditorM
 import BatchExportModal from './BatchExportModal';
 import { hasCompactedRuntimeMetadata, hydrateImageRawMetadata, type RawMetadataHydrationOptions } from '../services/rawMetadataHydration';
 import { useMediaDiagnostics } from '../hooks/useMediaDiagnostics';
+import { useSavePrompt } from '../hooks/useSavePrompt';
 
 const formatLoRA = (lora: string | LoRAInfo): string => {
   if (typeof lora === 'string') {
@@ -168,6 +169,8 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
     setSelectedImage,
   } = useImageStore();
   const recentTags = useImageStore((state) => state.recentTags);
+  const setSuccess = useImageStore((state) => state.setSuccess);
+  const setError = useImageStore((state) => state.setError);
   const directories = useImageStore((state) => state.directories);
   const filteredImages = useImageStore((state) => state.filteredImages);
   const selectedImages = useImageStore((state) => state.selectedImages);
@@ -211,7 +214,8 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
   const { a1111Enabled, comfyUIEnabled, singleVisibleProvider } = useGenerationProviderAvailability();
 
   const activeImage = previewImageFromStore || previewImage;
-  const { metadata: shadowMetadata, saveMetadata: saveShadowMetadata } = useShadowMetadata(activeImage);
+  const { metadata: shadowMetadata, isLoading: isShadowLoading, error: shadowError, saveMetadata: saveShadowMetadata } = useShadowMetadata(activeImage);
+  const savePrompt = useSavePrompt();
   const allImages = useImageStore((state) => state.images);
   const thumbnail = useResolvedThumbnail(activeImage);
   const isVideo = !!activeImage && isVideoFileName(activeImage.name, activeImage.fileType);
@@ -805,6 +809,29 @@ const ImagePreviewSidebar: React.FC<ImagePreviewSidebarProps> = ({
               />
               <MetadataItem label="Format" value={nMeta.format} onCopy={(v) => copyToClipboard(v, "Format")} />
               <MetadataItem label="Prompt" value={effectiveMetadata?.prompt} isPrompt onCopy={(v) => copyToClipboard(v, "Prompt")} />
+              {effectiveMetadata?.prompt && (
+                <button
+                  type="button"
+                  disabled={isShadowLoading || Boolean(shadowError)}
+                  onClick={async () => {
+                    if (!activeImage) return;
+                    try {
+                      const result = await savePrompt(activeImage, {
+                        directoryPath: activeImageDirectoryPath,
+                        showOriginal,
+                        shadowMetadata,
+                        shadowReady: !isShadowLoading && !shadowError,
+                      });
+                      setSuccess(result.status === 'already-saved' ? 'Already saved' : 'Prompt saved');
+                    } catch (cause) {
+                      setError(cause instanceof Error ? cause.message : 'Could not save prompt.');
+                    }
+                  }}
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2 text-sm font-medium text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Bookmark size={14} /> Save Prompt
+                </button>
+              )}
               <MetadataItem label="Negative Prompt" value={effectiveMetadata?.negativePrompt} isPrompt onCopy={(v) => copyToClipboard(v, "Negative Prompt")} />
               <MetadataItem label="Model" value={effectiveMetadata?.model} onCopy={(v) => copyToClipboard(v, "Model")} />
               {((nMeta as any).vae || (nMeta as any).vaes?.[0]?.name) && (

--- a/components/ImageTable.tsx
+++ b/components/ImageTable.tsx
@@ -5,7 +5,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { type IndexedImage, type Directory, SmartCollection } from '../types';
 import { useContextMenu } from '../hooks/useContextMenu';
 import { useImageStore } from '../store/useImageStore';
-import { Copy, Folder, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Search, Sparkles, Star, Workflow, Image as ImageIcon } from 'lucide-react';
+import { Copy, Folder, ArrowUpDown, ArrowUp, ArrowDown, ChevronRight, Info, Package, Play, Music, RefreshCw, Search, Sparkles, Star, Workflow, Image as ImageIcon, Bookmark } from 'lucide-react';
 import { useThumbnail } from '../hooks/useThumbnail';
 import { useResolvedThumbnail } from '../hooks/useResolvedThumbnail';
 import { useSettingsStore } from '../store/useSettingsStore';
@@ -29,6 +29,7 @@ import { getFileExtension, isAudioFileName, isModel3DFileName, isVideoFileName }
 import Model3DThumbnail from './Model3DThumbnail';
 import { groupImages, type ImageGroupByMode, type ImageGroupingSortOrder, type ImageGroupRenderItem } from '../utils/imageGrouping';
 import { clearInternalImageDragData, setInternalImageDragData } from '../utils/internalImageDrag';
+import { useSavePrompt } from '../hooks/useSavePrompt';
 
 interface ImageTableProps {
   images: IndexedImage[];
@@ -101,6 +102,9 @@ const ImageTable: React.FC<ImageTableProps> = ({
   jumpToGroupRequest = null,
 }) => {
   const directories = useImageStore((state) => state.directories);
+  const setSuccess = useImageStore((state) => state.setSuccess);
+  const setError = useImageStore((state) => state.setError);
+  const savePrompt = useSavePrompt();
   const transferProgress = useImageStore((state) => state.transferProgress);
   const [sortField, setSortField] = useState<SortField | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>(null);
@@ -142,6 +146,19 @@ const ImageTable: React.FC<ImageTableProps> = ({
   } = useContextMenu();
 
   const submenuHorizontalClass = contextMenu.horizontalDirection === 'left' ? 'right-full' : 'left-full';
+
+  const handleSaveContextPrompt = useCallback(async () => {
+    const target = contextMenu.image;
+    if (!target) return;
+    const directoryPath = directories.find((directory) => directory.id === target.directoryId)?.path;
+    hideContextMenu();
+    try {
+      const result = await savePrompt(target, { directoryPath, readAuthoritativeShadow: true });
+      setSuccess(result.status === 'already-saved' ? 'Already saved' : 'Prompt saved');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not save prompt.');
+    }
+  }, [contextMenu.image, directories, hideContextMenu, savePrompt, setError, setSuccess]);
 
   useEffect(() => {
     if (!contextMenu.visible && isCopySubmenuOpen) {
@@ -646,6 +663,14 @@ const ImageTable: React.FC<ImageTableProps> = ({
           >
             <Copy className="w-4 h-4" />
             Copy to Clipboard
+          </button>
+
+          <button
+            onClick={() => void handleSaveContextPrompt()}
+            className="w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-colors flex items-center gap-2"
+          >
+            <Bookmark className="w-4 h-4" />
+            Save Prompt
           </button>
 
           <div className="border-t border-gray-600 my-1"></div>

--- a/components/PromptLibrary.tsx
+++ b/components/PromptLibrary.tsx
@@ -19,7 +19,7 @@ import {
 } from 'lucide-react';
 import type { SavedPrompt } from '../types';
 import { resolveSavedPromptSource } from '../services/savedPromptService';
-import { initializeSavedPromptSynchronization, useSavedPromptStore } from '../store/useSavedPromptStore';
+import { useSavedPromptStore } from '../store/useSavedPromptStore';
 import { copyTextToClipboard } from '../utils/imageUtils';
 
 interface PromptLibraryProps {
@@ -127,7 +127,6 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
   const modalTriggerRef = useRef<HTMLElement | null>(null);
   const copyFeedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => initializeSavedPromptSynchronization(), []);
   useEffect(() => {
     isMountedRef.current = true;
     return () => {

--- a/components/PromptLibrary.tsx
+++ b/components/PromptLibrary.tsx
@@ -280,11 +280,11 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
             <select
               value={sortBy}
               onChange={(event) => setSortBy(event.target.value as 'saved' | 'created')}
-              className="bg-transparent font-medium text-gray-200 outline-none"
+              className="rounded bg-gray-900 font-medium text-gray-200 outline-none [color-scheme:dark]"
               aria-label="Sort prompts by"
             >
-              <option value="saved">Saved</option>
-              <option value="created">Created</option>
+              <option value="saved" className="bg-gray-900 text-gray-100">Saved</option>
+              <option value="created" className="bg-gray-900 text-gray-100">Created</option>
             </select>
           </label>
           <button

--- a/components/PromptLibrary.tsx
+++ b/components/PromptLibrary.tsx
@@ -1,5 +1,17 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Copy, Dices, ExternalLink, Library, Trash2 } from 'lucide-react';
+import {
+  Bookmark,
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  Dices,
+  ExternalLink,
+  Image as ImageIcon,
+  MoreHorizontal,
+  Search,
+  Trash2,
+  X,
+} from 'lucide-react';
 import type { SavedPrompt } from '../types';
 import { resolveSavedPromptSource } from '../services/savedPromptService';
 import { initializeSavedPromptSynchronization, useSavedPromptStore } from '../store/useSavedPromptStore';
@@ -9,17 +21,18 @@ interface PromptLibraryProps {
   onViewSource: (absolutePath: string) => void | Promise<void>;
 }
 
-const PromptSourceAction: React.FC<{
+const PromptSourcePreview: React.FC<{
   prompt: SavedPrompt;
   onViewSource: (absolutePath: string) => void | Promise<void>;
   onError: (message: string) => void;
 }> = ({ prompt, onViewSource, onError }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [resolution, setResolution] = useState<Awaited<ReturnType<typeof resolveSavedPromptSource>> | null>(null);
-  const [isResolving, setIsResolving] = useState(false);
+  const [isResolving, setIsResolving] = useState(Boolean(prompt.source));
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!prompt.source) return undefined;
     let cancelled = false;
     let objectUrl: string | null = null;
     const resolve = async () => {
@@ -29,7 +42,7 @@ const PromptSourceAction: React.FC<{
         if (cancelled) return;
         setResolution(next);
         if (next.status === 'available' && window.electronAPI?.generateThumbnailFromPath) {
-          const result = await window.electronAPI.generateThumbnailFromPath({ filePath: next.absolutePath, maxEdge: 160, quality: 78 });
+          const result = await window.electronAPI.generateThumbnailFromPath({ filePath: next.absolutePath, maxEdge: 420, quality: 82 });
           if (!cancelled && result.success && result.data) {
             objectUrl = URL.createObjectURL(new Blob([new Uint8Array(result.data)], { type: result.mimeType || 'image/webp' }));
             setThumbnailUrl(objectUrl);
@@ -50,32 +63,43 @@ const PromptSourceAction: React.FC<{
       if (!entries.some((entry) => entry.isIntersecting)) return;
       observer.disconnect();
       void resolve();
-    }, { rootMargin: '200px' });
+    }, { rootMargin: '240px' });
     observer.observe(element);
     return () => {
       cancelled = true;
       observer.disconnect();
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [onError, prompt.id]);
+  }, [onError, prompt.id, prompt.source]);
 
-  const unavailable = resolution?.status === 'unavailable';
-  const changed = resolution?.status === 'available' && resolution.sourceChanged;
+  const available = resolution?.status === 'available';
+  const changed = available && resolution.sourceChanged;
   return (
-    <div ref={containerRef} className="flex items-center gap-2">
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded border border-gray-700 bg-gray-950 text-[9px] text-gray-600">
-        {thumbnailUrl ? <img src={thumbnailUrl} alt="Current source" className="h-full w-full object-cover" /> : 'No preview'}
-      </div>
-      <button
-        type="button"
-        className="app-top-pill px-2.5 py-1.5 text-xs"
-        onClick={() => resolution?.status === 'available' && void onViewSource(resolution.absolutePath)}
-        disabled={isResolving || !resolution || unavailable}
-      >
-        <ExternalLink size={13} />
-        {isResolving || !resolution ? 'Checking…' : unavailable ? 'Source unavailable' : 'View Source'}
-      </button>
-      {changed && <span className="text-xs text-amber-300">Source has changed</span>}
+    <div ref={containerRef} className="relative h-36 overflow-hidden border-b border-gray-800 bg-gray-950">
+      {thumbnailUrl ? (
+        <img src={thumbnailUrl} alt="Current source" className="h-full w-full object-cover" />
+      ) : (
+        <div className="flex h-full flex-col items-center justify-center gap-2 text-xs text-gray-600">
+          <ImageIcon size={25} strokeWidth={1.5} />
+          <span>{isResolving ? 'Loading source…' : prompt.source ? 'Source unavailable' : 'No source'}</span>
+        </div>
+      )}
+      {available && (
+        <button
+          type="button"
+          onClick={() => void onViewSource(resolution.absolutePath)}
+          className="absolute bottom-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-md border border-white/15 bg-black/70 text-gray-100 shadow-md backdrop-blur-sm transition-colors hover:bg-black/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          title="View Source"
+          aria-label="View Source"
+        >
+          <ExternalLink size={14} />
+        </button>
+      )}
+      {changed && (
+        <span className="absolute bottom-2 left-2 rounded bg-amber-950/90 px-2 py-1 text-[10px] font-medium text-amber-200 shadow-md">
+          Source has changed
+        </span>
+      )}
     </div>
   );
 };
@@ -88,21 +112,39 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
   const load = useSavedPromptStore((state) => state.load);
   const remove = useSavedPromptStore((state) => state.remove);
   const select = useSavedPromptStore((state) => state.select);
+  const [query, setQuery] = useState('');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [menuId, setMenuId] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const cardRefs = useRef(new Map<string, HTMLElement>());
 
   useEffect(() => initializeSavedPromptSynchronization(), []);
 
+  const filteredPrompts = useMemo(() => {
+    const needle = query.toLocaleLowerCase();
+    if (!needle) return prompts;
+    return prompts.filter((prompt) => (
+      prompt.positivePrompt.toLocaleLowerCase().includes(needle)
+      || prompt.negativePrompt.toLocaleLowerCase().includes(needle)
+    ));
+  }, [prompts, query]);
+
+  const focusCard = useCallback((id: string) => {
+    const card = cardRefs.current.get(id);
+    card?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    card?.focus({ preventScroll: true });
+  }, []);
+
   const handleRandom = useCallback(() => {
-    if (prompts.length === 0) return;
-    const candidates = prompts.length > 1
-      ? prompts.filter((prompt) => prompt.id !== selectedPromptId)
-      : prompts;
+    if (filteredPrompts.length === 0) return;
+    const candidates = filteredPrompts.length > 1
+      ? filteredPrompts.filter((prompt) => prompt.id !== selectedPromptId)
+      : filteredPrompts;
     const selected = candidates[Math.floor(Math.random() * candidates.length)];
     select(selected.id);
-    cardRefs.current.get(selected.id)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  }, [prompts, select, selectedPromptId]);
+    focusCard(selected.id);
+  }, [filteredPrompts, focusCard, select, selectedPromptId]);
 
   const handleCopy = useCallback(async (text: string) => {
     const result = await copyTextToClipboard(text);
@@ -110,23 +152,38 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
   }, []);
 
   const empty = !isLoading && !error && prompts.length === 0;
-  const countLabel = useMemo(() => `${prompts.length} saved ${prompts.length === 1 ? 'prompt' : 'prompts'}`, [prompts.length]);
+  const noMatches = !isLoading && !error && prompts.length > 0 && filteredPrompts.length === 0;
+  const countLabel = query ? `${filteredPrompts.length} of ${prompts.length}` : `${prompts.length} saved`;
 
   return (
-    <section className="mx-auto flex h-full w-full max-w-6xl flex-col gap-4 overflow-hidden">
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-gray-800 bg-gray-900/70 p-4">
-        <div>
-          <div className="flex items-center gap-2 text-lg font-semibold text-gray-100">
-            <Library size={19} />
-            Prompt Library
-          </div>
-          <p className="mt-1 text-sm text-gray-400">{countLabel}. Saved across your whole profile.</p>
+    <section className="mx-auto flex h-full w-full max-w-7xl flex-col gap-3 overflow-hidden px-1">
+      <div className="flex flex-wrap items-center gap-2 border-b border-gray-800/80 pb-3">
+        <div className="mr-1 flex items-center gap-2 text-sm font-semibold text-gray-200">
+          <Bookmark size={16} />
+          Prompt Library
+          <span className="font-normal text-gray-500">{countLabel}</span>
         </div>
+        <label className="relative min-w-[220px] flex-1 sm:max-w-md">
+          <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" size={14} />
+          <span className="sr-only">Search saved prompts</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search prompts…"
+            className="h-9 w-full rounded-md border border-gray-700 bg-gray-900 pl-9 pr-8 text-sm text-gray-100 outline-none placeholder:text-gray-500 focus:border-accent/70 focus:ring-1 focus:ring-accent/40"
+          />
+          {query && (
+            <button type="button" onClick={() => setQuery('')} className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-gray-500 hover:text-gray-200" aria-label="Clear search">
+              <X size={13} />
+            </button>
+          )}
+        </label>
         <button
           type="button"
           onClick={handleRandom}
-          disabled={prompts.length === 0}
-          className="app-top-pill px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-40"
+          disabled={filteredPrompts.length === 0}
+          className="app-top-pill h-9 px-3 text-sm disabled:cursor-not-allowed disabled:opacity-40"
         >
           <Dices size={15} />
           Random
@@ -136,9 +193,7 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
       {(error || actionError) && (
         <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
           {actionError || error}
-          {error && (
-            <button type="button" className="ml-3 underline" onClick={() => void load()}>Try again</button>
-          )}
+          {error && <button type="button" className="ml-3 underline" onClick={() => void load()}>Try again</button>}
         </div>
       )}
 
@@ -147,15 +202,25 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
       )}
       {empty && (
         <div className="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 p-8 text-center">
-          <Library size={30} className="mb-3 text-gray-500" />
+          <Bookmark size={30} className="mb-3 text-gray-500" />
           <p className="font-medium text-gray-200">No saved prompts yet</p>
           <p className="mt-1 max-w-md text-sm text-gray-500">Use Save Prompt beside a prompt or from an image context menu.</p>
         </div>
       )}
+      {noMatches && (
+        <div className="flex flex-1 flex-col items-center justify-center text-center text-sm text-gray-500">
+          <Search size={27} className="mb-3" />
+          <p className="font-medium text-gray-300">No matching prompts</p>
+          <p className="mt-1">Try a different search.</p>
+        </div>
+      )}
 
-      {prompts.length > 0 && (
-        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pb-4 pr-1">
-          {prompts.map((prompt) => {
+      {filteredPrompts.length > 0 && (
+        <div className="grid min-h-0 flex-1 auto-rows-max grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-3 overflow-y-auto pb-4 pr-1">
+          {filteredPrompts.map((prompt) => {
+            const expanded = expandedId === prompt.id;
+            const selected = selectedPromptId === prompt.id;
+            const menuOpen = menuId === prompt.id;
             return (
               <article
                 key={prompt.id}
@@ -163,48 +228,98 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
                   if (element) cardRefs.current.set(prompt.id, element);
                   else cardRefs.current.delete(prompt.id);
                 }}
-                className={`rounded-xl border bg-gray-900/70 p-4 transition-colors ${
-                  selectedPromptId === prompt.id ? 'border-accent/70 ring-1 ring-accent/30' : 'border-gray-800'
+                tabIndex={-1}
+                aria-current={selected ? 'true' : undefined}
+                className={`relative overflow-visible rounded-xl border bg-gray-900/75 shadow-sm outline-none transition-all ${
+                  selected
+                    ? 'border-accent ring-2 ring-accent/70 shadow-lg shadow-accent/10'
+                    : 'border-gray-800 hover:border-gray-700'
                 }`}
               >
-                <div className="whitespace-pre-wrap break-words text-sm leading-6 text-gray-100">{prompt.positivePrompt}</div>
-                {prompt.negativePrompt && (
-                  <details className="mt-3 rounded-lg border border-gray-800 bg-gray-950/50 px-3 py-2">
-                    <summary className="cursor-pointer text-xs font-medium text-gray-400">Negative prompt</summary>
-                    <div className="mt-2 whitespace-pre-wrap break-words text-sm text-gray-300">{prompt.negativePrompt}</div>
-                  </details>
-                )}
-                <div className="mt-4 flex flex-wrap items-center gap-2">
-                  <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => void handleCopy(prompt.positivePrompt)}>
-                    <Copy size={13} /> Copy
-                  </button>
-                  {prompt.negativePrompt && (
-                    <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => void handleCopy(prompt.negativePrompt)}>
-                      <Copy size={13} /> Copy Negative
+                <div className="overflow-hidden rounded-t-xl">
+                  <PromptSourcePreview prompt={prompt} onViewSource={onViewSource} onError={setActionError} />
+                </div>
+                <div className="p-3">
+                  <p className={`whitespace-pre-wrap break-words text-sm leading-6 text-gray-100 ${expanded ? '' : 'line-clamp-4 min-h-24'}`}>
+                    {prompt.positivePrompt}
+                  </p>
+
+                  {expanded && (
+                    <div className="mt-3 space-y-3 border-t border-gray-800 pt-3">
+                      {prompt.negativePrompt ? (
+                        <div>
+                          <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Negative prompt</div>
+                          <p className="whitespace-pre-wrap break-words text-sm leading-5 text-gray-300">{prompt.negativePrompt}</p>
+                          <button type="button" className="mt-2 inline-flex items-center gap-1 text-xs text-gray-400 hover:text-gray-100" onClick={() => void handleCopy(prompt.negativePrompt)}>
+                            <Copy size={12} /> Copy Negative
+                          </button>
+                        </div>
+                      ) : (
+                        <p className="text-xs text-gray-500">No negative prompt</p>
+                      )}
+                      <div className="text-[11px] text-gray-600">Saved {new Date(prompt.createdAt).toLocaleString()}</div>
+                    </div>
+                  )}
+
+                  <div className="mt-3 flex items-center gap-1.5">
+                    <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => void handleCopy(prompt.positivePrompt)}>
+                      <Copy size={13} /> Copy
                     </button>
-                  )}
-                  {prompt.source && (
-                    <PromptSourceAction prompt={prompt} onViewSource={onViewSource} onError={setActionError} />
-                  )}
-                  <span className="ml-auto text-xs text-gray-500">{new Date(prompt.createdAt).toLocaleString()}</span>
-                  {confirmingId === prompt.id ? (
-                    <span className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      className="app-top-pill px-2 py-1.5 text-xs"
+                      onClick={() => setExpandedId(expanded ? null : prompt.id)}
+                      aria-expanded={expanded}
+                    >
+                      {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+                      {expanded ? 'Less' : 'Details'}
+                    </button>
+                    <div className="relative ml-auto">
                       <button
                         type="button"
-                        className="rounded-md bg-red-600 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-red-500"
-                        onClick={async () => {
-                          try { await remove(prompt.id); setConfirmingId(null); } catch (cause) {
-                            setActionError(cause instanceof Error ? cause.message : 'Could not remove the saved prompt.');
-                          }
+                        className="app-top-icon-button h-8 w-8 text-gray-500 hover:text-gray-200"
+                        onClick={() => {
+                          setMenuId(menuOpen ? null : prompt.id);
+                          setConfirmingId(null);
                         }}
-                      >Remove</button>
-                      <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => setConfirmingId(null)}>Cancel</button>
-                    </span>
-                  ) : (
-                    <button type="button" className="app-top-icon-button h-8 w-8 text-gray-400 hover:text-red-300" onClick={() => setConfirmingId(prompt.id)} title="Remove saved prompt" aria-label="Remove saved prompt">
-                      <Trash2 size={14} />
-                    </button>
-                  )}
+                        aria-label="Prompt actions"
+                        aria-expanded={menuOpen}
+                      >
+                        <MoreHorizontal size={15} />
+                      </button>
+                      {menuOpen && (
+                        <div className="absolute bottom-9 right-0 z-20 min-w-40 rounded-lg border border-gray-700 bg-gray-900 p-1.5 shadow-xl shadow-black/40">
+                          {confirmingId === prompt.id ? (
+                            <div className="p-1.5">
+                              <p className="mb-2 text-xs text-gray-300">Remove this saved prompt?</p>
+                              <div className="flex gap-1.5">
+                                <button
+                                  type="button"
+                                  className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-500"
+                                  onClick={async () => {
+                                    try {
+                                      await remove(prompt.id);
+                                      setMenuId(null);
+                                      setConfirmingId(null);
+                                    } catch (cause) {
+                                      setActionError(cause instanceof Error ? cause.message : 'Could not remove the saved prompt.');
+                                    }
+                                  }}
+                                >
+                                  Remove
+                                </button>
+                                <button type="button" className="rounded px-2 py-1 text-xs text-gray-400 hover:bg-gray-800 hover:text-gray-100" onClick={() => setConfirmingId(null)}>Cancel</button>
+                              </div>
+                            </div>
+                          ) : (
+                            <button type="button" className="flex w-full items-center gap-2 rounded px-2.5 py-2 text-left text-xs text-gray-300 hover:bg-gray-800 hover:text-red-300" onClick={() => setConfirmingId(prompt.id)}>
+                              <Trash2 size={13} /> Remove saved prompt
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
                 </div>
               </article>
             );

--- a/components/PromptLibrary.tsx
+++ b/components/PromptLibrary.tsx
@@ -5,6 +5,8 @@ import {
   Bookmark,
   Check,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   ChevronUp,
   Copy,
   Dices,
@@ -237,14 +239,36 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
     (modalTriggerRef.current ?? randomButtonRef.current)?.focus({ preventScroll: true });
   }, []);
 
+  const activePromptIndex = randomPromptId
+    ? visiblePrompts.findIndex((prompt) => prompt.id === randomPromptId)
+    : -1;
+  const canGoPrevious = activePromptIndex > 0;
+  const canGoNext = activePromptIndex >= 0 && activePromptIndex < visiblePrompts.length - 1;
+  const navigatePrompt = useCallback((direction: -1 | 1) => {
+    if (!randomPromptId) return;
+    const currentIndex = visiblePrompts.findIndex((prompt) => prompt.id === randomPromptId);
+    const nextPrompt = visiblePrompts[currentIndex + direction];
+    if (nextPrompt) openPrompt(nextPrompt);
+  }, [openPrompt, randomPromptId, visiblePrompts]);
+
   useEffect(() => {
     if (!randomPromptId) return undefined;
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') closeRandom();
+      if (event.key === 'Escape') {
+        closeRandom();
+        return;
+      }
+      if (event.key === 'ArrowLeft' && canGoPrevious) {
+        event.preventDefault();
+        navigatePrompt(-1);
+      } else if (event.key === 'ArrowRight' && canGoNext) {
+        event.preventDefault();
+        navigatePrompt(1);
+      }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [closeRandom, randomPromptId]);
+  }, [canGoNext, canGoPrevious, closeRandom, navigatePrompt, randomPromptId]);
 
   useEffect(() => {
     if (!menuId) return undefined;
@@ -562,9 +586,29 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
               >
                 <ExternalLink size={14} /> View Source
               </button>
-              <button type="button" className="app-top-pill ml-auto px-3 py-2 text-sm" onClick={() => chooseRandom(randomPrompt.id)}>
-                <Dices size={14} /> Another
-              </button>
+              <div className="ml-auto flex items-center gap-2">
+                <button
+                  type="button"
+                  className="app-top-pill px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-40"
+                  disabled={!canGoPrevious}
+                  onClick={() => navigatePrompt(-1)}
+                  title="Previous prompt (Left arrow)"
+                >
+                  <ChevronLeft size={14} /> Previous
+                </button>
+                <button
+                  type="button"
+                  className="app-top-pill px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-40"
+                  disabled={!canGoNext}
+                  onClick={() => navigatePrompt(1)}
+                  title="Next prompt (Right arrow)"
+                >
+                  Next <ChevronRight size={14} />
+                </button>
+                <button type="button" className="app-top-pill px-3 py-2 text-sm" onClick={() => chooseRandom(randomPrompt.id)}>
+                  <Dices size={14} /> Another
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/components/PromptLibrary.tsx
+++ b/components/PromptLibrary.tsx
@@ -1,0 +1,218 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Copy, Dices, ExternalLink, Library, Trash2 } from 'lucide-react';
+import type { SavedPrompt } from '../types';
+import { resolveSavedPromptSource } from '../services/savedPromptService';
+import { initializeSavedPromptSynchronization, useSavedPromptStore } from '../store/useSavedPromptStore';
+import { copyTextToClipboard } from '../utils/imageUtils';
+
+interface PromptLibraryProps {
+  onViewSource: (absolutePath: string) => void | Promise<void>;
+}
+
+const PromptSourceAction: React.FC<{
+  prompt: SavedPrompt;
+  onViewSource: (absolutePath: string) => void | Promise<void>;
+  onError: (message: string) => void;
+}> = ({ prompt, onViewSource, onError }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [resolution, setResolution] = useState<Awaited<ReturnType<typeof resolveSavedPromptSource>> | null>(null);
+  const [isResolving, setIsResolving] = useState(false);
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    const resolve = async () => {
+      setIsResolving(true);
+      try {
+        const next = await resolveSavedPromptSource(prompt.id);
+        if (cancelled) return;
+        setResolution(next);
+        if (next.status === 'available' && window.electronAPI?.generateThumbnailFromPath) {
+          const result = await window.electronAPI.generateThumbnailFromPath({ filePath: next.absolutePath, maxEdge: 160, quality: 78 });
+          if (!cancelled && result.success && result.data) {
+            objectUrl = URL.createObjectURL(new Blob([new Uint8Array(result.data)], { type: result.mimeType || 'image/webp' }));
+            setThumbnailUrl(objectUrl);
+          }
+        }
+      } catch (cause) {
+        if (!cancelled) onError(cause instanceof Error ? cause.message : 'Could not resolve the saved source.');
+      } finally {
+        if (!cancelled) setIsResolving(false);
+      }
+    };
+    const element = containerRef.current;
+    if (!element || typeof IntersectionObserver === 'undefined') {
+      void resolve();
+      return () => { cancelled = true; if (objectUrl) URL.revokeObjectURL(objectUrl); };
+    }
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      observer.disconnect();
+      void resolve();
+    }, { rootMargin: '200px' });
+    observer.observe(element);
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [onError, prompt.id]);
+
+  const unavailable = resolution?.status === 'unavailable';
+  const changed = resolution?.status === 'available' && resolution.sourceChanged;
+  return (
+    <div ref={containerRef} className="flex items-center gap-2">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded border border-gray-700 bg-gray-950 text-[9px] text-gray-600">
+        {thumbnailUrl ? <img src={thumbnailUrl} alt="Current source" className="h-full w-full object-cover" /> : 'No preview'}
+      </div>
+      <button
+        type="button"
+        className="app-top-pill px-2.5 py-1.5 text-xs"
+        onClick={() => resolution?.status === 'available' && void onViewSource(resolution.absolutePath)}
+        disabled={isResolving || !resolution || unavailable}
+      >
+        <ExternalLink size={13} />
+        {isResolving || !resolution ? 'Checking…' : unavailable ? 'Source unavailable' : 'View Source'}
+      </button>
+      {changed && <span className="text-xs text-amber-300">Source has changed</span>}
+    </div>
+  );
+};
+
+const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
+  const prompts = useSavedPromptStore((state) => state.prompts);
+  const isLoading = useSavedPromptStore((state) => state.isLoading);
+  const error = useSavedPromptStore((state) => state.error);
+  const selectedPromptId = useSavedPromptStore((state) => state.selectedPromptId);
+  const load = useSavedPromptStore((state) => state.load);
+  const remove = useSavedPromptStore((state) => state.remove);
+  const select = useSavedPromptStore((state) => state.select);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const cardRefs = useRef(new Map<string, HTMLElement>());
+
+  useEffect(() => initializeSavedPromptSynchronization(), []);
+
+  const handleRandom = useCallback(() => {
+    if (prompts.length === 0) return;
+    const candidates = prompts.length > 1
+      ? prompts.filter((prompt) => prompt.id !== selectedPromptId)
+      : prompts;
+    const selected = candidates[Math.floor(Math.random() * candidates.length)];
+    select(selected.id);
+    cardRefs.current.get(selected.id)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [prompts, select, selectedPromptId]);
+
+  const handleCopy = useCallback(async (text: string) => {
+    const result = await copyTextToClipboard(text);
+    if (!result.success) setActionError(result.error || 'Could not copy the prompt.');
+  }, []);
+
+  const empty = !isLoading && !error && prompts.length === 0;
+  const countLabel = useMemo(() => `${prompts.length} saved ${prompts.length === 1 ? 'prompt' : 'prompts'}`, [prompts.length]);
+
+  return (
+    <section className="mx-auto flex h-full w-full max-w-6xl flex-col gap-4 overflow-hidden">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-gray-800 bg-gray-900/70 p-4">
+        <div>
+          <div className="flex items-center gap-2 text-lg font-semibold text-gray-100">
+            <Library size={19} />
+            Prompt Library
+          </div>
+          <p className="mt-1 text-sm text-gray-400">{countLabel}. Saved across your whole profile.</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleRandom}
+          disabled={prompts.length === 0}
+          className="app-top-pill px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <Dices size={15} />
+          Random
+        </button>
+      </div>
+
+      {(error || actionError) && (
+        <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
+          {actionError || error}
+          {error && (
+            <button type="button" className="ml-3 underline" onClick={() => void load()}>Try again</button>
+          )}
+        </div>
+      )}
+
+      {isLoading && prompts.length === 0 && (
+        <div className="flex flex-1 items-center justify-center text-sm text-gray-400">Loading saved prompts…</div>
+      )}
+      {empty && (
+        <div className="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 p-8 text-center">
+          <Library size={30} className="mb-3 text-gray-500" />
+          <p className="font-medium text-gray-200">No saved prompts yet</p>
+          <p className="mt-1 max-w-md text-sm text-gray-500">Use Save Prompt beside a prompt or from an image context menu.</p>
+        </div>
+      )}
+
+      {prompts.length > 0 && (
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pb-4 pr-1">
+          {prompts.map((prompt) => {
+            return (
+              <article
+                key={prompt.id}
+                ref={(element) => {
+                  if (element) cardRefs.current.set(prompt.id, element);
+                  else cardRefs.current.delete(prompt.id);
+                }}
+                className={`rounded-xl border bg-gray-900/70 p-4 transition-colors ${
+                  selectedPromptId === prompt.id ? 'border-accent/70 ring-1 ring-accent/30' : 'border-gray-800'
+                }`}
+              >
+                <div className="whitespace-pre-wrap break-words text-sm leading-6 text-gray-100">{prompt.positivePrompt}</div>
+                {prompt.negativePrompt && (
+                  <details className="mt-3 rounded-lg border border-gray-800 bg-gray-950/50 px-3 py-2">
+                    <summary className="cursor-pointer text-xs font-medium text-gray-400">Negative prompt</summary>
+                    <div className="mt-2 whitespace-pre-wrap break-words text-sm text-gray-300">{prompt.negativePrompt}</div>
+                  </details>
+                )}
+                <div className="mt-4 flex flex-wrap items-center gap-2">
+                  <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => void handleCopy(prompt.positivePrompt)}>
+                    <Copy size={13} /> Copy
+                  </button>
+                  {prompt.negativePrompt && (
+                    <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => void handleCopy(prompt.negativePrompt)}>
+                      <Copy size={13} /> Copy Negative
+                    </button>
+                  )}
+                  {prompt.source && (
+                    <PromptSourceAction prompt={prompt} onViewSource={onViewSource} onError={setActionError} />
+                  )}
+                  <span className="ml-auto text-xs text-gray-500">{new Date(prompt.createdAt).toLocaleString()}</span>
+                  {confirmingId === prompt.id ? (
+                    <span className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        className="rounded-md bg-red-600 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-red-500"
+                        onClick={async () => {
+                          try { await remove(prompt.id); setConfirmingId(null); } catch (cause) {
+                            setActionError(cause instanceof Error ? cause.message : 'Could not remove the saved prompt.');
+                          }
+                        }}
+                      >Remove</button>
+                      <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => setConfirmingId(null)}>Cancel</button>
+                    </span>
+                  ) : (
+                    <button type="button" className="app-top-icon-button h-8 w-8 text-gray-400 hover:text-red-300" onClick={() => setConfirmingId(prompt.id)} title="Remove saved prompt" aria-label="Remove saved prompt">
+                      <Trash2 size={14} />
+                    </button>
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default PromptLibrary;

--- a/components/PromptLibrary.tsx
+++ b/components/PromptLibrary.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  ArrowDown,
+  ArrowUp,
   Bookmark,
   ChevronDown,
   ChevronUp,
@@ -21,73 +23,65 @@ interface PromptLibraryProps {
   onViewSource: (absolutePath: string) => void | Promise<void>;
 }
 
+type SourcePresentation = {
+  status: 'loading' | 'available' | 'unavailable';
+  absolutePath?: string;
+  sourceChanged?: boolean;
+  thumbnailUrl?: string | null;
+};
+
 const PromptSourcePreview: React.FC<{
   prompt: SavedPrompt;
+  presentation?: SourcePresentation;
+  ensureSource: (prompt: SavedPrompt) => Promise<void>;
   onViewSource: (absolutePath: string) => void | Promise<void>;
-  onError: (message: string) => void;
-}> = ({ prompt, onViewSource, onError }) => {
+  large?: boolean;
+}> = ({ prompt, presentation, ensureSource, onViewSource, large = false }) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [resolution, setResolution] = useState<Awaited<ReturnType<typeof resolveSavedPromptSource>> | null>(null);
-  const [isResolving, setIsResolving] = useState(Boolean(prompt.source));
-  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!prompt.source) return undefined;
-    let cancelled = false;
-    let objectUrl: string | null = null;
-    const resolve = async () => {
-      setIsResolving(true);
-      try {
-        const next = await resolveSavedPromptSource(prompt.id);
-        if (cancelled) return;
-        setResolution(next);
-        if (next.status === 'available' && window.electronAPI?.generateThumbnailFromPath) {
-          const result = await window.electronAPI.generateThumbnailFromPath({ filePath: next.absolutePath, maxEdge: 420, quality: 82 });
-          if (!cancelled && result.success && result.data) {
-            objectUrl = URL.createObjectURL(new Blob([new Uint8Array(result.data)], { type: result.mimeType || 'image/webp' }));
-            setThumbnailUrl(objectUrl);
-          }
-        }
-      } catch (cause) {
-        if (!cancelled) onError(cause instanceof Error ? cause.message : 'Could not resolve the saved source.');
-      } finally {
-        if (!cancelled) setIsResolving(false);
-      }
-    };
-    const element = containerRef.current;
-    if (!element || typeof IntersectionObserver === 'undefined') {
-      void resolve();
-      return () => { cancelled = true; if (objectUrl) URL.revokeObjectURL(objectUrl); };
+    if (!prompt.source || presentation) return undefined;
+    if (large || typeof IntersectionObserver === 'undefined') {
+      void ensureSource(prompt);
+      return undefined;
     }
+    const element = containerRef.current;
+    if (!element) return undefined;
     const observer = new IntersectionObserver((entries) => {
       if (!entries.some((entry) => entry.isIntersecting)) return;
       observer.disconnect();
-      void resolve();
+      void ensureSource(prompt);
     }, { rootMargin: '240px' });
     observer.observe(element);
-    return () => {
-      cancelled = true;
-      observer.disconnect();
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
-    };
-  }, [onError, prompt.id, prompt.source]);
+    return () => observer.disconnect();
+  }, [ensureSource, large, presentation, prompt]);
 
-  const available = resolution?.status === 'available';
-  const changed = available && resolution.sourceChanged;
+  const available = presentation?.status === 'available';
+  const heightClass = large ? 'h-[min(44vh,420px)] min-h-64' : 'h-36';
   return (
-    <div ref={containerRef} className="relative h-36 overflow-hidden border-b border-gray-800 bg-gray-950">
-      {thumbnailUrl ? (
-        <img src={thumbnailUrl} alt="Current source" className="h-full w-full object-cover" />
+    <div ref={containerRef} className={`relative overflow-hidden bg-gray-950 ${heightClass}`}>
+      {presentation?.thumbnailUrl ? (
+        <img
+          src={presentation.thumbnailUrl}
+          alt="Current source"
+          className={`h-full w-full ${large ? 'object-contain' : 'object-cover'}`}
+        />
       ) : (
         <div className="flex h-full flex-col items-center justify-center gap-2 text-xs text-gray-600">
-          <ImageIcon size={25} strokeWidth={1.5} />
-          <span>{isResolving ? 'Loading source…' : prompt.source ? 'Source unavailable' : 'No source'}</span>
+          <ImageIcon size={large ? 38 : 25} strokeWidth={1.5} />
+          <span>
+            {presentation?.status === 'loading' || (prompt.source && !presentation)
+              ? 'Loading source…'
+              : prompt.source
+                ? 'Source unavailable'
+                : 'No source'}
+          </span>
         </div>
       )}
-      {available && (
+      {!large && available && presentation.absolutePath && (
         <button
           type="button"
-          onClick={() => void onViewSource(resolution.absolutePath)}
+          onClick={() => void onViewSource(presentation.absolutePath as string)}
           className="absolute bottom-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-md border border-white/15 bg-black/70 text-gray-100 shadow-md backdrop-blur-sm transition-colors hover:bg-black/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           title="View Source"
           aria-label="View Source"
@@ -95,7 +89,7 @@ const PromptSourcePreview: React.FC<{
           <ExternalLink size={14} />
         </button>
       )}
-      {changed && (
+      {available && presentation.sourceChanged && (
         <span className="absolute bottom-2 left-2 rounded bg-amber-950/90 px-2 py-1 text-[10px] font-medium text-amber-200 shadow-md">
           Source has changed
         </span>
@@ -113,220 +107,400 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
   const remove = useSavedPromptStore((state) => state.remove);
   const select = useSavedPromptStore((state) => state.select);
   const [query, setQuery] = useState('');
+  const [sortBy, setSortBy] = useState<'saved' | 'created'>('saved');
+  const [sortDirection, setSortDirection] = useState<'newest' | 'oldest'>('newest');
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [menuId, setMenuId] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [randomPromptId, setRandomPromptId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-  const cardRefs = useRef(new Map<string, HTMLElement>());
+  const [sourcePresentations, setSourcePresentations] = useState<Record<string, SourcePresentation>>({});
+  const sourcePresentationsRef = useRef<Record<string, SourcePresentation>>({});
+  const sourceRequestsRef = useRef(new Map<string, Promise<void>>());
+  const sourceObjectUrlsRef = useRef(new Set<string>());
+  const isMountedRef = useRef(true);
+  const randomButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => initializeSavedPromptSynchronization(), []);
-
-  const filteredPrompts = useMemo(() => {
-    const needle = query.toLocaleLowerCase();
-    if (!needle) return prompts;
-    return prompts.filter((prompt) => (
-      prompt.positivePrompt.toLocaleLowerCase().includes(needle)
-      || prompt.negativePrompt.toLocaleLowerCase().includes(needle)
-    ));
-  }, [prompts, query]);
-
-  const focusCard = useCallback((id: string) => {
-    const card = cardRefs.current.get(id);
-    card?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    card?.focus({ preventScroll: true });
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      for (const url of sourceObjectUrlsRef.current) URL.revokeObjectURL(url);
+    };
   }, []);
 
-  const handleRandom = useCallback(() => {
-    if (filteredPrompts.length === 0) return;
-    const candidates = filteredPrompts.length > 1
-      ? filteredPrompts.filter((prompt) => prompt.id !== selectedPromptId)
-      : filteredPrompts;
+  const updateSourcePresentation = useCallback((id: string, presentation: SourcePresentation) => {
+    if (!isMountedRef.current) return;
+    sourcePresentationsRef.current = { ...sourcePresentationsRef.current, [id]: presentation };
+    setSourcePresentations(sourcePresentationsRef.current);
+  }, []);
+
+  const ensureSource = useCallback((prompt: SavedPrompt): Promise<void> => {
+    if (!prompt.source) return Promise.resolve();
+    const current = sourcePresentationsRef.current[prompt.id];
+    if (current?.status === 'available' || current?.status === 'unavailable') return Promise.resolve();
+    const pending = sourceRequestsRef.current.get(prompt.id);
+    if (pending) return pending;
+
+    updateSourcePresentation(prompt.id, { status: 'loading' });
+    const request = (async () => {
+      try {
+        const resolution = await resolveSavedPromptSource(prompt.id);
+        if (!isMountedRef.current) return;
+        if (resolution.status === 'unavailable') {
+          updateSourcePresentation(prompt.id, { status: 'unavailable' });
+          return;
+        }
+        const availablePresentation: SourcePresentation = {
+          status: 'available',
+          absolutePath: resolution.absolutePath,
+          sourceChanged: resolution.sourceChanged,
+          thumbnailUrl: null,
+        };
+        updateSourcePresentation(prompt.id, availablePresentation);
+        if (window.electronAPI?.generateThumbnailFromPath) {
+          try {
+            const result = await window.electronAPI.generateThumbnailFromPath({
+              filePath: resolution.absolutePath,
+              maxEdge: 840,
+              quality: 84,
+            });
+            if (!isMountedRef.current) return;
+            if (result.success && result.data) {
+              const thumbnailUrl = URL.createObjectURL(new Blob(
+                [new Uint8Array(result.data)],
+                { type: result.mimeType || 'image/webp' },
+              ));
+              sourceObjectUrlsRef.current.add(thumbnailUrl);
+              updateSourcePresentation(prompt.id, { ...availablePresentation, thumbnailUrl });
+            }
+          } catch {
+            // Source navigation remains available when thumbnail generation fails.
+          }
+        }
+      } catch (cause) {
+        if (!isMountedRef.current) return;
+        updateSourcePresentation(prompt.id, { status: 'unavailable' });
+        setActionError(cause instanceof Error ? cause.message : 'Could not resolve the saved source.');
+      } finally {
+        sourceRequestsRef.current.delete(prompt.id);
+      }
+    })();
+    sourceRequestsRef.current.set(prompt.id, request);
+    return request;
+  }, [updateSourcePresentation]);
+
+  const visiblePrompts = useMemo(() => {
+    const needle = query.toLocaleLowerCase();
+    const filtered = needle
+      ? prompts.filter((prompt) => (
+          prompt.positivePrompt.toLocaleLowerCase().includes(needle)
+          || prompt.negativePrompt.toLocaleLowerCase().includes(needle)
+        ))
+      : [...prompts];
+
+    return filtered.sort((left, right) => {
+      const leftTime = sortBy === 'saved' ? left.createdAt : left.sourceCreatedAt;
+      const rightTime = sortBy === 'saved' ? right.createdAt : right.sourceCreatedAt;
+      if (leftTime === null && rightTime !== null) return 1;
+      if (leftTime !== null && rightTime === null) return -1;
+      if (leftTime !== null && rightTime !== null && leftTime !== rightTime) {
+        return sortDirection === 'newest' ? rightTime - leftTime : leftTime - rightTime;
+      }
+      return right.createdAt - left.createdAt || right.id.localeCompare(left.id);
+    });
+  }, [prompts, query, sortBy, sortDirection]);
+
+  const chooseRandom = useCallback((excludeId: string | null = selectedPromptId) => {
+    if (visiblePrompts.length === 0) return;
+    const candidates = visiblePrompts.length > 1
+      ? visiblePrompts.filter((prompt) => prompt.id !== excludeId)
+      : visiblePrompts;
     const selected = candidates[Math.floor(Math.random() * candidates.length)];
     select(selected.id);
-    focusCard(selected.id);
-  }, [filteredPrompts, focusCard, select, selectedPromptId]);
+    setRandomPromptId(selected.id);
+    void ensureSource(selected);
+  }, [ensureSource, select, selectedPromptId, visiblePrompts]);
+
+  const closeRandom = useCallback(() => {
+    setRandomPromptId(null);
+    randomButtonRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  useEffect(() => {
+    if (!randomPromptId) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeRandom();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [closeRandom, randomPromptId]);
 
   const handleCopy = useCallback(async (text: string) => {
     const result = await copyTextToClipboard(text);
     if (!result.success) setActionError(result.error || 'Could not copy the prompt.');
   }, []);
 
+  const randomPrompt = randomPromptId
+    ? prompts.find((prompt) => prompt.id === randomPromptId) ?? null
+    : null;
+  const randomSource = randomPrompt ? sourcePresentations[randomPrompt.id] : undefined;
   const empty = !isLoading && !error && prompts.length === 0;
-  const noMatches = !isLoading && !error && prompts.length > 0 && filteredPrompts.length === 0;
-  const countLabel = query ? `${filteredPrompts.length} of ${prompts.length}` : `${prompts.length} saved`;
+  const noMatches = !isLoading && !error && prompts.length > 0 && visiblePrompts.length === 0;
+  const countLabel = query ? `${visiblePrompts.length} of ${prompts.length}` : `${prompts.length} saved`;
 
   return (
-    <section className="mx-auto flex h-full w-full max-w-7xl flex-col gap-3 overflow-hidden px-1">
-      <div className="flex flex-wrap items-center gap-2 border-b border-gray-800/80 pb-3">
-        <div className="mr-1 flex items-center gap-2 text-sm font-semibold text-gray-200">
-          <Bookmark size={16} />
-          Prompt Library
-          <span className="font-normal text-gray-500">{countLabel}</span>
+    <>
+      <section className="mx-auto flex h-full w-full max-w-7xl flex-col gap-3 overflow-hidden px-1">
+        <div className="flex flex-wrap items-center gap-2 border-b border-gray-800/80 pb-3">
+          <div className="mr-1 flex items-center gap-2 text-sm font-semibold text-gray-200">
+            <Bookmark size={16} />
+            Prompt Library
+            <span className="font-normal text-gray-500">{countLabel}</span>
+          </div>
+          <label className="relative min-w-[220px] flex-1 sm:max-w-md">
+            <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" size={14} />
+            <span className="sr-only">Search saved prompts</span>
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search prompts…"
+              className="h-9 w-full rounded-md border border-gray-700 bg-gray-900 pl-9 pr-8 text-sm text-gray-100 outline-none placeholder:text-gray-500 focus:border-accent/70 focus:ring-1 focus:ring-accent/40"
+            />
+            {query && (
+              <button type="button" onClick={() => setQuery('')} className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-gray-500 hover:text-gray-200" aria-label="Clear search">
+                <X size={13} />
+              </button>
+            )}
+          </label>
+          <label className="flex h-9 items-center gap-1.5 rounded-md border border-gray-700 bg-gray-900 px-2 text-xs text-gray-500">
+            Sort by
+            <select
+              value={sortBy}
+              onChange={(event) => setSortBy(event.target.value as 'saved' | 'created')}
+              className="bg-transparent font-medium text-gray-200 outline-none"
+              aria-label="Sort prompts by"
+            >
+              <option value="saved">Saved</option>
+              <option value="created">Created</option>
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={() => setSortDirection((current) => current === 'newest' ? 'oldest' : 'newest')}
+            className="app-top-pill h-9 px-2.5 text-xs"
+            aria-label={`Sort direction: ${sortDirection === 'newest' ? 'Newest' : 'Oldest'}`}
+            title={`Sort direction: ${sortDirection === 'newest' ? 'Newest' : 'Oldest'}`}
+          >
+            {sortDirection === 'newest' ? <ArrowDown size={14} /> : <ArrowUp size={14} />}
+            {sortDirection === 'newest' ? 'Newest' : 'Oldest'}
+          </button>
+          <button
+            ref={randomButtonRef}
+            type="button"
+            onClick={() => chooseRandom()}
+            disabled={visiblePrompts.length === 0}
+            className="app-top-pill h-9 px-3 text-sm disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Dices size={15} />
+            Random
+          </button>
         </div>
-        <label className="relative min-w-[220px] flex-1 sm:max-w-md">
-          <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" size={14} />
-          <span className="sr-only">Search saved prompts</span>
-          <input
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search prompts…"
-            className="h-9 w-full rounded-md border border-gray-700 bg-gray-900 pl-9 pr-8 text-sm text-gray-100 outline-none placeholder:text-gray-500 focus:border-accent/70 focus:ring-1 focus:ring-accent/40"
-          />
-          {query && (
-            <button type="button" onClick={() => setQuery('')} className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-gray-500 hover:text-gray-200" aria-label="Clear search">
-              <X size={13} />
-            </button>
-          )}
-        </label>
-        <button
-          type="button"
-          onClick={handleRandom}
-          disabled={filteredPrompts.length === 0}
-          className="app-top-pill h-9 px-3 text-sm disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          <Dices size={15} />
-          Random
-        </button>
-      </div>
 
-      {(error || actionError) && (
-        <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
-          {actionError || error}
-          {error && <button type="button" className="ml-3 underline" onClick={() => void load()}>Try again</button>}
-        </div>
-      )}
+        {(error || actionError) && (
+          <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
+            {actionError || error}
+            {error && <button type="button" className="ml-3 underline" onClick={() => void load()}>Try again</button>}
+          </div>
+        )}
 
-      {isLoading && prompts.length === 0 && (
-        <div className="flex flex-1 items-center justify-center text-sm text-gray-400">Loading saved prompts…</div>
-      )}
-      {empty && (
-        <div className="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 p-8 text-center">
-          <Bookmark size={30} className="mb-3 text-gray-500" />
-          <p className="font-medium text-gray-200">No saved prompts yet</p>
-          <p className="mt-1 max-w-md text-sm text-gray-500">Use Save Prompt beside a prompt or from an image context menu.</p>
-        </div>
-      )}
-      {noMatches && (
-        <div className="flex flex-1 flex-col items-center justify-center text-center text-sm text-gray-500">
-          <Search size={27} className="mb-3" />
-          <p className="font-medium text-gray-300">No matching prompts</p>
-          <p className="mt-1">Try a different search.</p>
-        </div>
-      )}
+        {isLoading && prompts.length === 0 && (
+          <div className="flex flex-1 items-center justify-center text-sm text-gray-400">Loading saved prompts…</div>
+        )}
+        {empty && (
+          <div className="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 p-8 text-center">
+            <Bookmark size={30} className="mb-3 text-gray-500" />
+            <p className="font-medium text-gray-200">No saved prompts yet</p>
+            <p className="mt-1 max-w-md text-sm text-gray-500">Use Save Prompt beside a prompt or from an image context menu.</p>
+          </div>
+        )}
+        {noMatches && (
+          <div className="flex flex-1 flex-col items-center justify-center text-center text-sm text-gray-500">
+            <Search size={27} className="mb-3" />
+            <p className="font-medium text-gray-300">No matching prompts</p>
+            <p className="mt-1">Try a different search.</p>
+          </div>
+        )}
 
-      {filteredPrompts.length > 0 && (
-        <div className="grid min-h-0 flex-1 auto-rows-max grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-3 overflow-y-auto pb-4 pr-1">
-          {filteredPrompts.map((prompt) => {
-            const expanded = expandedId === prompt.id;
-            const selected = selectedPromptId === prompt.id;
-            const menuOpen = menuId === prompt.id;
-            return (
-              <article
-                key={prompt.id}
-                ref={(element) => {
-                  if (element) cardRefs.current.set(prompt.id, element);
-                  else cardRefs.current.delete(prompt.id);
-                }}
-                tabIndex={-1}
-                aria-current={selected ? 'true' : undefined}
-                className={`relative overflow-visible rounded-xl border bg-gray-900/75 shadow-sm outline-none transition-all ${
-                  selected
-                    ? 'border-accent ring-2 ring-accent/70 shadow-lg shadow-accent/10'
-                    : 'border-gray-800 hover:border-gray-700'
-                }`}
-              >
-                <div className="overflow-hidden rounded-t-xl">
-                  <PromptSourcePreview prompt={prompt} onViewSource={onViewSource} onError={setActionError} />
-                </div>
-                <div className="p-3">
-                  <p className={`whitespace-pre-wrap break-words text-sm leading-6 text-gray-100 ${expanded ? '' : 'line-clamp-4 min-h-24'}`}>
-                    {prompt.positivePrompt}
-                  </p>
+        {visiblePrompts.length > 0 && (
+          <div className="grid min-h-0 flex-1 auto-rows-max grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-3 overflow-y-auto pb-4 pr-1">
+            {visiblePrompts.map((prompt) => {
+              const expanded = expandedId === prompt.id;
+              const menuOpen = menuId === prompt.id;
+              return (
+                <article key={prompt.id} className="relative overflow-visible rounded-xl border border-gray-800 bg-gray-900/75 shadow-sm transition-colors hover:border-gray-700">
+                  <div className="overflow-hidden rounded-t-xl border-b border-gray-800">
+                    <PromptSourcePreview
+                      prompt={prompt}
+                      presentation={sourcePresentations[prompt.id]}
+                      ensureSource={ensureSource}
+                      onViewSource={onViewSource}
+                    />
+                  </div>
+                  <div className="p-3">
+                    <p className={`whitespace-pre-wrap break-words text-sm leading-6 text-gray-100 ${expanded ? '' : 'line-clamp-4 min-h-24'}`}>
+                      {prompt.positivePrompt}
+                    </p>
 
-                  {expanded && (
-                    <div className="mt-3 space-y-3 border-t border-gray-800 pt-3">
-                      {prompt.negativePrompt ? (
-                        <div>
-                          <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Negative prompt</div>
-                          <p className="whitespace-pre-wrap break-words text-sm leading-5 text-gray-300">{prompt.negativePrompt}</p>
-                          <button type="button" className="mt-2 inline-flex items-center gap-1 text-xs text-gray-400 hover:text-gray-100" onClick={() => void handleCopy(prompt.negativePrompt)}>
-                            <Copy size={12} /> Copy Negative
-                          </button>
+                    {expanded && (
+                      <div className="mt-3 space-y-3 border-t border-gray-800 pt-3">
+                        {prompt.negativePrompt ? (
+                          <div>
+                            <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Negative prompt</div>
+                            <p className="whitespace-pre-wrap break-words text-sm leading-5 text-gray-300">{prompt.negativePrompt}</p>
+                            <button type="button" className="mt-2 inline-flex items-center gap-1 text-xs text-gray-400 hover:text-gray-100" onClick={() => void handleCopy(prompt.negativePrompt)}>
+                              <Copy size={12} /> Copy Negative
+                            </button>
+                          </div>
+                        ) : (
+                          <p className="text-xs text-gray-500">No negative prompt</p>
+                        )}
+                        <div className="space-y-0.5 text-[11px] text-gray-600">
+                          <div>Saved {new Date(prompt.createdAt).toLocaleString()}</div>
+                          <div>{prompt.sourceCreatedAt ? `Created ${new Date(prompt.sourceCreatedAt).toLocaleString()}` : 'Created date unavailable'}</div>
                         </div>
-                      ) : (
-                        <p className="text-xs text-gray-500">No negative prompt</p>
-                      )}
-                      <div className="text-[11px] text-gray-600">Saved {new Date(prompt.createdAt).toLocaleString()}</div>
-                    </div>
-                  )}
+                      </div>
+                    )}
 
-                  <div className="mt-3 flex items-center gap-1.5">
-                    <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => void handleCopy(prompt.positivePrompt)}>
-                      <Copy size={13} /> Copy
-                    </button>
-                    <button
-                      type="button"
-                      className="app-top-pill px-2 py-1.5 text-xs"
-                      onClick={() => setExpandedId(expanded ? null : prompt.id)}
-                      aria-expanded={expanded}
-                    >
-                      {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
-                      {expanded ? 'Less' : 'Details'}
-                    </button>
-                    <div className="relative ml-auto">
+                    <div className="mt-3 flex items-center gap-1.5">
+                      <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => void handleCopy(prompt.positivePrompt)}>
+                        <Copy size={13} /> Copy
+                      </button>
                       <button
                         type="button"
-                        className="app-top-icon-button h-8 w-8 text-gray-500 hover:text-gray-200"
-                        onClick={() => {
-                          setMenuId(menuOpen ? null : prompt.id);
-                          setConfirmingId(null);
-                        }}
-                        aria-label="Prompt actions"
-                        aria-expanded={menuOpen}
+                        className="app-top-pill px-2 py-1.5 text-xs"
+                        onClick={() => setExpandedId(expanded ? null : prompt.id)}
+                        aria-expanded={expanded}
                       >
-                        <MoreHorizontal size={15} />
+                        {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+                        {expanded ? 'Less' : 'Details'}
                       </button>
-                      {menuOpen && (
-                        <div className="absolute bottom-9 right-0 z-20 min-w-40 rounded-lg border border-gray-700 bg-gray-900 p-1.5 shadow-xl shadow-black/40">
-                          {confirmingId === prompt.id ? (
-                            <div className="p-1.5">
-                              <p className="mb-2 text-xs text-gray-300">Remove this saved prompt?</p>
-                              <div className="flex gap-1.5">
-                                <button
-                                  type="button"
-                                  className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-500"
-                                  onClick={async () => {
-                                    try {
-                                      await remove(prompt.id);
-                                      setMenuId(null);
-                                      setConfirmingId(null);
-                                    } catch (cause) {
-                                      setActionError(cause instanceof Error ? cause.message : 'Could not remove the saved prompt.');
-                                    }
-                                  }}
-                                >
-                                  Remove
-                                </button>
-                                <button type="button" className="rounded px-2 py-1 text-xs text-gray-400 hover:bg-gray-800 hover:text-gray-100" onClick={() => setConfirmingId(null)}>Cancel</button>
+                      <div className="relative ml-auto">
+                        <button
+                          type="button"
+                          className="app-top-icon-button h-8 w-8 text-gray-500 hover:text-gray-200"
+                          onClick={() => {
+                            setMenuId(menuOpen ? null : prompt.id);
+                            setConfirmingId(null);
+                          }}
+                          aria-label="Prompt actions"
+                          aria-expanded={menuOpen}
+                        >
+                          <MoreHorizontal size={15} />
+                        </button>
+                        {menuOpen && (
+                          <div className="absolute bottom-9 right-0 z-20 min-w-40 rounded-lg border border-gray-700 bg-gray-900 p-1.5 shadow-xl shadow-black/40">
+                            {confirmingId === prompt.id ? (
+                              <div className="p-1.5">
+                                <p className="mb-2 text-xs text-gray-300">Remove this saved prompt?</p>
+                                <div className="flex gap-1.5">
+                                  <button
+                                    type="button"
+                                    className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-500"
+                                    onClick={async () => {
+                                      try {
+                                        await remove(prompt.id);
+                                        setMenuId(null);
+                                        setConfirmingId(null);
+                                      } catch (cause) {
+                                        setActionError(cause instanceof Error ? cause.message : 'Could not remove the saved prompt.');
+                                      }
+                                    }}
+                                  >
+                                    Remove
+                                  </button>
+                                  <button type="button" className="rounded px-2 py-1 text-xs text-gray-400 hover:bg-gray-800 hover:text-gray-100" onClick={() => setConfirmingId(null)}>Cancel</button>
+                                </div>
                               </div>
-                            </div>
-                          ) : (
-                            <button type="button" className="flex w-full items-center gap-2 rounded px-2.5 py-2 text-left text-xs text-gray-300 hover:bg-gray-800 hover:text-red-300" onClick={() => setConfirmingId(prompt.id)}>
-                              <Trash2 size={13} /> Remove saved prompt
-                            </button>
-                          )}
-                        </div>
-                      )}
+                            ) : (
+                              <button type="button" className="flex w-full items-center gap-2 rounded px-2.5 py-2 text-left text-xs text-gray-300 hover:bg-gray-800 hover:text-red-300" onClick={() => setConfirmingId(prompt.id)}>
+                                <Trash2 size={13} /> Remove saved prompt
+                              </button>
+                            )}
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {randomPrompt && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) closeRandom();
+          }}
+        >
+          <div role="dialog" aria-modal="true" aria-label="Random saved prompt" className="flex max-h-[92vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl shadow-black/60">
+            <div className="relative border-b border-gray-800">
+              <PromptSourcePreview
+                prompt={randomPrompt}
+                presentation={randomSource}
+                ensureSource={ensureSource}
+                onViewSource={onViewSource}
+                large
+              />
+              <button type="button" onClick={closeRandom} className="absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/70 text-gray-200 backdrop-blur-sm hover:bg-black/90" aria-label="Close random prompt">
+                <X size={17} />
+              </button>
+            </div>
+            <div className="min-h-0 overflow-y-auto p-5">
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-500">Prompt</div>
+              <p className="whitespace-pre-wrap break-words text-sm leading-6 text-gray-100">{randomPrompt.positivePrompt}</p>
+              {randomPrompt.negativePrompt && (
+                <div className="mt-5 border-t border-gray-800 pt-4">
+                  <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-500">Negative prompt</div>
+                  <p className="whitespace-pre-wrap break-words text-sm leading-6 text-gray-300">{randomPrompt.negativePrompt}</p>
                 </div>
-              </article>
-            );
-          })}
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-2 border-t border-gray-800 bg-gray-950/50 px-5 py-3">
+              <button type="button" className="app-top-pill px-3 py-2 text-sm" onClick={() => void handleCopy(randomPrompt.positivePrompt)}>
+                <Copy size={14} /> Copy
+              </button>
+              {randomPrompt.negativePrompt && (
+                <button type="button" className="app-top-pill px-3 py-2 text-sm" onClick={() => void handleCopy(randomPrompt.negativePrompt)}>
+                  <Copy size={14} /> Copy Negative
+                </button>
+              )}
+              <button
+                type="button"
+                className="app-top-pill px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-40"
+                disabled={randomSource?.status !== 'available' || !randomSource.absolutePath}
+                onClick={() => {
+                  if (!randomSource?.absolutePath) return;
+                  const path = randomSource.absolutePath;
+                  closeRandom();
+                  void onViewSource(path);
+                }}
+              >
+                <ExternalLink size={14} /> View Source
+              </button>
+              <button type="button" className="app-top-pill ml-auto px-3 py-2 text-sm" onClick={() => chooseRandom(randomPrompt.id)}>
+                <Dices size={14} /> Another
+              </button>
+            </div>
+          </div>
         </div>
       )}
-    </section>
+    </>
   );
 };
 

--- a/components/PromptLibrary.tsx
+++ b/components/PromptLibrary.tsx
@@ -3,6 +3,7 @@ import {
   ArrowDown,
   ArrowUp,
   Bookmark,
+  Check,
   ChevronDown,
   ChevronUp,
   Copy,
@@ -114,18 +115,22 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [randomPromptId, setRandomPromptId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [copiedActionKey, setCopiedActionKey] = useState<string | null>(null);
   const [sourcePresentations, setSourcePresentations] = useState<Record<string, SourcePresentation>>({});
   const sourcePresentationsRef = useRef<Record<string, SourcePresentation>>({});
   const sourceRequestsRef = useRef(new Map<string, Promise<void>>());
   const sourceObjectUrlsRef = useRef(new Set<string>());
   const isMountedRef = useRef(true);
   const randomButtonRef = useRef<HTMLButtonElement>(null);
+  const modalTriggerRef = useRef<HTMLElement | null>(null);
+  const copyFeedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => initializeSavedPromptSynchronization(), []);
   useEffect(() => {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
+      if (copyFeedbackTimeoutRef.current) clearTimeout(copyFeedbackTimeoutRef.current);
       for (const url of sourceObjectUrlsRef.current) URL.revokeObjectURL(url);
     };
   }, []);
@@ -212,20 +217,24 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
     });
   }, [prompts, query, sortBy, sortDirection]);
 
+  const openPrompt = useCallback((prompt: SavedPrompt) => {
+    select(prompt.id);
+    setRandomPromptId(prompt.id);
+    void ensureSource(prompt);
+  }, [ensureSource, select]);
+
   const chooseRandom = useCallback((excludeId: string | null = selectedPromptId) => {
     if (visiblePrompts.length === 0) return;
     const candidates = visiblePrompts.length > 1
       ? visiblePrompts.filter((prompt) => prompt.id !== excludeId)
       : visiblePrompts;
     const selected = candidates[Math.floor(Math.random() * candidates.length)];
-    select(selected.id);
-    setRandomPromptId(selected.id);
-    void ensureSource(selected);
-  }, [ensureSource, select, selectedPromptId, visiblePrompts]);
+    openPrompt(selected);
+  }, [openPrompt, selectedPromptId, visiblePrompts]);
 
   const closeRandom = useCallback(() => {
     setRandomPromptId(null);
-    randomButtonRef.current?.focus({ preventScroll: true });
+    (modalTriggerRef.current ?? randomButtonRef.current)?.focus({ preventScroll: true });
   }, []);
 
   useEffect(() => {
@@ -237,9 +246,27 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [closeRandom, randomPromptId]);
 
-  const handleCopy = useCallback(async (text: string) => {
+  useEffect(() => {
+    if (!menuId) return undefined;
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target;
+      if (target instanceof Element && target.closest('[data-prompt-actions]')) return;
+      setMenuId(null);
+      setConfirmingId(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [menuId]);
+
+  const handleCopy = useCallback(async (text: string, actionKey: string) => {
     const result = await copyTextToClipboard(text);
-    if (!result.success) setActionError(result.error || 'Could not copy the prompt.');
+    if (!result.success) {
+      setActionError(result.error || 'Could not copy the prompt.');
+      return;
+    }
+    setCopiedActionKey(actionKey);
+    if (copyFeedbackTimeoutRef.current) clearTimeout(copyFeedbackTimeoutRef.current);
+    copyFeedbackTimeoutRef.current = setTimeout(() => setCopiedActionKey(null), 1400);
   }, []);
 
   const randomPrompt = randomPromptId
@@ -300,7 +327,10 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
           <button
             ref={randomButtonRef}
             type="button"
-            onClick={() => chooseRandom()}
+            onClick={(event) => {
+              modalTriggerRef.current = event.currentTarget;
+              chooseRandom();
+            }}
             disabled={visiblePrompts.length === 0}
             className="app-top-pill h-9 px-3 text-sm disabled:cursor-not-allowed disabled:opacity-40"
           >
@@ -339,8 +369,27 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
             {visiblePrompts.map((prompt) => {
               const expanded = expandedId === prompt.id;
               const menuOpen = menuId === prompt.id;
+              const positiveCopyKey = `positive:${prompt.id}`;
+              const negativeCopyKey = `negative:${prompt.id}`;
               return (
-                <article key={prompt.id} className="relative overflow-visible rounded-xl border border-gray-800 bg-gray-900/75 shadow-sm transition-colors hover:border-gray-700">
+                <article
+                  key={prompt.id}
+                  tabIndex={0}
+                  aria-label="Open saved prompt"
+                  onClick={(event) => {
+                    const target = event.target;
+                    if (target instanceof Element && target.closest('button, a, input, select, textarea, [data-prompt-actions]')) return;
+                    modalTriggerRef.current = event.currentTarget;
+                    openPrompt(prompt);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.target !== event.currentTarget || (event.key !== 'Enter' && event.key !== ' ')) return;
+                    event.preventDefault();
+                    modalTriggerRef.current = event.currentTarget;
+                    openPrompt(prompt);
+                  }}
+                  className="relative cursor-pointer overflow-visible rounded-xl border border-gray-800 bg-gray-900/75 shadow-sm transition-colors hover:border-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
                   <div className="overflow-hidden rounded-t-xl border-b border-gray-800">
                     <PromptSourcePreview
                       prompt={prompt}
@@ -360,8 +409,13 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
                           <div>
                             <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Negative prompt</div>
                             <p className="whitespace-pre-wrap break-words text-sm leading-5 text-gray-300">{prompt.negativePrompt}</p>
-                            <button type="button" className="mt-2 inline-flex items-center gap-1 text-xs text-gray-400 hover:text-gray-100" onClick={() => void handleCopy(prompt.negativePrompt)}>
-                              <Copy size={12} /> Copy Negative
+                            <button
+                              type="button"
+                              className={`mt-2 inline-flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors ${copiedActionKey === negativeCopyKey ? 'bg-accent text-white' : 'text-gray-400 hover:bg-gray-800 hover:text-gray-100'}`}
+                              onClick={() => void handleCopy(prompt.negativePrompt, negativeCopyKey)}
+                            >
+                              {copiedActionKey === negativeCopyKey ? <Check size={12} /> : <Copy size={12} />}
+                              {copiedActionKey === negativeCopyKey ? 'Copied' : 'Copy Negative'}
                             </button>
                           </div>
                         ) : (
@@ -375,8 +429,13 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
                     )}
 
                     <div className="mt-3 flex items-center gap-1.5">
-                      <button type="button" className="app-top-pill px-2.5 py-1.5 text-xs" onClick={() => void handleCopy(prompt.positivePrompt)}>
-                        <Copy size={13} /> Copy
+                      <button
+                        type="button"
+                        className={`app-top-pill px-2.5 py-1.5 text-xs ${copiedActionKey === positiveCopyKey ? 'border-accent bg-accent text-white hover:bg-accent/90' : ''}`}
+                        onClick={() => void handleCopy(prompt.positivePrompt, positiveCopyKey)}
+                      >
+                        {copiedActionKey === positiveCopyKey ? <Check size={13} /> : <Copy size={13} />}
+                        {copiedActionKey === positiveCopyKey ? 'Copied' : 'Copy'}
                       </button>
                       <button
                         type="button"
@@ -387,7 +446,7 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
                         {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
                         {expanded ? 'Less' : 'Details'}
                       </button>
-                      <div className="relative ml-auto">
+                      <div className="relative ml-auto" data-prompt-actions>
                         <button
                           type="button"
                           className="app-top-icon-button h-8 w-8 text-gray-500 hover:text-gray-200"
@@ -448,7 +507,7 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
             if (event.target === event.currentTarget) closeRandom();
           }}
         >
-          <div role="dialog" aria-modal="true" aria-label="Random saved prompt" className="flex max-h-[92vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl shadow-black/60">
+          <div role="dialog" aria-modal="true" aria-label="Saved prompt details" className="flex max-h-[92vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl shadow-black/60">
             <div className="relative border-b border-gray-800">
               <PromptSourcePreview
                 prompt={randomPrompt}
@@ -457,7 +516,7 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
                 onViewSource={onViewSource}
                 large
               />
-              <button type="button" onClick={closeRandom} className="absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/70 text-gray-200 backdrop-blur-sm hover:bg-black/90" aria-label="Close random prompt">
+              <button type="button" onClick={closeRandom} className="absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/70 text-gray-200 backdrop-blur-sm hover:bg-black/90" aria-label="Close prompt details">
                 <X size={17} />
               </button>
             </div>
@@ -472,12 +531,22 @@ const PromptLibrary: React.FC<PromptLibraryProps> = ({ onViewSource }) => {
               )}
             </div>
             <div className="flex flex-wrap items-center gap-2 border-t border-gray-800 bg-gray-950/50 px-5 py-3">
-              <button type="button" className="app-top-pill px-3 py-2 text-sm" onClick={() => void handleCopy(randomPrompt.positivePrompt)}>
-                <Copy size={14} /> Copy
+              <button
+                type="button"
+                className={`app-top-pill px-3 py-2 text-sm ${copiedActionKey === `positive:${randomPrompt.id}` ? 'border-accent bg-accent text-white hover:bg-accent/90' : ''}`}
+                onClick={() => void handleCopy(randomPrompt.positivePrompt, `positive:${randomPrompt.id}`)}
+              >
+                {copiedActionKey === `positive:${randomPrompt.id}` ? <Check size={14} /> : <Copy size={14} />}
+                {copiedActionKey === `positive:${randomPrompt.id}` ? 'Copied' : 'Copy'}
               </button>
               {randomPrompt.negativePrompt && (
-                <button type="button" className="app-top-pill px-3 py-2 text-sm" onClick={() => void handleCopy(randomPrompt.negativePrompt)}>
-                  <Copy size={14} /> Copy Negative
+                <button
+                  type="button"
+                  className={`app-top-pill px-3 py-2 text-sm ${copiedActionKey === `negative:${randomPrompt.id}` ? 'border-accent bg-accent text-white hover:bg-accent/90' : ''}`}
+                  onClick={() => void handleCopy(randomPrompt.negativePrompt, `negative:${randomPrompt.id}`)}
+                >
+                  {copiedActionKey === `negative:${randomPrompt.id}` ? <Check size={14} /> : <Copy size={14} />}
+                  {copiedActionKey === `negative:${randomPrompt.id}` ? 'Copied' : 'Copy Negative'}
                 </button>
               )}
               <button

--- a/components/settings/LibrarySettingsPanel.tsx
+++ b/components/settings/LibrarySettingsPanel.tsx
@@ -162,6 +162,7 @@ export const LibrarySettingsPanel: React.FC<{ onClose: () => void }> = ({ onClos
         '',
         'Your image files will not be deleted.',
         'Your license and trial state will be kept.',
+        'Saved prompts will be kept.',
         'The app will reload after the reset.',
         '',
         'This action cannot be undone.',

--- a/electron-deeplink.mjs
+++ b/electron-deeplink.mjs
@@ -14,6 +14,8 @@ const __dirname = path.dirname(__filename);
 const portableRuntime = resolvePortableRuntime();
 const packagedProvenanceSmokeEnabled = app.isPackaged
   && process.env.IMH_PACKAGED_PROVENANCE_FILE_OPERATIONS_SMOKE === '1';
+const packagedSavedPromptSmokeEnabled = app.isPackaged
+  && process.env.IMH_PACKAGED_SAVED_PROMPT_SMOKE === '1';
 let portableStartupError = null;
 
 try {
@@ -145,7 +147,7 @@ function registerProtocol() {
 }
 
 if (!portableStartupError) {
-  const lock = packagedProvenanceSmokeEnabled || app.requestSingleInstanceLock();
+  const lock = packagedProvenanceSmokeEnabled || packagedSavedPromptSmokeEnabled || app.requestSingleInstanceLock();
 
   if (!lock) {
     app.quit();
@@ -179,8 +181,11 @@ if (!portableStartupError) {
       await import('./electron.mjs');
     } catch (error) {
       console.error('[Electron bootstrap] Failed to import the main process:', error);
-      if (packagedProvenanceSmokeEnabled) {
-        const resultPath = process.env.IMH_PACKAGED_PROVENANCE_FILE_OPERATIONS_SMOKE_RESULT?.trim();
+      if (packagedProvenanceSmokeEnabled || packagedSavedPromptSmokeEnabled) {
+        const resultPath = (
+          process.env.IMH_PACKAGED_PROVENANCE_FILE_OPERATIONS_SMOKE_RESULT
+          || process.env.IMH_PACKAGED_SAVED_PROMPT_SMOKE_RESULT
+        )?.trim();
         if (resultPath) {
           try {
             fs.mkdirSync(path.dirname(resultPath), { recursive: true });

--- a/electron.mjs
+++ b/electron.mjs
@@ -47,6 +47,7 @@ import { StableIdentityIndexer } from './electron/stableIdentityIndexer.mjs';
 import { StableIdentityFileOperationCoordinator } from './electron/stableIdentityFileOperationCoordinator.mjs';
 import { StableIdentityUserDataService } from './electron/stableIdentityUserDataService.mjs';
 import { runStableIdentityFileOperationsSmoke } from './electron/stableIdentityFileOperationsSmoke.mjs';
+import { runSavedPromptPackagedSmoke } from './electron/savedPromptPackagedSmoke.mjs';
 import { openAuthorizedCacheDirectory } from './electron/cacheDirectory.mjs';
 import { appendEmbeddingSegmentAtOffset } from './electron/embeddingSegmentFile.mjs';
 import { hashFileSha256 } from './electron/fileFingerprint.mjs';
@@ -104,6 +105,8 @@ const provenanceIndexingEnabled = process.env.IMH_ENABLE_PROVENANCE_INDEXING ===
   || process.env.IMH_ENABLE_PROVENANCE_INDEXING === 'true';
 const packagedProvenanceFileOperationsSmokeEnabled = app.isPackaged
   && process.env.IMH_PACKAGED_PROVENANCE_FILE_OPERATIONS_SMOKE === '1';
+const packagedSavedPromptSmokeEnabled = app.isPackaged
+  && process.env.IMH_PACKAGED_SAVED_PROMPT_SMOKE === '1';
 const enabledMediaCommandLineSwitches = [];
 const disabledChromiumFeatures = new Set();
 
@@ -3020,6 +3023,32 @@ app.whenReady().then(async () => {
     },
   });
   await stableIdentityFileOperationCoordinator.initializeRecovery();
+
+  if (packagedSavedPromptSmokeEnabled) {
+    const resultPath = process.env.IMH_PACKAGED_SAVED_PROMPT_SMOKE_RESULT?.trim();
+    try {
+      if (!resultPath) throw new Error('Packaged saved-prompt smoke result path is required.');
+      const result = runSavedPromptPackagedSmoke({
+        userDataPath: app.getPath('userData'),
+        repositoryLifecycle: provenanceRepositoryLifecycle,
+        indexingEnabled: provenanceIndexingEnabled,
+      });
+      await fs.mkdir(path.dirname(resultPath), { recursive: true });
+      await fs.writeFile(resultPath, JSON.stringify(result, null, 2), 'utf8');
+      console.log('[packaged-saved-prompt-smoke] success');
+      app.exit(0);
+    } catch (error) {
+      console.error('[packaged-saved-prompt-smoke] failed', error);
+      if (resultPath) {
+        try {
+          await fs.mkdir(path.dirname(resultPath), { recursive: true });
+          await fs.writeFile(resultPath, JSON.stringify({ success: false, error: error?.message || String(error) }, null, 2), 'utf8');
+        } catch { /* console output remains the fallback diagnostic */ }
+      }
+      app.exit(1);
+    }
+    return;
+  }
 
   if (packagedProvenanceFileOperationsSmokeEnabled) {
     const smokeRoot = process.env.IMH_PACKAGED_PROVENANCE_FILE_OPERATIONS_SMOKE_ROOT?.trim();
@@ -6376,6 +6405,40 @@ function setupFileOperationHandlers() {
   ));
   ipcMain.handle('stable-user-data-tag-counts', () => (
     handleStableUserDataRequest((service) => service.getTagCounts())
+  ));
+
+  const handleSavedPromptRequest = (operation) => {
+    try {
+      return { success: true, data: provenanceRepositoryLifecycle.run(operation) };
+    } catch (error) {
+      return {
+        success: false,
+        error: error?.message || String(error),
+        errorCode: error?.code || 'SAVED_PROMPT_OPERATION_FAILED',
+      };
+    }
+  };
+  const notifySavedPromptsChanged = () => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) window.webContents.send('saved-prompts:changed');
+    }
+  };
+
+  ipcMain.handle('saved-prompts:list', () => (
+    handleSavedPromptRequest((repository) => repository.listSavedPrompts())
+  ));
+  ipcMain.handle('saved-prompts:save', (_event, input) => {
+    const result = handleSavedPromptRequest((repository) => repository.savePrompt(input));
+    if (result.success && result.data.status === 'saved') notifySavedPromptsChanged();
+    return result;
+  });
+  ipcMain.handle('saved-prompts:remove', (_event, id) => {
+    const result = handleSavedPromptRequest((repository) => repository.removeSavedPrompt(id));
+    if (result.success && result.data.removed) notifySavedPromptsChanged();
+    return result;
+  });
+  ipcMain.handle('saved-prompts:resolve-source', (_event, id) => (
+    handleSavedPromptRequest((repository) => repository.resolveSavedPromptSource(id))
   ));
 
   // ============================================================

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -8,9 +8,10 @@ import {
   resolveProvenanceCatalogPath,
 } from './provenancePaths.mjs';
 import { StableIdentityUserDataRepository } from './stableIdentityUserDataRepository.mjs';
+import { SavedPromptRepository } from './savedPromptRepository.mjs';
 
 export { PROVENANCE_DATABASE_NAME, PROVENANCE_DIRECTORY_NAME, resolveProvenanceCatalogPath };
-export const PROVENANCE_SCHEMA_VERSION = 5;
+export const PROVENANCE_SCHEMA_VERSION = 6;
 
 export const ASSET_STATES = Object.freeze(['active', 'missing', 'deleted']);
 export const LOCATION_STATES = Object.freeze(['present', 'missing', 'removed']);
@@ -277,12 +278,31 @@ function migrationFive(database) {
   `);
 }
 
+function migrationSix(database) {
+  database.exec(`
+    CREATE TABLE saved_prompts (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL CHECK (created_at >= 0),
+      positive_prompt TEXT NOT NULL,
+      negative_prompt TEXT NOT NULL,
+      text_basis TEXT NOT NULL CHECK (text_basis IN ('effective', 'original')),
+      source_json TEXT,
+      prompt_digest TEXT NOT NULL,
+      CHECK (length(trim(positive_prompt)) > 0)
+    ) STRICT;
+
+    CREATE INDEX saved_prompts_digest_idx ON saved_prompts(prompt_digest);
+    CREATE INDEX saved_prompts_created_idx ON saved_prompts(created_at DESC, id DESC);
+  `);
+}
+
 const MIGRATIONS = new Map([
   [1, migrationOne],
   [2, migrationTwo],
   [3, migrationThree],
   [4, migrationFour],
   [5, migrationFive],
+  [6, migrationSix],
 ]);
 
 function serializeAsset(row) {
@@ -387,6 +407,7 @@ export class AssetProvenanceRepository {
     this.backupDatabase = backupDatabase;
     this.database = null;
     this.userData = null;
+    this.savedPrompts = null;
   }
 
   open({ failMigrationVersion = null, targetSchemaVersion = PROVENANCE_SCHEMA_VERSION } = {}) {
@@ -419,6 +440,13 @@ export class AssetProvenanceRepository {
         this.userData = new StableIdentityUserDataRepository({
           database: this.database,
           now: this.now,
+        });
+      }
+      if (readSchemaVersion(this.database) >= 6) {
+        this.savedPrompts = new SavedPromptRepository({
+          database: this.database,
+          randomUUID: this.randomUUID,
+          now: () => this.now().getTime(),
         });
       }
       return this.getStatus();
@@ -527,6 +555,28 @@ export class AssetProvenanceRepository {
   getUserDataTagCounts() {
     this.#requireUserDataRepository();
     return this.userData.getTagCounts();
+  }
+
+  listSavedPrompts() {
+    this.#requireSavedPromptRepository();
+    return this.savedPrompts.list();
+  }
+
+  savePrompt(input) {
+    this.#requireWritable();
+    this.#requireSavedPromptRepository();
+    return this.savedPrompts.save(input);
+  }
+
+  removeSavedPrompt(id) {
+    this.#requireWritable();
+    this.#requireSavedPromptRepository();
+    return this.savedPrompts.remove(id);
+  }
+
+  resolveSavedPromptSource(id) {
+    this.#requireSavedPromptRepository();
+    return this.savedPrompts.resolveSource(id);
   }
 
   captureAssetUserDataSnapshot(assetId, copiedAt = this.now().getTime()) {
@@ -1156,6 +1206,7 @@ export class AssetProvenanceRepository {
     try { this.database.close(); } finally {
       this.database = null;
       this.userData = null;
+      this.savedPrompts = null;
     }
   }
 
@@ -1343,6 +1394,15 @@ export class AssetProvenanceRepository {
       throw new ProvenanceRepositoryError(
         'PROVENANCE_USER_DATA_UNAVAILABLE',
         'Stable-identity user-data storage is unavailable for this catalog schema.',
+      );
+    }
+  }
+
+  #requireSavedPromptRepository() {
+    if (!this.savedPrompts) {
+      throw new ProvenanceRepositoryError(
+        'SAVED_PROMPTS_UNAVAILABLE',
+        'Saved-prompt storage is unavailable for this catalog schema.',
       );
     }
   }

--- a/electron/provenanceRepository.mjs
+++ b/electron/provenanceRepository.mjs
@@ -11,7 +11,7 @@ import { StableIdentityUserDataRepository } from './stableIdentityUserDataReposi
 import { SavedPromptRepository } from './savedPromptRepository.mjs';
 
 export { PROVENANCE_DATABASE_NAME, PROVENANCE_DIRECTORY_NAME, resolveProvenanceCatalogPath };
-export const PROVENANCE_SCHEMA_VERSION = 6;
+export const PROVENANCE_SCHEMA_VERSION = 7;
 
 export const ASSET_STATES = Object.freeze(['active', 'missing', 'deleted']);
 export const LOCATION_STATES = Object.freeze(['present', 'missing', 'removed']);
@@ -296,6 +296,14 @@ function migrationSix(database) {
   `);
 }
 
+function migrationSeven(database) {
+  database.exec(`
+    ALTER TABLE saved_prompts
+    ADD COLUMN source_created_at INTEGER
+    CHECK (source_created_at IS NULL OR source_created_at > 0);
+  `);
+}
+
 const MIGRATIONS = new Map([
   [1, migrationOne],
   [2, migrationTwo],
@@ -303,6 +311,7 @@ const MIGRATIONS = new Map([
   [4, migrationFour],
   [5, migrationFive],
   [6, migrationSix],
+  [7, migrationSeven],
 ]);
 
 function serializeAsset(row) {

--- a/electron/savedPromptPackagedSmoke.mjs
+++ b/electron/savedPromptPackagedSmoke.mjs
@@ -1,0 +1,60 @@
+import { PROVENANCE_SCHEMA_VERSION, ProvenanceRepositoryLifecycle } from './provenanceRepository.mjs';
+
+function assertSmoke(condition, message) {
+  if (!condition) throw new Error(`Packaged saved-prompt smoke failed: ${message}`);
+}
+
+export function runSavedPromptPackagedSmoke({
+  userDataPath,
+  repositoryLifecycle,
+  indexingEnabled,
+}) {
+  const first = repositoryLifecycle.run((repository) => {
+    const saved = repository.savePrompt({
+      positivePrompt: '  packaged literal prompt\nsecond line  ',
+      negativePrompt: '',
+      textBasis: 'effective',
+      source: null,
+    });
+    const duplicate = repository.savePrompt({
+      positivePrompt: '  packaged literal prompt\nsecond line  ',
+      negativePrompt: '',
+      textBasis: 'original',
+      source: null,
+    });
+    assertSmoke(saved.status === 'saved', 'initial save did not commit');
+    assertSmoke(duplicate.status === 'already-saved', 'literal duplicate was not detected');
+    assertSmoke(duplicate.prompt.id === saved.prompt.id, 'duplicate changed prompt identity');
+    assertSmoke(duplicate.prompt.textBasis === 'effective', 'duplicate changed the historical text basis');
+    return saved.prompt;
+  });
+
+  repositoryLifecycle.close();
+  const reopenedLifecycle = new ProvenanceRepositoryLifecycle({ userDataPath });
+  const reopenedStatus = reopenedLifecycle.initialize();
+  const reopened = reopenedLifecycle.run((repository) => repository.listSavedPrompts());
+  assertSmoke(reopenedStatus.available, 'catalog was unavailable after reopen');
+  assertSmoke(reopenedStatus.schemaVersion === PROVENANCE_SCHEMA_VERSION, 'reopened catalog schema is not current');
+  assertSmoke(reopened.length === 1, 'saved prompt did not survive reopen exactly once');
+  assertSmoke(reopened[0]?.id === first.id, 'saved prompt identity changed after reopen');
+  assertSmoke(reopened[0]?.positivePrompt === first.positivePrompt, 'literal prompt text changed after reopen');
+
+  const removed = reopenedLifecycle.run((repository) => repository.removeSavedPrompt(first.id));
+  const removedAgain = reopenedLifecycle.run((repository) => repository.removeSavedPrompt(first.id));
+  const finalPrompts = reopenedLifecycle.run((repository) => repository.listSavedPrompts());
+  assertSmoke(removed?.removed === true, 'saved prompt was not removed');
+  assertSmoke(removedAgain?.removed === false, 'second removal was not idempotent');
+  assertSmoke(finalPrompts.length === 0, 'removed prompt remained in the catalog');
+  reopenedLifecycle.close();
+
+  return {
+    success: true,
+    indexingEnabled,
+    schemaVersion: reopenedStatus.schemaVersion,
+    authority: 'sqlite',
+    reopened: true,
+    duplicatePreservedIdentity: true,
+    literalTextPreserved: true,
+    idempotentRemove: true,
+  };
+}

--- a/electron/savedPromptPackagedSmoke.mjs
+++ b/electron/savedPromptPackagedSmoke.mjs
@@ -15,6 +15,7 @@ export function runSavedPromptPackagedSmoke({
       negativePrompt: '',
       textBasis: 'effective',
       source: null,
+      sourceCreatedAt: 1_700_000_000_000,
     });
     const duplicate = repository.savePrompt({
       positivePrompt: '  packaged literal prompt\nsecond line  ',
@@ -38,6 +39,7 @@ export function runSavedPromptPackagedSmoke({
   assertSmoke(reopened.length === 1, 'saved prompt did not survive reopen exactly once');
   assertSmoke(reopened[0]?.id === first.id, 'saved prompt identity changed after reopen');
   assertSmoke(reopened[0]?.positivePrompt === first.positivePrompt, 'literal prompt text changed after reopen');
+  assertSmoke(reopened[0]?.sourceCreatedAt === first.sourceCreatedAt, 'source creation timestamp changed after reopen');
 
   const removed = reopenedLifecycle.run((repository) => repository.removeSavedPrompt(first.id));
   const removedAgain = reopenedLifecycle.run((repository) => repository.removeSavedPrompt(first.id));
@@ -55,6 +57,7 @@ export function runSavedPromptPackagedSmoke({
     reopened: true,
     duplicatePreservedIdentity: true,
     literalTextPreserved: true,
+    sourceCreatedAtPreserved: true,
     idempotentRemove: true,
   };
 }

--- a/electron/savedPromptRepository.mjs
+++ b/electron/savedPromptRepository.mjs
@@ -1,0 +1,236 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export class SavedPromptRepositoryError extends Error {
+  constructor(code, message, cause = null) {
+    super(message, cause ? { cause } : undefined);
+    this.name = 'SavedPromptRepositoryError';
+    this.code = code;
+  }
+}
+
+const isUuid = (value) => (
+  typeof value === 'string'
+  && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+);
+
+const optionalStatValue = (value, name) => {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new SavedPromptRepositoryError('SAVED_PROMPT_INVALID_SOURCE', `${name} must be null or a non-negative finite number.`);
+  }
+  return value;
+};
+
+function normalizePathSnapshot(value) {
+  if (!value || typeof value !== 'object') {
+    throw new SavedPromptRepositoryError('SAVED_PROMPT_INVALID_SOURCE', 'A source path snapshot is required.');
+  }
+  const directoryPath = typeof value.directoryPath === 'string' ? value.directoryPath : '';
+  const relativePath = typeof value.relativePath === 'string' ? value.relativePath : '';
+  if (!path.isAbsolute(directoryPath) || !relativePath || path.isAbsolute(relativePath)) {
+    throw new SavedPromptRepositoryError('SAVED_PROMPT_INVALID_SOURCE', 'The source path locator is invalid.');
+  }
+  const absolutePath = path.resolve(directoryPath, relativePath);
+  const relativeCheck = path.relative(path.resolve(directoryPath), absolutePath);
+  if (relativeCheck.startsWith('..') || path.isAbsolute(relativeCheck)) {
+    throw new SavedPromptRepositoryError('SAVED_PROMPT_INVALID_SOURCE', 'The source path escapes its directory.');
+  }
+  return {
+    directoryPath,
+    relativePath,
+    fileSize: optionalStatValue(value.fileSize, 'fileSize'),
+    contentModifiedMs: optionalStatValue(value.contentModifiedMs, 'contentModifiedMs'),
+  };
+}
+
+function serializeRow(row) {
+  if (!row) return null;
+  let source = null;
+  if (typeof row.source_json === 'string') {
+    try { source = JSON.parse(row.source_json); } catch { source = null; }
+  }
+  return {
+    id: row.id,
+    createdAt: Number(row.created_at),
+    positivePrompt: row.positive_prompt,
+    negativePrompt: row.negative_prompt,
+    textBasis: row.text_basis,
+    source,
+  };
+}
+
+function runTransaction(database, operation) {
+  database.exec('BEGIN IMMEDIATE');
+  try {
+    const result = operation();
+    database.exec('COMMIT');
+    return result;
+  } catch (error) {
+    try { database.exec('ROLLBACK'); } catch { /* keep original error */ }
+    throw error;
+  }
+}
+
+export class SavedPromptRepository {
+  constructor({
+    database,
+    randomUUID = () => crypto.randomUUID(),
+    now = () => Date.now(),
+    digest = (positivePrompt, negativePrompt) => crypto
+      .createHash('sha256')
+      .update(positivePrompt, 'utf8')
+      .update('\0', 'utf8')
+      .update(negativePrompt, 'utf8')
+      .digest('hex'),
+    statSync = (filePath) => fs.statSync(filePath),
+  }) {
+    this.database = database;
+    this.randomUUID = randomUUID;
+    this.now = now;
+    this.digest = digest;
+    this.statSync = statSync;
+  }
+
+  list() {
+    return this.database.prepare('SELECT * FROM saved_prompts ORDER BY created_at DESC, id DESC').all().map(serializeRow);
+  }
+
+  save(input) {
+    const positivePrompt = typeof input?.positivePrompt === 'string' ? input.positivePrompt : '';
+    const negativePrompt = typeof input?.negativePrompt === 'string' ? input.negativePrompt : '';
+    if (!positivePrompt.trim()) {
+      throw new SavedPromptRepositoryError('SAVED_PROMPT_EMPTY_POSITIVE', 'A non-empty positive prompt is required.');
+    }
+    const textBasis = input?.textBasis === 'original' ? 'original' : 'effective';
+    const promptDigest = this.digest(positivePrompt, negativePrompt);
+    return runTransaction(this.database, () => {
+      const candidates = this.database.prepare('SELECT * FROM saved_prompts WHERE prompt_digest = ?').all(promptDigest);
+      const duplicate = candidates.find((row) => (
+        row.positive_prompt === positivePrompt && row.negative_prompt === negativePrompt
+      ));
+      if (duplicate) return { status: 'already-saved', prompt: serializeRow(duplicate) };
+
+      const prompt = {
+        id: this.randomUUID(),
+        createdAt: Math.trunc(this.now()),
+        positivePrompt,
+        negativePrompt,
+        textBasis,
+        source: this.#normalizeSource(input?.source),
+      };
+      if (!isUuid(prompt.id)) {
+        throw new SavedPromptRepositoryError('SAVED_PROMPT_INVALID_ID', 'The generated prompt id must be a UUID.');
+      }
+      this.database.prepare(`
+        INSERT INTO saved_prompts (
+          id, created_at, positive_prompt, negative_prompt, text_basis, source_json, prompt_digest
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        prompt.id.toLowerCase(), prompt.createdAt, prompt.positivePrompt, prompt.negativePrompt,
+        prompt.textBasis, prompt.source ? JSON.stringify(prompt.source) : null, promptDigest,
+      );
+      return { status: 'saved', prompt: { ...prompt, id: prompt.id.toLowerCase() } };
+    });
+  }
+
+  remove(id) {
+    if (!isUuid(id)) {
+      throw new SavedPromptRepositoryError('SAVED_PROMPT_INVALID_ID', 'Prompt id must be a UUID.');
+    }
+    const result = this.database.prepare('DELETE FROM saved_prompts WHERE id = ?').run(id.toLowerCase());
+    return { removed: Number(result.changes) > 0, id: id.toLowerCase() };
+  }
+
+  resolveSource(id) {
+    if (!isUuid(id)) {
+      throw new SavedPromptRepositoryError('SAVED_PROMPT_INVALID_ID', 'Prompt id must be a UUID.');
+    }
+    const prompt = serializeRow(this.database.prepare('SELECT * FROM saved_prompts WHERE id = ?').get(id.toLowerCase()));
+    if (!prompt?.source) return { status: 'unavailable', reason: 'no-source' };
+    return prompt.source.kind === 'stable'
+      ? this.#resolveStableSource(prompt.source)
+      : this.#resolvePathSource(prompt.source.pathAtSave);
+  }
+
+  #normalizeSource(source) {
+    if (!source) return null;
+    let pathAtSave;
+    try { pathAtSave = normalizePathSnapshot(source.pathAtSave); } catch { return null; }
+    if (source.kind !== 'stable') return source.kind === 'path' ? { kind: 'path', pathAtSave } : null;
+    const reference = source.reference;
+    if (!reference || ![reference.assetId, reference.revisionId, reference.locationId, reference.rootId].every(isUuid)) {
+      return { kind: 'path', pathAtSave };
+    }
+    const valid = this.database.prepare(`
+      SELECT 1
+      FROM asset_locations l
+      JOIN asset_revisions r ON r.revision_id = l.revision_id AND r.asset_id = l.asset_id
+      JOIN library_roots root ON root.root_id = ?
+      WHERE l.location_id = ? AND l.asset_id = ? AND l.root_id = ? AND l.revision_id = ?
+      LIMIT 1
+    `).get(
+      reference.rootId, reference.locationId, reference.assetId, reference.rootId, reference.revisionId,
+    );
+    if (!valid) return { kind: 'path', pathAtSave };
+    return {
+      kind: 'stable',
+      reference: {
+        assetId: reference.assetId.toLowerCase(),
+        revisionId: reference.revisionId.toLowerCase(),
+        locationId: reference.locationId.toLowerCase(),
+        rootId: reference.rootId.toLowerCase(),
+      },
+      pathAtSave,
+    };
+  }
+
+  #resolveStableSource(source) {
+    const row = this.database.prepare(`
+      SELECT l.revision_id, l.relative_path, l.state AS location_state,
+             a.state AS asset_state, root.absolute_path
+      FROM asset_locations l
+      JOIN assets a ON a.asset_id = l.asset_id
+      JOIN library_roots root ON root.root_id = l.root_id
+      WHERE l.location_id = ? AND l.asset_id = ? AND l.root_id = ?
+      LIMIT 1
+    `).get(source.reference.locationId, source.reference.assetId, source.reference.rootId);
+    if (!row || row.location_state !== 'present' || row.asset_state !== 'active') {
+      return { status: 'unavailable', reason: 'catalog-unavailable' };
+    }
+    const absolutePath = path.resolve(row.absolute_path, row.relative_path);
+    const withinRoot = path.relative(path.resolve(row.absolute_path), absolutePath);
+    if (withinRoot.startsWith('..') || path.isAbsolute(withinRoot)) {
+      return { status: 'unavailable', reason: 'invalid-location' };
+    }
+    try {
+      const stat = this.statSync(absolutePath);
+      if (!stat.isFile()) return { status: 'unavailable', reason: 'not-a-file' };
+    } catch {
+      return { status: 'unavailable', reason: 'offline-or-missing' };
+    }
+    return {
+      status: 'available',
+      absolutePath,
+      sourceChanged: row.revision_id !== source.reference.revisionId,
+    };
+  }
+
+  #resolvePathSource(pathAtSave) {
+    const absolutePath = path.resolve(pathAtSave.directoryPath, pathAtSave.relativePath);
+    try {
+      const stat = this.statSync(absolutePath);
+      if (!stat.isFile()) return { status: 'unavailable', reason: 'not-a-file' };
+      if (pathAtSave.fileSize !== null && Number(stat.size) !== pathAtSave.fileSize) {
+        return { status: 'unavailable', reason: 'source-changed' };
+      }
+      if (pathAtSave.contentModifiedMs !== null && Number(stat.mtimeMs) !== pathAtSave.contentModifiedMs) {
+        return { status: 'unavailable', reason: 'source-changed' };
+      }
+      return { status: 'available', absolutePath, sourceChanged: false };
+    } catch {
+      return { status: 'unavailable', reason: 'offline-or-missing' };
+    }
+  }
+}

--- a/electron/savedPromptRepository.mjs
+++ b/electron/savedPromptRepository.mjs
@@ -207,7 +207,7 @@ export class SavedPromptRepository {
     }
     const absolutePath = path.resolve(row.absolute_path, row.relative_path);
     const withinRoot = path.relative(path.resolve(row.absolute_path), absolutePath);
-    if (withinRoot.startsWith('..') || path.isAbsolute(withinRoot)) {
+    if (withinRoot === '..' || withinRoot.startsWith(`..${path.sep}`) || path.isAbsolute(withinRoot)) {
       return { status: 'unavailable', reason: 'invalid-location' };
     }
     try {

--- a/electron/savedPromptRepository.mjs
+++ b/electron/savedPromptRepository.mjs
@@ -34,7 +34,7 @@ function normalizePathSnapshot(value) {
   }
   const absolutePath = path.resolve(directoryPath, relativePath);
   const relativeCheck = path.relative(path.resolve(directoryPath), absolutePath);
-  if (relativeCheck.startsWith('..') || path.isAbsolute(relativeCheck)) {
+  if (relativeCheck === '..' || relativeCheck.startsWith(`..${path.sep}`) || path.isAbsolute(relativeCheck)) {
     throw new SavedPromptRepositoryError('SAVED_PROMPT_INVALID_SOURCE', 'The source path escapes its directory.');
   }
   return {

--- a/electron/savedPromptRepository.mjs
+++ b/electron/savedPromptRepository.mjs
@@ -54,6 +54,7 @@ function serializeRow(row) {
   return {
     id: row.id,
     createdAt: Number(row.created_at),
+    sourceCreatedAt: row.source_created_at == null ? null : Number(row.source_created_at),
     positivePrompt: row.positive_prompt,
     negativePrompt: row.negative_prompt,
     textBasis: row.text_basis,
@@ -115,6 +116,11 @@ export class SavedPromptRepository {
       const prompt = {
         id: this.randomUUID(),
         createdAt: Math.trunc(this.now()),
+        sourceCreatedAt: typeof input?.sourceCreatedAt === 'number'
+          && Number.isFinite(input.sourceCreatedAt)
+          && input.sourceCreatedAt > 0
+          ? Math.trunc(input.sourceCreatedAt)
+          : null,
         positivePrompt,
         negativePrompt,
         textBasis,
@@ -125,10 +131,10 @@ export class SavedPromptRepository {
       }
       this.database.prepare(`
         INSERT INTO saved_prompts (
-          id, created_at, positive_prompt, negative_prompt, text_basis, source_json, prompt_digest
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+          id, created_at, source_created_at, positive_prompt, negative_prompt, text_basis, source_json, prompt_digest
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
-        prompt.id.toLowerCase(), prompt.createdAt, prompt.positivePrompt, prompt.negativePrompt,
+        prompt.id.toLowerCase(), prompt.createdAt, prompt.sourceCreatedAt, prompt.positivePrompt, prompt.negativePrompt,
         prompt.textBasis, prompt.source ? JSON.stringify(prompt.source) : null, promptDigest,
       );
       return { status: 'saved', prompt: { ...prompt, id: prompt.id.toLowerCase() } };

--- a/electron/stableIdentityFileOperationsSmoke.mjs
+++ b/electron/stableIdentityFileOperationsSmoke.mjs
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { ProvenanceRepositoryLifecycle } from './provenanceRepository.mjs';
+import { PROVENANCE_SCHEMA_VERSION, ProvenanceRepositoryLifecycle } from './provenanceRepository.mjs';
 import { StableIdentityUserDataService } from './stableIdentityUserDataService.mjs';
 
 function assertSmoke(condition, message) {
@@ -148,6 +148,12 @@ export async function runStableIdentityFileOperationsSmoke({
           patch: { set: { rating: 2, updatedAt: 30 } },
         })
       : null;
+    const savedPrompt = repository.savePrompt({
+      positivePrompt: 'packaged smoke prompt',
+      negativePrompt: '',
+      textBasis: 'effective',
+      source: null,
+    }).prompt;
     return {
       root,
       renamed,
@@ -159,6 +165,7 @@ export async function runStableIdentityFileOperationsSmoke({
       copiedAnnotation,
       copiedShadow,
       editedCopy,
+      savedPrompt,
       pendingOperations: repository.listPendingFileOperations(),
       status: repository.getStatus(),
     };
@@ -196,17 +203,27 @@ export async function runStableIdentityFileOperationsSmoke({
     const sourceData = repository.captureAssetUserDataSnapshot(initial.assetId, 40);
     const copiedData = copied ? repository.captureAssetUserDataSnapshot(copied.assetId, 40) : [];
     const directoryData = repository.captureAssetUserDataSnapshot(directoryInitial.assetId, 40);
-    return { status: repository.getStatus(), copied, renamedDirectoryDescendant, sourceData, copiedData, directoryData };
+    return {
+      status: repository.getStatus(),
+      copied,
+      renamedDirectoryDescendant,
+      sourceData,
+      copiedData,
+      directoryData,
+      savedPrompts: repository.listSavedPrompts(),
+    };
   });
   reopenedLifecycle.close();
   assertSmoke(reopenedUserDataStatus.authority === 'sqlite', 'SQLite authority did not survive a flag-off reopen');
   assertSmoke(reopenedUserDataStatus.legacyScanComplete === true, 'legacy scan checkpoint did not survive reopen');
-  assertSmoke(reopened.status.schemaVersion === 5, 'reopened catalog schema is not current');
+  assertSmoke(reopened.status.schemaVersion === PROVENANCE_SCHEMA_VERSION, 'reopened catalog schema is not current');
   assertSmoke(reopened.sourceData.find((entry) => entry.domain === 'annotation')?.payload?.rating === 5, 'source annotation changed with its copy');
   assertSmoke(reopened.copiedData.find((entry) => entry.domain === 'annotation')?.payload?.rating === 2, 'copied annotation did not survive reopen');
   assertSmoke(reopened.copiedData.find((entry) => entry.domain === 'shadow')?.payload?.seed === 0, 'copied shadow metadata did not survive reopen');
   assertSmoke(reopened.renamedDirectoryDescendant?.assetId === directoryInitial.assetId, 'directory descendant identity did not survive reopen');
   assertSmoke(reopened.directoryData.find((entry) => entry.domain === 'annotation')?.payload?.rating === 4, 'directory descendant annotation did not survive reopen');
+  assertSmoke(reopened.savedPrompts.length === 1, 'saved prompt did not survive reopen');
+  assertSmoke(reopened.savedPrompts[0]?.id === snapshot.savedPrompt.id, 'saved prompt identity changed after reopen');
 
   return {
     success: true,

--- a/hooks/useSavePrompt.ts
+++ b/hooks/useSavePrompt.ts
@@ -80,3 +80,18 @@ export function useSavePrompt() {
     ));
   }, [persist]);
 }
+
+export function useIsPromptSaved(
+  positivePrompt: unknown,
+  negativePrompt: unknown,
+): boolean {
+  const positive = typeof positivePrompt === 'string' ? positivePrompt : '';
+  const negative = typeof negativePrompt === 'string' ? negativePrompt : '';
+  return useSavedPromptStore((state) => (
+    Boolean(positive.trim())
+    && state.prompts.some((prompt) => (
+      prompt.positivePrompt === positive
+      && prompt.negativePrompt === negative
+    ))
+  ));
+}

--- a/hooks/useSavePrompt.ts
+++ b/hooks/useSavePrompt.ts
@@ -55,6 +55,9 @@ export function composeSavedPromptInput(
     negativePrompt,
     textBasis: showOriginal ? 'original' : 'effective',
     source: buildSavedPromptSource(image, directoryPath),
+    sourceCreatedAt: Number.isFinite(image.lastModified) && image.lastModified > 0
+      ? Math.trunc(image.lastModified)
+      : null,
   };
 }
 

--- a/hooks/useSavePrompt.ts
+++ b/hooks/useSavePrompt.ts
@@ -1,0 +1,79 @@
+import { useCallback } from 'react';
+import type { IndexedImage, SavePromptInput, SavedPromptSaveResult, ShadowMetadata } from '../types';
+import { getPersistedShadowMetadata } from '../services/userDataPersistenceAdapter';
+import { useSavedPromptStore } from '../store/useSavedPromptStore';
+import { buildEffectiveMetadata } from '../utils/editableMetadata';
+import { getRelativeImagePath } from '../utils/imagePaths';
+
+interface SavePromptOptions {
+  directoryPath?: string | null;
+  showOriginal?: boolean;
+  shadowMetadata?: ShadowMetadata | null;
+  shadowReady?: boolean;
+  readAuthoritativeShadow?: boolean;
+}
+
+export function buildSavedPromptSource(image: IndexedImage, directoryPath?: string | null): SavePromptInput['source'] {
+  if (!window.electronAPI || !directoryPath) return null;
+  const pathAtSave = {
+    directoryPath,
+    relativePath: getRelativeImagePath(image),
+    fileSize: typeof image.fileSize === 'number' ? image.fileSize : null,
+    contentModifiedMs: typeof image.contentModifiedMs === 'number' ? image.contentModifiedMs : null,
+  };
+  if (image.assetId && image.revisionId && image.provenanceLocationId && image.provenanceRootId) {
+    return {
+      kind: 'stable',
+      reference: {
+        assetId: image.assetId,
+        revisionId: image.revisionId,
+        locationId: image.provenanceLocationId,
+        rootId: image.provenanceRootId,
+      },
+      pathAtSave,
+    };
+  }
+  return { kind: 'path', pathAtSave };
+}
+
+export function composeSavedPromptInput(
+  image: IndexedImage,
+  shadowMetadata: ShadowMetadata | null | undefined,
+  directoryPath?: string | null,
+  showOriginal = false,
+): SavePromptInput {
+  const effective = buildEffectiveMetadata(
+    image.metadata?.normalizedMetadata,
+    shadowMetadata,
+    showOriginal,
+  );
+  const positivePrompt = typeof effective?.prompt === 'string' ? effective.prompt : '';
+  const negativePrompt = typeof effective?.negativePrompt === 'string' ? effective.negativePrompt : '';
+  if (!positivePrompt.trim()) throw new Error('This image has no positive prompt to save.');
+  return {
+    positivePrompt,
+    negativePrompt,
+    textBasis: showOriginal ? 'original' : 'effective',
+    source: buildSavedPromptSource(image, directoryPath),
+  };
+}
+
+export function useSavePrompt() {
+  const persist = useSavedPromptStore((state) => state.save);
+  return useCallback(async (
+    image: IndexedImage,
+    options: SavePromptOptions = {},
+  ): Promise<SavedPromptSaveResult> => {
+    if (options.shadowReady === false) throw new Error('Prompt metadata is still loading.');
+    let shadowMetadata = options.shadowMetadata;
+    if (options.readAuthoritativeShadow) {
+      shadowMetadata = await getPersistedShadowMetadata(image);
+    }
+    return persist(composeSavedPromptInput(
+      image,
+      shadowMetadata,
+      options.directoryPath,
+      Boolean(options.showOriginal),
+    ));
+  }, [persist]);
+}

--- a/preload.js
+++ b/preload.js
@@ -251,6 +251,15 @@ const electronAPI = {
     ipcRenderer.on('stable-user-data-changed', handler);
     return () => ipcRenderer.removeListener('stable-user-data-changed', handler);
   },
+  savedPromptsList: () => ipcRenderer.invoke('saved-prompts:list'),
+  savedPromptsSave: (input) => ipcRenderer.invoke('saved-prompts:save', input),
+  savedPromptsRemove: (id) => ipcRenderer.invoke('saved-prompts:remove', id),
+  savedPromptsResolveSource: (id) => ipcRenderer.invoke('saved-prompts:resolve-source', id),
+  onSavedPromptsChanged: (callback) => {
+    const subscription = () => callback();
+    ipcRenderer.on('saved-prompts:changed', subscription);
+    return () => ipcRenderer.removeListener('saved-prompts:changed', subscription);
+  },
   resolveMediaUrl: (filePath) => ipcRenderer.invoke('resolve-media-url', filePath),
   readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),
   hashFileSha256: (filePath, requestId) => ipcRenderer.invoke('hash-file-sha256', { filePath, requestId }),

--- a/scripts/runPackagedSavedPromptSmoke.mjs
+++ b/scripts/runPackagedSavedPromptSmoke.mjs
@@ -68,11 +68,12 @@ try {
     if (
       !result.success
       || result.indexingEnabled !== indexingEnabled
-      || result.schemaVersion !== 6
+      || result.schemaVersion !== 7
       || result.authority !== 'sqlite'
       || result.reopened !== true
       || result.duplicatePreservedIdentity !== true
       || result.literalTextPreserved !== true
+      || result.sourceCreatedAtPreserved !== true
       || result.idempotentRemove !== true
     ) fail(`flag ${variant} returned an invalid result payload`);
     results.push(result);

--- a/scripts/runPackagedSavedPromptSmoke.mjs
+++ b/scripts/runPackagedSavedPromptSmoke.mjs
@@ -1,0 +1,92 @@
+import { spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+function fail(message) {
+  throw new Error(`Packaged saved-prompt smoke runner: ${message}`);
+}
+
+function runExecutable(executablePath, args, env, timeoutMs = 120_000) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executablePath, args, { env, windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+      process.stdout.write(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+      process.stderr.write(chunk);
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(`Timed out after ${timeoutMs}ms.\n${stdout}\n${stderr}`));
+    }, timeoutMs);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('exit', (code) => {
+      clearTimeout(timeout);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+const [inputExecutable] = process.argv.slice(2);
+if (!inputExecutable) fail('usage: node scripts/runPackagedSavedPromptSmoke.mjs <exe>');
+
+const executablePath = path.resolve(inputExecutable);
+await fs.access(executablePath);
+const temporaryRoot = path.join(os.tmpdir(), `Image MetaHub prompt smoke ç ${crypto.randomUUID()}`);
+await fs.mkdir(temporaryRoot, { recursive: true });
+
+let primaryError = null;
+try {
+  const results = [];
+  for (const indexingEnabled of [false, true]) {
+    const variant = indexingEnabled ? 'on' : 'off';
+    const resultPath = path.join(temporaryRoot, `saved-prompt-${variant}.json`);
+    const profilePath = path.join(temporaryRoot, `Perfil sintético flag ${variant} ç`);
+    const execution = await runExecutable(
+      executablePath,
+      [`--user-data-dir=${profilePath}`, '--enable-logging=stderr'],
+      {
+        ...process.env,
+        IMH_ENABLE_PROVENANCE_INDEXING: indexingEnabled ? '1' : '0',
+        IMH_PACKAGED_SAVED_PROMPT_SMOKE: '1',
+        IMH_PACKAGED_SAVED_PROMPT_SMOKE_RESULT: resultPath,
+        IMH_DISABLE_GPU: '1',
+        ELECTRON_ENABLE_LOGGING: 'true',
+      },
+    );
+    if (execution.code !== 0) fail(`flag ${variant} exited with ${execution.code}.\n${execution.stdout}\n${execution.stderr}`);
+    const result = JSON.parse(await fs.readFile(resultPath, 'utf8'));
+    if (
+      !result.success
+      || result.indexingEnabled !== indexingEnabled
+      || result.schemaVersion !== 6
+      || result.authority !== 'sqlite'
+      || result.reopened !== true
+      || result.duplicatePreservedIdentity !== true
+      || result.literalTextPreserved !== true
+      || result.idempotentRemove !== true
+    ) fail(`flag ${variant} returned an invalid result payload`);
+    results.push(result);
+  }
+  process.stdout.write(`${JSON.stringify({ success: true, results }, null, 2)}\n`);
+} catch (error) {
+  primaryError = error;
+} finally {
+  try {
+    await fs.rm(temporaryRoot, { recursive: true, force: true });
+  } catch (cleanupError) {
+    if (!primaryError) primaryError = cleanupError;
+    else process.stderr.write(`Smoke cleanup warning: ${cleanupError?.message || cleanupError}\n`);
+  }
+}
+
+if (primaryError) throw primaryError;

--- a/scripts/runPackagedStableIdentityFileOperationsSmoke.mjs
+++ b/scripts/runPackagedStableIdentityFileOperationsSmoke.mjs
@@ -72,7 +72,7 @@ try {
   if (
     !result.success
     || result.pendingOperations !== 0
-    || result.schemaVersion !== 6
+    || result.schemaVersion !== 7
     || result.userData?.authority !== 'sqlite'
     || result.userData?.legacyScanComplete !== true
     || result.userData?.copiedRating !== 2

--- a/scripts/runPackagedStableIdentityFileOperationsSmoke.mjs
+++ b/scripts/runPackagedStableIdentityFileOperationsSmoke.mjs
@@ -72,7 +72,7 @@ try {
   if (
     !result.success
     || result.pendingOperations !== 0
-    || result.schemaVersion !== 5
+    || result.schemaVersion !== 6
     || result.userData?.authority !== 'sqlite'
     || result.userData?.legacyScanComplete !== true
     || result.userData?.copiedRating !== 2

--- a/services/savedPromptService.ts
+++ b/services/savedPromptService.ts
@@ -1,0 +1,83 @@
+import type {
+  SavedPrompt,
+  SavedPromptSaveResult,
+  SavedPromptSourceResolution,
+  SavePromptInput,
+} from '../types';
+import {
+  listBrowserSavedPrompts,
+  removeBrowserSavedPrompt,
+  saveBrowserPrompt,
+} from './savedPromptStorage';
+
+const listeners = new Set<() => void>();
+let browserChannel: BroadcastChannel | null = null;
+
+const emitLocalChange = () => listeners.forEach((listener) => listener());
+
+const ensureBrowserChannel = () => {
+  if (browserChannel || typeof BroadcastChannel === 'undefined') return;
+  browserChannel = new BroadcastChannel('image-metahub-saved-prompts');
+  browserChannel.onmessage = emitLocalChange;
+};
+
+const unwrap = <T>(result: { success: true; data: T } | { success: false; error: string }): T => {
+  if (result.success === false) throw new Error(result.error);
+  return result.data;
+};
+
+const missingDesktopApi = (): never => {
+  throw new Error('Saved-prompt desktop storage is unavailable.');
+};
+
+export async function listSavedPrompts(): Promise<SavedPrompt[]> {
+  if (window.electronAPI) {
+    if (!window.electronAPI.savedPromptsList) return missingDesktopApi();
+    return unwrap(await window.electronAPI.savedPromptsList());
+  }
+  return listBrowserSavedPrompts();
+}
+
+export async function savePrompt(input: SavePromptInput): Promise<SavedPromptSaveResult> {
+  if (window.electronAPI) {
+    if (!window.electronAPI.savedPromptsSave) return missingDesktopApi();
+    return unwrap(await window.electronAPI.savedPromptsSave(input));
+  }
+  const result = await saveBrowserPrompt({ ...input, source: null });
+  if (result.status === 'saved') {
+    emitLocalChange();
+    ensureBrowserChannel();
+    browserChannel?.postMessage('changed');
+  }
+  return result;
+}
+
+export async function removeSavedPrompt(id: string): Promise<{ id: string; removed: boolean }> {
+  if (window.electronAPI) {
+    if (!window.electronAPI.savedPromptsRemove) return missingDesktopApi();
+    return unwrap(await window.electronAPI.savedPromptsRemove(id));
+  }
+  const result = await removeBrowserSavedPrompt(id);
+  if (result.removed) {
+    emitLocalChange();
+    ensureBrowserChannel();
+    browserChannel?.postMessage('changed');
+  }
+  return result;
+}
+
+export async function resolveSavedPromptSource(id: string): Promise<SavedPromptSourceResolution> {
+  if (!window.electronAPI) return { status: 'unavailable', reason: 'browser-session-ended' };
+  if (!window.electronAPI.savedPromptsResolveSource) return missingDesktopApi();
+  return unwrap(await window.electronAPI.savedPromptsResolveSource(id));
+}
+
+export function subscribeSavedPromptChanges(listener: () => void): () => void {
+  listeners.add(listener);
+  ensureBrowserChannel();
+  const unsubscribeElectron = window.electronAPI?.onSavedPromptsChanged?.(listener);
+  return () => {
+    listeners.delete(listener);
+    unsubscribeElectron?.();
+  };
+}

--- a/services/savedPromptStorage.ts
+++ b/services/savedPromptStorage.ts
@@ -1,0 +1,106 @@
+import type { SavedPrompt, SavedPromptSaveResult, SavePromptInput } from '../types';
+
+export const SAVED_PROMPTS_DATABASE_NAME = 'image-metahub-saved-prompts';
+const STORE_NAME = 'saved_prompts';
+const DATABASE_VERSION = 1;
+
+type StoredPrompt = SavedPrompt & { promptDigest: string };
+
+const requestResult = <T>(request: IDBRequest<T>): Promise<T> => new Promise((resolve, reject) => {
+  request.onsuccess = () => resolve(request.result);
+  request.onerror = () => reject(request.error ?? new Error('Saved-prompt database request failed.'));
+});
+
+const transactionComplete = (transaction: IDBTransaction): Promise<void> => new Promise((resolve, reject) => {
+  transaction.oncomplete = () => resolve();
+  transaction.onabort = () => reject(transaction.error ?? new Error('Saved-prompt transaction was aborted.'));
+  transaction.onerror = () => reject(transaction.error ?? new Error('Saved-prompt transaction failed.'));
+});
+
+const openDatabase = (): Promise<IDBDatabase> => new Promise((resolve, reject) => {
+  const request = indexedDB.open(SAVED_PROMPTS_DATABASE_NAME, DATABASE_VERSION);
+  request.onupgradeneeded = () => {
+    const database = request.result;
+    if (database.objectStoreNames.contains(STORE_NAME)) return;
+    const store = database.createObjectStore(STORE_NAME, { keyPath: 'id' });
+    store.createIndex('promptDigest', 'promptDigest', { unique: false });
+    store.createIndex('createdAt', 'createdAt', { unique: false });
+  };
+  request.onsuccess = () => resolve(request.result);
+  request.onerror = () => reject(request.error ?? new Error('Could not open saved-prompt storage.'));
+  request.onblocked = () => reject(new Error('Saved-prompt storage is blocked by another window.'));
+});
+
+export const savedPromptDigest = (positivePrompt: string, negativePrompt: string): string => {
+  let hash = 0x811c9dc5;
+  const value = `${positivePrompt}\u0000${negativePrompt}`;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+};
+
+const withoutDigest = ({ promptDigest: _promptDigest, ...prompt }: StoredPrompt): SavedPrompt => prompt;
+
+export async function listBrowserSavedPrompts(): Promise<SavedPrompt[]> {
+  const database = await openDatabase();
+  try {
+    const transaction = database.transaction(STORE_NAME, 'readonly');
+    const records = await requestResult(transaction.objectStore(STORE_NAME).getAll()) as StoredPrompt[];
+    await transactionComplete(transaction);
+    return records
+      .sort((left, right) => right.createdAt - left.createdAt || right.id.localeCompare(left.id))
+      .map(withoutDigest);
+  } finally {
+    database.close();
+  }
+}
+
+export async function saveBrowserPrompt(input: SavePromptInput): Promise<SavedPromptSaveResult> {
+  const positivePrompt = typeof input.positivePrompt === 'string' ? input.positivePrompt : '';
+  const negativePrompt = typeof input.negativePrompt === 'string' ? input.negativePrompt : '';
+  if (!positivePrompt.trim()) throw new Error('A non-empty positive prompt is required.');
+  const promptDigest = savedPromptDigest(positivePrompt, negativePrompt);
+  const database = await openDatabase();
+  try {
+    const transaction = database.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const candidates = await requestResult(store.index('promptDigest').getAll(promptDigest)) as StoredPrompt[];
+    const duplicate = candidates.find((record) => (
+      record.positivePrompt === positivePrompt && record.negativePrompt === negativePrompt
+    ));
+    if (duplicate) {
+      await transactionComplete(transaction);
+      return { status: 'already-saved', prompt: withoutDigest(duplicate) };
+    }
+    const prompt: StoredPrompt = {
+      id: crypto.randomUUID(),
+      createdAt: Date.now(),
+      positivePrompt,
+      negativePrompt,
+      textBasis: input.textBasis === 'original' ? 'original' : 'effective',
+      source: null,
+      promptDigest,
+    };
+    store.add(prompt);
+    await transactionComplete(transaction);
+    return { status: 'saved', prompt: withoutDigest(prompt) };
+  } finally {
+    database.close();
+  }
+}
+
+export async function removeBrowserSavedPrompt(id: string): Promise<{ id: string; removed: boolean }> {
+  const database = await openDatabase();
+  try {
+    const transaction = database.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const existing = await requestResult(store.getKey(id));
+    store.delete(id);
+    await transactionComplete(transaction);
+    return { id, removed: existing !== undefined };
+  } finally {
+    database.close();
+  }
+}

--- a/services/savedPromptStorage.ts
+++ b/services/savedPromptStorage.ts
@@ -2,9 +2,9 @@ import type { SavedPrompt, SavedPromptSaveResult, SavePromptInput } from '../typ
 
 export const SAVED_PROMPTS_DATABASE_NAME = 'image-metahub-saved-prompts';
 const STORE_NAME = 'saved_prompts';
-const DATABASE_VERSION = 1;
+const DATABASE_VERSION = 2;
 
-type StoredPrompt = SavedPrompt & { promptDigest: string };
+type StoredPrompt = Omit<SavedPrompt, 'sourceCreatedAt'> & { sourceCreatedAt?: number | null; promptDigest: string };
 
 const requestResult = <T>(request: IDBRequest<T>): Promise<T> => new Promise((resolve, reject) => {
   request.onsuccess = () => resolve(request.result);
@@ -41,7 +41,12 @@ export const savedPromptDigest = (positivePrompt: string, negativePrompt: string
   return (hash >>> 0).toString(16).padStart(8, '0');
 };
 
-const withoutDigest = ({ promptDigest: _promptDigest, ...prompt }: StoredPrompt): SavedPrompt => prompt;
+const withoutDigest = ({ promptDigest: _promptDigest, ...prompt }: StoredPrompt): SavedPrompt => ({
+  ...prompt,
+  sourceCreatedAt: typeof prompt.sourceCreatedAt === 'number' && Number.isFinite(prompt.sourceCreatedAt)
+    ? prompt.sourceCreatedAt
+    : null,
+});
 
 export async function listBrowserSavedPrompts(): Promise<SavedPrompt[]> {
   const database = await openDatabase();
@@ -77,6 +82,11 @@ export async function saveBrowserPrompt(input: SavePromptInput): Promise<SavedPr
     const prompt: StoredPrompt = {
       id: crypto.randomUUID(),
       createdAt: Date.now(),
+      sourceCreatedAt: typeof input.sourceCreatedAt === 'number'
+        && Number.isFinite(input.sourceCreatedAt)
+        && input.sourceCreatedAt > 0
+        ? Math.trunc(input.sourceCreatedAt)
+        : null,
       positivePrompt,
       negativePrompt,
       textBasis: input.textBasis === 'original' ? 'original' : 'effective',

--- a/store/useSavedPromptStore.ts
+++ b/store/useSavedPromptStore.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+import type { SavedPrompt, SavedPromptSaveResult, SavePromptInput } from '../types';
+import {
+  listSavedPrompts,
+  removeSavedPrompt,
+  savePrompt,
+  subscribeSavedPromptChanges,
+} from '../services/savedPromptService';
+
+interface SavedPromptState {
+  prompts: SavedPrompt[];
+  isLoading: boolean;
+  error: string | null;
+  selectedPromptId: string | null;
+  load: () => Promise<void>;
+  save: (input: SavePromptInput) => Promise<SavedPromptSaveResult>;
+  remove: (id: string) => Promise<void>;
+  select: (id: string | null) => void;
+}
+
+let readGeneration = 0;
+let subscribed = false;
+
+const sortPrompts = (prompts: SavedPrompt[]) => [...prompts].sort(
+  (left, right) => right.createdAt - left.createdAt || right.id.localeCompare(left.id),
+);
+
+export const useSavedPromptStore = create<SavedPromptState>((set, get) => ({
+  prompts: [],
+  isLoading: false,
+  error: null,
+  selectedPromptId: null,
+
+  load: async () => {
+    const generation = ++readGeneration;
+    set({ isLoading: true, error: null });
+    try {
+      const prompts = await listSavedPrompts();
+      if (generation !== readGeneration) return;
+      set({ prompts: sortPrompts(prompts), isLoading: false });
+    } catch (error) {
+      if (generation !== readGeneration) return;
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : 'Could not load saved prompts.',
+      });
+    }
+  },
+
+  save: async (input) => {
+    readGeneration += 1;
+    const result = await savePrompt(input);
+    set((state) => {
+      const withoutSameId = state.prompts.filter((prompt) => prompt.id !== result.prompt.id);
+      return { prompts: sortPrompts([result.prompt, ...withoutSameId]), error: null };
+    });
+    return result;
+  },
+
+  remove: async (id) => {
+    readGeneration += 1;
+    await removeSavedPrompt(id);
+    set((state) => ({
+      prompts: state.prompts.filter((prompt) => prompt.id !== id),
+      selectedPromptId: state.selectedPromptId === id ? null : state.selectedPromptId,
+      error: null,
+    }));
+  },
+
+  select: (id) => set({ selectedPromptId: id }),
+}));
+
+export function initializeSavedPromptSynchronization(): () => void {
+  if (subscribed) return () => undefined;
+  subscribed = true;
+  const unsubscribe = subscribeSavedPromptChanges(() => {
+    void useSavedPromptStore.getState().load();
+  });
+  void useSavedPromptStore.getState().load();
+  return () => {
+    subscribed = false;
+    unsubscribe();
+  };
+}

--- a/types.ts
+++ b/types.ts
@@ -518,6 +518,11 @@ export interface ElectronAPI {
   }) => Promise<StableUserDataIpcResult<StableUserDataRecord[]>>;
   stableUserDataTagCounts: () => Promise<StableUserDataIpcResult<TagInfo[]>>;
   onStableUserDataChanged: (callback: (payload: { records: StableUserDataRecord[] }) => void) => () => void;
+  savedPromptsList: () => Promise<SavedPromptIpcResult<SavedPrompt[]>>;
+  savedPromptsSave: (input: SavePromptInput) => Promise<SavedPromptIpcResult<SavedPromptSaveResult>>;
+  savedPromptsRemove: (id: string) => Promise<SavedPromptIpcResult<{ id: string; removed: boolean }>>;
+  savedPromptsResolveSource: (id: string) => Promise<SavedPromptIpcResult<SavedPromptSourceResolution>>;
+  onSavedPromptsChanged: (callback: () => void) => () => void;
   readFile: (filePath: string) => Promise<{ success: boolean; data?: Buffer; error?: string; errorType?: string; errorCode?: string }>;
   hashFileSha256: (filePath: string, requestId: string) => Promise<{ success: boolean; sha256?: string; error?: string; errorType?: string; errorCode?: string }>;
   cancelFileSha256: (requestId: string) => void;
@@ -727,6 +732,58 @@ export interface ElectronAPI {
   onWatchedFilesRemoved: (callback: (data: WatchedFileRemovalPayload) => void) => () => void;
   onWatcherDebug: (callback: (data: { message: string }) => void) => () => void;
 }
+
+export interface SourcePathSnapshot {
+  directoryPath: string;
+  relativePath: string;
+  fileSize: number | null;
+  contentModifiedMs: number | null;
+}
+
+export type SavedPromptSource =
+  | {
+      kind: 'stable';
+      reference: {
+        assetId: string;
+        revisionId: string;
+        locationId: string;
+        rootId: string;
+      };
+      pathAtSave: SourcePathSnapshot;
+    }
+  | {
+      kind: 'path';
+      pathAtSave: SourcePathSnapshot;
+    };
+
+export interface SavedPrompt {
+  id: string;
+  createdAt: number;
+  positivePrompt: string;
+  negativePrompt: string;
+  textBasis: 'effective' | 'original';
+  source: SavedPromptSource | null;
+}
+
+export interface SavePromptInput {
+  positivePrompt: string;
+  negativePrompt: string;
+  textBasis: 'effective' | 'original';
+  source: SavedPromptSource | null;
+}
+
+export interface SavedPromptSaveResult {
+  status: 'saved' | 'already-saved';
+  prompt: SavedPrompt;
+}
+
+export type SavedPromptSourceResolution =
+  | { status: 'available'; absolutePath: string; sourceChanged: boolean }
+  | { status: 'unavailable'; reason: string };
+
+export type SavedPromptIpcResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; errorCode?: string };
 
 declare global {
   interface Window {

--- a/types.ts
+++ b/types.ts
@@ -759,6 +759,7 @@ export type SavedPromptSource =
 export interface SavedPrompt {
   id: string;
   createdAt: number;
+  sourceCreatedAt: number | null;
   positivePrompt: string;
   negativePrompt: string;
   textBasis: 'effective' | 'original';
@@ -770,6 +771,7 @@ export interface SavePromptInput {
   negativePrompt: string;
   textBasis: 'effective' | 'original';
   source: SavedPromptSource | null;
+  sourceCreatedAt?: number | null;
 }
 
 export interface SavedPromptSaveResult {

--- a/utils/cacheReset.ts
+++ b/utils/cacheReset.ts
@@ -7,6 +7,7 @@
 
 import { useImageStore } from '../store/useImageStore';
 import { useSettingsStore } from '../store/useSettingsStore';
+import { SAVED_PROMPTS_DATABASE_NAME } from '../services/savedPromptStorage';
 
 const LICENSE_STORAGE_KEY = 'image-metahub-license';
 
@@ -78,7 +79,7 @@ export async function resetAllCaches(): Promise<void> {
     
     // Delete each database
     for (const db of databases) {
-      if (db.name) {
+      if (db.name && db.name !== SAVED_PROMPTS_DATABASE_NAME) {
         console.log(`🗑️ Deleting database: ${db.name}`);
         const deleteRequest = indexedDB.deleteDatabase(db.name);
         
@@ -99,6 +100,7 @@ export async function resetAllCaches(): Promise<void> {
         });
       }
     }
+    console.log(`✅ Preserved database: ${SAVED_PROMPTS_DATABASE_NAME}`);
 
   } catch (error) {
     console.error('❌ Error clearing IndexedDB:', error);


### PR DESCRIPTION
## Summary

- add the profile-wide Prompt Library flow: Save Prompt, Copy, Remove, View Source, and discovery-focused Random
- replace the full Prompts navigation tab with a compact Prompt Library bookmark action beside Library
- present saved prompts in a responsive searchable card grid with lazy source thumbnails and discreet removal controls
- open Random selections instantly in a modal with a larger source preview, full positive/negative prompts, Copy, View Source, and Another
- support Saved and source Created sorting in Newest/Oldest order; source creation time is captured immutably in the prompt snapshot
- persist user-created prompt snapshots in SQLite schema v7 on desktop and a dedicated IndexedDB database in browser builds
- preserve literal prompt pairs, historical source identity/timestamps, exact transactional deduplication, and post-commit cross-window synchronization
- preserve saved prompts during app-data reset and keep the feature independent from stable-identity indexing

## Validation

- TypeScript: `npx tsc --noEmit`
- production renderer bundle: `npm run build`
- targeted Prompt Library, persistence, migration, reset, and navigation suites: 42 tests passed across 9 files
- packaged Windows saved-prompt smoke passed with indexing disabled and enabled, using isolated synthetic profiles and schema v7

## Notes

- existing v6 prompts migrate with `sourceCreatedAt: null`; no source timestamp is inferred retroactively
- prompts without a source-created timestamp remain last when sorting by Created in either direction
- no `PARSER_VERSION` change
- no Pro gate
- visual acceptance remains manual
- pre-existing changelog edits are not included in this PR
